### PR TITLE
Implement basic text rendering for cmd output

### DIFF
--- a/pkg/display/integration_test.go
+++ b/pkg/display/integration_test.go
@@ -83,13 +83,12 @@ func TestDisplayIntegration_FullWorkflow(t *testing.T) {
 	// Verify output contains expected elements
 	expectedStrings := []string{
 		"deploy",
-		"✓ vim",                  // Pack succeeded
-		"✓ symlink",              // Symlink succeeded
+		"vim:",                   // Pack name with colon
+		"shell:",                 // Pack name with colon
+		"symlink",                // PowerUp name
 		"linked to $HOME/vimrc",  // PowerUp-aware message
-		"✗ shell",                // Pack has errors (alert status)
-		"✓ symlink",              // First operation succeeded
 		"linked to $HOME/bashrc", // PowerUp-aware message
-		"✗ install_script",       // Second operation failed
+		"install_script",         // PowerUp name
 		"installation failed",    // PowerUp-aware error message
 	}
 
@@ -102,7 +101,7 @@ func TestDisplayIntegration_FullWorkflow(t *testing.T) {
 	t.Logf("Full output:\n%s", output)
 
 	// Verify pack order (shell should come before vim due to alphabetical sorting)
-	shellIndex := strings.Index(output, "✗ shell")
-	vimIndex := strings.Index(output, "✓ vim")
+	shellIndex := strings.Index(output, "shell:")
+	vimIndex := strings.Index(output, "vim:")
 	testutil.AssertTrue(t, shellIndex < vimIndex, "Packs should be sorted alphabetically (shell before vim)")
 }

--- a/pkg/display/simple.go
+++ b/pkg/display/simple.go
@@ -26,15 +26,11 @@ func (r *TextRenderer) Render(result *types.DisplayResult) error {
 	}
 
 	// Command header
-	if _, err := fmt.Fprintf(r.writer, "%s", result.Command); err != nil {
-		return err
-	}
+	commandHeader := result.Command
 	if result.DryRun {
-		if _, err := fmt.Fprint(r.writer, " (dry run)"); err != nil {
-			return err
-		}
+		commandHeader += " (dry run)"
 	}
-	if _, err := fmt.Fprintln(r.writer); err != nil {
+	if _, err := fmt.Fprintln(r.writer, commandHeader); err != nil {
 		return err
 	}
 
@@ -58,15 +54,14 @@ func (r *TextRenderer) Render(result *types.DisplayResult) error {
 
 // renderPack renders a single pack
 func (r *TextRenderer) renderPack(pack types.DisplayPack) error {
-	// Pack header with status indicator
-	statusChar := r.getStatusChar(pack.Status)
-	if _, err := fmt.Fprintf(r.writer, "\n%s %s\n", statusChar, pack.Name); err != nil {
+	// Pack header - just the pack name with proper indentation
+	if _, err := fmt.Fprintf(r.writer, "\n    %s:\n", pack.Name); err != nil {
 		return err
 	}
 
 	// Render files
 	if len(pack.Files) == 0 {
-		if _, err := fmt.Fprintln(r.writer, "  (no files)"); err != nil {
+		if _, err := fmt.Fprintln(r.writer, "        (no files)"); err != nil {
 			return err
 		}
 		return nil
@@ -83,29 +78,14 @@ func (r *TextRenderer) renderPack(pack types.DisplayPack) error {
 
 // renderFile renders a single file
 func (r *TextRenderer) renderFile(file types.DisplayFile) error {
-	statusChar := r.getStatusChar(file.Status)
-
-	// Format: status powerup : path : message
-	_, err := fmt.Fprintf(r.writer, "  %s %-12s : %-30s : %s\n",
-		statusChar,
+	// Three-column format matching display.txxt spec:
+	// powerup : path : message
+	// Use consistent spacing with left-aligned columns
+	_, err := fmt.Fprintf(r.writer, "        %-12s : %-20s : %s\n",
 		file.PowerUp,
-		truncatePath(file.Path, 30),
+		file.Path,
 		file.Message)
 	return err
-}
-
-// getStatusChar returns a simple character to represent status
-func (r *TextRenderer) getStatusChar(status string) string {
-	switch status {
-	case "success":
-		return "✓"
-	case "error", "alert":
-		return "✗"
-	case "queue":
-		return "•"
-	default:
-		return " "
-	}
 }
 
 // truncatePath truncates a path to fit within maxLen characters

--- a/pkg/display/simple_test.go
+++ b/pkg/display/simple_test.go
@@ -69,8 +69,8 @@ func TestSimpleRenderer_Render(t *testing.T) {
 			},
 			expected: []string{
 				"deploy",
-				"✓ vim",
-				"✓ symlink",
+				"vim:",
+				"symlink",
 				"linked to .vimrc",
 				"linked to monokai.vim",
 			},
@@ -97,8 +97,8 @@ func TestSimpleRenderer_Render(t *testing.T) {
 			},
 			expected: []string{
 				"install",
-				"✗ tools",
-				"✗ install_script",
+				"tools:",
+				"install_script",
 				"install script failed",
 			},
 		},
@@ -130,9 +130,9 @@ func TestSimpleRenderer_Render(t *testing.T) {
 			},
 			expected: []string{
 				"status",
-				"• shell",
-				"✓ symlink",
-				"• shell_profile",
+				"shell:",
+				"symlink",
+				"shell_profile",
 				"not yet applied",
 			},
 		},
@@ -193,7 +193,7 @@ func TestSimpleRenderer_RenderExecutionContext(t *testing.T) {
 
 	// Check output contains expected elements
 	testutil.AssertTrue(t, strings.Contains(output, "deploy"), "Should contain command name")
-	testutil.AssertTrue(t, strings.Contains(output, "test-pack"), "Should contain pack name")
+	testutil.AssertTrue(t, strings.Contains(output, "test-pack:"), "Should contain pack name with colon")
 	testutil.AssertTrue(t, strings.Contains(output, "symlink"), "Should contain powerup name")
 	testutil.AssertTrue(t, strings.Contains(output, "linked to $HOME/testfile"), "Should contain PowerUp-aware message")
 }


### PR DESCRIPTION
## Summary
Implements basic text rendering for dodot commands using the completed display data collection system. This focuses on correct content and indentation structure without terminal formatting.

## Changes Made

### Text Renderer Updates
- **3-column format**: Updated to match `docs/design/display.txxt` specification
- **Proper indentation**: 4 spaces for pack names, 8 spaces for file entries
- **Clean structure**: Pack names display with colon (e.g., `vim:`, `shell:`)
- **No formatting**: Removed status characters to focus on content structure

### Output Format
The new format follows the specification exactly:
```
deploy

    shell:
        symlink      : bashrc               : linked to $HOME/bashrc
        install_script : install.sh           : installation failed

    vim:
        symlink      : vimrc                : linked to $HOME/vimrc
        symlink      : vim/colors/monokai.vim : linked to $HOME/monokai.vim
```

### Test Updates
- Updated all display tests to match new format expectations
- Verified pack sorting (alphabetical)
- Confirmed PowerUp-aware messages are properly displayed
- All tests passing with new format

## Implementation Notes
- Uses the complete Phase 1 data collection from previous work
- Config files (`.dodot.toml`, `.dodotignore`) display properly
- File override detection working
- Last execution timestamps integrated
- PowerUp-aware messages with proper verb tenses

## Next Steps
This provides the foundation for rich terminal formatting (colors, status indicators) which will be added in the next phase.

Closes #494

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>