### PR TITLE
fix: Status command improvements and CLI error handling

### DIFF
--- a/cmd/dodot/commands.go
+++ b/cmd/dodot/commands.go
@@ -58,8 +58,8 @@ func NewRootCmd() *cobra.Command {
 			_ = cmd.Help()
 			return fmt.Errorf("no command specified")
 		},
-		SilenceUsage:      false, // Show usage on command errors
-		SilenceErrors:     false, // Show cobra errors (like unknown commands)
+		SilenceUsage:      true, // We'll show help manually
+		SilenceErrors:     true, // We'll handle error display ourselves
 		DisableAutoGenTag: true,
 	}
 

--- a/cmd/dodot/commands.go
+++ b/cmd/dodot/commands.go
@@ -61,6 +61,7 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage:      true, // We'll show help manually
 		SilenceErrors:     true, // We'll handle error display ourselves
 		DisableAutoGenTag: true,
+		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true}, // Remove completion command
 	}
 
 	// Global flags

--- a/cmd/dodot/commands.go
+++ b/cmd/dodot/commands.go
@@ -58,8 +58,8 @@ func NewRootCmd() *cobra.Command {
 			_ = cmd.Help()
 			return fmt.Errorf("no command specified")
 		},
-		SilenceUsage:      true,
-		SilenceErrors:     true,
+		SilenceUsage:      false, // Show usage on command errors
+		SilenceErrors:     false, // Show cobra errors (like unknown commands)
 		DisableAutoGenTag: true,
 	}
 

--- a/cmd/dodot/main/main.go
+++ b/cmd/dodot/main/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/arthur-debert/dodot/cmd/dodot"
+	"github.com/arthur-debert/dodot/pkg/output/styles"
 
 	// Import packages to ensure their init() functions are called for registration
 	_ "github.com/arthur-debert/dodot/pkg/handlers"
@@ -13,6 +15,15 @@ import (
 func main() {
 	rootCmd := dodot.NewRootCmd()
 	if err := rootCmd.Execute(); err != nil {
+		// Print the error in red
+		errorStyle := styles.GetStyle("Error")
+		fmt.Fprintln(os.Stderr, errorStyle.Render(fmt.Sprintf("Error: %v", err)))
+
+		// Show the full help for the command that failed
+		// ExecuteContext sets cmd.Context() to the command that failed
+		fmt.Fprintln(os.Stderr)
+		_ = rootCmd.Help()
+
 		os.Exit(1)
 	}
 }

--- a/pkg/commands/status/action_status.go
+++ b/pkg/commands/status/action_status.go
@@ -69,6 +69,25 @@ func getActionHandler(action types.Action) string {
 	}
 }
 
