### PR TITLE
Make symlink the default catchall behavior for unmatched files

### DIFF
--- a/pkg/core/triggers_catchall_test.go
+++ b/pkg/core/triggers_catchall_test.go
@@ -1,0 +1,146 @@
+package core
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/arthur-debert/dodot/pkg/config"
+	"github.com/arthur-debert/dodot/pkg/testutil"
+	"github.com/arthur-debert/dodot/pkg/types"
+)
+
+func TestProcessPackTriggers_CatchallBehavior(t *testing.T) {
+	// Create test directory structure
+	testDir := testutil.TempDir(t, "catchall-test")
+	packDir := filepath.Join(testDir, "test-pack")
+	testutil.CreateDir(t, testDir, "test-pack")
+
+	// Create various test files
+	testFiles := map[string]string{
+		".vimrc":       "vim config",     // Should match vim-config
+		".bashrc":      "bash config",    // Should match bash-config
+		"Brewfile":     "brew 'git'",     // Should match brewfile
+		"install.sh":   "#!/bin/bash",    // Should match install-script
+		"custom.conf":  "custom config",  // Should match catchall
+		"random.txt":   "random content", // Should match catchall
+		".myapp":       "app config",     // Should match catchall
+		"data.json":    "{}",             // Should match catchall
+		".dodot.toml":  "# config",       // Should be skipped
+		".dodotignore": "*.tmp",          // Should be skipped by catchall
+	}
+
+	for filename, content := range testFiles {
+		testutil.CreateFile(t, packDir, filename, content)
+	}
+
+	// Create a subdirectory that should match
+	testutil.CreateDir(t, packDir, "subdir")
+	testutil.CreateFile(t, filepath.Join(packDir, "subdir"), "nested.txt", "nested")
+
+	// Create pack with default config (no pack config file)
+	pack := types.Pack{
+		Name:   "test-pack",
+		Path:   packDir,
+		Config: types.PackConfig{}, // Empty config, will use defaults
+	}
+
+	// Process triggers
+	matches, err := ProcessPackTriggers(pack)
+	testutil.AssertNoError(t, err)
+
+	// Build a map of matched files to their power-ups
+	matchMap := make(map[string]string)
+	for _, match := range matches {
+		matchMap[match.Path] = match.PowerUpName
+	}
+
+	// Verify specific matchers worked
+	testutil.AssertEqual(t, "symlink", matchMap[".vimrc"])
+	testutil.AssertEqual(t, "symlink", matchMap[".bashrc"])
+	testutil.AssertEqual(t, "brewfile", matchMap["Brewfile"])
+	testutil.AssertEqual(t, "install_script", matchMap["install.sh"])
+
+	// Verify catchall caught the remaining files
+	testutil.AssertEqual(t, "symlink", matchMap["custom.conf"])
+	testutil.AssertEqual(t, "symlink", matchMap["random.txt"])
+	testutil.AssertEqual(t, "symlink", matchMap[".myapp"])
+	testutil.AssertEqual(t, "symlink", matchMap["data.json"])
+	testutil.AssertEqual(t, "symlink", matchMap["subdir"])
+	testutil.AssertEqual(t, "symlink", matchMap["subdir/nested.txt"])
+
+	// Verify excluded files were not matched
+	if _, found := matchMap[".dodot.toml"]; found {
+		t.Error(".dodot.toml should not be matched")
+	}
+	if _, found := matchMap[".dodotignore"]; found {
+		t.Error(".dodotignore should not be matched")
+	}
+
+	// Verify we got the expected number of matches
+	expectedMatches := 10 // All files except .dodot.toml and .dodotignore
+	testutil.AssertEqual(t, expectedMatches, len(matches))
+}
+
+func TestProcessPackTriggers_CatchallWithOverrides(t *testing.T) {
+	// Create test directory structure
+	testDir := testutil.TempDir(t, "catchall-override-test")
+	packDir := filepath.Join(testDir, "test-pack")
+	testutil.CreateDir(t, testDir, "test-pack")
+
+	// Create pack.dodot.toml with overrides
+	packConfigContent := `
+[[override]]
+path = "custom.conf"
+powerup = "shell_profile"
+
+[[override]]
+path = "data.json"
+powerup = "template"
+`
+	testutil.CreateFile(t, packDir, "pack.dodot.toml", packConfigContent)
+
+	// Create test files
+	testFiles := map[string]string{
+		"custom.conf": "custom config",  // Should be overridden to shell_profile
+		"data.json":   "{}",             // Should be overridden to template
+		"random.txt":  "random content", // Should match catchall
+	}
+
+	for filename, content := range testFiles {
+		testutil.CreateFile(t, packDir, filename, content)
+	}
+
+	// Load the pack config
+	configPath := filepath.Join(packDir, "pack.dodot.toml")
+	packConfig, err := config.LoadPackConfig(configPath)
+	testutil.AssertNoError(t, err)
+
+	pack := types.Pack{
+		Name:   "test-pack",
+		Path:   packDir,
+		Config: packConfig,
+	}
+
+	// Process triggers
+	matches, err := ProcessPackTriggers(pack)
+	testutil.AssertNoError(t, err)
+
+	// Build a map of matched files to their power-ups
+	matchMap := make(map[string]string)
+	for _, match := range matches {
+		matchMap[match.Path] = match.PowerUpName
+	}
+
+	// Verify overrides took precedence over catchall
+	testutil.AssertEqual(t, "shell_profile", matchMap["custom.conf"])
+	testutil.AssertEqual(t, "template", matchMap["data.json"])
+
+	// Verify catchall still caught the remaining file
+	testutil.AssertEqual(t, "symlink", matchMap["random.txt"])
+}
+
+func TestProcessPackTriggers_NoCatchallIfDisabled(t *testing.T) {
+	// This test would require the ability to disable matchers,
+	// which might be added in the future
+	t.Skip("Test for disabling catchall matcher - to be implemented")
+}

