### PR TITLE
feat: implement adopt command for managing existing files

### DIFF
--- a/cmd/dodot/msgs.go
+++ b/cmd/dodot/msgs.go
@@ -17,6 +17,7 @@ const (
 	MsgInitShort       = "Create a new pack with template files"
 	MsgFillShort       = "Add placeholder files to an existing pack"
 	MsgAddIgnoreShort  = "Create a .dodotignore file to ignore a pack"
+	MsgAdoptShort      = "Adopt existing files into a pack"
 	MsgTopicsShort     = "Display available documentation topics"
 	MsgTopicsLong      = "Display a list of all available help topics that provide additional documentation beyond command help."
 	MsgCompletionShort = "Generate shell completion script"
@@ -35,6 +36,10 @@ const (
 	MsgPackHasAllFiles   = "Pack '%s' already has all standard files.\n"
 	MsgIgnoreFileCreated = "Created .dodotignore file in pack '%s'\n"
 	MsgIgnoreFileExists  = "Pack '%s' already has a .dodotignore file\n"
+	MsgFileAdopted       = "✔ Moving '%s' to '%s'\n"
+	MsgSymlinkCreated    = "✔ Creating symlink: '%s' -> '%s'\n"
+	MsgAdoptSuccess      = "✨ Success! %d file(s) are now managed by dodot in the '%s' pack.\n"
+	MsgNoFilesAdopted    = "No files were adopted.\n"
 	MsgPackStatusFormat  = "\n%s:\n"
 	MsgPowerUpStatus     = "  %s: %s"
 	MsgPowerUpDesc       = " - %s"
@@ -48,6 +53,7 @@ const (
 	MsgErrInitPack     = "failed to initialize pack: %w"
 	MsgErrFillPack     = "failed to fill pack: %w"
 	MsgErrAddIgnore    = "failed to add ignore file: %w"
+	MsgErrAdoptFiles   = "failed to adopt files: %w"
 
 	// Flag descriptions
 	MsgFlagVerbose = "Increase verbosity (-v INFO, -vv DEBUG, -vvv TRACE)"
@@ -117,6 +123,14 @@ var (
 	//go:embed msgs/addignore-example.txt
 	msgAddIgnoreExampleRaw string
 	MsgAddIgnoreExample    = strings.TrimSpace(msgAddIgnoreExampleRaw)
+
+	//go:embed msgs/adopt-long.txt
+	msgAdoptLongRaw string
+	MsgAdoptLong    = strings.TrimSpace(msgAdoptLongRaw)
+
+	//go:embed msgs/adopt-example.txt
+	msgAdoptExampleRaw string
+	MsgAdoptExample    = strings.TrimSpace(msgAdoptExampleRaw)
 
 	//go:embed msgs/fallback-warning.txt
 	msgFallbackWarningRaw string

--- a/cmd/dodot/msgs/adopt-example.txt
+++ b/cmd/dodot/msgs/adopt-example.txt
@@ -1,0 +1,11 @@
+# Adopt a single file into a pack
+dodot adopt git ~/.gitconfig
+
+# Adopt multiple files at once
+dodot adopt shell ~/.bashrc ~/.bash_profile ~/.bash_aliases
+
+# Adopt a configuration directory
+dodot adopt vim ~/.config/nvim
+
+# Force adoption even if destination exists
+dodot adopt --force tmux ~/.tmux.conf

--- a/cmd/dodot/msgs/adopt-long.txt
+++ b/cmd/dodot/msgs/adopt-long.txt
@@ -1,0 +1,18 @@
+Adopt existing configuration files into a pack by moving them to your dotfiles
+repository and immediately creating symlinks back to their original locations.
+
+This command streamlines the process of bringing files under dodot's management:
+1. Moves the source file/directory to the specified pack
+2. Creates a symlink from the original location to the new location
+
+The adoption is atomic - the file is moved and symlinked in one operation,
+ensuring your configuration continues to work without interruption.
+
+Smart path handling:
+- Files from $HOME go to the pack root (e.g., ~/.gitconfig -> pack/gitconfig)
+- Files from XDG paths preserve their structure (e.g., ~/.config/app/config.toml -> pack/app/config.toml)
+
+Safety features:
+- Won't overwrite existing files in the pack (use --force to override)
+- Detects if a file is already managed by dodot and exits gracefully
+- Shows clear output for each operation performed

--- a/docs/proposals/adopt.txxt
+++ b/docs/proposals/adopt.txxt
@@ -54,7 +54,9 @@ ADOPT: A COMMAND FOR MANAGING EXISTING FILES
     3.1 SMART PATH HANDLING
 
         The `adopt` command will be intelligent and respect the conventions
-        outlined in the [./link-paths.txxt] proposal.
+        outlined in the [./link-paths.txxt] proposal once that has landed. For
+        now it will use the regular behavior, and when link paths have support
+        it should work as in: 
 
             - Adopting a file from `$HOME` (e.g., `~/.gitconfig`) will place it
               at the top level of the pack (`<pack>/gitconfig`).

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.10.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 replace github.com/arthur-debert/synthfs => github.com/arthur-debert/go-synthfs v0.9.5
@@ -56,5 +57,4 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/term v0.32.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/commands/adopt/adopt.go
+++ b/pkg/commands/adopt/adopt.go
@@ -1,0 +1,234 @@
+package adopt
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arthur-debert/dodot/pkg/errors"
+	"github.com/arthur-debert/dodot/pkg/logging"
+	"github.com/arthur-debert/dodot/pkg/paths"
+	"github.com/arthur-debert/dodot/pkg/types"
+	"github.com/rs/zerolog"
+)
+
+// AdoptFilesOptions holds options for the adopt command
+type AdoptFilesOptions struct {
+	DotfilesRoot string
+	PackName     string
+	SourcePaths  []string
+	Force        bool
+}
+
+// AdoptFiles moves existing files into a pack and creates symlinks back to their original locations
+func AdoptFiles(opts AdoptFilesOptions) (*types.AdoptResult, error) {
+	logger := logging.GetLogger("commands.adopt")
+	logger.Info().
+		Str("pack", opts.PackName).
+		Str("dotfiles_root", opts.DotfilesRoot).
+		Strs("source_paths", opts.SourcePaths).
+		Bool("force", opts.Force).
+		Msg("Adopting files into pack")
+
+	// Normalize pack name (remove trailing slashes from shell completion)
+	packName := strings.TrimRight(opts.PackName, "/")
+
+	// Validate pack name
+	if err := paths.ValidatePackName(packName); err != nil {
+		return nil, errors.Wrap(err, errors.ErrPackNotFound, "invalid pack name")
+	}
+
+	// Find or create the pack
+	packPath := filepath.Join(opts.DotfilesRoot, packName)
+	packInfo, err := os.Stat(packPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Create the pack directory
+			if err := os.MkdirAll(packPath, 0755); err != nil {
+				return nil, fmt.Errorf("failed to create pack directory: %w", err)
+			}
+			logger.Info().Str("pack", packName).Msg("Created pack directory")
+		} else {
+			return nil, fmt.Errorf("failed to check pack directory: %w", err)
+		}
+	} else if !packInfo.IsDir() {
+		return nil, fmt.Errorf("pack path exists but is not a directory: %s", packPath)
+	}
+
+	// Prepare result
+	result := &types.AdoptResult{
+		PackName:     packName,
+		AdoptedFiles: []types.AdoptedFile{},
+	}
+
+	// Process each source path
+	for _, sourcePath := range opts.SourcePaths {
+		adopted, err := adoptSingleFile(logger, packPath, sourcePath, opts.Force)
+		if err != nil {
+			logAdopt(logger, opts, result, err)
+			return nil, fmt.Errorf("failed to adopt %s: %w", sourcePath, err)
+		}
+		if adopted != nil {
+			result.AdoptedFiles = append(result.AdoptedFiles, *adopted)
+		}
+	}
+
+	logAdopt(logger, opts, result, nil)
+	return result, nil
+}
+
+// adoptSingleFile handles the adoption of a single file or directory
+func adoptSingleFile(logger zerolog.Logger, packPath, sourcePath string, force bool) (*types.AdoptedFile, error) {
+	// Expand the source path
+	expandedPath := paths.ExpandHome(sourcePath)
+
+	// Check if source exists
+	sourceInfo, err := os.Lstat(expandedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("source file does not exist: %s", expandedPath)
+		}
+		return nil, fmt.Errorf("failed to stat source file: %w", err)
+	}
+
+	// Check if source is already a symlink managed by dodot
+	if sourceInfo.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(expandedPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read symlink: %w", err)
+		}
+
+		// Check if it points to a file within dotfiles
+		if strings.Contains(target, packPath) || strings.Contains(target, filepath.Dir(packPath)) {
+			logger.Info().
+				Str("source", expandedPath).
+				Str("target", target).
+				Msg("File is already managed by dodot")
+			// Idempotent operation - not an error, just skip
+			return nil, nil
+		}
+	}
+
+	// Determine destination path using smart path handling
+	destPath := determineDestinationPath(packPath, expandedPath)
+
+	// Check if destination already exists
+	if _, err := os.Stat(destPath); err == nil && !force {
+		return nil, fmt.Errorf("destination already exists: %s (use --force to overwrite)", destPath)
+	}
+
+	// Create destination directory if needed
+	destDir := filepath.Dir(destPath)
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	// Move the file
+	if err := os.Rename(expandedPath, destPath); err != nil {
+		// Handle cross-device moves
+		if strings.Contains(err.Error(), "cross-device") {
+			return nil, fmt.Errorf("cross-device move not supported in initial implementation: %w", err)
+		}
+		return nil, fmt.Errorf("failed to move file: %w", err)
+	}
+
+	// Create symlink back to original location
+	err = os.Symlink(destPath, expandedPath)
+	if err != nil {
+		// Try to move the file back on failure
+		_ = os.Rename(destPath, expandedPath)
+		return nil, fmt.Errorf("failed to create symlink: %w", err)
+	}
+
+	logger.Info().
+		Str("source", expandedPath).
+		Str("destination", destPath).
+		Msg("Successfully adopted file")
+
+	return &types.AdoptedFile{
+		OriginalPath: expandedPath,
+		NewPath:      destPath,
+		SymlinkPath:  expandedPath,
+	}, nil
+}
+
+// determineDestinationPath applies smart path handling rules
+func determineDestinationPath(packPath, sourcePath string) string {
+	homeDir := os.Getenv("HOME")
+	if homeDir == "" {
+		homeDir = filepath.Dir(sourcePath) // Fallback
+	}
+
+	// Get XDG paths
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome == "" {
+		xdgConfigHome = filepath.Join(homeDir, ".config")
+	}
+
+	// Get the base name of the file
+	baseName := filepath.Base(sourcePath)
+
+	// If file is directly in $HOME, place it at pack root
+	if filepath.Dir(sourcePath) == homeDir {
+		// Remove leading dot for cleaner pack organization
+		if strings.HasPrefix(baseName, ".") && len(baseName) > 1 {
+			baseName = baseName[1:]
+		}
+		return filepath.Join(packPath, baseName)
+	}
+
+	// If file is in XDG config path, preserve directory structure
+	if strings.HasPrefix(sourcePath, xdgConfigHome) {
+		// Get relative path from XDG_CONFIG_HOME
+		relPath, err := filepath.Rel(xdgConfigHome, sourcePath)
+		if err == nil {
+			return filepath.Join(packPath, relPath)
+		}
+	}
+
+	// For other paths, try to preserve some structure
+	// This is a simple heuristic - could be improved
+	if strings.Contains(sourcePath, "/.") {
+		// Hidden directory somewhere in the path
+		parts := strings.Split(sourcePath, "/")
+		for i, part := range parts {
+			if strings.HasPrefix(part, ".") && part != "." && i < len(parts)-1 {
+				// Found a hidden directory, use everything after it
+				subPath := filepath.Join(parts[i+1:]...)
+				return filepath.Join(packPath, subPath)
+			}
+		}
+	}
+
+	// Default: just use the base name
+	if strings.HasPrefix(baseName, ".") && len(baseName) > 1 {
+		baseName = baseName[1:]
+	}
+	return filepath.Join(packPath, baseName)
+}
+
+// logAdopt logs the adopt command execution
+func logAdopt(logger zerolog.Logger, opts AdoptFilesOptions, result *types.AdoptResult, err error) {
+	event := logger.Info()
+	if err != nil {
+		event = logger.Error().Err(err)
+	}
+
+	event.
+		Str("command", "adopt").
+		Str("pack", opts.PackName).
+		Str("dotfiles_root", opts.DotfilesRoot).
+		Strs("source_paths", opts.SourcePaths).
+		Bool("force", opts.Force)
+
+	if result != nil {
+		event.Int("files_adopted", len(result.AdoptedFiles))
+	}
+
+	if err != nil {
+		event.Msg("Adopt command failed")
+	} else {
+		event.Msg("Adopt command completed")
+	}
+}

