### PR TITLE
Link Paths Release C: Layer 2 - Exception List

### DIFF
--- a/pkg/config/central.go
+++ b/pkg/config/central.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"os"
+
+	"github.com/arthur-debert/dodot/pkg/constants"
 )
 
 // Security holds security-related configuration
@@ -73,6 +75,14 @@ type Paths struct {
 	LogFileName        string
 }
 
+// LinkPaths holds link path mapping configuration
+type LinkPaths struct {
+	// CoreUnixExceptions lists tools that should always deploy to $HOME
+	// These are typically security-critical or shell-expected locations
+	// Release C: Layer 2 - Exception List
+	CoreUnixExceptions map[string]bool
+}
+
 // Config is the main configuration structure
 type Config struct {
 	Security         Security
@@ -82,6 +92,7 @@ type Config struct {
 	FilePermissions  FilePermissions
 	ShellIntegration ShellIntegration
 	Paths            Paths
+	LinkPaths        LinkPaths
 }
 
 // Default returns the default configuration
@@ -173,6 +184,9 @@ end`,
 			HomebrewDir:        "homebrew",
 			InitScriptName:     "dodot-init.sh",
 			LogFileName:        "dodot.log",
+		},
+		LinkPaths: LinkPaths{
+			CoreUnixExceptions: constants.CoreUnixExceptions,
 		},
 	}
 }

--- a/pkg/constants/linkpaths.go
+++ b/pkg/constants/linkpaths.go
@@ -1,0 +1,19 @@
+// Package constants provides shared constants used across the dodot codebase.
+// This package has no dependencies to avoid circular imports.
+package constants
+
+// CoreUnixExceptions defines files/dirs that always deploy to $HOME.
+// These are typically security-critical or shell-expected locations.
+// The key is the first path segment in the pack (e.g., "ssh" for "ssh/config").
+// Release C: Layer 2 - Exception List
+var CoreUnixExceptions = map[string]bool{
+	"ssh":       true, // .ssh/ - security critical, expects $HOME
+	"gnupg":     true, // .gnupg/ - security critical, expects $HOME
+	"aws":       true, // .aws/ - credentials, expects $HOME
+	"kube":      true, // .kube/ - kubernetes config
+	"docker":    true, // .docker/ - docker config
+	"gitconfig": true, // .gitconfig - git expects in $HOME
+	"bashrc":    true, // .bashrc - shell expects in $HOME
+	"zshrc":     true, // .zshrc - shell expects in $HOME
+	"profile":   true, // .profile - shell expects in $HOME
+}

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -500,13 +500,9 @@ func getFirstSegment(relPath string) string {
 // Release C: Implements Layer 2 - Exception List (with Layer 1 fallback)
 func (p *Paths) MapPackFileToSystem(pack *types.Pack, relPath string) string {
 	// Get home directory first (used by multiple layers)
-	homeDir := os.Getenv("HOME")
-	if homeDir == "" {
-		var err error
-		homeDir, err = os.UserHomeDir()
-		if err != nil {
-			homeDir = "~"
-		}
+	homeDir, err := GetHomeDirectory()
+	if err != nil {
+		homeDir = "~" // Fallback for safety, though GetHomeDirectory is robust
 	}
 
 	// Layer 2: Check exception list based on first path segment
@@ -551,14 +547,10 @@ func (p *Paths) MapPackFileToSystem(pack *types.Pack, relPath string) string {
 // MapSystemFileToPack determines where a system file should be placed in a pack.
 // Release C: Updated to handle Layer 2 exception list (with Layer 1 fallback)
 func (p *Paths) MapSystemFileToPack(pack *types.Pack, systemPath string) string {
-	// Prefer HOME env var for testability
-	homeDir := os.Getenv("HOME")
-	if homeDir == "" {
-		var err error
-		homeDir, err = os.UserHomeDir()
-		if err != nil || homeDir == "" {
-			homeDir = filepath.Dir(systemPath) // Fallback
-		}
+	// Get home directory
+	homeDir, err := GetHomeDirectory()
+	if err != nil {
+		homeDir = filepath.Dir(systemPath) // Fallback
 	}
 
 	// Get XDG paths

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/adrg/xdg"
+	"github.com/arthur-debert/dodot/pkg/constants"
 	"github.com/arthur-debert/dodot/pkg/errors"
 	"github.com/arthur-debert/dodot/pkg/types"
 )
@@ -472,21 +473,6 @@ func (p *Paths) LogFilePath() string {
 	return filepath.Join(p.xdgState, LogFileName)
 }
 
-// coreUnixExceptions lists tools that should always deploy to $HOME
-// These are typically security-critical or shell-expected locations
-// Release C: Layer 2 - Exception List
-var coreUnixExceptions = map[string]bool{
-	"ssh":       true, // .ssh/ - security critical, expects $HOME
-	"gnupg":     true, // .gnupg/ - security critical, expects $HOME
-	"aws":       true, // .aws/ - credentials, expects $HOME
-	"kube":      true, // .kube/ - kubernetes config
-	"docker":    true, // .docker/ - docker config
-	"gitconfig": true, // .gitconfig - git expects in $HOME
-	"bashrc":    true, // .bashrc - shell expects in $HOME
-	"zshrc":     true, // .zshrc - shell expects in $HOME
-	"profile":   true, // .profile - shell expects in $HOME
-}
-
 // isTopLevel checks if a file is at the pack root (no directory separators)
 func isTopLevel(relPath string) bool {
 	return !strings.Contains(relPath, string(filepath.Separator))
@@ -527,7 +513,7 @@ func (p *Paths) MapPackFileToSystem(pack *types.Pack, relPath string) string {
 	firstSegment := getFirstSegment(relPath)
 	cleanSegment := stripDotPrefix(firstSegment)
 
-	if coreUnixExceptions[cleanSegment] {
+	if constants.CoreUnixExceptions[cleanSegment] {
 		// Exception list items always go to $HOME
 		// Reconstruct the path with dot prefix on first segment
 		parts := strings.Split(relPath, string(filepath.Separator))
@@ -594,7 +580,7 @@ func (p *Paths) MapSystemFileToPack(pack *types.Pack, systemPath string) string 
 				firstSegment := stripDotPrefix(parts[0])
 
 				// Layer 2: Check exception list
-				if coreUnixExceptions[firstSegment] {
+				if constants.CoreUnixExceptions[firstSegment] {
 					// Exception list items are stored without dot prefix
 					parts[0] = firstSegment
 					return filepath.Join(pack.Path, filepath.Join(parts...))


### PR DESCRIPTION
Part of #578

## Summary

This PR implements Release C of the link paths feature, adding Layer 2: Exception List. This introduces a hardcoded list of core UNIX tools that should always deploy to `$HOME` regardless of their directory structure.

## What Changed

### Layer 2 Implementation
- Added `coreUnixExceptions` map with tools that always go to `$HOME`
- Exception list includes: ssh, gnupg, aws, kube, docker, gitconfig, bashrc, zshrc, profile
- Layer 2 takes precedence over Layer 1's smart defaults

### Code Changes
- Updated `MapPackFileToSystem` to check exception list before Layer 1 logic
- Updated `MapSystemFileToPack` to handle reverse mapping for exceptions
- Added helper function `getFirstSegment()` to extract first path component
- Exception checking is based on the first path segment (e.g., "ssh" in "ssh/config")

### Test Updates
- Added `TestLayer2ExceptionList` for forward mapping
- Added `TestLayer2ExceptionListReverse` for reverse mapping
- Added `TestLayerPrecedence` to verify Layer 2 overrides Layer 1
- Added `TestAdoptExceptionListBehavior` integration test

## Examples

With Layer 2:
- `pack/ssh/config` → `$HOME/.ssh/config` (exception list)
- `pack/gitconfig` → `$HOME/.gitconfig` (exception list)
- `pack/aws/credentials` → `$HOME/.aws/credentials` (exception list)
- `pack/nvim/init.lua` → `$XDG_CONFIG_HOME/nvim/init.lua` (Layer 1 default)

## Verification

- ✅ All tests pass (1329 tests)
- ✅ Linting passes
- ✅ Pre-commit hooks pass
- ✅ Exception list properly overrides Layer 1 behavior
- ✅ Reverse mapping (adopt) works correctly

## Next Steps

After this PR is merged, we can proceed with:
- Release D: Layer 3 - Explicit Override Directories (#582)
- Release E: Layer 4 - Configuration File Support (#583)