--- a/pkg/matchers/matchers.go
+++ b/pkg/matchers/matchers.go
@@ -216,6 +216,18 @@ func DefaultMatchers() []types.Matcher {
 			},
 			Enabled: true,
 		},
+
+		// Catchall symlink matcher - must be last with lowest priority
+		{
+			Name:           "symlink-catchall",
+			TriggerName:    "catchall",
+			PowerUpName:    "symlink",
+			Priority:       0, // Lowest priority to run last
+			TriggerOptions: map[string]interface{}{
+				// Default excludes are handled by the catchall trigger itself
+			},
+			Enabled: true,
+		},
 	}
 
 	// Add any dynamically registered matchers

--- a/pkg/registry/global_test.go
+++ b/pkg/registry/global_test.go
@@ -19,6 +19,7 @@ func (m *mockTrigger) Priority() int       { return 1 }
 func (m *mockTrigger) Match(path string, info fs.FileInfo) (bool, map[string]interface{}) {
 	return true, nil
 }
+func (m *mockTrigger) Type() types.TriggerType { return types.TriggerTypeSpecific }
 
 // Mock power-up for testing
 type mockPowerUp struct {

--- a/pkg/testutil/mocks.go
+++ b/pkg/testutil/mocks.go
@@ -12,6 +12,7 @@ type MockTrigger struct {
 	DescriptionFunc func() string
 	PriorityFunc    func() int
 	MatchFunc       func(path string, info fs.FileInfo) (bool, map[string]interface{})
+	TypeFunc        func() types.TriggerType
 }
 
 // Name returns the mock's name.
@@ -44,6 +45,14 @@ func (m *MockTrigger) Match(path string, info fs.FileInfo) (bool, map[string]int
 		return m.MatchFunc(path, info)
 	}
 	return false, nil
+}
+
+// Type returns the mock's trigger type.
+func (m *MockTrigger) Type() types.TriggerType {
+	if m.TypeFunc != nil {
+		return m.TypeFunc()
+	}
+	return types.TriggerTypeSpecific
 }
 
 // MockPowerUp is a mock implementation of the types.PowerUp interface for testing.

