### PR TITLE
feat: Add Git root discovery for automatic DOTFILES_ROOT detection (#123)

### DIFF
--- a/docs/user/commands.txxt
+++ b/docs/user/commands.txxt
@@ -24,7 +24,7 @@ $ dodot install vim git ssh
 
 Options:
 • --force - Force re-execution of run-once power-ups even if already executed
-• --all (-a) - Install all packs in DOTFILES_ROOT
+• --all (-a) - Install all packs in your dotfiles directory
 
 Behavior:
 • Runs install.sh scripts (install_script power-up)
@@ -68,7 +68,7 @@ vim pack:
 4. list
 -------
 
-Show all available packs in your DOTFILES_ROOT directory.
+Show all available packs in your dotfiles directory.
 
 Usage:
 $ dodot list
@@ -90,7 +90,7 @@ Create a new pack with placeholder files and configuration.
 Usage:
 $ dodot init <packname>
 
-Creates a pack at DOTFILES_ROOT/<packname> with:
+Creates a pack at <dotfiles>/<packname> with:
 • Placeholder files for each power-up (install.sh, Brewfile, alias.sh, etc.)
 • A concise readme.txt explaining the pack structure
 • A .dodot.toml configuration file with commented examples
@@ -117,7 +117,9 @@ Global Options
 Environment Variables
 ---------------------
 
-• DOTFILES_ROOT - Path to your dotfiles directory (required)
+• DOTFILES_ROOT - Override path to your dotfiles directory (optional)
+  - If not set, dodot will use the git repository root
+  - If not in a git repo, uses current directory with a warning
 • DODOT_DATA_DIR - Path for dodot data files (optional, defaults to ~/.local/share/dodot)
 
 Examples

--- a/docs/user/getting-started.txxt
+++ b/docs/user/getting-started.txxt
@@ -21,27 +21,43 @@ Installation
 
 1. Download the latest release from GitHub
 2. Place the binary in your PATH
-3. Set the DOTFILES_ROOT environment variable to your dotfiles directory
 
 Quick Start
 -----------
 
-1. Initialize your first pack:
+1. Navigate to your dotfiles directory (a git repository):
+   $ cd ~/my-dotfiles
+
+2. Initialize your first pack:
    $ dodot init vim
 
-2. This creates a pack directory with placeholder files:
+3. This creates a pack directory with placeholder files:
    - install.sh (for setup scripts)
    - Brewfile (for package dependencies)
    - alias.sh (for shell aliases)
    - .dodot.toml (for pack configuration)
 
-3. Add your configuration files to the pack directory
+4. Add your configuration files to the pack directory
 
-4. Install the pack (runs setup scripts and deploys configs):
+5. Install the pack (runs setup scripts and deploys configs):
    $ dodot install vim
 
-5. Check the status:
+6. Check the status:
    $ dodot status vim
+
+How dodot Finds Your Dotfiles
+-----------------------------
+
+dodot automatically discovers your dotfiles directory in this order:
+
+1. DOTFILES_ROOT environment variable (if set)
+2. Git repository root (if you're in a git repo)
+3. Current directory (with a warning)
+
+This means you can simply:
+• cd into your dotfiles git repository and run dodot commands
+• No need to set environment variables for typical usage
+• DOTFILES_ROOT is still available for advanced cases
 
 Basic Commands
 --------------

--- a/pkg/paths/git_discovery_test.go
+++ b/pkg/paths/git_discovery_test.go
@@ -1,0 +1,304 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arthur-debert/dodot/pkg/testutil"
+)
+
+func TestFindDotfilesRoot(t *testing.T) {
+	// Save current directory to restore later
+	originalCwd, err := os.Getwd()
+	testutil.AssertNoError(t, err)
+	defer func() {
+		_ = os.Chdir(originalCwd)
+	}()
+
+	tests := []struct {
+		name           string
+		setupEnv       map[string]string
+		setupFunc      func(t *testing.T) string
+		expectedPath   string
+		expectFallback bool
+		skipIfNoGit    bool
+	}{
+		{
+			name: "DOTFILES_ROOT env var takes precedence",
+			setupEnv: map[string]string{
+				EnvDotfilesRoot: "/env/dotfiles",
+			},
+			expectedPath:   "/env/dotfiles",
+			expectFallback: false,
+		},
+		{
+			name: "DOTFILES_HOME env var (legacy)",
+			setupEnv: map[string]string{
+				EnvDotfilesHome: "/legacy/dotfiles",
+			},
+			expectedPath:   "/legacy/dotfiles",
+			expectFallback: false,
+		},
+		{
+			name: "Git repository root discovery",
+			setupFunc: func(t *testing.T) string {
+				// Create a temporary git repo
+				tmpDir := testutil.TempDir(t, "git-test")
+
+				// Change to the temp directory
+				err := os.Chdir(tmpDir)
+				testutil.AssertNoError(t, err)
+
+				// Initialize git repo
+				testutil.RunCommand(t, "git", "init")
+
+				// Create a subdirectory and change into it
+				subDir := filepath.Join(tmpDir, "sub", "dir")
+				err = os.MkdirAll(subDir, 0755)
+				testutil.AssertNoError(t, err)
+
+				err = os.Chdir(subDir)
+				testutil.AssertNoError(t, err)
+
+				return tmpDir
+			},
+			expectedPath:   "", // Will be set by setupFunc
+			expectFallback: false,
+			skipIfNoGit:    true,
+		},
+		{
+			name: "Fallback to current directory when not in git repo",
+			setupFunc: func(t *testing.T) string {
+				// Create a temporary directory that's not a git repo
+				tmpDir := testutil.TempDir(t, "no-git-test")
+
+				err := os.Chdir(tmpDir)
+				testutil.AssertNoError(t, err)
+
+				return tmpDir
+			},
+			expectedPath:   "", // Will be set to cwd
+			expectFallback: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipIfNoGit && !isGitAvailable() {
+				t.Skip("Git not available")
+			}
+
+			// Clear environment
+			t.Setenv(EnvDotfilesRoot, "")
+			t.Setenv(EnvDotfilesHome, "")
+
+			// Set up environment
+			for k, v := range tt.setupEnv {
+				t.Setenv(k, v)
+			}
+
+			// Run setup function if provided
+			expectedPath := tt.expectedPath
+			if tt.setupFunc != nil {
+				result := tt.setupFunc(t)
+				if expectedPath == "" {
+					expectedPath = result
+				}
+			}
+
+			// Test findDotfilesRoot
+			path, usedFallback, err := findDotfilesRoot()
+			testutil.AssertNoError(t, err)
+
+			if expectedPath != "" {
+				// Resolve symlinks for comparison
+				expected, _ := filepath.EvalSymlinks(expectedPath)
+				actual, _ := filepath.EvalSymlinks(path)
+				testutil.AssertEqual(t, expected, actual)
+			}
+
+			testutil.AssertEqual(t, tt.expectFallback, usedFallback)
+		})
+	}
+}
+
+func TestGitRootFromSubdirectory(t *testing.T) {
+	if !isGitAvailable() {
+		t.Skip("Git not available")
+	}
+
+	// Save current directory
+	originalCwd, err := os.Getwd()
+	testutil.AssertNoError(t, err)
+	defer func() {
+		_ = os.Chdir(originalCwd)
+	}()
+
+	// Create temporary git repo
+	tmpDir := testutil.TempDir(t, "git-subdir-test")
+
+	// Initialize git repo
+	err = os.Chdir(tmpDir)
+	testutil.AssertNoError(t, err)
+	testutil.RunCommand(t, "git", "init")
+
+	// Create nested subdirectories
+	deepPath := filepath.Join(tmpDir, "a", "b", "c", "d")
+	err = os.MkdirAll(deepPath, 0755)
+	testutil.AssertNoError(t, err)
+
+	// Change to deep subdirectory
+	err = os.Chdir(deepPath)
+	testutil.AssertNoError(t, err)
+
+	// Test that git root is found correctly
+	gitRoot, err := findGitRoot()
+	testutil.AssertNoError(t, err)
+
+	// Resolve symlinks for comparison (macOS /var -> /private/var)
+	expectedPath, _ := filepath.EvalSymlinks(tmpDir)
+	actualPath, _ := filepath.EvalSymlinks(gitRoot)
+	testutil.AssertEqual(t, expectedPath, actualPath)
+}
+
+func TestPathsWithGitDiscovery(t *testing.T) {
+	if !isGitAvailable() {
+		t.Skip("Git not available")
+	}
+
+	// Save current directory
+	originalCwd, err := os.Getwd()
+	testutil.AssertNoError(t, err)
+	defer func() {
+		_ = os.Chdir(originalCwd)
+	}()
+
+	// Test 1: Git repo as dotfiles root
+	t.Run("git repo discovery", func(t *testing.T) {
+		// Clear environment to avoid interference
+		t.Setenv(EnvDotfilesRoot, "")
+		t.Setenv(EnvDotfilesHome, "")
+
+		tmpDir := testutil.TempDir(t, "paths-git-test")
+		err := os.Chdir(tmpDir)
+		testutil.AssertNoError(t, err)
+		testutil.RunCommand(t, "git", "init")
+
+		p, err := New("")
+		testutil.AssertNoError(t, err)
+
+		// Resolve symlinks for comparison
+		expectedPath, _ := filepath.EvalSymlinks(tmpDir)
+		actualPath, _ := filepath.EvalSymlinks(p.DotfilesRoot())
+		testutil.AssertEqual(t, expectedPath, actualPath)
+		testutil.AssertFalse(t, p.UsedFallback())
+	})
+
+	// Test 2: Fallback with warning
+	t.Run("fallback to cwd", func(t *testing.T) {
+		// Clear environment to avoid interference
+		t.Setenv(EnvDotfilesRoot, "")
+		t.Setenv(EnvDotfilesHome, "")
+
+		tmpDir := testutil.TempDir(t, "paths-no-git-test")
+		err := os.Chdir(tmpDir)
+		testutil.AssertNoError(t, err)
+
+		p, err := New("")
+		testutil.AssertNoError(t, err)
+
+		// Resolve symlinks for comparison
+		expectedPath, _ := filepath.EvalSymlinks(tmpDir)
+		actualPath, _ := filepath.EvalSymlinks(p.DotfilesRoot())
+		testutil.AssertEqual(t, expectedPath, actualPath)
+		testutil.AssertTrue(t, p.UsedFallback())
+	})
+}
+
+// Helper function to check if git is available
+func isGitAvailable() bool {
+	_, err := findGitRoot()
+	// If we're in a git repo, git is available
+	if err == nil {
+		return true
+	}
+
+	// Try to run git --version
+	cmd := testutil.CommandAvailable("git")
+	return cmd
+}
+
+// TestCLIIntegration tests the CLI integration with paths
+func TestCLIIntegration(t *testing.T) {
+	// This test verifies that warnings are shown correctly
+	tests := []struct {
+		name           string
+		envSetup       map[string]string
+		setupFunc      func(t *testing.T) (cleanup func())
+		expectFallback bool
+	}{
+		{
+			name: "DOTFILES_ROOT set - no warning",
+			envSetup: map[string]string{
+				EnvDotfilesRoot: "/custom/dotfiles",
+			},
+			expectFallback: false,
+		},
+		{
+			name: "Git repo - no warning",
+			setupFunc: func(t *testing.T) (cleanup func()) {
+				// We're already in a git repo (dodot), so no setup needed
+				return func() {}
+			},
+			expectFallback: false,
+		},
+		{
+			name: "No git, no env - shows warning",
+			setupFunc: func(t *testing.T) (cleanup func()) {
+				if !isGitAvailable() {
+					t.Skip("Git not available")
+				}
+
+				// Save current directory
+				originalCwd, err := os.Getwd()
+				testutil.AssertNoError(t, err)
+
+				// Create a temporary directory
+				tmpDir := testutil.TempDir(t, "cli-test")
+				err = os.Chdir(tmpDir)
+				testutil.AssertNoError(t, err)
+
+				return func() {
+					_ = os.Chdir(originalCwd)
+				}
+			},
+			expectFallback: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear environment
+			t.Setenv(EnvDotfilesRoot, "")
+			t.Setenv(EnvDotfilesHome, "")
+
+			// Set up environment
+			for k, v := range tt.envSetup {
+				t.Setenv(k, v)
+			}
+
+			// Run setup if provided
+			var cleanup func()
+			if tt.setupFunc != nil {
+				cleanup = tt.setupFunc(t)
+				defer cleanup()
+			}
+
+			// Test paths initialization
+			p, err := New("")
+			testutil.AssertNoError(t, err)
+			testutil.AssertEqual(t, tt.expectFallback, p.UsedFallback())
+		})
+	}
+}

