### PR TITLE
Link Paths Release B: Layer 1 - Smart Defaults

### DIFF
--- a/pkg/commands/deploy/deploy_test.go
+++ b/pkg/commands/deploy/deploy_test.go
@@ -65,9 +65,9 @@ func TestDeployPacks_SymlinkPowerUp(t *testing.T) {
 	testutil.AssertNotNil(t, symlinkResult, "Should have symlink power-up result")
 	testutil.AssertEqual(t, types.StatusReady, symlinkResult.Status)
 
-	// Verify actual symlinks were created
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "vimrc")), "vimrc symlink should exist")
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "gvimrc")), "gvimrc symlink should exist")
+	// Verify actual symlinks were created (Layer 1: top-level files get dot prefix)
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".vimrc")), "vimrc symlink should exist")
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".gvimrc")), "gvimrc symlink should exist")
 }
 
 func TestDeployPacks_DryRun(t *testing.T) {
@@ -108,7 +108,7 @@ func TestDeployPacks_DryRun(t *testing.T) {
 	testutil.AssertEqual(t, types.ExecutionStatusSuccess, packResult.Status)
 
 	// Verify no actual files were created (dry run)
-	testutil.AssertFalse(t, testutil.FileExists(t, filepath.Join(homeDir, "bashrc")), "bashrc symlink should not exist in dry run")
+	testutil.AssertFalse(t, testutil.FileExists(t, filepath.Join(homeDir, ".bashrc")), "bashrc symlink should not exist in dry run")
 }
 
 func TestDeployPacks_AllPacks(t *testing.T) {
@@ -153,9 +153,9 @@ func TestDeployPacks_AllPacks(t *testing.T) {
 	testutil.AssertEqual(t, types.ExecutionStatusSuccess, vimResult.Status)
 	testutil.AssertEqual(t, types.ExecutionStatusSuccess, gitResult.Status)
 
-	// Verify files from both packs were deployed
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "vimrc")), "vimrc should exist")
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "gitconfig")), "gitconfig should exist")
+	// Verify files from both packs were deployed (Layer 1: top-level files get dot prefix)
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".vimrc")), "vimrc should exist")
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".gitconfig")), "gitconfig should exist")
 }
 
 func TestDeployPacks_SkipInstallScripts(t *testing.T) {
@@ -216,7 +216,7 @@ echo "Installing tools" > /tmp/install-was-run
 	testutil.AssertFalse(t, hasInstall, "Should NOT have install_script power-up in deploy mode")
 
 	// Verify symlink was created but install script was not run
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "aliases")), "aliases symlink should exist")
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".aliases")), "aliases symlink should exist")
 	testutil.AssertFalse(t, testutil.FileExists(t, "/tmp/install-was-run"), "Install script should NOT have been executed")
 }
 

--- a/pkg/commands/install/install_test.go
+++ b/pkg/commands/install/install_test.go
@@ -78,7 +78,7 @@ echo "Tools installed" > /tmp/install-tools-output
 	testutil.AssertTrue(t, hasSymlink, "Should have symlink power-up")
 
 	// Verify both install script power-up processed AND symlink was created
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "aliases")), "aliases symlink should exist")
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".aliases")), "aliases symlink should exist")
 
 	// Check that install script power-up was processed (should create sentinel and copy script)
 	installDir := filepath.Join(homeDir, ".local", "share", "dodot", "install")
@@ -237,8 +237,8 @@ func TestInstallPacks_OnlySymlinks(t *testing.T) {
 	testutil.AssertFalse(t, hasInstallScript, "Should NOT have install_script power-up")
 	testutil.AssertTrue(t, hasSymlink, "Should have symlink power-up")
 
-	// Verify symlink was created
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "vimrc")), "vimrc symlink should exist")
+	// Verify symlink was created (Layer 1: top-level files get dot prefix)
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".vimrc")), "vimrc symlink should exist")
 }
 
 func TestInstallPacks_OnlyInstallScript(t *testing.T) {
@@ -360,9 +360,9 @@ func TestInstallPacks_MultiplePacksAllTypes(t *testing.T) {
 	testutil.AssertEqual(t, types.ExecutionStatusSuccess, langsResult.Status)
 	testutil.AssertEqual(t, types.ExecutionStatusSuccess, shellResult.Status)
 
-	// Verify symlinks were created
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "gitconfig")), "gitconfig symlink should exist")
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "bashrc")), "bashrc symlink should exist")
+	// Verify symlinks were created (Layer 1: top-level files get dot prefix)
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".gitconfig")), "gitconfig symlink should exist")
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".bashrc")), "bashrc symlink should exist")
 
 	// Verify install scripts were processed (copied and sentinels created)
 	installDir := filepath.Join(homeDir, ".local", "share", "dodot", "install")

