### PR TITLE
Release 1: Dangling link detection and removal

### DIFF
--- a/docs/guides/50_data-storage.txxt
+++ b/docs/guides/50_data-storage.txxt
@@ -1,7 +1,115 @@
                    Data Storage and Organization
 
-This guide explains how dodot organizes and stores your configuration
-files, how symlinks work, and what happens during deployment.
+This guide explains dodot's approach to state management, how it stores
+deployment information, and the rationale behind its design decisions.
+
+The Double-Link Architecture
+----------------------------
+
+dodot could simply create direct symlinks from deployed paths (e.g., ~/.zshrc)
+to source files (e.g., $DOTFILES_ROOT/shell/zshrc). Instead, it uses a 
+double-link structure where the deployed file points to an intermediate 
+symlink in dodot's state directory, which then points to the source file.
+
+Why this design? The answer is state management. This structure ties together
+the deployment result, the thing itself, and our state representation.
+
+Alternative approaches like direct links with a JSON state file would require
+keeping the deployment and state in sync. Our design has key advantages:
+
+• No risk of being out of sync - the deployment IS the state
+• Easy debugging - if a state symlink points to a missing source file,
+  it's immediately visible
+• Robust and simple - no parsing, no corruption, just filesystem operations
+
+In essence: the filesystem structure itself is the state database.
+
+State Storage Structure
+-----------------------
+
+Here's what dodot's state storage looks like after deploying various powerups:
+
+```
+~/.local/share/dodot/
+├── deployed/
+│   ├── symlink/         # Intermediate symlinks for regular files
+│   │   ├── .vimrc → ~/dotfiles/vim/vimrc
+│   │   ├── .zshrc → ~/dotfiles/zsh/zshrc
+│   │   └── .gitconfig → ~/dotfiles/git/gitconfig
+│   │
+│   ├── shell_profile/   # Shell scripts to source
+│   │   ├── vim_aliases.sh → ~/dotfiles/vim/aliases.sh
+│   │   ├── git_functions.sh → ~/dotfiles/git/functions.sh
+│   │   └── tools_env.sh → ~/dotfiles/tools/env.sh
+│   │
+│   └── path/           # Directories to add to PATH
+│       ├── tools-bin → ~/dotfiles/tools/bin
+│       └── scripts-local → ~/dotfiles/scripts/.local/bin
+│
+├── homebrew/           # Brew execution tracking
+│   ├── tools_Brewfile.sentinel    # "sha256:2024-01-15T10:00:00Z"
+│   └── dev_Brewfile.sentinel      # "sha256:2024-01-20T14:30:00Z"
+│
+├── install/            # Install script tracking
+│   ├── vim_install.sh.sentinel    # "sha256:2024-01-10T09:00:00Z"
+│   ├── tools_setup.sh.sentinel    # "sha256:2024-01-12T11:00:00Z"
+│   └── tools/                     # Copied scripts
+│       └── setup.sh
+│
+└── shell/
+    └── dodot-init.sh   # Sources everything in shell_profile/ and adds path/ to PATH
+```
+
+How Each PowerUp Stores State
+------------------------------
+
+1. Symlink PowerUp:
+   • Creates intermediate symlink in deployed/symlink/
+   • User's file (e.g., ~/.vimrc) points to intermediate
+   • Intermediate points to source in pack
+   • State = existence of these symlinks
+
+2. Shell Profile PowerUp:
+   • Creates symlinks in deployed/shell_profile/
+   • Naming: <pack>_<filename> (e.g., vim_aliases.sh)
+   • dodot-init.sh sources all files in this directory
+   • State = existence of symlinks
+
+3. Path PowerUp:
+   • Creates symlinks in deployed/path/
+   • Naming: <pack>-<dirname> (e.g., tools-bin)
+   • Each symlink points to a directory to add to PATH
+   • dodot-init.sh iterates through these and adds to PATH
+   • State = existence of directory symlinks
+
+4. Homebrew PowerUp:
+   • Creates sentinel files in homebrew/
+   • Format: <pack>_Brewfile.sentinel
+   • Content: "checksum:timestamp"
+   • State = sentinel existence and checksum match
+
+5. Install Script PowerUp:
+   • Creates sentinel files in install/
+   • Copies scripts before execution for safety
+   • Format: <pack>_<script>.sentinel
+   • Content: "checksum:timestamp"
+   • State = sentinel existence and checksum match
+
+File Deployment Mapping
+-----------------------
+
+The relationship between source files and deployed locations follows
+intelligent mapping rules:
+
+Default Mapping:
+• Pack root files → home with dot prefix (vimrc → ~/.vimrc)
+• Pack subdirectories → XDG directories or home subdirectories
+• Special handling for known directories (ssh, vim, etc.)
+
+Mapping can be customized via:
+• Pack configuration in .dodot.toml
+• Explicit _home/ or _xdg/ prefixes in paths
+• PowerUp options like target_dir
 
 The Pack Concept
 ----------------