+// getActionAdditionalInfo extracts additional display information from an Action
+func getActionAdditionalInfo(action types.Action) string {
+	switch a := action.(type) {
+	case *types.LinkAction:
+		// For symlinks, show the target path
+		return a.TargetFile
+	case *types.AddToPathAction:
+		return "add to $PATH"
+	case *types.AddToShellProfileAction:
+		return "shell source"
+	case *types.RunScriptAction:
+		return "run script"
+	case *types.BrewAction:
+		return "brew install"
+	default:
+		return ""
+	}
+}
+
 // statusStateToDisplayStatus converts internal status states to display status strings
 func statusStateToDisplayStatus(state types.StatusState) string {
 	switch state {

--- a/pkg/commands/status/action_status.go
+++ b/pkg/commands/status/action_status.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/arthur-debert/dodot/pkg/types"
@@ -73,8 +74,9 @@ func getActionHandler(action types.Action) string {
 func getActionAdditionalInfo(action types.Action) string {
 	switch a := action.(type) {
 	case *types.LinkAction:
-		// For symlinks, show the target path
-		return a.TargetFile
+		// For symlinks, show the target path formatted with ~ for home
+		homeDir := os.Getenv("HOME")
+		return types.FormatSymlinkForDisplay(a.TargetFile, homeDir, 46)
 	case *types.AddToPathAction:
 		return "add to $PATH"
 	case *types.AddToShellProfileAction:

--- a/pkg/commands/status/status.go
+++ b/pkg/commands/status/status.go
@@ -146,13 +146,13 @@ func getPackDisplayStatus(pack types.Pack, dataStore types.DataStore, fs types.F
 
 		// Convert to display format
 		displayFile := types.DisplayFile{
-			Handler:       getActionHandler(action),
-			Path:          getActionFilePath(action),
-			Status:        statusStateToDisplayStatus(status.State),
-			Message:       status.Message,
-			LastExecuted:  status.Timestamp,
-			HandlerSymbol: types.GetHandlerSymbol(getActionHandler(action)),
-			// TODO: Add additional info like symlink targets
+			Handler:        getActionHandler(action),
+			Path:           getActionFilePath(action),
+			Status:         statusStateToDisplayStatus(status.State),
+			Message:        status.Message,
+			LastExecuted:   status.Timestamp,
+			HandlerSymbol:  types.GetHandlerSymbol(getActionHandler(action)),
+			AdditionalInfo: getActionAdditionalInfo(action),
 		}
 
 		displayPack.Files = append(displayPack.Files, displayFile)

--- a/pkg/commands/status/status_test.go
+++ b/pkg/commands/status/status_test.go
@@ -355,3 +355,77 @@ func TestStatusPacksRealFS(t *testing.T) {
 	assert.Len(t, result2.Packs, 1)
 	assert.Equal(t, "vim", result2.Packs[0].Name)
 }
+
+func TestStatusPacksAdditionalInfo(t *testing.T) {
+	// Test that AdditionalInfo field is properly populated for different handler types
+	tmpDir := t.TempDir()
+	homeDir := filepath.Join(tmpDir, "home")
+	require.NoError(t, os.MkdirAll(homeDir, 0755))
+
+	// Create a pack with different file types
+	packDir := filepath.Join(tmpDir, "test-pack")
+	require.NoError(t, os.MkdirAll(packDir, 0755))
+
+	// Create files that trigger different handlers
+	require.NoError(t, os.WriteFile(filepath.Join(packDir, ".vimrc"), []byte("vim config"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(packDir, "install.sh"), []byte("#!/bin/sh\necho test"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(packDir, "Brewfile"), []byte("brew \"git\""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(packDir, "aliases.sh"), []byte("alias ll='ls -l'"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(packDir, "bin"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(packDir, "bin/mytool"), []byte("#!/bin/sh\necho tool"), 0755))
+
+	// Set HOME to our test directory
+	t.Setenv("HOME", homeDir)
+
+	testPaths, err := paths.New(tmpDir)
+	require.NoError(t, err)
+
+	result, err := StatusPacks(StatusPacksOptions{
+		DotfilesRoot: tmpDir,
+		PackNames:    []string{"test-pack"},
+		Paths:        testPaths,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Packs, 1)
+
+	pack := result.Packs[0]
+	assert.Equal(t, "test-pack", pack.Name)
+
+	// Check that each file has appropriate AdditionalInfo
+	fileInfoMap := make(map[string]types.DisplayFile)
+	for _, file := range pack.Files {
+		fileInfoMap[file.Path] = file
+	}
+
+	// Test symlink handler - should show target path
+	vimrcFile, ok := fileInfoMap[".vimrc"]
+	assert.True(t, ok, ".vimrc should be in status")
+	assert.Equal(t, "symlink", vimrcFile.Handler)
+	assert.Equal(t, filepath.Join(homeDir, ".vimrc"), vimrcFile.AdditionalInfo, "Symlink should show target path")
+
+	// Test provision handler - should show "run script"
+	installFile, ok := fileInfoMap["install.sh"]
+	assert.True(t, ok, "install.sh should be in status")
+	assert.Equal(t, "provision", installFile.Handler)
+	assert.Equal(t, "run script", installFile.AdditionalInfo, "Provision script should show 'run script'")
+
+	// Test homebrew handler - should show "brew install"
+	brewFile, ok := fileInfoMap["Brewfile"]
+	assert.True(t, ok, "Brewfile should be in status")
+	assert.Equal(t, "homebrew", brewFile.Handler)
+	assert.Equal(t, "brew install", brewFile.AdditionalInfo, "Brewfile should show 'brew install'")
+
+	// Test shell_profile handler - should show "shell source"
+	aliasesFile, ok := fileInfoMap["aliases.sh"]
+	assert.True(t, ok, "aliases.sh should be in status")
+	assert.Equal(t, "shell_profile", aliasesFile.Handler)
+	assert.Equal(t, "shell source", aliasesFile.AdditionalInfo, "Shell profile should show 'shell source'")
+
+	// Test path handler - should show "add to $PATH"
+	binDir, ok := fileInfoMap["bin"]
+	assert.True(t, ok, "bin directory should be in status")
+	assert.Equal(t, "path", binDir.Handler)
+	assert.Equal(t, "add to $PATH", binDir.AdditionalInfo, "Path handler should show 'add to $PATH'")
+}

--- a/pkg/commands/status/status_test.go
+++ b/pkg/commands/status/status_test.go
@@ -399,11 +399,11 @@ func TestStatusPacksAdditionalInfo(t *testing.T) {
 		fileInfoMap[file.Path] = file
 	}
 
-	// Test symlink handler - should show target path
+	// Test symlink handler - should show target path with ~ for home
 	vimrcFile, ok := fileInfoMap[".vimrc"]
 	assert.True(t, ok, ".vimrc should be in status")
 	assert.Equal(t, "symlink", vimrcFile.Handler)
-	assert.Equal(t, filepath.Join(homeDir, ".vimrc"), vimrcFile.AdditionalInfo, "Symlink should show target path")
+	assert.Equal(t, "~/.vimrc", vimrcFile.AdditionalInfo, "Symlink should show target path with ~ for home")
 
 	// Test provision handler - should show "run script"
 	installFile, ok := fileInfoMap["install.sh"]

--- a/pkg/output/renderer_test.go
+++ b/pkg/output/renderer_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/arthur-debert/dodot/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -40,7 +39,6 @@ func TestRenderer_Render(t *testing.T) {
 				},
 			},
 			wantContent: []string{
-				"Command: status",
 				"git",
 				".gitconfig",
 				"deployed",
@@ -72,7 +70,6 @@ func TestRenderer_Render(t *testing.T) {
 			},
 			wantContent: []string{
 				"DRY RUN MODE",
-				"Command: link",
 				"vim",
 				".vimrc",
 				"queued",
@@ -170,23 +167,6 @@ func TestRenderer_Render(t *testing.T) {
 			},
 		},
 		{
-			name:    "renders timestamp",
-			noColor: true,
-			result: &types.DisplayResult{
-				Command:   "link",
-				Timestamp: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
-				Packs: []types.DisplayPack{
-					{
-						Name:   "test",
-						Status: "success",
-					},
-				},
-			},
-			wantContent: []string{
-				"Executed at: 2024-01-15 10:30:00",
-			},
-		},
-		{
 			name:    "renders empty packs message",
 			noColor: true,
 			result: &types.DisplayResult{
@@ -278,7 +258,6 @@ func TestRenderer_RenderExecutionContext(t *testing.T) {
 	require.NoError(t, err)
 
 	output := buf.String()
-	assert.Contains(t, output, "Command: test")
 	assert.Contains(t, output, "test-pack")
 	assert.Contains(t, output, ".testfile")
 	assert.Contains(t, output, "deployed")

--- a/pkg/output/styles/styles.yaml
+++ b/pkg/output/styles/styles.yaml
@@ -76,7 +76,7 @@ styles:
     # foreground: success
     bold: true
   Error:
-    # foreground: error
+    foreground: error
     bold: true
   Warning:
     # foreground: warning

--- a/pkg/output/templates/result.tmpl
+++ b/pkg/output/templates/result.tmpl
@@ -1,9 +1,6 @@
 {{if .DryRun}}<DryRunBanner>DRY RUN MODE</DryRunBanner>
 
-{{end}}<CommandHeader>Command: {{.Command}}</CommandHeader>
-
-{{if .Packs}}{{range .Packs}}
+{{end}}{{if .Packs}}{{range .Packs}}
 {{template "pack.tmpl" .}}
 {{end}}{{else}}<NoContent>No packs found.</NoContent>
 {{end}}
-{{if .Timestamp}}<Timestamp>Executed at: {{.Timestamp.Format "2006-01-02 15:04:05"}}</Timestamp>{{end}}


### PR DESCRIPTION
## Summary
- Fix missing AdditionalInfo in status command output (symlink targets, "add to $PATH", etc.)
- Format symlink paths with ~ for home directory
- Show CLI errors in red with full help output
- Remove completion command from user-facing CLI
- Clean up status output by removing unnecessary header/footer

## Changes

### Status Command Fixes
- Restored the `AdditionalInfo` field that was missing after recent refactoring
- Symlink targets now show as `~/.vimrc` instead of `/Users/username/.vimrc`
- Removed "Command: status" header and "Executed at: <timestamp>" footer for cleaner output

### CLI Improvements  
- Command parsing errors (unknown command, bad option) now show in red
- Full help is displayed on errors instead of just usage
- Completion command is hidden from users (still available via dedicated tool)

## Test Plan
- [x] Manual testing of status command output
- [x] Verified CLI error handling with bad commands
- [x] All existing tests pass
- [x] Updated renderer tests for new output format

🤖 Generated with [Claude Code](https://claude.ai/code)