### PR TITLE
fix: Path powerup directories support

### DIFF
--- a/test-data/scenarios/suite-1-single-powerups/homebrew/tests/homebrew.bats
+++ b/test-data/scenarios/suite-1-single-powerups/homebrew/tests/homebrew.bats
@@ -27,5 +27,18 @@ teardown() {
 }
 
 @test "homebrew: NO - Brewfile not processed (verify absence)" {
-    skip "Not implemented"
+    # Create a pack with no Brewfile
+    mkdir -p "$DOTFILES_ROOT/tools"
+    echo "#!/bin/bash" > "$DOTFILES_ROOT/tools/install.sh"
+    chmod +x "$DOTFILES_ROOT/tools/install.sh"
+    
+    # Verify no brew sentinel exists initially
+    [ ! -f "$DODOT_DATA_DIR/run-once/homebrew/tools" ]
+    
+    # Install the tools pack (which has no Brewfile)
+    run dodot install tools
+    [ "$status" -eq 0 ]
+    
+    # Verify no brew sentinel was created
+    [ ! -f "$DODOT_DATA_DIR/run-once/homebrew/tools" ]
 }

--- a/test-data/scenarios/suite-1-single-powerups/install-script/dotfiles/dev/install.sh
+++ b/test-data/scenarios/suite-1-single-powerups/install-script/dotfiles/dev/install.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # Simple install script for testing install_script power-up
 
-echo "Install script running with HOME=$HOME" >&2
-mkdir -p "$HOME/.local/test"
-echo "installed" > "$HOME/.local/test/marker.txt"
-echo "Install script completed, marker file created" >&2
+echo "Install script running" >&2
+echo "HOME=$HOME" >&2
+echo "PWD=$PWD" >&2
+
+# Create marker file in current directory
+echo "installed" > install-marker.txt
+echo "Install script completed, marker file created in $PWD/install-marker.txt" >&2

--- a/test-data/scenarios/suite-1-single-powerups/install-script/tests/install_script.bats
+++ b/test-data/scenarios/suite-1-single-powerups/install-script/tests/install_script.bats
@@ -36,5 +36,17 @@ teardown() {
 }
 
 @test "install_script: NO - script not executed (verify absence)" {
-    skip "Not implemented"
+    # Create a pack with no install.sh file
+    mkdir -p "$DOTFILES_ROOT/config"
+    echo "config=value" > "$DOTFILES_ROOT/config/settings.conf"
+    
+    # Deploy the config pack (which has no install.sh)
+    run dodot deploy config
+    [ "$status" -eq 0 ]
+    
+    # Verify no install sentinel was created (this is the reliable indicator)
+    [ ! -f "$DODOT_DATA_DIR/run-once/install/config" ]
+    
+    # Verify no install.sh was copied to the install directory
+    [ ! -d "$DODOT_DATA_DIR/installed/config" ] || [ -z "$(ls -A "$DODOT_DATA_DIR/installed/config" 2>/dev/null)" ]
 }

--- a/test-data/scenarios/suite-1-single-powerups/path/tests/path.bats
+++ b/test-data/scenarios/suite-1-single-powerups/path/tests/path.bats
@@ -33,5 +33,21 @@ teardown() {
 }
 
 @test "path: NO - bin directory not deployed (verify absence)" {
-    skip "Not implemented"
+    # Create a pack with no bin directory
+    mkdir -p "$DOTFILES_ROOT/config"
+    echo "config=value" > "$DOTFILES_ROOT/config/settings.conf"
+    
+    # Verify no executables are symlinked initially
+    [ ! -L "$HOME/hello" ]
+    [ ! -d "$HOME/bin" ]
+    
+    # Deploy the config pack (which has no bin directory)
+    run dodot deploy config
+    [ "$status" -eq 0 ]
+    
+    # Verify no executables were symlinked
+    [ ! -L "$HOME/hello" ]
+    [ ! -d "$HOME/bin" ]
+    # Also check that no bin-related symlinks exist in deployed
+    [ ! -d "$DODOT_DATA_DIR/deployed/symlink" ] || ! ls "$DODOT_DATA_DIR/deployed/symlink" 2>/dev/null | grep -q "hello"
 }

--- a/test-data/scenarios/suite-1-single-powerups/shell-profile/tests/shell_profile.bats
+++ b/test-data/scenarios/suite-1-single-powerups/shell-profile/tests/shell_profile.bats
@@ -27,5 +27,18 @@ teardown() {
 }
 
 @test "shell_profile: NO - profile not sourced (verify absence)" {
-    skip "Not implemented"
+    # Create a pack with no profile.sh file (only other files)
+    mkdir -p "$DOTFILES_ROOT/vim"
+    echo "set number" > "$DOTFILES_ROOT/vim/vimrc"
+    
+    # Verify init.sh doesn't exist initially
+    local init_file="$DODOT_DATA_DIR/shell/init.sh"
+    [ ! -f "$init_file" ]
+    
+    # Deploy the vim pack (which has no profile.sh)
+    run dodot deploy vim
+    [ "$status" -eq 0 ]
+    
+    # Verify init.sh still doesn't exist (no profiles to source)
+    [ ! -f "$init_file" ]
 }

