### PR TITLE
feat: Add shell completion support

### DIFF
--- a/cmd/dodot/msgs.go
+++ b/cmd/dodot/msgs.go
@@ -16,8 +16,9 @@ const (
 	MsgStatusShort  = "Show deployment status of packs"
 	MsgInitShort    = "Create a new pack with template files"
 	MsgFillShort    = "Add placeholder files to an existing pack"
-	MsgTopicsShort  = "Display available documentation topics"
-	MsgTopicsLong   = "Display a list of all available help topics that provide additional documentation beyond command help."
+	MsgTopicsShort     = "Display available documentation topics"
+	MsgTopicsLong      = "Display a list of all available help topics that provide additional documentation beyond command help."
+	MsgCompletionShort = "Generate shell completion script"
 
 	// Status messages
 	MsgDryRunNotice      = "\nDRY RUN MODE - No changes were made"
@@ -111,4 +112,8 @@ var (
 	//go:embed msgs/usage-template.txt
 	msgUsageTemplateRaw string
 	MsgUsageTemplate    = strings.TrimSpace(msgUsageTemplateRaw)
+
+	//go:embed msgs/completion-long.txt
+	msgCompletionLongRaw string
+	MsgCompletionLong    = strings.TrimSpace(msgCompletionLongRaw)
 )

--- a/cmd/dodot/msgs/completion-long.txt
+++ b/cmd/dodot/msgs/completion-long.txt
@@ -1,0 +1,27 @@
+Generate a shell completion script for dodot.
+
+Shell completions allow you to use <TAB> to complete commands, flags, and pack names.
+
+To enable completions, you need to:
+1. Generate the completion script for your shell
+2. Source it in your shell configuration
+
+Bash:
+  $ dodot completion bash > ~/.local/share/bash-completion/completions/dodot
+  $ source ~/.bashrc
+
+Zsh:
+  $ dodot completion zsh > ~/.zfunc/_dodot
+  $ echo "fpath=(~/.zfunc $fpath)" >> ~/.zshrc
+  $ echo "autoload -Uz compinit && compinit" >> ~/.zshrc
+  $ source ~/.zshrc
+
+Fish:
+  $ dodot completion fish > ~/.config/fish/completions/dodot.fish
+  $ source ~/.config/fish/config.fish
+
+PowerShell:
+  $ dodot completion powershell | Out-String | Invoke-Expression
+
+Note: After installing completions, you may need to restart your shell
+or source your shell configuration file.

--- a/cmd/dodot/topics/shell-completions.txxt
+++ b/cmd/dodot/topics/shell-completions.txxt
@@ -1,0 +1,120 @@
+Shell Completions
+=================
+
+dodot supports tab completion for commands, flags, and pack names in popular shells.
+
+Quick Start
+-----------
+
+    # Bash
+    $ dodot completion bash > ~/.local/share/bash-completion/completions/dodot
+    
+    # Zsh
+    $ dodot completion zsh > ~/.zfunc/_dodot
+    
+    # Fish
+    $ dodot completion fish > ~/.config/fish/completions/dodot.fish
+    
+    # PowerShell
+    $ dodot completion powershell | Out-String | Invoke-Expression
+
+What Gets Completed
+-------------------
+
+1. Commands and subcommands
+   $ dodot <TAB>         # Shows: deploy, install, list, status, etc.
+
+2. Flags and options
+   $ dodot deploy --<TAB>  # Shows: --dry-run, --force, --verbose
+
+3. Pack names (context-aware)
+   $ dodot deploy <TAB>    # Shows available pack names
+   $ dodot deploy vim <TAB> # Shows remaining packs (vim excluded)
+
+Setup Instructions
+------------------
+
+BASH
+....
+
+1. Generate the completion script:
+   $ dodot completion bash > ~/.local/share/bash-completion/completions/dodot
+
+2. Ensure bash-completion is installed:
+   # macOS
+   $ brew install bash-completion@2
+   
+   # Linux
+   $ sudo apt install bash-completion  # Debian/Ubuntu
+   $ sudo dnf install bash-completion  # Fedora
+
+3. Source your bashrc:
+   $ source ~/.bashrc
+
+ZSH
+...
+
+1. Create completion directory if needed:
+   $ mkdir -p ~/.zfunc
+
+2. Generate the completion script:
+   $ dodot completion zsh > ~/.zfunc/_dodot
+
+3. Add to your ~/.zshrc:
+   fpath=(~/.zfunc $fpath)
+   autoload -Uz compinit && compinit
+
+4. Reload your shell:
+   $ source ~/.zshrc
+
+FISH
+....
+
+1. Generate the completion script:
+   $ dodot completion fish > ~/.config/fish/completions/dodot.fish
+
+2. Completions are loaded automatically in new shells
+
+POWERSHELL
+..........
+
+1. Add to your PowerShell profile:
+   $ dodot completion powershell >> $PROFILE
+
+2. Or load for current session only:
+   $ dodot completion powershell | Out-String | Invoke-Expression
+
+Troubleshooting
+---------------
+
+Not Working After Setup?
+- Try opening a new terminal session
+- Verify the completion file was created
+- Check that completion is enabled in your shell
+
+Bash on macOS:
+- Ensure you're using bash 4.0+ (check with `bash --version`)
+- Default macOS bash is too old; install via Homebrew
+
+Zsh:
+- Run `rm ~/.zcompdump*` to clear completion cache
+- Run `compinit` to rebuild completions
+
+Custom Pack Names Not Showing?
+- Ensure DOTFILES_ROOT is set or you're in the dotfiles directory
+- Check that packs exist with `dodot list`
+
+Advanced Usage
+--------------
+
+Debugging completions:
+    # See what completions are generated
+    $ dodot __complete deploy ""
+    
+    # Enable debug output
+    $ DODOT_DEBUG=1 dodot deploy <TAB>
+
+The completion system is smart:
+- Pack names are only suggested for commands that accept them
+- Already specified packs are filtered from suggestions
+- Completions work even when DOTFILES_ROOT uses fallback detection


### PR DESCRIPTION
## Summary
- Implements tab completion for commands, flags, and pack names across bash, zsh, fish, and PowerShell
- Enables Cobra's built-in completion generation
- Adds smart pack name completion for deploy/install/status commands

## Details
This PR adds shell completion support that was developed in the cli/fine-tuning branch but wasn't included in the main merge.

Key features:
- Enable Cobra's built-in completion generation
- Add 'completion' command to generate shell scripts
- Implement smart pack name completion that:
  - Shows available packs for deploy/install/status commands
  - Filters out already-specified packs from suggestions
  - Works with DOTFILES_ROOT detection
- Add comprehensive help topic covering setup and troubleshooting

Users can now use TAB to complete commands and pack names, significantly improving the CLI experience. For example:
  $ dodot deploy <TAB>      # Shows all available packs
  $ dodot deploy vim <TAB>  # Shows remaining packs

## Test plan
- [x] Generate completion scripts for each shell
- [x] Test pack name completion filters out already specified packs
- [x] Verify completion command appears in help
- [x] Check shell-completions help topic is accessible

🤖 Generated with [Claude Code](https://claude.ai/code)