--- a/pkg/paths/paths_test.go
+++ b/pkg/paths/paths_test.go
@@ -43,11 +43,13 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name: "default to ~/dotfiles",
+			name: "git repository or fallback",
 			validate: func(t *testing.T, p *Paths) {
-				homeDir, _ := os.UserHomeDir()
-				expected := filepath.Join(homeDir, DefaultDotfilesDir)
-				testutil.AssertEqual(t, expected, p.DotfilesRoot())
+				// This test will either find the git root if we're in a git repo,
+				// or fall back to the current directory
+				testutil.AssertNotEmpty(t, p.DotfilesRoot())
+				// The path should be absolute
+				testutil.AssertTrue(t, filepath.IsAbs(p.DotfilesRoot()), "Path should be absolute")
 			},
 		},
 		{

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -6,6 +6,7 @@ import (
 
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -231,4 +232,21 @@ func CalculateFileChecksum(filepath string) (string, error) {
 	}
 
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+// RunCommand runs a command and fails the test if it returns an error
+func RunCommand(t *testing.T, name string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Command failed: %s %v\nOutput: %s\nError: %v", name, args, string(output), err)
+	}
+}
+
+// CommandAvailable checks if a command is available in the system PATH
+func CommandAvailable(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
 }


### PR DESCRIPTION
## Summary

This PR implements automatic discovery of the dotfiles directory by checking for git repository root, addressing issue #123.

## Problem

Previously, `dodot` relied exclusively on the `DOTFILES_ROOT` environment variable. This added a setup step for new users and was less convenient than what modern CLI tools offer. A user who has just cloned their dotfiles repository should be able to `cd` into it and run `dodot` commands immediately.

## Solution

Implemented intelligent discovery mechanism with clear order of precedence:

1. **`DOTFILES_ROOT` Environment Variable (Highest Priority)**: If set, its value is used unconditionally
2. **Git Repository Root (Primary Auto-Discovery)**: If `DOTFILES_ROOT` is not set, dodot attempts to find the root of the current git repository
3. **Fallback to `cwd` (with Warning)**: If git command fails, dodot falls back to using the current working directory and prints a clear warning

## Changes Made

### Core Implementation
- Modified `findDotfilesRoot()` in `pkg/paths/paths.go` to check for git repository root
- Added `findGitRoot()` function that uses `git rev-parse --show-toplevel`
- Added `UsedFallback()` method to track when current directory fallback is used
- Updated `Paths` struct to include `usedFallback` field

### CLI Integration
- Added `initPaths()` helper in `internal/cli/commands.go` to initialize paths and show warnings
- Integrated path initialization into `deploy` and `list` commands (with TODO for actual implementation)
- Warning message clearly explains the fallback and suggests better alternatives

### Testing
- Added comprehensive test suite in `pkg/paths/git_discovery_test.go`
- Tests cover all three precedence cases
- Added integration tests to verify warning behavior
- Updated existing tests to handle new git discovery behavior

### Documentation
- Updated `docs/user/getting-started.txxt` to promote `cd` workflow
- Updated `docs/user/commands.txxt` to clarify DOTFILES_ROOT is optional
- Changed references from "required" to "optional" for environment variable

## Test Results

All tests pass:
```
DONE 673 tests, 1 skipped in 0.932s
```

## Example Usage

```bash
# Primary workflow - just cd into your dotfiles repo
$ cd ~/my-dotfiles
$ dodot list
Listing packs from: /Users/user/my-dotfiles

# With environment variable (highest priority)
$ DOTFILES_ROOT=/custom/path dodot list
Listing packs from: /custom/path

# Fallback with warning
$ cd /tmp/not-a-git-repo
$ dodot list
Warning: Not in a git repository and DOTFILES_ROOT not set.
Using current directory: /tmp/not-a-git-repo
For better results, either:
  - Run from within a git repository containing your dotfiles
  - Set DOTFILES_ROOT environment variable

Listing packs from: /tmp/not-a-git-repo
```

## Benefits

- **Improved User Experience**: Primary workflow becomes `cd ~/dotfiles && dodot deploy`
- **Predictability**: Using `git rev-parse` works correctly from any subdirectory
- **Backward Compatibility**: DOTFILES_ROOT still works as before
- **Graceful Fallback**: Worst case defaults to current behavior with helpful guidance

Fixes #123

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>