### PR TITLE
Phase 3: Update CLI to use DirectExecutor functions

### DIFF
--- a/cmd/dodot/commands.go
+++ b/cmd/dodot/commands.go
@@ -193,36 +193,34 @@ func newDeployCmd() *cobra.Command {
 				Bool("dry_run", dryRun).
 				Msg("Deploying from dotfiles root")
 
-			// Use the actual DeployPacks implementation
-			result, err := commands.DeployPacks(commands.DeployPacksOptions{
-				DotfilesRoot: p.DotfilesRoot(),
-				PackNames:    args,
-				DryRun:       dryRun,
+			// Use the new DeployPacksDirect implementation with DirectExecutor
+			context, err := commands.DeployPacksDirect(commands.DeployPacksOptions{
+				DotfilesRoot:       p.DotfilesRoot(),
+				PackNames:          args,
+				DryRun:             dryRun,
+				EnableHomeSymlinks: true,
 			})
 			if err != nil {
 				return fmt.Errorf(MsgErrDeployPacks, err)
 			}
-
-			// Execute operations
-			opResults, err := execution.ExecuteOperations(execution.ExecuteOperationsOptions{
-				Operations:          result.Operations,
-				DryRun:              dryRun,
-				EnableHomeSymlinks:  true,
-				UseCombinedExecutor: true,
-			})
-			if err != nil {
-				return err
-			}
-			// TODO: Use opResults for better display/tracking
-			_ = opResults
 
 			// Display results using rich output
 			if dryRun {
 				fmt.Println(MsgDryRunNotice)
 			}
 
+			// Convert execution context to operations for display
+			var operations []types.Operation
+			for _, packResult := range context.PackResults {
+				for _, opResult := range packResult.Operations {
+					if opResult.Operation != nil {
+						operations = append(operations, *opResult.Operation)
+					}
+				}
+			}
+
 			renderer := style.NewTerminalRenderer()
-			fmt.Println(renderer.RenderOperations(result.Operations))
+			fmt.Println(renderer.RenderOperations(operations))
 
 			return nil
 		},
@@ -254,37 +252,35 @@ func newInstallCmd() *cobra.Command {
 				Bool("force", force).
 				Msg("Installing from dotfiles root")
 
-			// Use the actual InstallPacks implementation
-			result, err := commands.InstallPacks(commands.InstallPacksOptions{
-				DotfilesRoot: p.DotfilesRoot(),
-				PackNames:    args,
-				DryRun:       dryRun,
-				Force:        force,
+			// Use the new InstallPacksDirect implementation with DirectExecutor
+			context, err := commands.InstallPacksDirect(commands.InstallPacksOptions{
+				DotfilesRoot:       p.DotfilesRoot(),
+				PackNames:          args,
+				DryRun:             dryRun,
+				Force:              force,
+				EnableHomeSymlinks: true,
 			})
 			if err != nil {
 				return fmt.Errorf(MsgErrInstallPacks, err)
 			}
-
-			// Execute operations
-			opResults, err := execution.ExecuteOperations(execution.ExecuteOperationsOptions{
-				Operations:          result.Operations,
-				DryRun:              dryRun,
-				EnableHomeSymlinks:  true,
-				UseCombinedExecutor: true,
-			})
-			if err != nil {
-				return err
-			}
-			// TODO: Use opResults for better display/tracking
-			_ = opResults
 
 			// Display results using rich output
 			if dryRun {
 				fmt.Println(MsgDryRunNotice)
 			}
 
+			// Convert execution context to operations for display
+			var operations []types.Operation
+			for _, packResult := range context.PackResults {
+				for _, opResult := range packResult.Operations {
+					if opResult.Operation != nil {
+						operations = append(operations, *opResult.Operation)
+					}
+				}
+			}
+
 			renderer := style.NewTerminalRenderer()
-			fmt.Println(renderer.RenderOperations(result.Operations))
+			fmt.Println(renderer.RenderOperations(operations))
 
 			return nil
 		},
@@ -341,8 +337,8 @@ func newStatusCmd() *cobra.Command {
 
 			log.Info().Str("dotfiles_root", p.DotfilesRoot()).Msg("Checking status from dotfiles root")
 
-			// Use the actual StatusPacks implementation
-			result, err := commands.StatusPacks(commands.StatusPacksOptions{
+			// Use the new StatusPacksDirect implementation
+			result, err := commands.StatusPacksDirect(commands.StatusPacksOptions{
 				DotfilesRoot: p.DotfilesRoot(),
 				PackNames:    args,
 			})


### PR DESCRIPTION
## Summary
- Updates deploy command to use `DeployPacksDirect()` instead of separate `DeployPacks()` + `ExecuteOperations()` calls
- Updates install command to use `InstallPacksDirect()` instead of separate `InstallPacks()` + `ExecuteOperations()` calls
- Updates status command to use `StatusPacksDirect()` instead of `StatusPacks()`
- Eliminates intermediate operation execution step since DirectExecutor handles execution during pipeline
- Converts `ExecutionContext` to operations for display compatibility with existing renderers

## Key Benefits
- **Simplified execution flow**: Main commands now use Action→DirectExecutor→synthfs directly
- **Reduced complexity**: Eliminates separate operation execution step for core commands
- **Better error handling**: DirectExecutor provides fail-fast validation during conversion
- **Performance improvement**: No intermediate Operation creation or translation overhead

## Technical Changes
- Removed separate `execution.ExecuteOperations()` calls for deploy/install/status
- Added ExecutionContext → Operation conversion for display compatibility
- Kept execution import for init/fill commands (still use legacy Operation-based approach)
- All existing display logic continues to work unchanged

## Test Plan
- [x] Build completes successfully
- [x] All linting checks pass  
- [x] All tests pass (including pre-commit hooks)
- [x] CLI binary builds and basic functionality verified
- [x] Backward compatibility maintained for display rendering

## Notes
- Init and fill commands still use the legacy Operation-based approach (will be addressed in future phase)
- Display logic remains unchanged - ExecutionContext is converted to Operations for existing renderers
- All core commands (deploy, install, status) now use DirectExecutor approach

🤖 Generated with [Claude Code](https://claude.ai/code)