### PR TITLE
Release E: Layer 4 - Configuration File

### DIFF
--- a/pkg/config/pack.go
+++ b/pkg/config/pack.go
@@ -28,6 +28,7 @@ func LoadPackConfig(configPath string) (types.PackConfig, error) {
 	logger.Debug().
 		Int("ignore_rules", len(config.Ignore)).
 		Int("override_rules", len(config.Override)).
+		Int("mappings", len(config.Mappings)).
 		Msg("Pack config loaded")
 
 	return config, nil

--- a/pkg/types/pack.go
+++ b/pkg/types/pack.go
@@ -22,8 +22,9 @@ type Pack struct {
 
 // PackConfig represents configuration options for a pack from .dodot.toml
 type PackConfig struct {
-	Ignore   []IgnoreRule   `toml:"ignore"`
-	Override []OverrideRule `toml:"override"`
+	Ignore   []IgnoreRule      `toml:"ignore"`
+	Override []OverrideRule    `toml:"override"`
+	Mappings map[string]string `toml:"mappings"`
 }
 
 // IgnoreRule defines a file or pattern to be ignored


### PR DESCRIPTION
## Summary
- Implements custom path mappings via .dodot.toml configuration files
- Completes the 4-layer link paths feature with maximum user flexibility
- Allows fine-grained control over file deployment locations

## Changes
- Added `Mappings` field to `PackConfig` struct for storing custom mappings
- Implemented `expandMapping()` to handle `$HOME` and `$XDG_CONFIG_HOME` variables
- Implemented `findMapping()` for exact match and glob pattern support
- Updated `MapPackFileToSystem` to check Layer 4 mappings before other layers
- Added comprehensive unit tests for custom mappings
- Added integration tests demonstrating config file usage
- Ensured proper layer precedence (Layer 4 > 3 > 2 > 1)

## Example Usage
Users can now add custom mappings to their `.dodot.toml`:
```toml
[mappings]
"special/config" = "$HOME/.special_location"
"app.conf" = "$XDG_CONFIG_HOME/myapp/app.conf"
"*.secret" = "$HOME/.secrets/"
"data/*.json" = "$HOME/.local/share/myapp/"
```

## Test Plan
- [x] All existing tests pass
- [x] New unit tests for Layer 4 functionality
- [x] Integration tests for custom mappings
- [x] Layer precedence tests ensuring Layer 4 overrides all others
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)