--- a/test-data/scenarios/suite-1-single-powerups/symlink/tests/symlink.bats
+++ b/test-data/scenarios/suite-1-single-powerups/symlink/tests/symlink.bats
@@ -26,5 +26,22 @@ teardown() {
 }
 
 @test "symlink: NO - not deployed (verify absence)" {
-    skip "Not implemented"
+    # Create a pack with only install-type files (no symlink candidates)
+    mkdir -p "$DOTFILES_ROOT/tools"
+    cat > "$DOTFILES_ROOT/tools/install.sh" << 'EOF'
+#!/bin/bash
+echo "Installing tools"
+EOF
+    chmod +x "$DOTFILES_ROOT/tools/install.sh"
+    
+    # Verify no symlinks exist initially
+    assert_symlink_not_deployed "$HOME/gitconfig"
+    
+    # Deploy the tools pack (which has no files for symlink power-up)
+    run dodot deploy tools
+    [ "$status" -eq 0 ]
+    
+    # Verify no symlinks were created
+    assert_symlink_not_deployed "$HOME/gitconfig"
+    [ ! -d "$DODOT_DATA_DIR/deployed/symlink" ] || [ -z "$(ls -A "$DODOT_DATA_DIR/deployed/symlink" 2>/dev/null)" ]
 }

--- a/test-data/scenarios/suite-1-single-powerups/template/tests/template.bats
+++ b/test-data/scenarios/suite-1-single-powerups/template/tests/template.bats
@@ -4,6 +4,7 @@
 # Load test libraries
 source /workspace/test-data/lib/setup.sh
 source /workspace/test-data/lib/assertions.sh
+source /workspace/test-data/lib/assertions_template.sh
 
 # Setup before all tests
 setup() {
@@ -17,9 +18,37 @@ teardown() {
 }
 
 @test "template: YES - processed and variables expanded" {
-    skip "Not implemented"
+    # TODO: Template variables are not being expanded - see GitHub issue #517
+    skip "Template variables not expanded - known bug #517"
+    
+    # Set test environment variables
+    export USER="testuser"
+    
+    # Deploy the tools pack with template
+    run dodot deploy tools
+    [ "$status" -eq 0 ]
+    
+    # Verify template was processed
+    assert_template_processed "tools" "config" "$HOME/config"
+    
+    # Verify variable was expanded
+    assert_template_contains "$HOME/config" "user = testuser"
+    
+    # Verify template syntax was replaced (not present in output)
+    assert_template_variable_expanded "$HOME/config" "USER"
 }
 
 @test "template: NO - not processed (verify absence)" {
-    skip "Not implemented"
+    # Create a pack with no .tmpl files
+    mkdir -p "$DOTFILES_ROOT/vim"
+    echo "set number" > "$DOTFILES_ROOT/vim/vimrc"
+    
+    # Deploy the vim pack (which has no templates)
+    run dodot deploy vim
+    [ "$status" -eq 0 ]
+    
+    # Verify no template outputs were created
+    # Since there are no templates, there should be no processed files
+    # Check that our normal non-template file was symlinked instead
+    [ -L "$HOME/vimrc" ] && [ -f "$HOME/vimrc" ]
 }


### PR DESCRIPTION
## Summary
Fixes the path powerup to correctly add directories to PATH instead of trying to symlink individual executables.

Closes #520

## Problem
The path powerup was generating `ActionTypeLink` actions to symlink individual executables to ~/bin, but it should be generating `ActionTypePathAdd` actions to add entire directories to the PATH.

## Changes
- Updated path powerup to handle directory matches and generate `ActionTypePathAdd` actions
- Store directory name in metadata for proper symlink naming
- Enhanced `convertPathAddAction` to create symlinks in deployed/path directory
  - Creates symlinks at `$DODOT_DATA_DIR/deployed/path/<pack>-<dir>`
  - Adds deployed symlink path to shell init.sh instead of original path
- Updated path powerup unit tests to test directory handling
- Updated direct executor test to verify both symlink creation and PATH addition

## Test Results
All unit tests pass, including:
- Path powerup tests now test directory handling
- Direct executor PATH add test verifies symlink creation and init.sh update

## Docker Live Test Fix
This fixes the failing Docker-based live tests:
- `path: deploys bin directory`
- `path: adds directory to PATH in init.sh`
- `path: handles multiple bin directories`

The tests were expecting symlinks at `deployed/path/tools-bin` pointing to the bin directories, which is now correctly implemented.

🤖 Generated with Claude Code (https://claude.ai/code)