### PR TITLE
Fix test-framework self-tests by allowing container check bypass

### DIFF
--- a/.todos
+++ b/.todos
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "desc": "Clean up live tests",
+    "status": "pending",
+    "modified": "2025-08-11 14:47:22.285377 -0300 -03"
+  },
+  {
+    "id": 2,
+    "desc": "Remove test-plan-2 from containers/dev",
+    "status": "pending",
+    "modified": "2025-08-11 14:47:42.329264 -0300 -03"
+  }
+]

--- a/test-data/lib/common.sh
+++ b/test-data/lib/common.sh
@@ -2,11 +2,14 @@
 # Common test setup that includes all necessary libraries and debug hooks
 # All test files should source this single file instead of individual libraries
 
-# Safety check: Ensure we're running in a container
+# Safety check: Ensure we're running in a container (unless testing the test framework itself)
 if [ -z "$DODOT_TEST_CONTAINER" ] || [ "$DODOT_TEST_CONTAINER" != "1" ]; then
-    echo "ERROR: Tests must be run inside the Docker container!"
-    echo "Use: ./containers/dev/run-tests.sh"
-    exit 1
+    # Allow test-framework self-tests to bypass this check
+    if [ "$DODOT_TEST_FRAMEWORK_SELF_TEST" != "1" ]; then
+        echo "ERROR: Tests must be run inside the Docker container!"
+        echo "Use: ./containers/dev/run-tests.sh"
+        exit 1
+    fi
 fi
 
 # Source all test libraries

--- a/test-data/scenarios/test-framework/tests/setup_teardown.bats
+++ b/test-data/scenarios/test-framework/tests/setup_teardown.bats
@@ -1,11 +1,18 @@
 #!/usr/bin/env bats
 # Test the test framework itself - setup_test_env and clean_test_env functions
 
+# Set environment variable to allow test-framework self-tests
+export DODOT_TEST_FRAMEWORK_SELF_TEST=1
+
 # Load common test setup with debug support
 source /workspace/test-data/lib/common.sh
 
 # We'll need to manage our own setup/teardown since we're testing the framework
 setup() {
+    # Set the scenario directory for test-framework tests
+    TEST_SCENARIO_DIR="$BATS_TEST_DIRNAME/.."
+    export TEST_SCENARIO_DIR
+    
     setup_with_debug
 }
 


### PR DESCRIPTION
Closes #537

## Problem
The test-framework suite was failing because tests that test the test infrastructure itself were being blocked by the container safety check added in commit a93861a.

## Solution
Implemented Option 2 from the issue discussion:
- Added `DODOT_TEST_FRAMEWORK_SELF_TEST` environment variable
- Modified the safety check in `common.sh` to allow bypass when this variable is set
- Set the variable in `setup_teardown.bats` before sourcing `common.sh`
- Fixed missing `TEST_SCENARIO_DIR` variable in test setup

## Results
- **Before**: 8 out of 13 tests failing with "Tests must be run inside Docker container" error
- **After**: 10 out of 13 tests passing

The 3 remaining failures appear to be legitimate test issues that were previously hidden:
1. `clean_test_env: restores original environment variables` - HOME restoration issue
2. `with_test_env: sets up and tears down correctly` - HOME restoration issue  
3. `setup_test_env: sources .envrc files if present` - Environment variable not being set

These can be addressed in a follow-up PR as they represent actual bugs in the test framework, not issues with the container safety check.

## Testing
Run `./containers/dev/run-tests.sh` and verify that test-framework tests now execute instead of being blocked by the safety check.