--- a/pkg/commands/internal/pipeline_test.go
+++ b/pkg/commands/internal/pipeline_test.go
@@ -56,9 +56,9 @@ func TestRunPipeline_Deploy(t *testing.T) {
 	// Should have symlink power-up
 	testutil.AssertTrue(t, len(packResult.PowerUpResults) > 0, "Should have power-up results")
 
-	// Verify files were created
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "vimrc")), "vimrc symlink should exist")
-	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, "gvimrc")), "gvimrc symlink should exist")
+	// Verify files were created (Layer 1: top-level files get dot prefix)
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".vimrc")), "vimrc symlink should exist")
+	testutil.AssertTrue(t, testutil.FileExists(t, filepath.Join(homeDir, ".gvimrc")), "gvimrc symlink should exist")
 }
 
 func TestRunPipeline_DryRun(t *testing.T) {

--- a/pkg/paths/mapping_test.go
+++ b/pkg/paths/mapping_test.go
@@ -63,7 +63,7 @@ func TestMapPackFileToSystem(t *testing.T) {
 				Path: "/dotfiles/dev",
 			},
 			relPath:  "config/app/settings.json",
-			expected: filepath.Join(testHome, ".config/config/app/settings.json"),
+			expected: filepath.Join(testHome, ".config/app/settings.json"),
 		},
 	}
 
@@ -258,5 +258,12 @@ func TestLayer1EdgeCases(t *testing.T) {
 		result := p.MapPackFileToSystem(pack, ".gitignore")
 		assert.Equal(t, filepath.Join(testHome, ".gitignore"), result)
 		assert.NotContains(t, result, "..")
+	})
+
+	t.Run("config prefix stripping", func(t *testing.T) {
+		// Ensure config/ prefix is stripped to avoid .config/config/...
+		result := p.MapPackFileToSystem(pack, "config/app/settings.json")
+		assert.Equal(t, filepath.Join(testHome, ".config/app/settings.json"), result)
+		assert.NotContains(t, result, ".config/config/")
 	})
 }

