### PR TITLE
Release 2: Integrate dangling link cleanup with deploy

### DIFF
--- a/pkg/config/central.go
+++ b/pkg/config/central.go
@@ -8,10 +8,11 @@ import (
 
 // Security holds security-related configuration
 type Security struct {
-	ProtectedPaths    map[string]bool
-	AllowHomeSymlinks bool
-	BackupExisting    bool
-	EnableRollback    bool
+	ProtectedPaths       map[string]bool
+	AllowHomeSymlinks    bool
+	BackupExisting       bool
+	EnableRollback       bool
+	CleanupDanglingLinks bool // Controls whether to remove dangling links during deploy
 }
 
 // Patterns holds various ignore and exclude patterns
@@ -110,9 +111,10 @@ func Default() *Config {
 				".kube/config":         true,
 				".docker/config.json":  true,
 			},
-			AllowHomeSymlinks: false,
-			BackupExisting:    true,
-			EnableRollback:    true,
+			AllowHomeSymlinks:    false,
+			BackupExisting:       true,
+			EnableRollback:       true,
+			CleanupDanglingLinks: true, // Default to cleaning up dangling links
 		},
 		Patterns: Patterns{
 			PackIgnore: []string{

--- a/pkg/core/direct_executor_dangling_test.go
+++ b/pkg/core/direct_executor_dangling_test.go
@@ -1,0 +1,374 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arthur-debert/dodot/pkg/config"
+	"github.com/arthur-debert/dodot/pkg/paths"
+	"github.com/arthur-debert/dodot/pkg/testutil"
+	"github.com/arthur-debert/dodot/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectExecutor_CleanupDanglingLinks(t *testing.T) {
+	tests := []struct {
+		name                string
+		setupDangling       func(t *testing.T, tempDir, dotfilesRoot, homeDir string) types.Action
+		cleanupEnabled      bool
+		expectCleanup       bool
+		expectDeploySuccess bool
+	}{
+		{
+			name: "cleanup enabled - removes dangling link before deploy",
+			setupDangling: func(t *testing.T, tempDir, dotfilesRoot, homeDir string) types.Action {
+				// Create a deployed symlink that will become dangling
+				pack := "vim"
+				sourceFile := "vimrc"
+				targetFile := ".vimrc"
+
+				// Create pack directory
+				testutil.CreateDir(t, dotfilesRoot, pack)
+
+				sourcePath := filepath.Join(dotfilesRoot, pack, sourceFile)
+				targetPath := filepath.Join(homeDir, targetFile)
+				dataDir := filepath.Join(homeDir, ".local", "share", "dodot")
+				intermediatePath := filepath.Join(dataDir, "deployed", "symlink", targetFile)
+
+				// Create the initial deployment
+				testutil.CreateFile(t, dotfilesRoot, filepath.Join(pack, sourceFile), "vim config")
+				testutil.CreateDir(t, dataDir, "deployed/symlink")
+				testutil.CreateSymlink(t, sourcePath, intermediatePath)
+				testutil.CreateSymlink(t, intermediatePath, targetPath)
+
+				// Remove source to make it dangling
+				require.NoError(t, os.Remove(sourcePath))
+
+				// Re-create source for new deployment
+				testutil.CreateFile(t, dotfilesRoot, filepath.Join(pack, sourceFile), "new vim config")
+
+				// Return action for the same file (will be re-deployed)
+				return types.Action{
+					Type:        types.ActionTypeLink,
+					Source:      sourcePath,
+					Target:      targetPath,
+					Pack:        pack,
+					PowerUpName: "symlink",
+					Description: "Link vimrc",
+				}
+			},
+			cleanupEnabled:      true,
+			expectCleanup:       true,
+			expectDeploySuccess: true,
+		},
+		{
+			name: "cleanup disabled - deployment succeeds with force behavior",
+			setupDangling: func(t *testing.T, tempDir, dotfilesRoot, homeDir string) types.Action {
+				pack := "git"
+				sourceFile := "gitconfig"
+				targetFile := ".gitconfig"
+
+				// Create pack directory
+				testutil.CreateDir(t, dotfilesRoot, pack)
+
+				sourcePath := filepath.Join(dotfilesRoot, pack, sourceFile)
+				targetPath := filepath.Join(homeDir, targetFile)
+				dataDir := filepath.Join(homeDir, ".local", "share", "dodot")
+				intermediatePath := filepath.Join(dataDir, "deployed", "symlink", targetFile)
+
+				// Create the initial deployment
+				testutil.CreateFile(t, dotfilesRoot, filepath.Join(pack, sourceFile), "git config")
+				testutil.CreateDir(t, dataDir, "deployed/symlink")
+				testutil.CreateSymlink(t, sourcePath, intermediatePath)
+				testutil.CreateSymlink(t, intermediatePath, targetPath)
+
+				// Remove source to make it dangling
+				require.NoError(t, os.Remove(sourcePath))
+
+				// Create new source file
+				newSourceFile := "gitconfig-new"
+				testutil.CreateFile(t, dotfilesRoot, filepath.Join(pack, newSourceFile), "new git config")
+
+				// Deploy same target from different source
+				return types.Action{
+					Type:        types.ActionTypeLink,
+					Source:      filepath.Join(dotfilesRoot, pack, newSourceFile),
+					Target:      targetPath,
+					Pack:        pack,
+					PowerUpName: "symlink",
+					Description: "Link gitconfig-new",
+				}
+			},
+			cleanupEnabled:      false,
+			expectCleanup:       false,
+			expectDeploySuccess: true, // DirectExecutor will handle the conflict
+		},
+		{
+			name: "no dangling links - normal deploy",
+			setupDangling: func(t *testing.T, tempDir, dotfilesRoot, homeDir string) types.Action {
+				// No dangling setup, just return action
+				pack := "zsh"
+				sourceFile := "zshrc"
+				targetFile := ".zshrc"
+
+				// Create pack directory and source file
+				testutil.CreateDir(t, dotfilesRoot, pack)
+				testutil.CreateFile(t, dotfilesRoot, filepath.Join(pack, sourceFile), "zsh config")
+
+				sourcePath := filepath.Join(dotfilesRoot, pack, sourceFile)
+				targetPath := filepath.Join(homeDir, targetFile)
+
+				return types.Action{
+					Type:        types.ActionTypeLink,
+					Source:      sourcePath,
+					Target:      targetPath,
+					Pack:        pack,
+					PowerUpName: "symlink",
+					Description: "Link zshrc",
+				}
+			},
+			cleanupEnabled:      true,
+			expectCleanup:       false,
+			expectDeploySuccess: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test environment
+			tempDir := testutil.TempDir(t, "direct-executor-dangling")
+			dotfilesDir := filepath.Join(tempDir, "dotfiles")
+			homeDir := filepath.Join(tempDir, "home")
+
+			testutil.CreateDir(t, tempDir, "dotfiles")
+			testutil.CreateDir(t, tempDir, "home")
+			testutil.CreateDir(t, homeDir, ".local/share/dodot")
+
+			t.Setenv("HOME", homeDir)
+			t.Setenv("DOTFILES_ROOT", dotfilesDir)
+			t.Setenv("DODOT_DATA_DIR", filepath.Join(homeDir, ".local", "share", "dodot"))
+
+			// Setup dangling link scenario and get action
+			action := tt.setupDangling(t, tempDir, dotfilesDir, homeDir)
+
+			// Create paths
+			p, err := paths.New(dotfilesDir)
+			require.NoError(t, err)
+
+			// Create config with cleanup flag
+			cfg := config.Default()
+			cfg.Security.CleanupDanglingLinks = tt.cleanupEnabled
+
+			// Create executor
+			executor := NewDirectExecutor(&DirectExecutorOptions{
+				Paths:             p,
+				DryRun:            false,
+				Force:             false,
+				AllowHomeSymlinks: true,
+				Config:            cfg,
+			})
+
+			// Execute action
+			results, err := executor.ExecuteActions([]types.Action{action})
+
+			if tt.expectDeploySuccess {
+				require.NoError(t, err)
+				require.Len(t, results, 1)
+				assert.Equal(t, types.StatusReady, results[0].Status)
+
+				// Verify the new deployment exists
+				info, err := os.Lstat(action.Target)
+				require.NoError(t, err)
+				assert.True(t, info.Mode()&os.ModeSymlink != 0)
+			} else {
+				// Should fail
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestDirectExecutor_CleanupDanglingLinks_MultipleActions(t *testing.T) {
+	// Setup test environment
+	tempDir := testutil.TempDir(t, "direct-executor-dangling-multi")
+	dotfilesDir := filepath.Join(tempDir, "dotfiles")
+	homeDir := filepath.Join(tempDir, "home")
+	dataDir := filepath.Join(homeDir, ".local", "share", "dodot")
+
+	testutil.CreateDir(t, tempDir, "dotfiles")
+	testutil.CreateDir(t, tempDir, "home")
+	testutil.CreateDir(t, homeDir, ".local/share/dodot")
+	testutil.CreateDir(t, dataDir, "deployed/symlink")
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("DOTFILES_ROOT", dotfilesDir)
+	t.Setenv("DODOT_DATA_DIR", dataDir)
+
+	// Create multiple packs
+	testutil.CreateDir(t, dotfilesDir, "vim")
+	testutil.CreateDir(t, dotfilesDir, "git")
+	testutil.CreateDir(t, dotfilesDir, "zsh")
+
+	// Create multiple dangling links
+	actions := []types.Action{}
+
+	// First dangling link
+	sourcePath1 := filepath.Join(dotfilesDir, "vim", "vimrc")
+	targetPath1 := filepath.Join(homeDir, ".vimrc")
+	intermediatePath1 := filepath.Join(dataDir, "deployed", "symlink", ".vimrc")
+
+	testutil.CreateFile(t, dotfilesDir, "vim/vimrc", "vim config")
+	testutil.CreateSymlink(t, sourcePath1, intermediatePath1)
+	testutil.CreateSymlink(t, intermediatePath1, targetPath1)
+	require.NoError(t, os.Remove(sourcePath1))
+
+	// Re-create source for new deployment
+	testutil.CreateFile(t, dotfilesDir, "vim/vimrc", "new vim config")
+	actions = append(actions, types.Action{
+		Type:        types.ActionTypeLink,
+		Source:      sourcePath1,
+		Target:      targetPath1,
+		Pack:        "vim",
+		PowerUpName: "symlink",
+	})
+
+	// Second dangling link
+	sourcePath2 := filepath.Join(dotfilesDir, "git", "gitconfig")
+	targetPath2 := filepath.Join(homeDir, ".gitconfig")
+	intermediatePath2 := filepath.Join(dataDir, "deployed", "symlink", ".gitconfig")
+
+	testutil.CreateFile(t, dotfilesDir, "git/gitconfig", "git config")
+	testutil.CreateSymlink(t, sourcePath2, intermediatePath2)
+	testutil.CreateSymlink(t, intermediatePath2, targetPath2)
+	require.NoError(t, os.Remove(sourcePath2))
+
+	// Re-create source for new deployment
+	testutil.CreateFile(t, dotfilesDir, "git/gitconfig", "new git config")
+	actions = append(actions, types.Action{
+		Type:        types.ActionTypeLink,
+		Source:      sourcePath2,
+		Target:      targetPath2,
+		Pack:        "git",
+		PowerUpName: "symlink",
+	})
+
+	// Third action - no dangling link
+	sourcePath3 := filepath.Join(dotfilesDir, "zsh", "zshrc")
+	targetPath3 := filepath.Join(homeDir, ".zshrc")
+	testutil.CreateFile(t, dotfilesDir, "zsh/zshrc", "zsh config")
+	actions = append(actions, types.Action{
+		Type:        types.ActionTypeLink,
+		Source:      sourcePath3,
+		Target:      targetPath3,
+		Pack:        "zsh",
+		PowerUpName: "symlink",
+	})
+
+	// Create paths
+	p, err := paths.New(dotfilesDir)
+	require.NoError(t, err)
+
+	// Create executor with cleanup enabled
+	cfg := config.Default()
+	cfg.Security.CleanupDanglingLinks = true
+
+	executor := NewDirectExecutor(&DirectExecutorOptions{
+		Paths:             p,
+		DryRun:            false,
+		Force:             false,
+		AllowHomeSymlinks: true,
+		Config:            cfg,
+	})
+
+	// Execute actions
+	results, err := executor.ExecuteActions(actions)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	// All deployments should succeed
+	for i, result := range results {
+		assert.Equal(t, types.StatusReady, result.Status, "Action %d failed", i)
+	}
+
+	// Verify all symlinks exist and point to correct locations
+	for _, action := range actions {
+		info, err := os.Lstat(action.Target)
+		require.NoError(t, err)
+		assert.True(t, info.Mode()&os.ModeSymlink != 0)
+	}
+}
+
+func TestDirectExecutor_CleanupDanglingLinks_DryRun(t *testing.T) {
+	// Setup test environment
+	tempDir := testutil.TempDir(t, "direct-executor-dangling-dryrun")
+	dotfilesDir := filepath.Join(tempDir, "dotfiles")
+	homeDir := filepath.Join(tempDir, "home")
+	dataDir := filepath.Join(homeDir, ".local", "share", "dodot")
+
+	testutil.CreateDir(t, tempDir, "dotfiles")
+	testutil.CreateDir(t, tempDir, "home")
+	testutil.CreateDir(t, homeDir, ".local/share/dodot")
+	testutil.CreateDir(t, dataDir, "deployed/symlink")
+	testutil.CreateDir(t, dotfilesDir, "vim")
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("DOTFILES_ROOT", dotfilesDir)
+	t.Setenv("DODOT_DATA_DIR", dataDir)
+
+	// Create a dangling link
+	sourcePath := filepath.Join(dotfilesDir, "vim", "vimrc")
+	targetPath := filepath.Join(homeDir, ".vimrc")
+	intermediatePath := filepath.Join(dataDir, "deployed", "symlink", ".vimrc")
+
+	testutil.CreateFile(t, dotfilesDir, "vim/vimrc", "vim config")
+	testutil.CreateSymlink(t, sourcePath, intermediatePath)
+	testutil.CreateSymlink(t, intermediatePath, targetPath)
+	require.NoError(t, os.Remove(sourcePath))
+
+	// Re-create source for new deployment
+	testutil.CreateFile(t, dotfilesDir, "vim/vimrc", "new vim config")
+
+	action := types.Action{
+		Type:        types.ActionTypeLink,
+		Source:      sourcePath,
+		Target:      targetPath,
+		Pack:        "vim",
+		PowerUpName: "symlink",
+	}
+
+	// Create paths
+	p, err := paths.New(dotfilesDir)
+	require.NoError(t, err)
+
+	// Create executor with cleanup enabled but dry run
+	cfg := config.Default()
+	cfg.Security.CleanupDanglingLinks = true
+
+	executor := NewDirectExecutor(&DirectExecutorOptions{
+		Paths:             p,
+		DryRun:            true, // Dry run mode
+		Force:             false,
+		AllowHomeSymlinks: true,
+		Config:            cfg,
+	})
+
+	// Execute action in dry run
+	results, err := executor.ExecuteActions([]types.Action{action})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	// Dry run should report what would be done
+	assert.Equal(t, types.StatusReady, results[0].Status)
+
+	// Dangling link should still exist (not cleaned up in dry run)
+	info, err := os.Lstat(targetPath)
+	require.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink != 0)
+
+	// And it should still be dangling
+	target, err := os.Readlink(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, intermediatePath, target)
+}

--- a/pkg/core/pack_status_dangling_test.go
+++ b/pkg/core/pack_status_dangling_test.go
@@ -1,0 +1,279 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arthur-debert/dodot/pkg/filesystem"
+	"github.com/arthur-debert/dodot/pkg/paths"
+	"github.com/arthur-debert/dodot/pkg/testutil"
+	"github.com/arthur-debert/dodot/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPackStatus_DanglingLinks(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupDangling  func(t *testing.T, tempDir, dotfilesRoot, homeDir string) types.Action
+		expectedStatus string
+		expectedInMsg  string
+	}{
+		{
+			name: "detects missing source file",
+			setupDangling: func(t *testing.T, tempDir, dotfilesRoot, homeDir string) types.Action {
+				pack := "vim"
+				sourceFile := "vimrc"
+				targetFile := ".vimrc"
+				dataDir := filepath.Join(homeDir, ".local", "share", "dodot")
+
+				// Create pack directory
+				testutil.CreateDir(t, dotfilesRoot, pack)
+
+				sourcePath := filepath.Join(dotfilesRoot, pack, sourceFile)
+				targetPath := filepath.Join(homeDir, targetFile)
+				intermediatePath := filepath.Join(dataDir, "deployed", "symlink", targetFile)
+
+				// Create the initial deployment
+				testutil.CreateFile(t, dotfilesRoot, filepath.Join(pack, sourceFile), "vim config")
+				testutil.CreateDir(t, dataDir, "deployed/symlink")
+				testutil.CreateSymlink(t, sourcePath, intermediatePath)
+				testutil.CreateSymlink(t, intermediatePath, targetPath)
+
+				// Remove source to make it dangling
+				require.NoError(t, os.Remove(sourcePath))
+
+				// Return action for status check
+				return types.Action{
+					Type:        types.ActionTypeLink,
+					Source:      sourcePath,
+					Target:      targetPath,
+					Pack:        pack,
+					PowerUpName: "symlink",
+					Description: "Link vimrc",
+				}
+			},
+			expectedStatus: "warning",
+			expectedInMsg:  "dangling: source file removed",
+		},
+		{
+			name: "detects missing intermediate link",
+			setupDangling: func(t *testing.T, tempDir, dotfilesRoot, homeDir string) types.Action {
+				pack := "git"
+				sourceFile := "gitconfig"
+				targetFile := ".gitconfig"
+				dataDir := filepath.Join(homeDir, ".local", "share", "dodot")
+
+				// Create pack directory
+				testutil.CreateDir(t, dotfilesRoot, pack)
+
+				sourcePath := filepath.Join(dotfilesRoot, pack, sourceFile)
+				targetPath := filepath.Join(homeDir, targetFile)
+				intermediatePath := filepath.Join(dataDir, "deployed", "symlink", targetFile)
+
+				// Create the initial deployment
+				testutil.CreateFile(t, dotfilesRoot, filepath.Join(pack, sourceFile), "git config")
+				testutil.CreateDir(t, dataDir, "deployed/symlink")
+				testutil.CreateSymlink(t, sourcePath, intermediatePath)
+				testutil.CreateSymlink(t, intermediatePath, targetPath)
+
+				// Remove intermediate to make it dangling
+				require.NoError(t, os.Remove(intermediatePath))
+
+				// Return action for status check
+				return types.Action{
+					Type:        types.ActionTypeLink,
+					Source:      sourcePath,
+					Target:      targetPath,
+					Pack:        pack,
+					PowerUpName: "symlink",
+					Description: "Link gitconfig",
+				}
+			},
+			expectedStatus: "warning",
+			expectedInMsg:  "dangling: intermediate link missing",
+		},
+		{
+			name: "normal deployed link shows as success",
+			setupDangling: func(t *testing.T, tempDir, dotfilesRoot, homeDir string) types.Action {
+				pack := "zsh"
+				sourceFile := "zshrc"
+				targetFile := ".zshrc"
+				dataDir := filepath.Join(homeDir, ".local", "share", "dodot")
+
+				// Create pack directory
+				testutil.CreateDir(t, dotfilesRoot, pack)
+
+				sourcePath := filepath.Join(dotfilesRoot, pack, sourceFile)
+				targetPath := filepath.Join(homeDir, targetFile)
+				intermediatePath := filepath.Join(dataDir, "deployed", "symlink", targetFile)
+
+				// Create a proper deployment
+				testutil.CreateFile(t, dotfilesRoot, filepath.Join(pack, sourceFile), "zsh config")
+				testutil.CreateDir(t, dataDir, "deployed/symlink")
+				testutil.CreateSymlink(t, sourcePath, intermediatePath)
+				testutil.CreateSymlink(t, intermediatePath, targetPath)
+
+				// Return action for status check
+				return types.Action{
+					Type:        types.ActionTypeLink,
+					Source:      sourcePath,
+					Target:      targetPath,
+					Pack:        pack,
+					PowerUpName: "symlink",
+					Description: "Link zshrc",
+				}
+			},
+			expectedStatus: "success",
+			expectedInMsg:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test environment
+			tempDir := testutil.TempDir(t, "pack-status-dangling")
+			dotfilesRoot := filepath.Join(tempDir, "dotfiles")
+			homeDir := filepath.Join(tempDir, "home")
+
+			testutil.CreateDir(t, tempDir, "dotfiles")
+			testutil.CreateDir(t, tempDir, "home")
+			testutil.CreateDir(t, homeDir, ".local/share/dodot")
+
+			t.Setenv("HOME", homeDir)
+			t.Setenv("DOTFILES_ROOT", dotfilesRoot)
+			t.Setenv("DODOT_DATA_DIR", filepath.Join(homeDir, ".local", "share", "dodot"))
+
+			// Setup dangling link scenario and get action
+			action := tt.setupDangling(t, tempDir, dotfilesRoot, homeDir)
+
+			// Create paths
+			p, err := paths.New(dotfilesRoot)
+			require.NoError(t, err)
+
+			// Create filesystem
+			fs := filesystem.NewOS()
+
+			// Get display status for the action
+			displayFile, err := getActionDisplayStatus(action, fs, p)
+			require.NoError(t, err)
+
+			// Verify status
+			assert.Equal(t, tt.expectedStatus, displayFile.Status)
+
+			// Verify message contains expected text
+			if tt.expectedInMsg != "" {
+				assert.Contains(t, displayFile.Message, tt.expectedInMsg)
+			}
+		})
+	}
+}
+
+func TestGetMultiPackStatus_WithDanglingLinks(t *testing.T) {
+	// Setup test environment
+	tempDir := testutil.TempDir(t, "multi-pack-status-dangling")
+	dotfilesRoot := filepath.Join(tempDir, "dotfiles")
+	homeDir := filepath.Join(tempDir, "home")
+	dataDir := filepath.Join(homeDir, ".local", "share", "dodot")
+
+	testutil.CreateDir(t, tempDir, "dotfiles")
+	testutil.CreateDir(t, tempDir, "home")
+	testutil.CreateDir(t, homeDir, ".local/share/dodot")
+	testutil.CreateDir(t, dataDir, "deployed/symlink")
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("DOTFILES_ROOT", dotfilesRoot)
+	t.Setenv("DODOT_DATA_DIR", dataDir)
+
+	// Create multiple packs
+	testutil.CreateDir(t, dotfilesRoot, "vim")
+	testutil.CreateDir(t, dotfilesRoot, "git")
+	testutil.CreateDir(t, dotfilesRoot, "zsh")
+
+	// Pack 1: vim with dangling link
+	// First create with different name to make intermediate point to non-existent file
+	vimOldSource := filepath.Join(dotfilesRoot, "vim", "vimrc.old")
+	vimTarget := filepath.Join(homeDir, ".vimrc")
+	vimIntermediate := filepath.Join(dataDir, "deployed", "symlink", ".vimrc")
+
+	// Create deployment pointing to vimrc.old
+	testutil.CreateFile(t, dotfilesRoot, "vim/vimrc.old", "old vim config")
+	testutil.CreateSymlink(t, vimOldSource, vimIntermediate)
+	testutil.CreateSymlink(t, vimIntermediate, vimTarget)
+
+	// Remove the old source
+	require.NoError(t, os.Remove(vimOldSource))
+
+	// Create new source file with standard name so triggers will pick it up
+	testutil.CreateFile(t, dotfilesRoot, "vim/vimrc", "new vim config")
+
+	// Pack 2: git - normal deployment
+	gitSource := filepath.Join(dotfilesRoot, "git", "gitconfig")
+	gitTarget := filepath.Join(homeDir, ".gitconfig")
+	gitIntermediate := filepath.Join(dataDir, "deployed", "symlink", ".gitconfig")
+
+	testutil.CreateFile(t, dotfilesRoot, "git/gitconfig", "git config")
+	testutil.CreateSymlink(t, gitSource, gitIntermediate)
+	testutil.CreateSymlink(t, gitIntermediate, gitTarget)
+
+	// Pack 3: zsh - not deployed
+	testutil.CreateFile(t, dotfilesRoot, "zsh/zshrc", "zsh config")
+
+	// Create packs
+	packs := []types.Pack{
+		{Name: "vim", Path: filepath.Join(dotfilesRoot, "vim")},
+		{Name: "git", Path: filepath.Join(dotfilesRoot, "git")},
+		{Name: "zsh", Path: filepath.Join(dotfilesRoot, "zsh")},
+	}
+
+	// Create paths and filesystem
+	p, err := paths.New(dotfilesRoot)
+	require.NoError(t, err)
+	fs := filesystem.NewOS()
+
+	// Get multi-pack status
+	result, err := GetMultiPackStatus(packs, "status", fs, p)
+	require.NoError(t, err)
+	require.Len(t, result.Packs, 3)
+
+	// Check vim pack - should have warning
+	vimPack := findPackByName(result.Packs, "vim")
+	require.NotNil(t, vimPack)
+	assert.Equal(t, "partial", vimPack.Status) // Pack with warnings
+
+	// Find the vimrc file
+	vimrcFile := findFileByPath(vimPack.Files, "vimrc")
+	require.NotNil(t, vimrcFile)
+	assert.Equal(t, "warning", vimrcFile.Status)
+	assert.Contains(t, vimrcFile.Message, "dangling")
+
+	// Check git pack - should be success
+	gitPack := findPackByName(result.Packs, "git")
+	require.NotNil(t, gitPack)
+	assert.Equal(t, "success", gitPack.Status)
+
+	// Check zsh pack - should be queue (not deployed yet)
+	zshPack := findPackByName(result.Packs, "zsh")
+	require.NotNil(t, zshPack)
+	assert.Equal(t, "queue", zshPack.Status)
+}
+
+// Helper functions
+func findPackByName(packs []types.DisplayPack, name string) *types.DisplayPack {
+	for i := range packs {
+		if packs[i].Name == name {
+			return &packs[i]
+		}
+	}
+	return nil
+}
+
+func findFileByPath(files []types.DisplayFile, path string) *types.DisplayFile {
+	for i := range files {
+		if files[i].Path == path {
+			return &files[i]
+		}
+	}
+	return nil
+}

--- a/pkg/core/pack_status_integration_test.go
+++ b/pkg/core/pack_status_integration_test.go
@@ -127,11 +127,11 @@ func TestGetPackStatus(t *testing.T) {
 				testutil.CreateDirT(t, fs, "home/user")
 				require.NoError(t, fs.Symlink(deployedPath, "home/user/.config"))
 			},
-			expectedStatus: "alert",
+			expectedStatus: "partial",
 			expectedFiles:  1,
 			checkResult: func(t *testing.T, result *types.DisplayPack) {
-				assert.Equal(t, "error", result.Files[0].Status)
-				assert.Contains(t, result.Files[0].Message, "broken")
+				assert.Equal(t, "warning", result.Files[0].Status)
+				assert.Contains(t, result.Files[0].Message, "dangling")
 				// Verify display path uses source basename
 				assert.Equal(t, "config", result.Files[0].Path)
 			},

--- a/pkg/types/results.go
+++ b/pkg/types/results.go
@@ -60,6 +60,7 @@ type DisplayFile struct {
 // GetPackStatus determines the pack-level status based on its files.
 // Following the aggregation rules from the design:
 // - If ANY file has ERROR status → Pack status is "alert"
+// - If ANY file has WARNING status (but no errors) → Pack status is "partial"
 // - If ALL files have SUCCESS status → Pack status is "success"
 // - Empty pack or mixed states → Pack status is "queue"
 func (dp *DisplayPack) GetPackStatus() string {
@@ -68,6 +69,7 @@ func (dp *DisplayPack) GetPackStatus() string {
 	}
 
 	hasError := false
+	hasWarning := false
 	allSuccess := true
 
 	for _, file := range dp.Files {
@@ -79,6 +81,9 @@ func (dp *DisplayPack) GetPackStatus() string {
 		if file.Status == "error" {
 			hasError = true
 		}
+		if file.Status == "warning" {
+			hasWarning = true
+		}
 		if file.Status != "success" {
 			allSuccess = false
 		}
@@ -86,6 +91,9 @@ func (dp *DisplayPack) GetPackStatus() string {
 
 	if hasError {
 		return "alert" // Will be displayed with ALERT styling
+	}
+	if hasWarning {
+		return "partial" // Has warnings but no errors
 	}
 	if allSuccess {
 		return "success"


### PR DESCRIPTION
## Summary
- Automatically detects and removes dangling links before deployment
- Adds configuration flag `Security.CleanupDanglingLinks` (default: true)
- Logs cleanup actions as WARNING level for visibility

Part of #592 - Handle changes in source files after deployment

## Test plan
- [x] Run `go test ./pkg/core/... -run TestDirectExecutor_CleanupDanglingLinks` - all tests pass
- [x] Run `./scripts/lint` - no issues
- [x] Run `./scripts/test` - all tests pass
- [ ] Manual testing: deploy a symlink, remove source file, redeploy - verify cleanup
- [ ] Manual testing: disable cleanup flag, verify dangling links remain

## Changes
- Added `CleanupDanglingLinks` flag to Security config
- Integrated dangling link detection/removal into DirectExecutor
- Added filesystem wrapper to bridge interface differences
- Comprehensive test coverage for various deployment scenarios

## Related Issues
Closes #594

🤖 Generated with [Claude Code](https://claude.ai/code)