--- a/pkg/triggers/catchall.go
+++ b/pkg/triggers/catchall.go
@@ -1,0 +1,125 @@
+package triggers
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+
+	"github.com/arthur-debert/dodot/pkg/logging"
+	"github.com/arthur-debert/dodot/pkg/registry"
+	"github.com/arthur-debert/dodot/pkg/types"
+)
+
+const (
+	CatchallTriggerName     = "catchall"
+	CatchallTriggerPriority = 0 // Lowest priority to run last
+)
+
+// CatchallTrigger matches all files and directories not matched by other triggers
+type CatchallTrigger struct {
+	excludePatterns []string
+	priority        int
+}
+
+// NewCatchallTrigger creates a new CatchallTrigger with the given options
+func NewCatchallTrigger(options map[string]interface{}) (*CatchallTrigger, error) {
+	logger := logging.GetLogger("triggers.catchall")
+
+	trigger := &CatchallTrigger{
+		excludePatterns: []string{
+			".dodot.toml",
+			"pack.dodot.toml",
+			".dodotignore",
+		},
+		priority: CatchallTriggerPriority,
+	}
+
+	// Extract additional exclude patterns from options if provided
+	if excludes, ok := options["excludePatterns"]; ok {
+		switch v := excludes.(type) {
+		case []string:
+			trigger.excludePatterns = append(trigger.excludePatterns, v...)
+		case []interface{}:
+			for _, pattern := range v {
+				if str, ok := pattern.(string); ok {
+					trigger.excludePatterns = append(trigger.excludePatterns, str)
+				}
+			}
+		}
+	}
+
+	logger.Trace().
+		Strs("excludePatterns", trigger.excludePatterns).
+		Msg("created catchall trigger")
+
+	return trigger, nil
+}
+
+// Name returns the unique name of this trigger
+func (t *CatchallTrigger) Name() string {
+	return CatchallTriggerName
+}
+
+// Description returns a human-readable description of what this trigger matches
+func (t *CatchallTrigger) Description() string {
+	return "Matches all files and directories not matched by specific triggers"
+}
+
+// Match checks if the given file should be caught by the catchall
+func (t *CatchallTrigger) Match(path string, info fs.FileInfo) (bool, map[string]interface{}) {
+	logger := logging.GetLogger("triggers.catchall")
+
+	// Check if the file matches any exclude pattern
+	basename := filepath.Base(path)
+	for _, pattern := range t.excludePatterns {
+		matched, err := filepath.Match(pattern, basename)
+		if err != nil {
+			logger.Error().
+				Err(err).
+				Str("pattern", pattern).
+				Str("path", path).
+				Msg("error matching exclude pattern")
+			continue
+		}
+		if matched {
+			logger.Trace().
+				Str("path", path).
+				Str("pattern", pattern).
+				Msg("file excluded by pattern")
+			return false, nil
+		}
+	}
+
+	// Catchall matches everything not excluded
+	logger.Trace().
+		Str("path", path).
+		Bool("isDir", info.IsDir()).
+		Msg("file matched catchall trigger")
+
+	metadata := map[string]interface{}{
+		"isDir":    info.IsDir(),
+		"basename": basename,
+	}
+
+	return true, metadata
+}
+
+// Priority returns the priority of this trigger
+func (t *CatchallTrigger) Priority() int {
+	return t.priority
+}
+
+// Type returns the trigger type - this is a catchall trigger
+func (t *CatchallTrigger) Type() types.TriggerType {
+	return types.TriggerTypeCatchall
+}
+
+func init() {
+	// Register the catchall trigger factory
+	err := registry.RegisterTriggerFactory(CatchallTriggerName, func(config map[string]interface{}) (types.Trigger, error) {
+		return NewCatchallTrigger(config)
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed to register CatchallTrigger factory: %v", err))
+	}
+}

--- a/pkg/triggers/catchall_test.go
+++ b/pkg/triggers/catchall_test.go
@@ -1,0 +1,211 @@
+package triggers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arthur-debert/dodot/pkg/registry"
+	"github.com/arthur-debert/dodot/pkg/testutil"
+	"github.com/arthur-debert/dodot/pkg/types"
+)
+
+func TestCatchallTrigger_Creation(t *testing.T) {
+	tests := []struct {
+		name           string
+		options        map[string]interface{}
+		wantErr        bool
+		expectExcludes []string
+	}{
+		{
+			name:    "default excludes",
+			options: nil,
+			wantErr: false,
+			expectExcludes: []string{
+				".dodot.toml",
+				"pack.dodot.toml",
+				".dodotignore",
+			},
+		},
+		{
+			name: "additional excludes as []string",
+			options: map[string]interface{}{
+				"excludePatterns": []string{"*.tmp", "*.bak"},
+			},
+			wantErr: false,
+			expectExcludes: []string{
+				".dodot.toml",
+				"pack.dodot.toml",
+				".dodotignore",
+				"*.tmp",
+				"*.bak",
+			},
+		},
+		{
+			name: "additional excludes as []interface{}",
+			options: map[string]interface{}{
+				"excludePatterns": []interface{}{"*.log", "temp*"},
+			},
+			wantErr: false,
+			expectExcludes: []string{
+				".dodot.toml",
+				"pack.dodot.toml",
+				".dodotignore",
+				"*.log",
+				"temp*",
+			},
+		},
+		{
+			name:    "empty options",
+			options: map[string]interface{}{},
+			wantErr: false,
+			expectExcludes: []string{
+				".dodot.toml",
+				"pack.dodot.toml",
+				".dodotignore",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trigger, err := NewCatchallTrigger(tt.options)
+
+			if tt.wantErr {
+				testutil.AssertError(t, err)
+				return
+			}
+
+			testutil.AssertNoError(t, err)
+			testutil.AssertNotNil(t, trigger)
+			testutil.AssertEqual(t, CatchallTriggerName, trigger.Name())
+			testutil.AssertEqual(t, CatchallTriggerPriority, trigger.Priority())
+			testutil.AssertEqual(t, types.TriggerTypeCatchall, trigger.Type())
+			testutil.AssertSliceEqual(t, tt.expectExcludes, trigger.excludePatterns)
+		})
+	}
+}
+
+func TestCatchallTrigger_Match(t *testing.T) {
+	// Create a catchall trigger with custom excludes for testing
+	trigger, err := NewCatchallTrigger(map[string]interface{}{
+		"excludePatterns": []string{"*.tmp", "test-*"},
+	})
+	testutil.AssertNoError(t, err)
+
+	tests := []struct {
+		name        string
+		path        string
+		isDir       bool
+		shouldMatch bool
+	}{
+		// Default excludes
+		{
+			name:        "exclude .dodot.toml",
+			path:        "/home/user/dotfiles/pack/.dodot.toml",
+			isDir:       false,
+			shouldMatch: false,
+		},
+		{
+			name:        "exclude pack.dodot.toml",
+			path:        "/home/user/dotfiles/pack/pack.dodot.toml",
+			isDir:       false,
+			shouldMatch: false,
+		},
+		{
+			name:        "exclude .dodotignore",
+			path:        "/home/user/dotfiles/pack/.dodotignore",
+			isDir:       false,
+			shouldMatch: false,
+		},
+		// Custom excludes
+		{
+			name:        "exclude .tmp file",
+			path:        "/home/user/dotfiles/pack/cache.tmp",
+			isDir:       false,
+			shouldMatch: false,
+		},
+		{
+			name:        "exclude test- prefix",
+			path:        "/home/user/dotfiles/pack/test-file.txt",
+			isDir:       false,
+			shouldMatch: false,
+		},
+		// Should match
+		{
+			name:        "match regular file",
+			path:        "/home/user/dotfiles/pack/.vimrc",
+			isDir:       false,
+			shouldMatch: true,
+		},
+		{
+			name:        "match config file",
+			path:        "/home/user/dotfiles/pack/.config/nvim/init.vim",
+			isDir:       false,
+			shouldMatch: true,
+		},
+		{
+			name:        "match directory",
+			path:        "/home/user/dotfiles/pack/bin",
+			isDir:       true,
+			shouldMatch: true,
+		},
+		{
+			name:        "match hidden file",
+			path:        "/home/user/dotfiles/pack/.gitignore",
+			isDir:       false,
+			shouldMatch: true,
+		},
+		{
+			name:        "match file with spaces",
+			path:        "/home/user/dotfiles/pack/my file.txt",
+			isDir:       false,
+			shouldMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &mockFileInfo{
+				name:    tt.path,
+				isDir:   tt.isDir,
+				mode:    0644,
+				modTime: time.Now(),
+			}
+
+			matched, metadata := trigger.Match(tt.path, info)
+
+			testutil.AssertEqual(t, tt.shouldMatch, matched)
+
+			if matched {
+				testutil.AssertNotNil(t, metadata)
+				testutil.AssertEqual(t, tt.isDir, metadata["isDir"])
+				testutil.AssertNotNil(t, metadata["basename"])
+			}
+		})
+	}
+}
+
+func TestCatchallTrigger_Description(t *testing.T) {
+	trigger, err := NewCatchallTrigger(nil)
+	testutil.AssertNoError(t, err)
+
+	desc := trigger.Description()
+	testutil.AssertContains(t, desc, "all files")
+	testutil.AssertContains(t, desc, "not matched")
+}
+
+func TestCatchallTrigger_FactoryRegistration(t *testing.T) {
+	// Test that the factory is registered
+	factory, err := registry.GetTriggerFactory(CatchallTriggerName)
+	testutil.AssertNoError(t, err)
+	testutil.AssertNotNil(t, factory)
+
+	// Test creating a trigger through the factory
+	trigger, err := factory(map[string]interface{}{
+		"excludePatterns": []string{"test.txt"},
+	})
+	testutil.AssertNoError(t, err)
+	testutil.AssertNotNil(t, trigger)
+	testutil.AssertEqual(t, CatchallTriggerName, trigger.Name())
+	testutil.AssertEqual(t, types.TriggerTypeCatchall, trigger.Type())
+}