@@ -28,118 +136,18 @@ DOTFILES_ROOT/
     └── install.sh         # executed once
 ```
 
-File Deployment Strategies
----------------------------
+Shell Integration
+-----------------
 
-dodot uses different strategies based on file types and locations:
+dodot uses a single shell integration point: dodot-init.sh. This script:
 
-1. Symbolic Links:
-   Most configuration files are deployed via symbolic links:
-   • Source: DOTFILES_ROOT/pack/filename  
-   • Target: ~/.filename (with dot prefix)
-   • Changes to source file are immediately live
+1. Sources all files in deployed/shell_profile/
+2. Adds all directories in deployed/path/ to PATH
+3. Exports environment variables for tracking
+4. Provides helper functions for status checking
 
-2. Shell Integration:
-   Shell files are sourced rather than linked:
-   • alias.sh files are sourced in shell profiles
-   • env.sh files export environment variables
-   • Custom PATH additions are handled specially
-
-3. Run-Once Operations:
-   Some files trigger one-time operations:
-   • install.sh scripts are executed
-   • Brewfiles are processed by Homebrew
-   • Tracked via sentinel files to prevent re-execution
-
-Symlink Behavior
-----------------
-
-File Naming Rules:
-• Files in pack root: pack/vimrc → ~/.vimrc (dot prefix added)
-• Directories in pack root: pack/config → ~/config (no dot prefix)
-• Files in subdirectories: keep original path structure
-
-Target Directory Rules:
-• Default target: user home directory (~)
-• Override via power-up options: target_dir = "~/.config"
-• Nested directories created automatically if needed
-
-Link Safety:
-• Existing files backed up if backup=true option set
-• Existing symlinks replaced if overwrite=true
-• Directory creation handled automatically
-
-Data Persistence
-----------------
-
-dodot stores minimal persistent data:
-
-Sentinel Files:
-Location: DODOT_DATA_DIR (default: ~/.local/share/dodot)
-Purpose: Track run-once operations to prevent re-execution
-
-Structure:
-```
-~/.local/share/dodot/
-├── homebrew/
-│   ├── pack1           # checksum of pack1/Brewfile
-│   └── pack2           # checksum of pack2/Brewfile
-└── install/
-    ├── pack1           # checksum of pack1/install.sh
-    └── pack2           # checksum of pack2/install.sh
-```
-
-Shell Integration Method:
-dodot uses a central directory for shell integration. It creates symlinks
-from your source files (e.g., `aliases.sh`) into this directory:
-`~/.local/share/dodot/shell/profile.d/`
-
-Your shell startup script (e.g., `.zshrc`, `.bashrc`) is configured once
-to source all `.sh` files from that directory. This avoids creating
-multiple `~/.dodot_*` files in your home directory.
-
-No State Database:
-dodot deliberately avoids state databases. Deployment status is determined
-by examining the current filesystem, not by consulting stored metadata.
-
-Directory Structure Examples
------------------------------
-
-Minimal Pack:
-```
-vim/
-├── vimrc              # basic vim configuration
-└── .dodot.toml        # optional overrides
-```
-
-Complex Pack:
-```
-development/
-├── bin/               # executables added to PATH
-│   ├── git-helpers
-│   └── dev-scripts
-├── config/            # configuration directory
-│   ├── git/
-│   │   └── hooks/
-│   └── editors/
-├── aliases.sh         # shell aliases
-├── env.sh            # environment variables
-├── Brewfile          # package dependencies
-├── install.sh        # setup script
-└── .dodot.toml       # pack configuration
-```
-
-Configuration Override:
-```
-.dodot.toml:
-[[ignore]]
-  path = "*.backup"    # skip backup files
-
-[[override]]
-  path = "config"
-  powerup = "symlink"
-  with = { target_dir = "~/.config" }
-```
+Your shell profile (.zshrc, .bashrc) only needs one line to source
+dodot-init.sh, avoiding multiple integration points.
 
 Storage Benefits
 ----------------
@@ -151,8 +159,8 @@ Version Control Integration:
 
 Transparency:
 • You can see exactly what will be deployed
-• No hidden state or magic transformations
-• Easy to debug and understand
+• The state IS the deployment - no hidden metadata
+• Easy to debug by examining symlinks
 
 Portability:
 • Works on any system with git and dodot
@@ -195,6 +203,39 @@ Since everything is in git:
 
 To completely remove dodot traces:
 1. Remove symlinks: replace with actual files if desired
-2. Remove shell integration lines from profiles
+2. Remove shell integration line from profiles
 3. Clean up DODOT_DATA_DIR if desired
 4. Your dotfiles repository remains intact and usable
+
+Understanding State Through Examples
+------------------------------------
+
+To check what's deployed:
+```
+# See all intermediate symlinks
+ls -la ~/.local/share/dodot/deployed/symlink/
+
+# See what's added to PATH
+ls -la ~/.local/share/dodot/deployed/path/
+
+# Check if a Brewfile was processed
+ls ~/.local/share/dodot/homebrew/
+```
+
+To understand a deployment:
+```
+# Follow the symlink chain for .vimrc
+readlink ~/.vimrc
+# → /Users/you/.local/share/dodot/deployed/symlink/.vimrc
+
+readlink /Users/you/.local/share/dodot/deployed/symlink/.vimrc  
+# → /Users/you/dotfiles/vim/vimrc
+```
+
+The beauty is that the deployment structure tells you everything:
+• What's deployed (symlinks exist)
+• Where it came from (follow the symlinks)
+• What's broken (dangling symlinks)
+• What changed (checksum mismatches in sentinels)
+
+No database queries, no state files to parse - just ls and readlink.

--- a/pkg/state/dangling.go
+++ b/pkg/state/dangling.go
@@ -1,0 +1,298 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/arthur-debert/dodot/pkg/errors"
+	"github.com/arthur-debert/dodot/pkg/logging"
+	"github.com/arthur-debert/dodot/pkg/types"
+)
+
+// DanglingLink represents a dangling symlink in the deployment
+type DanglingLink struct {
+	// DeployedPath is the user-facing symlink (e.g., ~/.vimrc)
+	DeployedPath string
+	// IntermediatePath is the dodot state symlink
+	IntermediatePath string
+	// SourcePath is the expected source file that's missing
+	SourcePath string
+	// Pack is the pack that originally deployed this link
+	Pack string
+	// Problem describes what's wrong with the link
+	Problem string
+}
+
+// LinkDetector handles detection of dangling and orphaned links
+type LinkDetector struct {
+	fs    types.FS
+	paths types.Pather
+}
+
+// NewLinkDetector creates a new LinkDetector
+func NewLinkDetector(fs types.FS, paths types.Pather) *LinkDetector {
+	return &LinkDetector{
+		fs:    fs,
+		paths: paths,
+	}
+}
+
+// DetectDanglingLinks scans for dangling symlinks in the deployment
+// Returns only user-facing dangling links (not orphaned intermediate links)
+func (ld *LinkDetector) DetectDanglingLinks(actions []types.Action) ([]DanglingLink, error) {
+	var dangling []DanglingLink
+
+	for _, action := range actions {
+		if action.Type != types.ActionTypeLink {
+			continue
+		}
+
+		// Check the symlink chain
+		dl, err := ld.checkSymlinkChain(&action)
+		if err != nil {
+			logger := logging.GetLogger("state.dangling")
+			logger.Error().
+				Err(err).
+				Str("pack", action.Pack).
+				Str("target", action.Target).
+				Msg("error checking symlink chain")
+			continue
+		}
+
+		if dl != nil {
+			dangling = append(dangling, *dl)
+		}
+	}
+
+	return dangling, nil
+}
+
+// checkSymlinkChain checks a single symlink action for dangling links
+func (ld *LinkDetector) checkSymlinkChain(action *types.Action) (*DanglingLink, error) {
+	logger := logging.GetLogger("state.dangling")
+
+	// Get intermediate path
+	intermediatePath, err := action.GetDeployedSymlinkPath(ld.paths)
+	if err != nil {
+		return nil, errors.Wrap(err, errors.ErrConfigParse, "failed to get intermediate symlink path")
+	}
+
+	logger.Debug().
+		Str("target", action.Target).
+		Str("intermediate", intermediatePath).
+		Str("source", action.Source).
+		Msg("checking symlink chain")
+
+	// Check if deployed symlink exists
+	targetInfo, err := ld.fs.Lstat(action.Target)
+	if err != nil {
+		// Target doesn't exist - not deployed, not dangling
+		logger.Debug().Str("target", action.Target).Msg("target doesn't exist - not deployed")
+		return nil, nil
+	}
+
+	// Check if it's a symlink
+	if targetInfo.Mode()&os.ModeSymlink == 0 {
+		// Not a symlink - not our concern
+		return nil, nil
+	}
+
+	// Read where the deployed symlink points
+	targetDest, err := ld.fs.Readlink(action.Target)
+	if err != nil {
+		// Can't read symlink - treat as not ours
+		logger.Debug().Err(err).Msg("can't read deployed symlink")
+		return nil, nil
+	}
+
+	// Resolve the target destination
+	resolvedTarget := targetDest
+	if !filepath.IsAbs(targetDest) {
+		resolvedTarget = filepath.Join(filepath.Dir(action.Target), targetDest)
+	}
+
+	logger.Debug().
+		Str("targetDest", targetDest).
+		Str("resolvedTarget", resolvedTarget).
+		Str("expectedIntermediate", intermediatePath).
+		Msg("checking if deployed points to intermediate")
+
+	// Check if it points to our intermediate symlink
+	// We need to handle both absolute and relative paths
+	if !pathsMatch(targetDest, intermediatePath, resolvedTarget) {
+		// Points somewhere else - not managed by us
+		logger.Debug().Msg("deployed symlink points elsewhere - not managed by us")
+		return nil, nil
+	}
+
+	// Now check the intermediate symlink
+	intermediateInfo, err := ld.fs.Lstat(intermediatePath)
+	if err != nil {
+		// Intermediate missing - this is dangling
+		return &DanglingLink{
+			DeployedPath:     action.Target,
+			IntermediatePath: intermediatePath,
+			SourcePath:       action.Source,
+			Pack:             action.Pack,
+			Problem:          "intermediate symlink missing",
+		}, nil
+	}
+
+	// Check if intermediate is a symlink
+	if intermediateInfo.Mode()&os.ModeSymlink == 0 {
+		// Intermediate is not a symlink - corrupted state
+		return &DanglingLink{
+			DeployedPath:     action.Target,
+			IntermediatePath: intermediatePath,
+			SourcePath:       action.Source,
+			Pack:             action.Pack,
+			Problem:          "intermediate is not a symlink",
+		}, nil
+	}
+
+	// Read where intermediate points
+	intermediateDest, err := ld.fs.Readlink(intermediatePath)
+	if err != nil {
+		return &DanglingLink{
+			DeployedPath:     action.Target,
+			IntermediatePath: intermediatePath,
+			SourcePath:       action.Source,
+			Pack:             action.Pack,
+			Problem:          "cannot read intermediate symlink",
+		}, nil
+	}
+
+	// Resolve intermediate destination
+	resolvedIntermediate := intermediateDest
+	if !filepath.IsAbs(intermediateDest) {
+		resolvedIntermediate = filepath.Join(filepath.Dir(intermediatePath), intermediateDest)
+	}
+
+	// Check if intermediate points to the correct source
+	if !pathsMatch(intermediateDest, action.Source, resolvedIntermediate) {
+		// Points to wrong file
+		logger.Debug().
+			Str("intermediateDest", intermediateDest).
+			Str("expectedSource", action.Source).
+			Str("resolvedIntermediate", resolvedIntermediate).
+			Msg("intermediate points to wrong file")
+		return &DanglingLink{
+			DeployedPath:     action.Target,
+			IntermediatePath: intermediatePath,
+			SourcePath:       action.Source,
+			Pack:             action.Pack,
+			Problem:          "intermediate points to wrong file",
+		}, nil
+	}
+
+	// Finally check if source exists
+	if _, err := ld.fs.Stat(action.Source); err != nil {
+		// Source missing - this is dangling
+		logger.Debug().
+			Str("source", action.Source).
+			Err(err).
+			Msg("source file missing - link is dangling")
+		return &DanglingLink{
+			DeployedPath:     action.Target,
+			IntermediatePath: intermediatePath,
+			SourcePath:       action.Source,
+			Pack:             action.Pack,
+			Problem:          "source file missing",
+		}, nil
+	}
+
+	// Everything is fine
+	logger.Debug().Msg("symlink chain is healthy")
+	return nil, nil
+}
+
+// pathsMatch checks if symlink paths match, handling both relative and absolute paths
+func pathsMatch(targetDest, expectedPath, resolvedPath string) bool {
+	// Direct match
+	if targetDest == expectedPath {
+		return true
+	}
+
+	// Clean and compare
+	if filepath.Clean(targetDest) == filepath.Clean(expectedPath) {
+		return true
+	}
+
+	// Compare resolved path
+	if filepath.Clean(resolvedPath) == filepath.Clean(expectedPath) {
+		return true
+	}
+
+	// In test environments with relative paths, the target might be exactly what we expect
+	// without resolution (e.g., "data/dodot/deployed/symlink/.vimrc")
+	if targetDest == expectedPath {
+		return true
+	}
+
+	return false
+}
+
+// RemoveDanglingLink safely removes a dangling symlink
+// It verifies ownership before removal to avoid affecting user-created symlinks
+// TODO: This will be implemented in a separate commit for Release 1
+/*
+func (ld *LinkDetector) RemoveDanglingLink(dl *DanglingLink) error {
+	// First verify the deployed symlink still points to our intermediate
+	targetDest, err := ld.fs.Readlink(dl.DeployedPath)
+	if err != nil {
+		// Can't read - maybe already removed
+		return nil
+	}
+
+	// Resolve the target
+	resolvedTarget := targetDest
+	if !filepath.IsAbs(targetDest) {
+		resolvedTarget = filepath.Join(filepath.Dir(dl.DeployedPath), targetDest)
+	}
+
+	// Only remove if it still points to our intermediate
+	if !pathsMatch(targetDest, dl.IntermediatePath, resolvedTarget) {
+		logger := logging.GetLogger("state.dangling")
+		logger.Debug().
+			Str("deployed", dl.DeployedPath).
+			Str("expected_intermediate", dl.IntermediatePath).
+			Str("actual_target", resolvedTarget).
+			Msg("not removing symlink - no longer points to our intermediate")
+		return nil
+	}
+
+	logger := logging.GetLogger("state.dangling")
+
+	// Remove the deployed symlink first
+	if err := ld.fs.Remove(dl.DeployedPath); err != nil && !os.IsNotExist(err) {
+		logger.Debug().
+			Err(err).
+			Str("path", dl.DeployedPath).
+			Msg("error removing deployed symlink")
+		return errors.Wrapf(err, errors.ErrFileAccess, "failed to remove deployed symlink %s", dl.DeployedPath)
+	}
+
+	logger.Warn().
+		Str("path", dl.DeployedPath).
+		Str("pack", dl.Pack).
+		Str("problem", dl.Problem).
+		Msg("removed dangling symlink")
+
+	// Try to remove the intermediate symlink if it exists
+	if _, err := ld.fs.Lstat(dl.IntermediatePath); err == nil {
+		if err := ld.fs.Remove(dl.IntermediatePath); err != nil && !os.IsNotExist(err) {
+			// Log but don't fail - the important part is removing the user-facing link
+			logger.Debug().
+				Err(err).
+				Str("path", dl.IntermediatePath).
+				Msg("failed to remove intermediate symlink")
+		} else {
+			logger.Debug().
+				Str("path", dl.IntermediatePath).
+				Msg("removed intermediate symlink")
+		}
+	}
+
+	return nil
+}
+*/

--- a/pkg/state/dangling.go
+++ b/pkg/state/dangling.go
@@ -234,13 +234,17 @@ func pathsMatch(targetDest, expectedPath, resolvedPath string) bool {
 
 // RemoveDanglingLink safely removes a dangling symlink
 // It verifies ownership before removal to avoid affecting user-created symlinks
-// TODO: This will be implemented in a separate commit for Release 1
-/*
 func (ld *LinkDetector) RemoveDanglingLink(dl *DanglingLink) error {
+	logger := logging.GetLogger("state.dangling")
+
 	// First verify the deployed symlink still points to our intermediate
 	targetDest, err := ld.fs.Readlink(dl.DeployedPath)
 	if err != nil {
 		// Can't read - maybe already removed
+		logger.Debug().
+			Str("path", dl.DeployedPath).
+			Err(err).
+			Msg("deployed symlink no longer exists or unreadable")
 		return nil
 	}
 
@@ -252,7 +256,6 @@ func (ld *LinkDetector) RemoveDanglingLink(dl *DanglingLink) error {
 
 	// Only remove if it still points to our intermediate
 	if !pathsMatch(targetDest, dl.IntermediatePath, resolvedTarget) {
-		logger := logging.GetLogger("state.dangling")
 		logger.Debug().
 			Str("deployed", dl.DeployedPath).
 			Str("expected_intermediate", dl.IntermediatePath).
@@ -261,18 +264,20 @@ func (ld *LinkDetector) RemoveDanglingLink(dl *DanglingLink) error {
 		return nil
 	}
 
-	logger := logging.GetLogger("state.dangling")
-
 	// Remove the deployed symlink first
+	logger.Debug().
+		Str("path", dl.DeployedPath).
+		Msg("attempting to remove deployed symlink")
+
 	if err := ld.fs.Remove(dl.DeployedPath); err != nil && !os.IsNotExist(err) {
-		logger.Debug().
+		logger.Error().
 			Err(err).
 			Str("path", dl.DeployedPath).
 			Msg("error removing deployed symlink")
 		return errors.Wrapf(err, errors.ErrFileAccess, "failed to remove deployed symlink %s", dl.DeployedPath)
 	}
 
-	logger.Warn().
+	logger.Info().
 		Str("path", dl.DeployedPath).
 		Str("pack", dl.Pack).
 		Str("problem", dl.Problem).
@@ -295,4 +300,3 @@ func (ld *LinkDetector) RemoveDanglingLink(dl *DanglingLink) error {
 
 	return nil
 }
-*/

--- a/pkg/state/dangling_test.go
+++ b/pkg/state/dangling_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -213,4 +214,223 @@ func TestDetectMultipleDanglingLinks(t *testing.T) {
 	assert.Equal(t, "intermediate symlink missing", problems["git"])
 }
 
-// TestRemoveDanglingLink will be added in a separate commit for Release 1
+func TestRemoveDanglingLink(t *testing.T) {
+	tests := []struct {
+		name           string
+		setup          func(t *testing.T, fs types.FS, action types.Action, intermediatePath string, dl *DanglingLink)
+		expectedRemove bool
+		expectedError  bool
+	}{
+		{
+			name: "removes dangling symlink with missing source",
+			setup: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string, dl *DanglingLink) {
+				// Remove the source file to make it dangling
+				err := fs.Remove(action.Source)
+				require.NoError(t, err)
+			},
+			expectedRemove: true,
+		},
+		{
+			name: "removes dangling symlink with missing intermediate",
+			setup: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string, dl *DanglingLink) {
+				// Remove the intermediate symlink
+				err := fs.Remove(intermediatePath)
+				require.NoError(t, err)
+			},
+			expectedRemove: true,
+		},
+		{
+			name: "does not remove if deployed symlink points elsewhere",
+			setup: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string, dl *DanglingLink) {
+				// Make deployed symlink point to a different file
+				otherFile := filepath.Join("home", "other-file")
+				testutil.CreateFileT(t, fs, otherFile, "other content")
+
+				// Re-create deployed symlink pointing elsewhere
+				err := fs.Remove(action.Target)
+				require.NoError(t, err)
+				testutil.CreateSymlinkT(t, fs, otherFile, action.Target)
+			},
+			expectedRemove: false,
+		},
+		{
+			name: "handles already removed deployed symlink gracefully",
+			setup: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string, dl *DanglingLink) {
+				// Remove the deployed symlink before removal attempt
+				err := fs.Remove(action.Target)
+				require.NoError(t, err)
+			},
+			expectedRemove: false, // Already gone, nothing to remove
+		},
+		{
+			name: "removes both deployed and intermediate symlinks",
+			setup: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string, dl *DanglingLink) {
+				// Remove source to make it dangling
+				err := fs.Remove(action.Source)
+				require.NoError(t, err)
+			},
+			expectedRemove: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			fs := testutil.NewTestFS()
+			dataDir := filepath.Join("data", "dodot")
+			dotfilesRoot := filepath.Join("dotfiles")
+
+			// Create a working deployment first
+			action, intermediatePath := setupWorkingDeployment(t, fs, dataDir, dotfilesRoot, "vim", "vimrc", ".vimrc")
+
+			// Create DanglingLink object
+			dl := &DanglingLink{
+				DeployedPath:     action.Target,
+				IntermediatePath: intermediatePath,
+				SourcePath:       action.Source,
+				Pack:             action.Pack,
+				Problem:          "test problem",
+			}
+
+			// Apply test-specific setup
+			tt.setup(t, fs, action, intermediatePath, dl)
+
+			// Test removal
+			pather := &testutil.MockPaths{
+				DataDirPath:      dataDir,
+				DotfilesRootPath: dotfilesRoot,
+			}
+			detector := NewLinkDetector(fs, pather)
+			err := detector.RemoveDanglingLink(dl)
+
+			// Verify error expectation
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Verify removal
+			if tt.expectedRemove {
+				// Deployed symlink should be gone
+				_, err := fs.Lstat(action.Target)
+				if err == nil {
+					t.Errorf("deployed symlink still exists at %s", action.Target)
+				}
+
+				// If intermediate still existed before removal, it should be gone too
+				_, err = fs.Lstat(intermediatePath)
+				if err == nil {
+					t.Errorf("intermediate symlink still exists at %s", intermediatePath)
+				}
+			} else {
+				// Check if deployed symlink still exists (might have been removed in setup)
+				if _, err := fs.Lstat(action.Target); err == nil {
+					// It exists, verify it's not pointing to our intermediate
+					target, err := fs.Readlink(action.Target)
+					require.NoError(t, err)
+					assert.NotEqual(t, intermediatePath, target, "deployed symlink should not point to our intermediate")
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveDanglingLinkSafety(t *testing.T) {
+	// This test ensures we never remove user-created symlinks
+	fs := testutil.NewTestFS()
+	dataDir := filepath.Join("data", "dodot")
+	dotfilesRoot := filepath.Join("dotfiles")
+
+	// Create a user's own symlink (not managed by dodot)
+	userConfig := filepath.Join("home", "my-config")
+	userSymlink := filepath.Join("home", ".myconfig")
+	testutil.CreateFileT(t, fs, userConfig, "user's config")
+	testutil.CreateSymlinkT(t, fs, userConfig, userSymlink)
+
+	// Create a DanglingLink that refers to the user's symlink
+	dl := &DanglingLink{
+		DeployedPath:     userSymlink,
+		IntermediatePath: filepath.Join(dataDir, "deployed", "symlink", ".myconfig"),
+		SourcePath:       filepath.Join(dotfilesRoot, "mypack", "myconfig"),
+		Pack:             "mypack",
+		Problem:          "source missing",
+	}
+
+	// Try to remove it
+	pather := &testutil.MockPaths{
+		DataDirPath:      dataDir,
+		DotfilesRootPath: dotfilesRoot,
+	}
+	detector := NewLinkDetector(fs, pather)
+	err := detector.RemoveDanglingLink(dl)
+	assert.NoError(t, err)
+
+	// User's symlink should still exist
+	info, err := fs.Lstat(userSymlink)
+	require.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink != 0, "user's symlink should still exist")
+
+	// And it should still point to user's config
+	target, err := fs.Readlink(userSymlink)
+	require.NoError(t, err)
+	assert.Equal(t, userConfig, target)
+}
+
+func TestRemoveMultipleDanglingLinks(t *testing.T) {
+	// Setup
+	fs := testutil.NewTestFS()
+	dataDir := filepath.Join("data", "dodot")
+	dotfilesRoot := filepath.Join("dotfiles")
+
+	// Create multiple working deployments
+	action1, intermediatePath1 := setupWorkingDeployment(t, fs, dataDir, dotfilesRoot, "vim", "vimrc", ".vimrc")
+	action2, intermediatePath2 := setupWorkingDeployment(t, fs, dataDir, dotfilesRoot, "git", "gitconfig", ".gitconfig")
+	action3, _ := setupWorkingDeployment(t, fs, dataDir, dotfilesRoot, "zsh", "zshrc", ".zshrc")
+
+	// Break first two by removing source files
+	err := fs.Remove(action1.Source)
+	require.NoError(t, err)
+	err = fs.Remove(action2.Source)
+	require.NoError(t, err)
+
+	// Detect dangling links
+	pather := &testutil.MockPaths{
+		DataDirPath:      dataDir,
+		DotfilesRootPath: dotfilesRoot,
+	}
+	detector := NewLinkDetector(fs, pather)
+	dangling, err := detector.DetectDanglingLinks([]types.Action{action1, action2, action3})
+	require.NoError(t, err)
+	assert.Len(t, dangling, 2, "should find 2 dangling links")
+
+	// Remove all dangling links
+	for _, dl := range dangling {
+		err := detector.RemoveDanglingLink(&dl)
+		assert.NoError(t, err)
+	}
+
+	// Verify removals
+	_, err = fs.Lstat(action1.Target)
+	if err == nil {
+		t.Errorf("first deployed symlink still exists at %s", action1.Target)
+	}
+	_, err = fs.Lstat(intermediatePath1)
+	if err == nil {
+		t.Errorf("first intermediate still exists at %s", intermediatePath1)
+	}
+
+	_, err = fs.Lstat(action2.Target)
+	if err == nil {
+		t.Errorf("second deployed symlink still exists at %s", action2.Target)
+	}
+	_, err = fs.Lstat(intermediatePath2)
+	if err == nil {
+		t.Errorf("second intermediate still exists at %s", intermediatePath2)
+	}
+
+	// Third deployment should still exist
+	info, err := fs.Lstat(action3.Target)
+	require.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink != 0, "third deployed symlink should still exist")
+}

--- a/pkg/state/dangling_test.go
+++ b/pkg/state/dangling_test.go
@@ -1,0 +1,216 @@
+package state
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/arthur-debert/dodot/pkg/testutil"
+	"github.com/arthur-debert/dodot/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupWorkingDeployment creates a complete, working symlink deployment
+func setupWorkingDeployment(t *testing.T, fs types.FS, dataDir, dotfilesRoot, pack, sourceFile, targetFile string) (types.Action, string) {
+	t.Helper()
+
+	// Create the action
+	sourcePath := filepath.Join(dotfilesRoot, pack, sourceFile)
+	targetPath := filepath.Join("home", targetFile)
+
+	action := types.Action{
+		Type:   types.ActionTypeLink,
+		Source: sourcePath,
+		Target: targetPath,
+		Pack:   pack,
+	}
+
+	// Get intermediate path using the API
+	pather := &testutil.MockPaths{
+		DataDirPath:      dataDir,
+		DotfilesRootPath: dotfilesRoot,
+	}
+	intermediatePath, err := action.GetDeployedSymlinkPath(pather)
+	require.NoError(t, err)
+
+	// Create a complete working deployment:
+	// 1. Source file exists
+	testutil.CreateFileT(t, fs, sourcePath, "file content")
+
+	// 2. Intermediate symlink points to source
+	testutil.CreateDirT(t, fs, filepath.Dir(intermediatePath))
+	testutil.CreateSymlinkT(t, fs, sourcePath, intermediatePath)
+
+	// 3. Deployed symlink points to intermediate
+	testutil.CreateSymlinkT(t, fs, intermediatePath, targetPath)
+
+	return action, intermediatePath
+}
+
+func TestDetectDanglingLinks(t *testing.T) {
+	tests := []struct {
+		name     string
+		breakage func(t *testing.T, fs types.FS, action types.Action, intermediatePath string)
+		expected []DanglingLink
+	}{
+		{
+			name: "no dangling links - all healthy",
+			breakage: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string) {
+				// Don't break anything - deployment should be healthy
+			},
+			expected: []DanglingLink{},
+		},
+		{
+			name: "source file missing",
+			breakage: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string) {
+				// Remove the source file to create a dangling link
+				err := fs.Remove(action.Source)
+				require.NoError(t, err)
+			},
+			expected: []DanglingLink{
+				{
+					Problem: "source file missing",
+					Pack:    "vim",
+				},
+			},
+		},
+		{
+			name: "intermediate symlink missing",
+			breakage: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string) {
+				// Remove the intermediate symlink
+				err := fs.Remove(intermediatePath)
+				require.NoError(t, err)
+			},
+			expected: []DanglingLink{
+				{
+					Problem: "intermediate symlink missing",
+					Pack:    "vim",
+				},
+			},
+		},
+		{
+			name: "intermediate is not a symlink",
+			breakage: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string) {
+				// Replace intermediate symlink with a regular file
+				err := fs.Remove(intermediatePath)
+				require.NoError(t, err)
+				testutil.CreateFileT(t, fs, intermediatePath, "not a symlink")
+			},
+			expected: []DanglingLink{
+				{
+					Problem: "intermediate is not a symlink",
+					Pack:    "vim",
+				},
+			},
+		},
+		{
+			name: "intermediate points to wrong file",
+			breakage: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string) {
+				// Create a wrong file and make intermediate point to it
+				wrongPath := filepath.Join(filepath.Dir(action.Source), "wrong")
+				testutil.CreateFileT(t, fs, wrongPath, "wrong file")
+
+				// Re-create intermediate pointing to wrong file
+				err := fs.Remove(intermediatePath)
+				require.NoError(t, err)
+				testutil.CreateSymlinkT(t, fs, wrongPath, intermediatePath)
+			},
+			expected: []DanglingLink{
+				{
+					Problem: "intermediate points to wrong file",
+					Pack:    "vim",
+				},
+			},
+		},
+		{
+			name: "deployed symlink points elsewhere - not managed by us",
+			breakage: func(t *testing.T, fs types.FS, action types.Action, intermediatePath string) {
+				// Make deployed symlink point to a different file
+				otherFile := filepath.Join("home", "other-vimrc")
+				testutil.CreateFileT(t, fs, otherFile, "other config")
+
+				// Re-create deployed symlink pointing elsewhere
+				err := fs.Remove(action.Target)
+				require.NoError(t, err)
+				testutil.CreateSymlinkT(t, fs, otherFile, action.Target)
+			},
+			expected: []DanglingLink{}, // Not managed by us, so not dangling
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			fs := testutil.NewTestFS()
+			dataDir := filepath.Join("data", "dodot")
+			dotfilesRoot := filepath.Join("dotfiles")
+
+			// Create a working deployment
+			action, intermediatePath := setupWorkingDeployment(t, fs, dataDir, dotfilesRoot, "vim", "vimrc", ".vimrc")
+
+			// Break it according to test case
+			tt.breakage(t, fs, action, intermediatePath)
+
+			// Test detection
+			pather := &testutil.MockPaths{
+				DataDirPath:      dataDir,
+				DotfilesRootPath: dotfilesRoot,
+			}
+			detector := NewLinkDetector(fs, pather)
+			dangling, err := detector.DetectDanglingLinks([]types.Action{action})
+			require.NoError(t, err)
+
+			// Verify
+			assert.Len(t, dangling, len(tt.expected))
+			for i, expected := range tt.expected {
+				if i < len(dangling) {
+					assert.Equal(t, expected.Problem, dangling[i].Problem)
+					assert.Equal(t, expected.Pack, dangling[i].Pack)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectMultipleDanglingLinks(t *testing.T) {
+	// Setup
+	fs := testutil.NewTestFS()
+	dataDir := filepath.Join("data", "dodot")
+	dotfilesRoot := filepath.Join("dotfiles")
+
+	// Create two working deployments
+	action1, _ := setupWorkingDeployment(t, fs, dataDir, dotfilesRoot, "vim", "vimrc", ".vimrc")
+	action2, intermediatePath2 := setupWorkingDeployment(t, fs, dataDir, dotfilesRoot, "git", "gitconfig", ".gitconfig")
+
+	// Break them in different ways
+	// 1. Remove source file for vim
+	err := fs.Remove(action1.Source)
+	require.NoError(t, err)
+
+	// 2. Remove intermediate symlink for git
+	err = fs.Remove(intermediatePath2)
+	require.NoError(t, err)
+
+	// Test detection
+	pather := &testutil.MockPaths{
+		DataDirPath:      dataDir,
+		DotfilesRootPath: dotfilesRoot,
+	}
+	detector := NewLinkDetector(fs, pather)
+	dangling, err := detector.DetectDanglingLinks([]types.Action{action1, action2})
+	require.NoError(t, err)
+
+	// Should find both issues
+	assert.Len(t, dangling, 2)
+
+	// Check specific problems (order might vary)
+	problems := map[string]string{}
+	for _, d := range dangling {
+		problems[d.Pack] = d.Problem
+	}
+
+	assert.Equal(t, "source file missing", problems["vim"])
+	assert.Equal(t, "intermediate symlink missing", problems["git"])
+}
+
+// TestRemoveDanglingLink will be added in a separate commit for Release 1

--- a/pkg/state/doc.go
+++ b/pkg/state/doc.go
@@ -1,0 +1,3 @@
+// Package state provides functionality for managing and detecting the state of dodot deployments.
+// This includes detecting dangling symlinks, orphaned intermediate links, and other state-related operations.
+package state

--- a/pkg/state/integration.go
+++ b/pkg/state/integration.go
@@ -1,0 +1,55 @@
+package state
+
+import (
+	"github.com/arthur-debert/dodot/pkg/types"
+)
+
+// DetectDanglingFromStatus creates DanglingLink objects from actions with error status
+// This provides an alternative way to detect dangling links using the existing status checking
+func DetectDanglingFromStatus(actions []types.Action, fs types.FS, paths types.Pather) ([]DanglingLink, error) {
+	var dangling []DanglingLink
+
+	for _, action := range actions {
+		if action.Type != types.ActionTypeLink {
+			continue
+		}
+
+		status, err := action.CheckStatus(fs, paths)
+		if err != nil {
+			continue
+		}
+
+		// Only interested in error states with details
+		if status.State != types.StatusStateError || status.ErrorDetails == nil {
+			continue
+		}
+
+		// Convert error details to dangling link
+		dl := DanglingLink{
+			DeployedPath:     status.ErrorDetails.DeployedPath,
+			IntermediatePath: status.ErrorDetails.IntermediatePath,
+			SourcePath:       status.ErrorDetails.SourcePath,
+			Pack:             action.Pack,
+		}
+
+		// Map error type to problem description
+		switch status.ErrorDetails.ErrorType {
+		case "missing_source":
+			dl.Problem = "source file missing"
+		case "missing_intermediate":
+			dl.Problem = "intermediate symlink missing"
+		case "invalid_intermediate":
+			dl.Problem = "intermediate is not a symlink"
+		case "wrong_intermediate_target":
+			dl.Problem = "intermediate points to wrong file"
+		case "unreadable_intermediate":
+			dl.Problem = "cannot read intermediate symlink"
+		default:
+			dl.Problem = "unknown error"
+		}
+
+		dangling = append(dangling, dl)
+	}
+
+	return dangling, nil
+}

--- a/pkg/testutil/synthfs_helpers.go
+++ b/pkg/testutil/synthfs_helpers.go
@@ -31,3 +31,28 @@ func CreateDirT(t *testing.T, fs types.FS, path string) {
 		t.Fatalf("Failed to create directory %s: %v", path, err)
 	}
 }
+
+// CreateSymlinkT creates a symlink in the given synthfs filesystem
+func CreateSymlinkT(t *testing.T, fs types.FS, target, link string) {
+	t.Helper()
+
+	// Create parent directories if needed
+	dir := filepath.Dir(link)
+	if err := fs.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("Failed to create parent directories for %s: %v", link, err)
+	}
+
+	// Create the symlink
+	if err := fs.Symlink(target, link); err != nil {
+		t.Fatalf("Failed to create symlink %s -> %s: %v", link, target, err)
+	}
+}
+
+// IsNotExist returns true if the error indicates a file does not exist
+func IsNotExist(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Check for the standard not exist error
+	return err.Error() == "file does not exist"
+}

--- a/pkg/types/action_status.go
+++ b/pkg/types/action_status.go
@@ -62,6 +62,12 @@ func (a *Action) checkSymlinkStatus(fs FS, paths Pather) (Status, error) {
 		return Status{
 			State:   StatusStateError,
 			Message: fmt.Sprintf("linked to %s (broken - intermediate symlink missing)", filepath.Base(a.Target)),
+			ErrorDetails: &StatusErrorDetails{
+				ErrorType:        "missing_intermediate",
+				DeployedPath:     a.Target,
+				IntermediatePath: intermediatePath,
+				SourcePath:       a.Source,
+			},
 		}, nil
 	}
 
@@ -71,6 +77,12 @@ func (a *Action) checkSymlinkStatus(fs FS, paths Pather) (Status, error) {
 		return Status{
 			State:   StatusStateError,
 			Message: fmt.Sprintf("linked to %s (broken - intermediate is not a symlink)", filepath.Base(a.Target)),
+			ErrorDetails: &StatusErrorDetails{
+				ErrorType:        "invalid_intermediate",
+				DeployedPath:     a.Target,
+				IntermediatePath: intermediatePath,
+				SourcePath:       a.Source,
+			},
 		}, nil
 	}
 
@@ -81,6 +93,12 @@ func (a *Action) checkSymlinkStatus(fs FS, paths Pather) (Status, error) {
 		return Status{
 			State:   StatusStateError,
 			Message: fmt.Sprintf("linked to %s (broken - cannot read intermediate symlink)", filepath.Base(a.Target)),
+			ErrorDetails: &StatusErrorDetails{
+				ErrorType:        "unreadable_intermediate",
+				DeployedPath:     a.Target,
+				IntermediatePath: intermediatePath,
+				SourcePath:       a.Source,
+			},
 		}, nil
 	}
 
@@ -99,6 +117,12 @@ func (a *Action) checkSymlinkStatus(fs FS, paths Pather) (Status, error) {
 			return Status{
 				State:   StatusStateError,
 				Message: fmt.Sprintf("linked to %s (broken - intermediate points to wrong file)", filepath.Base(a.Target)),
+				ErrorDetails: &StatusErrorDetails{
+					ErrorType:        "wrong_intermediate_target",
+					DeployedPath:     a.Target,
+					IntermediatePath: intermediatePath,
+					SourcePath:       a.Source,
+				},
 			}, nil
 		}
 	}
@@ -109,6 +133,12 @@ func (a *Action) checkSymlinkStatus(fs FS, paths Pather) (Status, error) {
 		return Status{
 			State:   StatusStateError,
 			Message: fmt.Sprintf("linked to %s (broken - source file missing)", filepath.Base(a.Target)),
+			ErrorDetails: &StatusErrorDetails{
+				ErrorType:        "missing_source",
+				DeployedPath:     a.Target,
+				IntermediatePath: intermediatePath,
+				SourcePath:       a.Source,
+			},
 		}, nil
 	}
 

--- a/pkg/types/status.go
+++ b/pkg/types/status.go
@@ -32,4 +32,22 @@ type Status struct {
 
 	// Timestamp is when the action was last executed (optional)
 	Timestamp *time.Time
+
+	// ErrorDetails provides additional information about errors (optional)
+	ErrorDetails *StatusErrorDetails
+}
+
+// StatusErrorDetails provides detailed information about status errors
+type StatusErrorDetails struct {
+	// ErrorType describes the type of error (e.g., "missing_source", "missing_intermediate")
+	ErrorType string
+
+	// DeployedPath is the user-facing path that has an issue
+	DeployedPath string
+
+	// IntermediatePath is the dodot state path involved
+	IntermediatePath string
+
+	// SourcePath is the source file path
+	SourcePath string
 }


### PR DESCRIPTION
## Summary
- Implements core dangling link detection functionality in `pkg/state/`
- Adds safe link removal with ownership verification
- Provides foundation for handling source file changes in dodot deployments

Part of #592 - Handle changes in source files after deployment

## Test plan
- [x] Run `go test ./pkg/state/...` - all tests pass
- [x] Run `./scripts/lint` - no issues
- [x] Run `./scripts/test` - all tests pass
- [ ] Manual testing: deploy a symlink, remove source file, verify detection works
- [ ] Manual testing: verify removal only affects dodot-managed symlinks

## Changes
- Added `pkg/state/` package with dangling link detection and removal
- Enhanced `types.Status` with `StatusErrorDetails` for richer error information
- Added test helpers for symlink creation in `pkg/testutil/synthfs_helpers.go`
- Documentation updates in `docs/guides/50_data-storage.txxt`

## Related Issues
Closes #593

🤖 Generated with [Claude Code](https://claude.ai/code)