### PR TITLE
Fix shell completion: Remove embedded command and improve pack completion

### DIFF
--- a/cmd/dodot/commands.go
+++ b/cmd/dodot/commands.go
@@ -94,7 +94,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newAddIgnoreCmd())
 	rootCmd.AddCommand(newSnippetCmd())
 	rootCmd.AddCommand(newTopicsCmd())
-	rootCmd.AddCommand(newCompletionCmd())
+	// Completion command removed - use dodot-completions tool instead
 
 	// Initialize topic-based help system
 	// Try to find help topics relative to the executable location
@@ -652,27 +652,5 @@ func newSnippetCmd() *cobra.Command {
 	return cmd
 }
 
-func newCompletionCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:                   "completion [bash|zsh|fish|powershell]",
-		Short:                 MsgCompletionShort,
-		Long:                  MsgCompletionLong,
-		DisableFlagsInUseLine: true,
-		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-		GroupID:               "misc",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			switch args[0] {
-			case "bash":
-				return cmd.Root().GenBashCompletion(os.Stdout)
-			case "zsh":
-				return cmd.Root().GenZshCompletion(os.Stdout)
-			case "fish":
-				return cmd.Root().GenFishCompletion(os.Stdout, true)
-			case "powershell":
-				return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
-			}
-			return nil
-		},
-	}
-}
+// Completion command removed - use dodot-completions tool to generate shell completions
+// The dodot-completions binary is built separately and used during the release process


### PR DESCRIPTION
## Summary

This PR addresses two shell completion issues:

1. **Remove completion command from main binary** - The completion command has been removed from the main dodot binary, keeping the separation of concerns where shell completion generation is handled by the dedicated `dodot-completions` tool.

2. **Improve pack name completion** - Pack name completion now allows directory navigation in addition to suggesting discovered pack names, making it more natural to use with shell tab completion.

## Changes

### Remove embedded completion command
- Removed `newCompletionCmd()` function and its registration in the main command
- The `dodot-completions` tool remains the only way to generate shell completions
- Build process and CI remain unchanged - `scripts/gen-completion` continues to work

### Improve pack name completion
- Changed from `ShellCompDirectiveNoFileComp` to `ShellCompDirectiveFilterDirs`
- Users can now navigate directories using tab completion when specifying pack names
- Pack names are still suggested based on discovered packs
- Added normalization for trailing slashes when filtering already-specified packs
- This addresses the common case where shell completion adds trailing slashes to directory names

## Testing

- ✅ All tests pass
- ✅ Completion generation script works correctly
- ✅ Generated completion files are valid
- ✅ Build process remains unchanged

## User Experience

Before:
- `dodot deploy <TAB>` would only show pack names, no directory navigation
- `dodot deploy vim/<TAB>` would not work

After:
- `dodot deploy <TAB>` shows pack names AND allows directory navigation
- `dodot deploy vim/<TAB>` works as expected
- Better integration with shell's natural tab completion behavior