--- a/pkg/triggers/directory.go
+++ b/pkg/triggers/directory.go
@@ -91,6 +91,11 @@ func (t *DirectoryTrigger) Priority() int {
 	return 100 // High priority for directory matching
 }
 
+// Type returns the trigger type - this is a specific trigger
+func (t *DirectoryTrigger) Type() types.TriggerType {
+	return types.TriggerTypeSpecific
+}
+
 // ValidateOptions checks if the provided options are valid for this trigger
 func (t *DirectoryTrigger) ValidateOptions(options map[string]interface{}) error {
 	if options == nil {

--- a/pkg/triggers/extension.go
+++ b/pkg/triggers/extension.go
@@ -86,6 +86,11 @@ func (t *ExtensionTrigger) Priority() int {
 	return 80 // Medium-high priority
 }
 
+// Type returns the trigger type - this is a specific trigger
+func (t *ExtensionTrigger) Type() types.TriggerType {
+	return types.TriggerTypeSpecific
+}
+
 // ValidateOptions checks if the provided options are valid for this trigger
 func (t *ExtensionTrigger) ValidateOptions(options map[string]interface{}) error {
 	if options == nil {

--- a/pkg/triggers/filename.go
+++ b/pkg/triggers/filename.go
@@ -96,6 +96,11 @@ func (t *FileNameTrigger) Priority() int {
 	return t.priority
 }
 
+// Type returns the trigger type - this is a specific trigger
+func (t *FileNameTrigger) Type() types.TriggerType {
+	return types.TriggerTypeSpecific
+}
+
 // GetPattern returns the pattern this trigger matches
 func (t *FileNameTrigger) GetPattern() string {
 	return t.pattern

--- a/pkg/triggers/path_pattern.go
+++ b/pkg/triggers/path_pattern.go
@@ -85,6 +85,11 @@ func (t *PathPatternTrigger) Priority() int {
 	return 70 // Medium priority
 }
 
+// Type returns the trigger type - this is a specific trigger
+func (t *PathPatternTrigger) Type() types.TriggerType {
+	return types.TriggerTypeSpecific
+}
+
 // ValidateOptions checks if the provided options are valid for this trigger
 func (t *PathPatternTrigger) ValidateOptions(options map[string]interface{}) error {
 	if options == nil {

--- a/pkg/types/trigger.go
+++ b/pkg/types/trigger.go
@@ -2,6 +2,16 @@ package types
 
 import "io/fs"
 
+// TriggerType represents the type of trigger - specific or catchall
+type TriggerType int
+
+const (
+	// TriggerTypeSpecific is for triggers that match specific patterns
+	TriggerTypeSpecific TriggerType = iota
+	// TriggerTypeCatchall is for triggers that match everything not already matched
+	TriggerTypeCatchall
+)
+
 // Trigger is an interface for pattern-matching engines that scan files
 // and directories within packs. When a trigger finds a match, it returns
 // metadata about what was found.
@@ -18,6 +28,9 @@ type Trigger interface {
 
 	// Priority returns the priority of this trigger (higher = evaluated first)
 	Priority() int
+
+	// Type returns whether this is a specific or catchall trigger
+	Type() TriggerType
 }
 
 // TriggerMatch represents a successful trigger match on a file or directory

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -22,6 +22,7 @@ func (m *mockTrigger) Priority() int       { return m.priority }
 func (m *mockTrigger) Match(path string, info fs.FileInfo) (bool, map[string]interface{}) {
 	return m.shouldMatch, m.metadata
 }
+func (m *mockTrigger) Type() TriggerType { return TriggerTypeSpecific }
 
 type mockPowerUp struct {
 	name        string

--- a/test-environment/spec/integration/test_defaults_spec.sh
+++ b/test-environment/spec/integration/test_defaults_spec.sh
@@ -1,0 +1,33 @@
+#!/bin/zsh
+# Test if default matchers work without pack.dodot.toml
+
+Describe 'Default Matchers Test'
+  BeforeEach 'reset_test_environment'
+  AfterEach 'cleanup_test_environment'
+  
+  It 'symlinks .bashrc without pack.dodot.toml'
+    mkdir -p "$TEST_DOTFILES_ROOT/defaults"
+    echo "test bashrc" > "$TEST_DOTFILES_ROOT/defaults/.bashrc"
+    
+    # NO pack.dodot.toml!
+    
+    When call "$DODOT" deploy defaults
+    The status should be success
+    
+    # Should create symlink
+    The file "$HOME/.bashrc" should be symlink
+  End
+  
+  It 'handles aliases.sh for shell_profile without pack.dodot.toml'
+    mkdir -p "$TEST_DOTFILES_ROOT/profile"
+    echo "alias x=exit" > "$TEST_DOTFILES_ROOT/profile/aliases.sh"
+    
+    # NO pack.dodot.toml!
+    
+    When call "$DODOT" deploy profile
+    The status should be success
+    
+    # Should deploy to shell_profile
+    The file "$HOME/.local/share/dodot/deployed/shell_profile/profile.sh" should exist
+  End
+End


### PR DESCRIPTION
## Summary

This PR implements symlink as the default catchall behavior for all files that don't match specific patterns. This makes dodot behave like a traditional dotfiles manager where everything is symlinked by default unless configured otherwise.

## Changes

### 1. Added TriggerType Classification
- Added `TriggerType` enum to the Trigger interface with `TriggerTypeSpecific` and `TriggerTypeCatchall` values
- Updated all existing triggers to return `TriggerTypeSpecific`
- This allows the system to distinguish between specific pattern matchers and catchall matchers

### 2. Implemented Catchall Trigger
- Created new `CatchallTrigger` that matches all files and directories not already matched
- Excludes `.dodot.toml`, `pack.dodot.toml`, and `.dodotignore` files by default
- Supports additional exclude patterns via configuration

### 3. Two-Phase Matching System
- Refactored `ProcessPackTriggers` to process matchers in two phases:
  - Phase 1: Run all specific matchers (existing behavior)
  - Phase 2: Run catchall matchers on unmatched files
- Tracks matched files to prevent double processing
- Ensures overrides and ignores are respected

### 4. Default Catchall Symlink Matcher
- Added catchall symlink matcher to `DefaultMatchers()` with priority 0 (lowest)
- This ensures it runs last after all specific matchers
- Makes every unmatched file in a pack symlinked by default

## Breaking Changes

⚠️ **This is a BREAKING CHANGE** - Files that were previously ignored will now be symlinked by default.

Users who don't want certain files symlinked will need to:
- Add them to `.dodotignore`
- Use pack.dodot.toml overrides to assign them to different powerups
- Or create specific matchers to handle them differently

## Testing

- Added comprehensive tests for catchall behavior
- Verified that specific matchers take precedence
- Tested that overrides prevent catchall matching
- Confirmed excluded files are not caught by catchall
- All existing tests pass

## Examples

Before this change:
```
dotfiles/
  mypack/
    .vimrc       # ✓ Symlinked (matches vim-config matcher)
    .bashrc      # ✓ Symlinked (matches bash-config matcher)
    custom.conf  # ✗ Ignored (no matcher)
    notes.txt    # ✗ Ignored (no matcher)
```

After this change:
```
dotfiles/
  mypack/
    .vimrc       # ✓ Symlinked (matches vim-config matcher)
    .bashrc      # ✓ Symlinked (matches bash-config matcher)  
    custom.conf  # ✓ Symlinked (caught by catchall)
    notes.txt    # ✓ Symlinked (caught by catchall)
```

Closes #434

🤖 Generated with [Claude Code](https://claude.ai/code)