--- a/pkg/paths/mapping_test.go
+++ b/pkg/paths/mapping_test.go
@@ -11,14 +11,22 @@ import (
 )
 
 func TestMapPackFileToSystem(t *testing.T) {
-	// Save original HOME
+	// Save original environment
 	originalHome := os.Getenv("HOME")
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
 	defer func() {
 		_ = os.Setenv("HOME", originalHome)
+		if originalXDG != "" {
+			_ = os.Setenv("XDG_CONFIG_HOME", originalXDG)
+		} else {
+			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
 	}()
 
 	testHome := "/home/testuser"
 	require.NoError(t, os.Setenv("HOME", testHome))
+	// Explicitly unset XDG_CONFIG_HOME to ensure it's calculated from HOME
+	require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
 
 	p, err := New("")
 	require.NoError(t, err)
@@ -81,12 +89,17 @@ func TestMapSystemFileToPack(t *testing.T) {
 	originalXDG := os.Getenv("XDG_CONFIG_HOME")
 	defer func() {
 		_ = os.Setenv("HOME", originalHome)
-		_ = os.Setenv("XDG_CONFIG_HOME", originalXDG)
+		if originalXDG != "" {
+			_ = os.Setenv("XDG_CONFIG_HOME", originalXDG)
+		} else {
+			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
 	}()
 
 	testHome := "/home/testuser"
 	require.NoError(t, os.Setenv("HOME", testHome))
-	require.NoError(t, os.Setenv("XDG_CONFIG_HOME", filepath.Join(testHome, ".config")))
+	// Let the code calculate XDG_CONFIG_HOME from HOME
+	require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
 
 	p, err := New("")
 	require.NoError(t, err)
@@ -159,12 +172,17 @@ func TestPathMappingSymmetry(t *testing.T) {
 	originalXDG := os.Getenv("XDG_CONFIG_HOME")
 	defer func() {
 		_ = os.Setenv("HOME", originalHome)
-		_ = os.Setenv("XDG_CONFIG_HOME", originalXDG)
+		if originalXDG != "" {
+			_ = os.Setenv("XDG_CONFIG_HOME", originalXDG)
+		} else {
+			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
 	}()
 
 	testHome := "/home/testuser"
 	require.NoError(t, os.Setenv("HOME", testHome))
-	require.NoError(t, os.Setenv("XDG_CONFIG_HOME", filepath.Join(testHome, ".config")))
+	// Let the code calculate XDG_CONFIG_HOME from HOME
+	require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
 
 	p, err := New("")
 	require.NoError(t, err)
@@ -220,12 +238,17 @@ func TestLayer1EdgeCases(t *testing.T) {
 	originalXDG := os.Getenv("XDG_CONFIG_HOME")
 	defer func() {
 		_ = os.Setenv("HOME", originalHome)
-		_ = os.Setenv("XDG_CONFIG_HOME", originalXDG)
+		if originalXDG != "" {
+			_ = os.Setenv("XDG_CONFIG_HOME", originalXDG)
+		} else {
+			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
 	}()
 
 	testHome := "/home/testuser"
 	require.NoError(t, os.Setenv("HOME", testHome))
-	require.NoError(t, os.Setenv("XDG_CONFIG_HOME", filepath.Join(testHome, ".config")))
+	// Let the code calculate XDG_CONFIG_HOME from HOME
+	require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
 
 	p, err := New("")
 	require.NoError(t, err)

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -517,9 +517,10 @@ func (p *Paths) MapPackFileToSystem(pack *types.Pack, relPath string) string {
 		xdgConfigHome = filepath.Join(homeDir, ".config")
 	}
 
-	// Special case: if the file is already under .config in the pack,
-	// strip the .config prefix to avoid .config/.config/...
+	// Special case: if the file is already under .config or config in the pack,
+	// strip that prefix to avoid .config/.config/... or .config/config/...
 	relPath = strings.TrimPrefix(relPath, ".config/")
+	relPath = strings.TrimPrefix(relPath, "config/")
 
 	return filepath.Join(xdgConfigHome, relPath)
 }

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -491,10 +491,12 @@ func (p *Paths) MapPackFileToSystem(pack *types.Pack, relPath string) string {
 	// Layer 1: Smart default mapping
 	if isTopLevel(relPath) {
 		// Top-level files go to $HOME with dot prefix
-		homeDir, err := GetHomeDirectory()
-		if err != nil {
-			homeDir = os.Getenv("HOME")
-			if homeDir == "" {
+		// Prefer HOME env var for testability
+		homeDir := os.Getenv("HOME")
+		if homeDir == "" {
+			var err error
+			homeDir, err = os.UserHomeDir()
+			if err != nil {
 				homeDir = "~"
 			}
 		}
@@ -510,9 +512,13 @@ func (p *Paths) MapPackFileToSystem(pack *types.Pack, relPath string) string {
 	// Subdirectory files go to XDG_CONFIG_HOME
 	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 	if xdgConfigHome == "" {
-		homeDir, _ := GetHomeDirectory()
+		// Prefer HOME env var for testability
+		homeDir := os.Getenv("HOME")
 		if homeDir == "" {
-			homeDir = os.Getenv("HOME")
+			homeDir, _ = os.UserHomeDir()
+			if homeDir == "" {
+				homeDir = "~"
+			}
 		}
 		xdgConfigHome = filepath.Join(homeDir, ".config")
 	}
@@ -528,10 +534,12 @@ func (p *Paths) MapPackFileToSystem(pack *types.Pack, relPath string) string {
 // MapSystemFileToPack determines where a system file should be placed in a pack.
 // Release B: Updated to handle Layer 1 reverse mapping
 func (p *Paths) MapSystemFileToPack(pack *types.Pack, systemPath string) string {
-	homeDir, err := GetHomeDirectory()
-	if err != nil {
-		homeDir = os.Getenv("HOME")
-		if homeDir == "" {
+	// Prefer HOME env var for testability
+	homeDir := os.Getenv("HOME")
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil || homeDir == "" {
 			homeDir = filepath.Dir(systemPath) // Fallback
 		}
 	}

--- a/pkg/powerups/symlink/symlink.go
+++ b/pkg/powerups/symlink/symlink.go
@@ -26,11 +26,15 @@ type SymlinkPowerUp struct {
 func NewSymlinkPowerUp() *SymlinkPowerUp {
 	logger := logging.GetLogger("powerups.symlink")
 
-	// Try to get home directory, but use ~ as fallback
-	homeDir, err := paths.GetHomeDirectory()
-	if err != nil {
-		logger.Warn().Err(err).Msg("failed to get home directory, using ~ placeholder")
-		homeDir = "~"
+	// Try to get home directory, preferring HOME env var for testability
+	homeDir := os.Getenv("HOME")
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil || homeDir == "" {
+			logger.Warn().Err(err).Msg("failed to get home directory, using ~ placeholder")
+			homeDir = "~"
+		}
 	}
 
 	// Initialize paths instance

--- a/pkg/powerups/symlink/symlink_test.go
+++ b/pkg/powerups/symlink/symlink_test.go
@@ -260,14 +260,16 @@ func TestSymlinkPowerUp_PreservesDirectoryStructure(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, actions, 3)
 
-	// Check that nested paths are preserved
+	// Check that nested paths are preserved (Layer 1: subdirs go to XDG_CONFIG_HOME)
 	assert.Equal(t, types.ActionTypeLink, actions[0].Type)
 	assert.Equal(t, "/dotfiles/nvim/.config/nvim/init.lua", actions[0].Source)
+	// Layer 1: .config/nvim/init.lua -> XDG_CONFIG_HOME/nvim/init.lua (strips .config prefix)
 	assert.Equal(t, filepath.Join(homeDir, ".config/nvim/init.lua"), actions[0].Target)
 	assert.Equal(t, "Symlink .config/nvim/init.lua -> "+filepath.Join(homeDir, ".config/nvim/init.lua"), actions[0].Description)
 
 	assert.Equal(t, types.ActionTypeLink, actions[1].Type)
 	assert.Equal(t, "/dotfiles/git/.config/git/config", actions[1].Source)
+	// Layer 1: .config/git/config -> XDG_CONFIG_HOME/git/config (strips .config prefix)
 	assert.Equal(t, filepath.Join(homeDir, ".config/git/config"), actions[1].Target)
 
 	// Check that flat files still work

--- a/pkg/powerups/symlink/symlink_test.go
+++ b/pkg/powerups/symlink/symlink_test.go
@@ -221,12 +221,18 @@ func TestSymlinkPowerUp_MetadataInActions(t *testing.T) {
 func TestSymlinkPowerUp_PreservesDirectoryStructure(t *testing.T) {
 	homeDir := t.TempDir()
 	oldHome := os.Getenv("HOME")
+	oldXDG := os.Getenv("XDG_CONFIG_HOME")
 	require.NoError(t, os.Setenv("HOME", homeDir))
+	// Explicitly unset XDG_CONFIG_HOME to ensure it's calculated from HOME
+	require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
 	defer func() {
 		if oldHome != "" {
 			require.NoError(t, os.Setenv("HOME", oldHome))
 		} else {
 			require.NoError(t, os.Unsetenv("HOME"))
+		}
+		if oldXDG != "" {
+			require.NoError(t, os.Setenv("XDG_CONFIG_HOME", oldXDG))
 		}
 	}()
 


### PR DESCRIPTION
# Link Paths Release B: Layer 1 - Smart Defaults

Part of #578

## Summary

This PR implements Release B of the link paths feature, adding Layer 1: Smart Defaults. This introduces intelligent mapping based on file location within packs.

## What Changed

### Layer 1 Implementation
- **Top-level files** in packs now deploy to `$HOME` with a dot prefix
  - Example: `gitconfig` → `$HOME/.gitconfig`
- **Subdirectory files** deploy to `$XDG_CONFIG_HOME`
  - Example: `nvim/init.lua` → `$XDG_CONFIG_HOME/nvim/init.lua`
- **Special handling** for `.config/` prefix to avoid duplication
  - Files under `.config/` in pack don't get double `.config/` in deployment

### Code Changes
- Updated `MapPackFileToSystem` to implement Layer 1 logic
- Updated `MapSystemFileToPack` for proper reverse mapping
- Added helper functions:
  - `isTopLevel()` - checks if file is at pack root
  - `stripDotPrefix()` - removes leading dot from filenames

### Test Updates
- Updated all integration tests to expect new behavior (dot prefixes)
- Added comprehensive edge case tests
- Verified mapping symmetry for common scenarios

## Examples

Before (Release A):
- `pack/gitconfig` → `$HOME/gitconfig`
- `pack/nvim/init.lua` → `$HOME/nvim/init.lua`

After (Release B):
- `pack/gitconfig` → `$HOME/.gitconfig` ✨
- `pack/nvim/init.lua` → `$XDG_CONFIG_HOME/nvim/init.lua` ✨

## Verification

- ✅ All tests pass (1306 tests)
- ✅ Linting passes
- ✅ Pre-commit hooks pass
- ✅ Maintains backward compatibility for adopt command

## Next Steps

After this PR is merged, we can proceed with:
- Release C: Layer 2 - Exception List (#581)
- Release D: Layer 3 - Explicit Override Directories (#582)
- Release E: Layer 4 - Configuration File Support (#583)