### PR TITLE
feat: add snippet command for shell integration setup (closes #419)

### DIFF
--- a/cmd/dodot/commands.go
+++ b/cmd/dodot/commands.go
@@ -11,6 +11,7 @@ import (
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/paths"
 	"github.com/arthur-debert/dodot/pkg/synthfs"
+	"github.com/arthur-debert/dodot/pkg/types"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -75,6 +76,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newStatusCmd())
 	rootCmd.AddCommand(newInitCmd())
 	rootCmd.AddCommand(newFillCmd())
+	rootCmd.AddCommand(newSnippetCmd())
 	rootCmd.AddCommand(newTopicsCmd())
 	rootCmd.AddCommand(newCompletionCmd())
 
@@ -507,6 +509,49 @@ func newTopicsCmd() *cobra.Command {
 			return fmt.Errorf("help command not found")
 		},
 	}
+}
+
+func newSnippetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "snippet",
+		Short:   MsgSnippetShort,
+		Long:    MsgSnippetLong,
+		Example: MsgSnippetExample,
+		GroupID: "misc",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			shell, _ := cmd.Flags().GetString("shell")
+
+			// Initialize paths to get custom data directory if set
+			p, err := initPaths()
+			if err != nil {
+				return err
+			}
+
+			// Get custom data directory if using non-default paths
+			var customDataDir string
+			if p.UsedFallback() {
+				// Using default location, no custom dir needed
+				customDataDir = ""
+			} else {
+				// Check if using custom DODOT_DATA_DIR
+				if dataDir := os.Getenv("DODOT_DATA_DIR"); dataDir != "" {
+					customDataDir = dataDir
+				}
+			}
+
+			// Get the appropriate snippet for the shell
+			snippet := types.GetShellIntegrationSnippet(shell, customDataDir)
+
+			// Output the snippet
+			fmt.Print(snippet)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("shell", "s", "bash", "Shell type (bash, zsh, fish)")
+
+	return cmd
 }
 
 func newCompletionCmd() *cobra.Command {

--- a/cmd/dodot/msgs.go
+++ b/cmd/dodot/msgs.go
@@ -19,6 +19,7 @@ const (
 	MsgTopicsShort     = "Display available documentation topics"
 	MsgTopicsLong      = "Display a list of all available help topics that provide additional documentation beyond command help."
 	MsgCompletionShort = "Generate shell completion script"
+	MsgSnippetShort    = "Output shell integration snippet"
 
 	// Status messages
 	MsgDryRunNotice      = "\nDRY RUN MODE - No changes were made"
@@ -116,4 +117,12 @@ var (
 	//go:embed msgs/completion-long.txt
 	msgCompletionLongRaw string
 	MsgCompletionLong    = strings.TrimSpace(msgCompletionLongRaw)
+
+	//go:embed msgs/snippet-long.txt
+	msgSnippetLongRaw string
+	MsgSnippetLong    = strings.TrimSpace(msgSnippetLongRaw)
+
+	//go:embed msgs/snippet-example.txt
+	msgSnippetExampleRaw string
+	MsgSnippetExample    = strings.TrimSpace(msgSnippetExampleRaw)
 )

--- a/cmd/dodot/msgs/snippet-example.txt
+++ b/cmd/dodot/msgs/snippet-example.txt
@@ -1,0 +1,11 @@
+  # Output the shell integration snippet for bash/zsh
+  dodot snippet
+
+  # Add to your shell config
+  dodot snippet >> ~/.zshrc
+
+  # For Fish shell
+  dodot snippet --shell fish >> ~/.config/fish/config.fish
+
+  # Preview what will be added without appending
+  dodot snippet --shell bash

--- a/cmd/dodot/msgs/snippet-long.txt
+++ b/cmd/dodot/msgs/snippet-long.txt
@@ -1,0 +1,9 @@
+The snippet command outputs the shell integration code that you need to add to your shell configuration file (e.g., .bashrc, .zshrc, .config/fish/config.fish).
+
+By default, it outputs the snippet for bash/zsh. Use the --shell flag to specify fish or other shells.
+
+This command is designed to make shell integration setup more convenient:
+
+    dodot snippet >> ~/.zshrc
+
+After adding the snippet to your shell config, restart your shell or source the config file to enable dodot's shell integration.

--- a/cmd/dodot/snippet_test.go
+++ b/cmd/dodot/snippet_test.go
@@ -1,0 +1,165 @@
+package dodot
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdout captures stdout during command execution
+func captureStdout(t *testing.T, fn func()) string {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = w
+
+	// Execute the function
+	fn()
+
+	// Restore stdout
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	// Read captured output
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+
+	return buf.String()
+}
+
+// TestSnippetCommandDefaultBash tests the snippet command with default bash output
+func TestSnippetCommandDefaultBash(t *testing.T) {
+	output := captureStdout(t, func() {
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"snippet"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	// Verify the output contains expected bash/zsh snippet
+	assert.Contains(t, output, `[ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ]`)
+	assert.Contains(t, output, `source "$HOME/.local/share/dodot/shell/dodot-init.sh"`)
+}
+
+// TestSnippetCommandBashExplicit tests the snippet command with explicit bash flag
+func TestSnippetCommandBashExplicit(t *testing.T) {
+	output := captureStdout(t, func() {
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"snippet", "--shell", "bash"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, `[ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ]`)
+	assert.Contains(t, output, `source "$HOME/.local/share/dodot/shell/dodot-init.sh"`)
+}
+
+// TestSnippetCommandZsh tests the snippet command with zsh flag
+func TestSnippetCommandZsh(t *testing.T) {
+	output := captureStdout(t, func() {
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"snippet", "--shell", "zsh"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, `[ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ]`)
+	assert.Contains(t, output, `source "$HOME/.local/share/dodot/shell/dodot-init.sh"`)
+}
+
+// TestSnippetCommandFish tests the snippet command with fish flag
+func TestSnippetCommandFish(t *testing.T) {
+	output := captureStdout(t, func() {
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"snippet", "--shell", "fish"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, `if test -f "$HOME/.local/share/dodot/shell/dodot-init.fish"`)
+	assert.Contains(t, output, `source "$HOME/.local/share/dodot/shell/dodot-init.fish"`)
+	assert.Contains(t, output, "end")
+}
+
+// TestSnippetCommandShortFlag tests the snippet command with short shell flag
+func TestSnippetCommandShortFlag(t *testing.T) {
+	output := captureStdout(t, func() {
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"snippet", "-s", "fish"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, `if test -f "$HOME/.local/share/dodot/shell/dodot-init.fish"`)
+}
+
+// TestSnippetCommandCustomDataDir tests the snippet command with custom DODOT_DATA_DIR
+func TestSnippetCommandCustomDataDir(t *testing.T) {
+	// Set custom data directory
+	customDir := "/custom/dodot/path"
+	require.NoError(t, os.Setenv("DODOT_DATA_DIR", customDir))
+	defer func() { _ = os.Unsetenv("DODOT_DATA_DIR") }()
+
+	output := captureStdout(t, func() {
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"snippet"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, customDir+"/shell/dodot-init.sh")
+	assert.NotContains(t, output, "$HOME/.local/share/dodot")
+}
+
+// TestSnippetCommandCustomDataDirFish tests fish snippet with custom data directory
+func TestSnippetCommandCustomDataDirFish(t *testing.T) {
+	customDir := "/custom/dodot/path"
+	require.NoError(t, os.Setenv("DODOT_DATA_DIR", customDir))
+	defer func() { _ = os.Unsetenv("DODOT_DATA_DIR") }()
+
+	output := captureStdout(t, func() {
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"snippet", "--shell", "fish"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, customDir+"/shell/dodot-init.fish")
+	assert.NotContains(t, output, "$HOME/.local/share/dodot")
+}
+
+// TestSnippetCommandOutput tests that the snippet output is correct
+func TestSnippetCommandOutput(t *testing.T) {
+	output := captureStdout(t, func() {
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"snippet"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	// The output should be exactly the snippet
+	expectedSnippet := `[ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ] && source "$HOME/.local/share/dodot/shell/dodot-init.sh"`
+	assert.Equal(t, expectedSnippet, strings.TrimSpace(output))
+}
+
+// TestSnippetCommandFishOutput tests fish-specific output format
+func TestSnippetCommandFishOutput(t *testing.T) {
+	output := captureStdout(t, func() {
+		rootCmd := NewRootCmd()
+		rootCmd.SetArgs([]string{"snippet", "--shell", "fish"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	expectedSnippet := `if test -f "$HOME/.local/share/dodot/shell/dodot-init.fish"
+    source "$HOME/.local/share/dodot/shell/dodot-init.fish"
+end`
+	assert.Equal(t, expectedSnippet, strings.TrimSpace(output))
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #419 by adding a `dodot snippet` command that outputs the shell integration code needed for dotfiles deployment.

This makes it much more convenient for users to set up shell integration without having to manually copy the snippet from documentation.

### Features
- Default bash/zsh snippet output
- Fish shell support via `--shell` flag  
- Custom `DODOT_DATA_DIR` support
- Comprehensive test coverage (9 test cases)
- Proper help text and examples

### Usage Examples
```bash
# Add to bash/zsh config
dodot snippet >> ~/.zshrc

# Add to fish config  
dodot snippet --shell fish >> ~/.config/fish/config.fish

# Preview snippet without appending
dodot snippet --shell bash
```

## Test Plan

- [x] Unit tests for all shell types (bash, zsh, fish)
- [x] Custom data directory scenarios tested
- [x] Short and long flag variations tested
- [x] Output format validation
- [x] Help text verification
- [x] Pre-commit hooks pass (linting, formatting, tests)
- [x] Manual testing with built binary

🤖 Generated with [Claude Code](https://claude.ai/code)