--- a/pkg/commands/adopt/adopt_integration_test.go
+++ b/pkg/commands/adopt/adopt_integration_test.go
@@ -18,6 +18,9 @@ func TestAdoptFullWorkflow(t *testing.T) {
 	dotfilesPath := filepath.Join(root, "dotfiles")
 	homePath := filepath.Join(root, "home")
 
+	// Create dotfiles directory
+	require.NoError(t, os.MkdirAll(dotfilesPath, 0755))
+
 	// Set HOME to test directory
 	oldHome := os.Getenv("HOME")
 	require.NoError(t, os.Setenv("HOME", homePath))
@@ -91,6 +94,9 @@ func TestAdoptWithExistingDestination(t *testing.T) {
 	dotfilesPath := filepath.Join(root, "dotfiles")
 	homePath := filepath.Join(root, "home")
 
+	// Create dotfiles directory
+	require.NoError(t, os.MkdirAll(dotfilesPath, 0755))
+
 	// Set HOME to test directory
 	oldHome := os.Getenv("HOME")
 	require.NoError(t, os.Setenv("HOME", homePath))
@@ -141,6 +147,9 @@ func TestAdoptMultipleFiles(t *testing.T) {
 	root := testutil.TempDir(t, "adopt-integration-test")
 	dotfilesPath := filepath.Join(root, "dotfiles")
 	homePath := filepath.Join(root, "home")
+
+	// Create dotfiles directory
+	require.NoError(t, os.MkdirAll(dotfilesPath, 0755))
 
 	// Set HOME to test directory
 	oldHome := os.Getenv("HOME")

--- a/pkg/commands/adopt/adopt_integration_test.go
+++ b/pkg/commands/adopt/adopt_integration_test.go
@@ -1,0 +1,193 @@
+package adopt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/arthur-debert/dodot/pkg/matchers" // register default matchers
+	"github.com/arthur-debert/dodot/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdoptFullWorkflow tests the complete adopt workflow with real file system operations
+func TestAdoptFullWorkflow(t *testing.T) {
+	// Setup test filesystem
+	root := testutil.TempDir(t, "adopt-integration-test")
+	dotfilesPath := filepath.Join(root, "dotfiles")
+	homePath := filepath.Join(root, "home")
+
+	// Set HOME to test directory
+	oldHome := os.Getenv("HOME")
+	require.NoError(t, os.Setenv("HOME", homePath))
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	// Set XDG_CONFIG_HOME
+	require.NoError(t, os.Setenv("XDG_CONFIG_HOME", filepath.Join(homePath, ".config")))
+	defer func() { _ = os.Unsetenv("XDG_CONFIG_HOME") }()
+
+	// Create initial files
+	gitconfig := filepath.Join(homePath, ".gitconfig")
+	testutil.CreateFile(t, homePath, ".gitconfig", "[user]\n\tname = Test User\n\temail = test@example.com")
+
+	starshipConfig := filepath.Join(homePath, ".config", "starship", "starship.toml")
+	testutil.CreateFile(t, filepath.Join(homePath, ".config", "starship"), "starship.toml", "format = \"$all$character\"")
+
+	// Test 1: Adopt a single file
+	result1, err := AdoptFiles(AdoptFilesOptions{
+		DotfilesRoot: dotfilesPath,
+		PackName:     "git",
+		SourcePaths:  []string{gitconfig},
+		Force:        false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(result1.AdoptedFiles))
+
+	// Verify file was moved
+	_, err = os.Stat(filepath.Join(dotfilesPath, "git", "gitconfig"))
+	require.NoError(t, err)
+
+	// Verify symlink exists and works
+	info, err := os.Lstat(gitconfig)
+	require.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink != 0)
+
+	// Verify content is accessible through symlink
+	content, err := os.ReadFile(gitconfig)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "Test User")
+
+	// Test 2: Adopt file with directory structure preservation
+	result2, err := AdoptFiles(AdoptFilesOptions{
+		DotfilesRoot: dotfilesPath,
+		PackName:     "starship",
+		SourcePaths:  []string{starshipConfig},
+		Force:        false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(result2.AdoptedFiles))
+
+	// Verify directory structure was preserved
+	movedPath := filepath.Join(dotfilesPath, "starship", "starship", "starship.toml")
+	_, err = os.Stat(movedPath)
+	require.NoError(t, err)
+
+	// Test 3: Try to adopt already managed file (idempotent)
+	result3, err := AdoptFiles(AdoptFilesOptions{
+		DotfilesRoot: dotfilesPath,
+		PackName:     "git",
+		SourcePaths:  []string{gitconfig},
+		Force:        false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(result3.AdoptedFiles), "Should not re-adopt already managed file")
+}
+
+// TestAdoptWithExistingDestination tests the behavior when destination already exists
+func TestAdoptWithExistingDestination(t *testing.T) {
+	// Setup test filesystem
+	root := testutil.TempDir(t, "adopt-integration-test")
+	dotfilesPath := filepath.Join(root, "dotfiles")
+	homePath := filepath.Join(root, "home")
+
+	// Set HOME to test directory
+	oldHome := os.Getenv("HOME")
+	require.NoError(t, os.Setenv("HOME", homePath))
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	// Create source file
+	gitconfig := filepath.Join(homePath, ".gitconfig")
+	testutil.CreateFile(t, homePath, ".gitconfig", "[user]\n\tname = New User")
+
+	// Create existing destination file
+	existingPath := filepath.Join(dotfilesPath, "git", "gitconfig")
+	testutil.CreateFile(t, filepath.Join(dotfilesPath, "git"), "gitconfig", "[user]\n\tname = Old User")
+
+	// Test 1: Without force flag - should fail
+	_, err := AdoptFiles(AdoptFilesOptions{
+		DotfilesRoot: dotfilesPath,
+		PackName:     "git",
+		SourcePaths:  []string{gitconfig},
+		Force:        false,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination already exists")
+
+	// Verify source file was not moved
+	_, err = os.Stat(gitconfig)
+	require.NoError(t, err)
+
+	// Test 2: With force flag - should succeed
+	result, err := AdoptFiles(AdoptFilesOptions{
+		DotfilesRoot: dotfilesPath,
+		PackName:     "git",
+		SourcePaths:  []string{gitconfig},
+		Force:        true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(result.AdoptedFiles))
+
+	// Verify new content replaced old
+	content, err := os.ReadFile(existingPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "New User")
+	assert.NotContains(t, string(content), "Old User")
+}
+
+// TestAdoptMultipleFiles tests adopting multiple files in one operation
+func TestAdoptMultipleFiles(t *testing.T) {
+	// Setup test filesystem
+	root := testutil.TempDir(t, "adopt-integration-test")
+	dotfilesPath := filepath.Join(root, "dotfiles")
+	homePath := filepath.Join(root, "home")
+
+	// Set HOME to test directory
+	oldHome := os.Getenv("HOME")
+	require.NoError(t, os.Setenv("HOME", homePath))
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	// Create multiple shell config files
+	files := map[string]string{
+		".bashrc":       "# bashrc content",
+		".bash_profile": "# bash_profile content",
+		".bash_aliases": "# aliases content",
+	}
+
+	sourcePaths := []string{}
+	for name, content := range files {
+		path := filepath.Join(homePath, name)
+		testutil.CreateFile(t, homePath, name, content)
+		sourcePaths = append(sourcePaths, path)
+	}
+
+	// Adopt all files at once
+	result, err := AdoptFiles(AdoptFilesOptions{
+		DotfilesRoot: dotfilesPath,
+		PackName:     "shell",
+		SourcePaths:  sourcePaths,
+		Force:        false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, len(files), len(result.AdoptedFiles))
+
+	// Verify all files were moved and symlinked
+	for name, expectedContent := range files {
+		// Check symlink exists
+		symlinkPath := filepath.Join(homePath, name)
+		info, err := os.Lstat(symlinkPath)
+		require.NoError(t, err)
+		assert.True(t, info.Mode()&os.ModeSymlink != 0)
+
+		// Check file was moved to pack
+		movedName := name[1:] // Remove leading dot
+		movedPath := filepath.Join(dotfilesPath, "shell", movedName)
+		_, err = os.Stat(movedPath)
+		require.NoError(t, err)
+
+		// Verify content through symlink
+		content, err := os.ReadFile(symlinkPath)
+		require.NoError(t, err)
+		assert.Equal(t, expectedContent, string(content))
+	}
+}

--- a/pkg/commands/adopt/adopt_test.go
+++ b/pkg/commands/adopt/adopt_test.go
@@ -147,6 +147,9 @@ func TestAdoptFiles(t *testing.T) {
 			dotfilesPath := filepath.Join(root, "dotfiles")
 			homePath := filepath.Join(root, "home")
 
+			// Create dotfiles directory
+			require.NoError(t, os.MkdirAll(dotfilesPath, 0755))
+
 			// Set HOME to test directory
 			oldHome := os.Getenv("HOME")
 			require.NoError(t, os.Setenv("HOME", homePath))
@@ -206,6 +209,9 @@ func TestAdoptIdempotency(t *testing.T) {
 	root := testutil.TempDir(t, "adopt-idempotent-test")
 	dotfilesPath := filepath.Join(root, "dotfiles")
 	homePath := filepath.Join(root, "home")
+
+	// Create dotfiles directory
+	require.NoError(t, os.MkdirAll(dotfilesPath, 0755))
 
 	// Set HOME to test directory
 	oldHome := os.Getenv("HOME")

--- a/pkg/commands/adopt/adopt_test.go
+++ b/pkg/commands/adopt/adopt_test.go
@@ -1,0 +1,286 @@
+package adopt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arthur-debert/dodot/pkg/errors"
+	_ "github.com/arthur-debert/dodot/pkg/matchers" // register default matchers
+	"github.com/arthur-debert/dodot/pkg/testutil"
+	"github.com/arthur-debert/dodot/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdoptFiles(t *testing.T) {
+	tests := []struct {
+		name             string
+		setupFiles       map[string]string
+		packName         string
+		sourcePaths      []string
+		force            bool
+		wantErr          bool
+		errCode          errors.ErrorCode
+		wantAdoptedCount int
+		checkResults     func(t *testing.T, result *types.AdoptResult, root string)
+	}{
+		{
+			name: "adopt single file from home",
+			setupFiles: map[string]string{
+				"home/.gitconfig": "user.name = Test",
+			},
+			packName:         "git",
+			sourcePaths:      []string{"$HOME/.gitconfig"},
+			wantErr:          false,
+			wantAdoptedCount: 1,
+			checkResults: func(t *testing.T, result *types.AdoptResult, root string) {
+				// Check file was moved and symlinked
+				adopted := result.AdoptedFiles[0]
+				assert.Contains(t, adopted.NewPath, "git/gitconfig")
+
+				// Verify symlink exists and points to new location
+				target, err := os.Readlink(adopted.SymlinkPath)
+				require.NoError(t, err)
+				assert.Equal(t, adopted.NewPath, target)
+			},
+		},
+		{
+			name: "adopt multiple files",
+			setupFiles: map[string]string{
+				"home/.bashrc":       "# bashrc",
+				"home/.bash_profile": "# profile",
+			},
+			packName:         "shell",
+			sourcePaths:      []string{"$HOME/.bashrc", "$HOME/.bash_profile"},
+			wantErr:          false,
+			wantAdoptedCount: 2,
+		},
+		{
+			name: "adopt file from XDG config",
+			setupFiles: map[string]string{
+				"home/.config/starship/starship.toml": "format = \"$all$character\"",
+			},
+			packName:         "starship",
+			sourcePaths:      []string{"$HOME/.config/starship/starship.toml"},
+			wantErr:          false,
+			wantAdoptedCount: 1,
+			checkResults: func(t *testing.T, result *types.AdoptResult, root string) {
+				// Check XDG structure is preserved
+				adopted := result.AdoptedFiles[0]
+				assert.Contains(t, adopted.NewPath, "starship/starship/starship.toml")
+			},
+		},
+		{
+			name:        "adopt non-existent file",
+			setupFiles:  map[string]string{},
+			packName:    "test",
+			sourcePaths: []string{"$HOME/.nonexistent"},
+			wantErr:     true,
+		},
+		{
+			name: "adopt to non-existent pack creates it",
+			setupFiles: map[string]string{
+				"home/.vimrc": "set number",
+			},
+			packName:         "newpack",
+			sourcePaths:      []string{"$HOME/.vimrc"},
+			wantErr:          false,
+			wantAdoptedCount: 1,
+			checkResults: func(t *testing.T, result *types.AdoptResult, root string) {
+				// Verify pack was created
+				packPath := filepath.Join(root, "dotfiles", "newpack")
+				info, err := os.Stat(packPath)
+				require.NoError(t, err)
+				assert.True(t, info.IsDir())
+			},
+		},
+		{
+			name: "destination already exists without force",
+			setupFiles: map[string]string{
+				"home/.gitconfig":        "new content",
+				"dotfiles/git/gitconfig": "old content",
+			},
+			packName:    "git",
+			sourcePaths: []string{"$HOME/.gitconfig"},
+			force:       false,
+			wantErr:     true,
+		},
+		{
+			name: "destination already exists with force",
+			setupFiles: map[string]string{
+				"home/.gitconfig":        "new content",
+				"dotfiles/git/gitconfig": "old content",
+			},
+			packName:         "git",
+			sourcePaths:      []string{"$HOME/.gitconfig"},
+			force:            true,
+			wantErr:          false,
+			wantAdoptedCount: 1,
+		},
+		{
+			name: "empty pack name",
+			setupFiles: map[string]string{
+				"home/.gitconfig": "content",
+			},
+			packName:    "",
+			sourcePaths: []string{"$HOME/.gitconfig"},
+			wantErr:     true,
+			errCode:     errors.ErrPackNotFound,
+		},
+		{
+			name: "pack name with trailing slash",
+			setupFiles: map[string]string{
+				"home/.gitconfig": "content",
+			},
+			packName:         "git/",
+			sourcePaths:      []string{"$HOME/.gitconfig"},
+			wantErr:          false,
+			wantAdoptedCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test filesystem
+			root := testutil.TempDir(t, "adopt-test")
+			dotfilesPath := filepath.Join(root, "dotfiles")
+			homePath := filepath.Join(root, "home")
+
+			// Set HOME to test directory
+			oldHome := os.Getenv("HOME")
+			require.NoError(t, os.Setenv("HOME", homePath))
+			defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+			// Set XDG_CONFIG_HOME
+			require.NoError(t, os.Setenv("XDG_CONFIG_HOME", filepath.Join(homePath, ".config")))
+			defer func() { _ = os.Unsetenv("XDG_CONFIG_HOME") }()
+
+			// Create files from setupFiles map
+			for path, content := range tt.setupFiles {
+				fullPath := filepath.Join(root, path)
+				testutil.CreateFile(t, filepath.Dir(fullPath), filepath.Base(fullPath), content)
+			}
+
+			// Expand source paths
+			expandedPaths := make([]string, len(tt.sourcePaths))
+			for i, path := range tt.sourcePaths {
+				expandedPaths[i] = os.ExpandEnv(path)
+			}
+
+			// Run AdoptFiles
+			result, err := AdoptFiles(AdoptFilesOptions{
+				DotfilesRoot: dotfilesPath,
+				PackName:     tt.packName,
+				SourcePaths:  expandedPaths,
+				Force:        tt.force,
+			})
+
+			// Check error
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errCode != "" {
+					var dodotErr *errors.DodotError
+					require.ErrorAs(t, err, &dodotErr)
+					assert.Equal(t, tt.errCode, dodotErr.Code)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			// Verify result
+			assert.Equal(t, tt.wantAdoptedCount, len(result.AdoptedFiles))
+
+			// Run custom checks
+			if tt.checkResults != nil {
+				tt.checkResults(t, result, root)
+			}
+		})
+	}
+}
+
+func TestAdoptIdempotency(t *testing.T) {
+	// Setup test filesystem
+	root := testutil.TempDir(t, "adopt-idempotent-test")
+	dotfilesPath := filepath.Join(root, "dotfiles")
+	homePath := filepath.Join(root, "home")
+
+	// Set HOME to test directory
+	oldHome := os.Getenv("HOME")
+	require.NoError(t, os.Setenv("HOME", homePath))
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	// Create a file
+	testutil.CreateFile(t, homePath, ".gitconfig", "user.name = Test")
+
+	// First adoption
+	result1, err := AdoptFiles(AdoptFilesOptions{
+		DotfilesRoot: dotfilesPath,
+		PackName:     "git",
+		SourcePaths:  []string{filepath.Join(homePath, ".gitconfig")},
+		Force:        false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(result1.AdoptedFiles))
+
+	// Second adoption (should be idempotent - no files adopted)
+	result2, err := AdoptFiles(AdoptFilesOptions{
+		DotfilesRoot: dotfilesPath,
+		PackName:     "git",
+		SourcePaths:  []string{filepath.Join(homePath, ".gitconfig")},
+		Force:        false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(result2.AdoptedFiles))
+}
+
+func TestDetermineDestinationPath(t *testing.T) {
+	oldHome := os.Getenv("HOME")
+	testHome := "/home/testuser"
+	require.NoError(t, os.Setenv("HOME", testHome))
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	require.NoError(t, os.Setenv("XDG_CONFIG_HOME", filepath.Join(testHome, ".config")))
+	defer func() { _ = os.Unsetenv("XDG_CONFIG_HOME") }()
+
+	tests := []struct {
+		name       string
+		packPath   string
+		sourcePath string
+		want       string
+	}{
+		{
+			name:       "file in home directory",
+			packPath:   "/dotfiles/git",
+			sourcePath: filepath.Join(testHome, ".gitconfig"),
+			want:       "/dotfiles/git/gitconfig",
+		},
+		{
+			name:       "file in XDG config",
+			packPath:   "/dotfiles/starship",
+			sourcePath: filepath.Join(testHome, ".config/starship/starship.toml"),
+			want:       "/dotfiles/starship/starship/starship.toml",
+		},
+		{
+			name:       "nested hidden directory",
+			packPath:   "/dotfiles/app",
+			sourcePath: "/opt/.myapp/config/settings.json",
+			want:       "/dotfiles/app/config/settings.json",
+		},
+		{
+			name:       "file without leading dot",
+			packPath:   "/dotfiles/misc",
+			sourcePath: filepath.Join(testHome, "myconfig"),
+			want:       "/dotfiles/misc/myconfig",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineDestinationPath(tt.packPath, tt.sourcePath)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -11,6 +11,7 @@
 //   - fill/     - FillPack command
 //   - initialize/ - InitPack command
 //   - addignore/ - AddIgnore command
+//   - adopt/    - AdoptFiles command
 //   - internal/ - Shared execution pipeline logic
 //
 // This file serves as the main entry point and re-exports all command functions
@@ -19,6 +20,7 @@ package commands
 
 import (
 	"github.com/arthur-debert/dodot/pkg/commands/addignore"
+	"github.com/arthur-debert/dodot/pkg/commands/adopt"
 	"github.com/arthur-debert/dodot/pkg/commands/deploy"
 	"github.com/arthur-debert/dodot/pkg/commands/fill"
 	"github.com/arthur-debert/dodot/pkg/commands/initialize"
@@ -77,4 +79,11 @@ type AddIgnoreOptions = addignore.AddIgnoreOptions
 
 func AddIgnore(opts AddIgnoreOptions) (*types.AddIgnoreResult, error) {
 	return addignore.AddIgnore(opts)
+}
+
+// AdoptFiles moves existing files into a pack and creates symlinks.
+type AdoptFilesOptions = adopt.AdoptFilesOptions
+
+func AdoptFiles(opts AdoptFilesOptions) (*types.AdoptResult, error) {
+	return adopt.AdoptFiles(opts)
 }

--- a/pkg/types/results.go
+++ b/pkg/types/results.go
@@ -141,3 +141,16 @@ type AddIgnoreResult struct {
 	Created        bool   `json:"created"`
 	AlreadyExisted bool   `json:"alreadyExisted"`
 }
+
+// AdoptResult holds the result of the 'adopt' command.
+type AdoptResult struct {
+	PackName     string        `json:"packName"`
+	AdoptedFiles []AdoptedFile `json:"adoptedFiles"`
+}
+
+// AdoptedFile represents a single file that was adopted.
+type AdoptedFile struct {
+	OriginalPath string `json:"originalPath"` // Original file path (e.g., ~/.gitconfig)
+	NewPath      string `json:"newPath"`      // New path in pack (e.g., /path/to/dotfiles/git/gitconfig)
+	SymlinkPath  string `json:"symlinkPath"`  // Symlink path (usually same as OriginalPath)
+}


### PR DESCRIPTION
## Summary

Implements the `dodot adopt` command as specified in `docs/proposals/adopt.txxt`. This command streamlines the process of bringing existing configuration files under dodot's management by moving them to the appropriate pack and creating symlinks.

## Changes

- Added new `adopt` command to CLI with proper help and examples
- Implemented core adoption logic in `pkg/commands/adopt/`
- Added `AdoptResult` type for command results
- Smart path handling for HOME vs XDG config paths
- Safety features (no overwrites without --force, idempotent for already-managed files)

## Testing

- **Unit tests**: Comprehensive coverage of path resolution, validation, and error cases
- **Integration tests**: 3 full workflow tests covering:
  1. Complete adoption workflow with symlink verification
  2. Existing destination handling (with and without --force)
  3. Multiple file adoption in one operation
- All tests passing with linting checks

## Implementation Notes

- Uses direct OS operations (not synthfs) as this is a simpler operation
- Follows existing command patterns from `init`, `fill`, and `addignore`
- Proper error handling with descriptive messages
- Idempotent operation - safe to run multiple times

Fixes #576

🤖 Generated with [Claude Code](https://claude.ai/code)