### PR TITLE
fix: clean up default matchers to only handle special naming conventions

### DIFF
--- a/pkg/commands/fill/fill_test.go
+++ b/pkg/commands/fill/fill_test.go
@@ -32,11 +32,12 @@ func TestFillPack(t *testing.T) {
 				t.Logf("Files created: %v", result.FilesCreated)
 
 				// Since we're not executing operations yet, we only check the reported files
-				testutil.AssertEqual(t, 3, len(result.FilesCreated))
+				testutil.AssertEqual(t, 4, len(result.FilesCreated))
 
 				// Check that all expected files are in the result
 				expectedFiles := map[string]bool{
 					"aliases.sh": false,
+					"profile.sh": false,
 					"install.sh": false,
 					"Brewfile":   false,
 				}
@@ -63,7 +64,7 @@ func TestFillPack(t *testing.T) {
 			packName: "partial-pack",
 			validate: func(t *testing.T, result *types.FillResult, packPath string) {
 				// Since aliases.sh already exists, only 2 files should be created
-				testutil.AssertEqual(t, 2, len(result.FilesCreated))
+				testutil.AssertEqual(t, 3, len(result.FilesCreated))
 
 				// Check that existing file was not overwritten
 				content := testutil.ReadFile(t, filepath.Join(packPath, "aliases.sh"))

--- a/pkg/commands/initialize/init_test.go
+++ b/pkg/commands/initialize/init_test.go
@@ -27,13 +27,14 @@ func TestInitPack(t *testing.T) {
 			packName: "new-pack",
 			validate: func(t *testing.T, result *types.InitResult, packPath string) {
 				// Since we're not executing operations yet, we only check the reported files
-				testutil.AssertEqual(t, 5, len(result.FilesCreated))
+				testutil.AssertEqual(t, 6, len(result.FilesCreated))
 
 				// Check that all expected files are in the result
 				expectedFiles := map[string]bool{
 					".dodot.toml": false,
 					"README.txt":  false,
 					"aliases.sh":  false,
+					"profile.sh":  false,
 					"install.sh":  false,
 					"Brewfile":    false,
 				}

--- a/pkg/matchers/matchers.go
+++ b/pkg/matchers/matchers.go
@@ -39,107 +39,31 @@ func RegisterDefaultMatcher(name string, matcher types.Matcher) {
 // DefaultMatchers returns a set of common matchers for typical dotfiles
 func DefaultMatchers() []types.Matcher {
 	matchers := []types.Matcher{
-		// Vim configuration
+		// Install powerups (run once)
 		{
-			Name:        "vim-config",
+			Name:        "install-script",
 			TriggerName: "filename",
-			PowerUpName: "symlink",
-			Priority:    100,
-			TriggerOptions: map[string]interface{}{
-				"pattern": ".vimrc",
-			},
-			Enabled: true,
-		},
-		{
-			Name:        "neovim-config",
-			TriggerName: "filename",
-			PowerUpName: "symlink",
-			Priority:    100,
-			TriggerOptions: map[string]interface{}{
-				"pattern": ".config/nvim",
-			},
-			Enabled: true,
-		},
-
-		// Shell configurations
-		{
-			Name:        "bash-config",
-			TriggerName: "filename",
-			PowerUpName: "symlink",
-			Priority:    100,
-			TriggerOptions: map[string]interface{}{
-				"pattern": ".bashrc",
-			},
-			Enabled: true,
-		},
-		{
-			Name:        "zsh-config",
-			TriggerName: "filename",
-			PowerUpName: "symlink",
-			Priority:    100,
-			TriggerOptions: map[string]interface{}{
-				"pattern": ".zshrc",
-			},
-			Enabled: true,
-		},
-		{
-			Name:        "fish-config",
-			TriggerName: "filename",
-			PowerUpName: "symlink",
-			Priority:    100,
-			TriggerOptions: map[string]interface{}{
-				"pattern": ".config/fish",
-			},
-			Enabled: true,
-		},
-
-		// Git configuration
-		{
-			Name:        "git-config",
-			TriggerName: "filename",
-			PowerUpName: "symlink",
-			Priority:    100,
-			TriggerOptions: map[string]interface{}{
-				"pattern": ".gitconfig",
-			},
-			Enabled: true,
-		},
-		{
-			Name:        "git-ignore",
-			TriggerName: "filename",
-			PowerUpName: "symlink",
-			Priority:    100,
-			TriggerOptions: map[string]interface{}{
-				"pattern": ".gitignore_global",
-			},
-			Enabled: true,
-		},
-
-		// Common development tools
-		{
-			Name:        "tmux-config",
-			TriggerName: "filename",
-			PowerUpName: "symlink",
-			Priority:    100,
-			TriggerOptions: map[string]interface{}{
-				"pattern": ".tmux.conf",
-			},
-			Enabled: true,
-		},
-		{
-			Name:        "ssh-config",
-			TriggerName: "filename",
-			PowerUpName: "symlink",
+			PowerUpName: "install_script",
 			Priority:    90,
 			TriggerOptions: map[string]interface{}{
-				"pattern": ".ssh/config",
+				"pattern": "install.sh",
+			},
+			Enabled: true,
+		},
+		{
+			Name:        "brewfile",
+			TriggerName: "filename",
+			PowerUpName: "brewfile",
+			Priority:    90,
+			TriggerOptions: map[string]interface{}{
+				"pattern": "Brewfile",
 			},
 			Enabled: true,
 		},
 
-		// Shell profile and path
+		// Shell profile integration
 		{
-			Name:        "shell-profile",
+			Name:        "shell-aliases",
 			TriggerName: "filename",
 			PowerUpName: "shell_profile",
 			Priority:    80,
@@ -149,17 +73,17 @@ func DefaultMatchers() []types.Matcher {
 			Enabled: true,
 		},
 		{
-			Name:        "shell-path",
-			TriggerName: "directory",
-			PowerUpName: "shell_add_path",
+			Name:        "shell-profile",
+			TriggerName: "filename",
+			PowerUpName: "shell_profile",
 			Priority:    80,
 			TriggerOptions: map[string]interface{}{
-				"pattern": "bin",
+				"pattern": "profile.sh",
 			},
 			Enabled: true,
 		},
 
-		// Bin power-up matchers
+		// Bin directories - handled by both bin and shell_add_path powerups
 		{
 			Name:        "bin-dir",
 			TriggerName: "directory",
@@ -171,10 +95,30 @@ func DefaultMatchers() []types.Matcher {
 			Enabled: true,
 		},
 		{
-			Name:        "bin-local",
+			Name:        "bin-path",
+			TriggerName: "directory",
+			PowerUpName: "shell_add_path",
+			Priority:    80,
+			TriggerOptions: map[string]interface{}{
+				"pattern": "bin",
+			},
+			Enabled: true,
+		},
+		{
+			Name:        "local-bin-dir",
 			TriggerName: "directory",
 			PowerUpName: "bin",
 			Priority:    90,
+			TriggerOptions: map[string]interface{}{
+				"pattern": ".local/bin",
+			},
+			Enabled: true,
+		},
+		{
+			Name:        "local-bin-path",
+			TriggerName: "directory",
+			PowerUpName: "shell_add_path",
+			Priority:    80,
 			TriggerOptions: map[string]interface{}{
 				"pattern": ".local/bin",
 			},
@@ -189,30 +133,6 @@ func DefaultMatchers() []types.Matcher {
 			Priority:    70,
 			TriggerOptions: map[string]interface{}{
 				"extension": ".tmpl",
-			},
-			Enabled: true,
-		},
-
-		// Brewfile power-up matcher
-		{
-			Name:        "brewfile",
-			TriggerName: "filename",
-			PowerUpName: "brewfile",
-			Priority:    90,
-			TriggerOptions: map[string]interface{}{
-				"pattern": "Brewfile",
-			},
-			Enabled: true,
-		},
-
-		// Install script power-up matcher
-		{
-			Name:        "install-script",
-			TriggerName: "filename",
-			PowerUpName: "install_script",
-			Priority:    90,
-			TriggerOptions: map[string]interface{}{
-				"pattern": "install.sh",
 			},
 			Enabled: true,
 		},

--- a/pkg/matchers/matchers_test.go
+++ b/pkg/matchers/matchers_test.go
@@ -29,18 +29,21 @@ func init() {
 func TestDefaultMatchers(t *testing.T) {
 	defaults := DefaultMatchers()
 
-	// Should have a reasonable number of default matchers
-	assert.GreaterOrEqual(t, len(defaults), 11)
+	// Should have exactly the matchers we defined
+	assert.Equal(t, 10, len(defaults)) // 2 install + 2 shell + 4 bin + 1 template + 1 catchall
 
 	// Check some expected matchers exist
 	expectedNames := map[string]bool{
-		"vim-config":    false,
-		"bash-config":   false,
-		"zsh-config":    false,
-		"git-config":    false,
-		"tmux-config":   false,
-		"shell-profile": false,
-		"shell-path":    false,
+		"install-script":   false,
+		"brewfile":         false,
+		"shell-aliases":    false,
+		"shell-profile":    false,
+		"bin-dir":          false,
+		"bin-path":         false,
+		"local-bin-dir":    false,
+		"local-bin-path":   false,
+		"template":         false,
+		"symlink-catchall": false,
 	}
 
 	for _, m := range defaults {


### PR DESCRIPTION
## Summary
- Removes hardcoded dotfile matchers that were treating specific files specially  
- Now only special naming conventions trigger special powerups
- Everything else is handled by the catchall symlink matcher

## Changes
This PR removes all the hardcoded dotfile matchers like:
- `.vimrc` → symlink
- `.bashrc` → symlink  
- `.gitconfig` → symlink
- etc.

Now the default matchers ONLY handle special naming conventions:
- `install.sh` → install_script powerup
- `Brewfile` → brewfile powerup
- `*aliases.sh` → shell_profile powerup
- `profile.sh` → shell_profile powerup
- `bin/` → bin powerup AND shell_add_path powerup
- `.local/bin/` → bin powerup AND shell_add_path powerup
- `*.tmpl` → template powerup
- `*` (catchall) → symlink powerup

This aligns with dodot's philosophy: special names get special behavior, everything else gets symlinked.

## Breaking Change
This is a **BREAKING CHANGE** - users who were relying on the specific dotfile matchers will need to update their configs if they want different behavior than the default symlink.

## Related Issues
Fixes #436

## Test Plan
- [x] All existing tests pass
- [x] Updated tests to expect new matcher count
- [x] Manually verified catchall handles all dotfiles

🤖 Generated with [Claude Code](https://claude.ai/code)