### PR TITLE
Unify pack command outputs with PackCommandResult

### DIFF
--- a/pack-command-result-analysis.md
+++ b/pack-command-result-analysis.md
@@ -1,0 +1,95 @@
+# Pack-Related Command Result Analysis
+
+## Overview
+This analysis examines how each pack-related command returns results and how they are rendered.
+
+## Current Patterns
+
+### Command Layer (pkg/commands/)
+
+1. **status** - Returns `*types.DisplayResult`
+   - Direct display of pack status
+   - No additional processing needed
+
+2. **on** - Returns `*OnResult` (custom type)
+   - Contains LinkResult and ProvisionResult (*types.ExecutionContext)
+   - Additional fields: TotalDeployed, DryRun, Errors
+   - CLI converts to status display
+
+3. **off** - Returns `*OffResult` (custom type)
+   - Contains array of PackRemovalResult
+   - Additional fields: TotalCleared, DryRun, Errors
+   - CLI converts to status display
+
+4. **adopt** - Returns `*types.AdoptResult`
+   - Contains PackName and AdoptedFiles array
+   - CLI converts to status display
+
+5. **fill** - Returns `*types.FillResult`
+   - Contains PackName and FilesCreated array
+   - CLI converts to status display
+
+6. **add-ignore** - Returns `*types.AddIgnoreResult`
+   - Contains PackName, IgnoreFilePath, Created, AlreadyExisted
+   - CLI converts to status display
+
+### CLI Layer (cmd/dodot/root.go)
+
+All commands except `status` follow this pattern:
+1. Execute the command
+2. Call `StatusPacks()` to get current state
+3. Wrap in `types.CommandResult` with a message
+4. Render the result
+
+The message is generated using `types.FormatCommandMessage()` for on/off commands, or custom messages for others.
+
+## Inconsistencies
+
+### 1. **Result Type Inconsistency**
+- `status` returns `DisplayResult` directly
+- `on` and `off` return custom result types with execution details
+- `adopt`, `fill`, and `add-ignore` return specific result types in `types` package
+
+### 2. **Rendering Pattern**
+- All commands convert to `DisplayResult` via status command
+- This creates unnecessary coupling and extra status queries
+- The original command results are mostly discarded
+
+### 3. **Error Handling**
+- `on` and `off` have Errors arrays in their results
+- Other commands rely on error return values only
+- Inconsistent error aggregation
+
+### 4. **Information Loss**
+- Command-specific information (e.g., what files were adopted, what was filled) is lost
+- Everything is normalized to pack status display
+- Users don't see the specific changes made
+
+## Recommendations
+
+### 1. **Standardize Result Types**
+All pack commands should return `*types.CommandResult` containing:
+- Message (optional)
+- DisplayResult showing current state
+- Command-specific details (if needed)
+
+### 2. **Move Status Logic to Command Layer**
+Each command should:
+- Perform its operation
+- Generate its own DisplayResult
+- Return complete CommandResult
+
+### 3. **Preserve Command-Specific Information**
+- Add command-specific fields to DisplayFile or DisplayPack
+- Show what changed, not just final state
+- Example: adopt should show which files were moved
+
+### 4. **Consistent Error Handling**
+- All commands should aggregate errors consistently
+- Consider adding Errors field to CommandResult
+- Show warnings/errors in the display
+
+### 5. **Eliminate Double Status Queries**
+- Commands should build DisplayResult as part of their operation
+- No need to query status separately after command execution
+- More efficient and accurate

--- a/pkg/commands/addignore/addignore.go
+++ b/pkg/commands/addignore/addignore.go
@@ -1,12 +1,7 @@
 package addignore
 
 import (
-	"time"
-
 	"github.com/arthur-debert/dodot/pkg/commands/status"
-	"github.com/arthur-debert/dodot/pkg/config"
-	"github.com/arthur-debert/dodot/pkg/core"
-	"github.com/arthur-debert/dodot/pkg/filesystem"
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/pack"
 	"github.com/arthur-debert/dodot/pkg/types"
@@ -26,59 +21,24 @@ func AddIgnore(opts AddIgnoreOptions) (*types.PackCommandResult, error) {
 		Str("dotfiles_root", opts.DotfilesRoot).
 		Msg("Creating ignore file for pack")
 
-	// Get configuration
-	cfg := config.Default()
-
-	// Initialize filesystem
-	fs := filesystem.NewOS()
-
-	// Find the pack using core abstraction
-	targetPack, err := core.FindPack(opts.DotfilesRoot, opts.PackName)
-	if err != nil {
-		return nil, err
+	// Create status function that wraps the status command
+	getStatusFunc := func(packName, dotfilesRoot string, fs types.FS) ([]types.DisplayPack, error) {
+		statusOpts := status.StatusPacksOptions{
+			DotfilesRoot: dotfilesRoot,
+			PackNames:    []string{packName},
+			FileSystem:   fs,
+		}
+		result, err := status.StatusPacks(statusOpts)
+		if err != nil {
+			return nil, err
+		}
+		return result.Packs, nil
 	}
 
-	// Wrap in our enhanced Pack type and delegate to AddIgnore method
-	p := pack.New(targetPack)
-	ignoreResult, err := p.AddIgnore(fs, cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get current pack status
-	statusOpts := status.StatusPacksOptions{
-		DotfilesRoot: opts.DotfilesRoot,
-		PackNames:    []string{opts.PackName},
-		FileSystem:   fs,
-	}
-	packStatus, statusErr := status.StatusPacks(statusOpts)
-	if statusErr != nil {
-		logger.Error().Err(statusErr).Msg("Failed to get pack status")
-	}
-
-	// Build result
-	result := &types.PackCommandResult{
-		Command:   "add-ignore",
-		Timestamp: time.Now(),
-		DryRun:    false,
-		Packs:     []types.DisplayPack{},
-		Metadata: types.CommandMetadata{
-			IgnoreCreated:  ignoreResult.Created,
-			AlreadyExisted: ignoreResult.AlreadyExisted,
-		},
-	}
-
-	// Copy packs from status if available
-	if packStatus != nil {
-		result.Packs = packStatus.Packs
-	}
-
-	// Generate message
-	if ignoreResult.AlreadyExisted {
-		result.Message = "A .dodotignore file already exists in the pack " + opts.PackName + "."
-	} else {
-		result.Message = "A .dodotignore file has been added to the pack " + opts.PackName + "."
-	}
-
-	return result, nil
+	// Delegate to pack.AddIgnore
+	return pack.AddIgnore(pack.AddIgnoreOptions{
+		PackName:      opts.PackName,
+		DotfilesRoot:  opts.DotfilesRoot,
+		GetPackStatus: getStatusFunc,
+	})
 }

--- a/pkg/commands/adopt/adopt.go
+++ b/pkg/commands/adopt/adopt.go
@@ -1,11 +1,7 @@
 package adopt
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/arthur-debert/dodot/pkg/commands/status"
-	"github.com/arthur-debert/dodot/pkg/filesystem"
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/pack"
 	"github.com/arthur-debert/dodot/pkg/types"
@@ -30,63 +26,27 @@ func AdoptFiles(opts AdoptFilesOptions) (*types.PackCommandResult, error) {
 		Bool("force", opts.Force).
 		Msg("Adopting files into pack")
 
-	// Use provided filesystem or default to OS
-	fs := opts.FileSystem
-	if fs == nil {
-		fs = filesystem.NewOS()
+	// Create status function that wraps the status command
+	getStatusFunc := func(packName, dotfilesRoot string, fs types.FS) ([]types.DisplayPack, error) {
+		statusOpts := status.StatusPacksOptions{
+			DotfilesRoot: dotfilesRoot,
+			PackNames:    []string{packName},
+			FileSystem:   fs,
+		}
+		result, err := status.StatusPacks(statusOpts)
+		if err != nil {
+			return nil, err
+		}
+		return result.Packs, nil
 	}
 
-	// Use pack.AdoptOrCreate which handles pack creation if needed
-	adoptResult, err := pack.AdoptOrCreate(fs, opts.DotfilesRoot, opts.PackName, pack.AdoptOptions{
-		SourcePaths:  opts.SourcePaths,
-		Force:        opts.Force,
-		DotfilesRoot: opts.DotfilesRoot,
+	// Delegate to pack.Adopt
+	return pack.Adopt(pack.AdoptOptions{
+		SourcePaths:   opts.SourcePaths,
+		Force:         opts.Force,
+		DotfilesRoot:  opts.DotfilesRoot,
+		PackName:      opts.PackName,
+		FileSystem:    opts.FileSystem,
+		GetPackStatus: getStatusFunc,
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Get current pack status
-	statusOpts := status.StatusPacksOptions{
-		DotfilesRoot: opts.DotfilesRoot,
-		PackNames:    []string{opts.PackName},
-		FileSystem:   fs,
-	}
-	packStatus, statusErr := status.StatusPacks(statusOpts)
-	if statusErr != nil {
-		logger.Error().Err(statusErr).Msg("Failed to get pack status")
-	}
-
-	// Build result
-	result := &types.PackCommandResult{
-		Command:   "adopt",
-		Timestamp: time.Now(),
-		DryRun:    false,
-		Packs:     []types.DisplayPack{},
-		Metadata: types.CommandMetadata{
-			FilesAdopted: len(adoptResult.AdoptedFiles),
-			AdoptedPaths: make([]string, 0, len(adoptResult.AdoptedFiles)),
-		},
-	}
-
-	// Collect adopted paths
-	for _, file := range adoptResult.AdoptedFiles {
-		result.Metadata.AdoptedPaths = append(result.Metadata.AdoptedPaths, file.OriginalPath)
-	}
-
-	// Copy packs from status if available
-	if packStatus != nil {
-		result.Packs = packStatus.Packs
-	}
-
-	// Generate message
-	if len(adoptResult.AdoptedFiles) == 1 {
-		result.Message = "1 file has been adopted into the pack " + opts.PackName + "."
-	} else {
-		result.Message = types.FormatCommandMessage("files have been adopted into the pack "+opts.PackName, []string{})
-		// Override with custom message for adopt
-		result.Message = fmt.Sprintf("%d files have been adopted into the pack %s.", len(adoptResult.AdoptedFiles), opts.PackName)
-	}
-
-	return result, nil
 }

--- a/pkg/commands/adopt/adopt.go
+++ b/pkg/commands/adopt/adopt.go
@@ -1,6 +1,10 @@
 package adopt
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/arthur-debert/dodot/pkg/commands/status"
 	"github.com/arthur-debert/dodot/pkg/filesystem"
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/pack"
@@ -17,7 +21,7 @@ type AdoptFilesOptions struct {
 }
 
 // AdoptFiles moves existing files into a pack and creates symlinks back to their original locations
-func AdoptFiles(opts AdoptFilesOptions) (*types.AdoptResult, error) {
+func AdoptFiles(opts AdoptFilesOptions) (*types.PackCommandResult, error) {
 	logger := logging.GetLogger("commands.adopt")
 	logger.Info().
 		Str("pack", opts.PackName).
@@ -33,9 +37,56 @@ func AdoptFiles(opts AdoptFilesOptions) (*types.AdoptResult, error) {
 	}
 
 	// Use pack.AdoptOrCreate which handles pack creation if needed
-	return pack.AdoptOrCreate(fs, opts.DotfilesRoot, opts.PackName, pack.AdoptOptions{
+	adoptResult, err := pack.AdoptOrCreate(fs, opts.DotfilesRoot, opts.PackName, pack.AdoptOptions{
 		SourcePaths:  opts.SourcePaths,
 		Force:        opts.Force,
 		DotfilesRoot: opts.DotfilesRoot,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current pack status
+	statusOpts := status.StatusPacksOptions{
+		DotfilesRoot: opts.DotfilesRoot,
+		PackNames:    []string{opts.PackName},
+		FileSystem:   fs,
+	}
+	packStatus, statusErr := status.StatusPacks(statusOpts)
+	if statusErr != nil {
+		logger.Error().Err(statusErr).Msg("Failed to get pack status")
+	}
+
+	// Build result
+	result := &types.PackCommandResult{
+		Command:   "adopt",
+		Timestamp: time.Now(),
+		DryRun:    false,
+		Packs:     []types.DisplayPack{},
+		Metadata: types.CommandMetadata{
+			FilesAdopted: len(adoptResult.AdoptedFiles),
+			AdoptedPaths: make([]string, 0, len(adoptResult.AdoptedFiles)),
+		},
+	}
+
+	// Collect adopted paths
+	for _, file := range adoptResult.AdoptedFiles {
+		result.Metadata.AdoptedPaths = append(result.Metadata.AdoptedPaths, file.OriginalPath)
+	}
+
+	// Copy packs from status if available
+	if packStatus != nil {
+		result.Packs = packStatus.Packs
+	}
+
+	// Generate message
+	if len(adoptResult.AdoptedFiles) == 1 {
+		result.Message = "1 file has been adopted into the pack " + opts.PackName + "."
+	} else {
+		result.Message = types.FormatCommandMessage("files have been adopted into the pack "+opts.PackName, []string{})
+		// Override with custom message for adopt
+		result.Message = fmt.Sprintf("%d files have been adopted into the pack %s.", len(adoptResult.AdoptedFiles), opts.PackName)
+	}
+
+	return result, nil
 }

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -22,6 +22,8 @@ import (
 	"github.com/arthur-debert/dodot/pkg/commands/fill"
 	"github.com/arthur-debert/dodot/pkg/commands/genconfig"
 	"github.com/arthur-debert/dodot/pkg/commands/initialize"
+	"github.com/arthur-debert/dodot/pkg/commands/off"
+	"github.com/arthur-debert/dodot/pkg/commands/on"
 	"github.com/arthur-debert/dodot/pkg/commands/status"
 	"github.com/arthur-debert/dodot/pkg/types"
 )
@@ -31,35 +33,35 @@ import (
 // StatusPacks shows the link status of specified packs.
 type StatusPacksOptions = status.StatusPacksOptions
 
-func StatusPacks(opts StatusPacksOptions) (*types.DisplayResult, error) {
+func StatusPacks(opts StatusPacksOptions) (*types.PackCommandResult, error) {
 	return status.StatusPacks(opts)
 }
 
 // FillPack adds missing template files to an existing pack.
 type FillPackOptions = fill.FillPackOptions
 
-func FillPack(opts FillPackOptions) (*types.FillResult, error) {
+func FillPack(opts FillPackOptions) (*types.PackCommandResult, error) {
 	return fill.FillPack(opts)
 }
 
 // InitPack creates a new pack directory with template files and configuration.
 type InitPackOptions = initialize.InitPackOptions
 
-func InitPack(opts InitPackOptions) (*types.InitResult, error) {
+func InitPack(opts InitPackOptions) (*types.PackCommandResult, error) {
 	return initialize.InitPack(opts)
 }
 
 // AddIgnore creates a .dodotignore file in the specified pack.
 type AddIgnoreOptions = addignore.AddIgnoreOptions
 
-func AddIgnore(opts AddIgnoreOptions) (*types.AddIgnoreResult, error) {
+func AddIgnore(opts AddIgnoreOptions) (*types.PackCommandResult, error) {
 	return addignore.AddIgnore(opts)
 }
 
 // AdoptFiles moves existing files into a pack and creates symlinks.
 type AdoptFilesOptions = adopt.AdoptFilesOptions
 
-func AdoptFiles(opts AdoptFilesOptions) (*types.AdoptResult, error) {
+func AdoptFiles(opts AdoptFilesOptions) (*types.PackCommandResult, error) {
 	return adopt.AdoptFiles(opts)
 }
 
@@ -68,4 +70,18 @@ type GenConfigOptions = genconfig.GenConfigOptions
 
 func GenConfig(opts GenConfigOptions) (*types.GenConfigResult, error) {
 	return genconfig.GenConfig(opts)
+}
+
+// OnPacks turns on the specified packs by deploying all handlers.
+type OnPacksOptions = on.OnPacksOptions
+
+func OnPacks(opts OnPacksOptions) (*types.PackCommandResult, error) {
+	return on.OnPacks(opts)
+}
+
+// OffPacks turns off the specified packs by removing all handler state.
+type OffPacksOptions = off.OffPacksOptions
+
+func OffPacks(opts OffPacksOptions) (*types.PackCommandResult, error) {
+	return off.OffPacks(opts)
 }

--- a/pkg/commands/fill/fill.go
+++ b/pkg/commands/fill/fill.go
@@ -1,12 +1,7 @@
 package fill
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/arthur-debert/dodot/pkg/commands/status"
-	"github.com/arthur-debert/dodot/pkg/core"
-	"github.com/arthur-debert/dodot/pkg/filesystem"
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/pack"
 	"github.com/arthur-debert/dodot/pkg/types"
@@ -27,59 +22,25 @@ func FillPack(opts FillPackOptions) (*types.PackCommandResult, error) {
 	log := logging.GetLogger("core.commands")
 	log.Debug().Str("command", "FillPack").Str("pack", opts.PackName).Msg("Executing command")
 
-	// Use provided filesystem or default
-	fs := opts.FileSystem
-	if fs == nil {
-		fs = filesystem.NewOS()
+	// Create status function that wraps the status command
+	getStatusFunc := func(packName, dotfilesRoot string, fs types.FS) ([]types.DisplayPack, error) {
+		statusOpts := status.StatusPacksOptions{
+			DotfilesRoot: dotfilesRoot,
+			PackNames:    []string{packName},
+			FileSystem:   fs,
+		}
+		result, err := status.StatusPacks(statusOpts)
+		if err != nil {
+			return nil, err
+		}
+		return result.Packs, nil
 	}
 
-	// Find the specific pack
-	targetPack, err := core.FindPackFS(opts.DotfilesRoot, opts.PackName, fs)
-	if err != nil {
-		return nil, err
-	}
-
-	// Wrap in our enhanced Pack type and delegate to Fill method
-	p := pack.New(targetPack)
-	fillResult, err := p.Fill(fs)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get current pack status
-	statusOpts := status.StatusPacksOptions{
-		DotfilesRoot: opts.DotfilesRoot,
-		PackNames:    []string{opts.PackName},
-		FileSystem:   fs,
-	}
-	packStatus, statusErr := status.StatusPacks(statusOpts)
-	if statusErr != nil {
-		log.Error().Err(statusErr).Msg("Failed to get pack status")
-	}
-
-	// Build result
-	result := &types.PackCommandResult{
-		Command:   "fill",
-		Timestamp: time.Now(),
-		DryRun:    false,
-		Packs:     []types.DisplayPack{},
-		Metadata: types.CommandMetadata{
-			FilesCreated: len(fillResult.FilesCreated),
-			CreatedPaths: fillResult.FilesCreated,
-		},
-	}
-
-	// Copy packs from status if available
-	if packStatus != nil {
-		result.Packs = packStatus.Packs
-	}
-
-	// Generate message
-	if len(fillResult.FilesCreated) == 1 {
-		result.Message = "The pack " + opts.PackName + " has been filled with 1 placeholder file."
-	} else {
-		result.Message = fmt.Sprintf("The pack %s has been filled with %d placeholder files.", opts.PackName, len(fillResult.FilesCreated))
-	}
-
-	return result, nil
+	// Delegate to pack.Fill
+	return pack.Fill(pack.FillOptions{
+		PackName:      opts.PackName,
+		DotfilesRoot:  opts.DotfilesRoot,
+		FileSystem:    opts.FileSystem,
+		GetPackStatus: getStatusFunc,
+	})
 }

--- a/pkg/commands/fill/fill.go
+++ b/pkg/commands/fill/fill.go
@@ -1,6 +1,10 @@
 package fill
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/arthur-debert/dodot/pkg/commands/status"
 	"github.com/arthur-debert/dodot/pkg/core"
 	"github.com/arthur-debert/dodot/pkg/filesystem"
 	"github.com/arthur-debert/dodot/pkg/logging"
@@ -19,7 +23,7 @@ type FillPackOptions struct {
 }
 
 // FillPack adds placeholder files for handlers to an existing pack.
-func FillPack(opts FillPackOptions) (*types.FillResult, error) {
+func FillPack(opts FillPackOptions) (*types.PackCommandResult, error) {
 	log := logging.GetLogger("core.commands")
 	log.Debug().Str("command", "FillPack").Str("pack", opts.PackName).Msg("Executing command")
 
@@ -37,5 +41,45 @@ func FillPack(opts FillPackOptions) (*types.FillResult, error) {
 
 	// Wrap in our enhanced Pack type and delegate to Fill method
 	p := pack.New(targetPack)
-	return p.Fill(fs)
+	fillResult, err := p.Fill(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current pack status
+	statusOpts := status.StatusPacksOptions{
+		DotfilesRoot: opts.DotfilesRoot,
+		PackNames:    []string{opts.PackName},
+		FileSystem:   fs,
+	}
+	packStatus, statusErr := status.StatusPacks(statusOpts)
+	if statusErr != nil {
+		log.Error().Err(statusErr).Msg("Failed to get pack status")
+	}
+
+	// Build result
+	result := &types.PackCommandResult{
+		Command:   "fill",
+		Timestamp: time.Now(),
+		DryRun:    false,
+		Packs:     []types.DisplayPack{},
+		Metadata: types.CommandMetadata{
+			FilesCreated: len(fillResult.FilesCreated),
+			CreatedPaths: fillResult.FilesCreated,
+		},
+	}
+
+	// Copy packs from status if available
+	if packStatus != nil {
+		result.Packs = packStatus.Packs
+	}
+
+	// Generate message
+	if len(fillResult.FilesCreated) == 1 {
+		result.Message = "The pack " + opts.PackName + " has been filled with 1 placeholder file."
+	} else {
+		result.Message = fmt.Sprintf("The pack %s has been filled with %d placeholder files.", opts.PackName, len(fillResult.FilesCreated))
+	}
+
+	return result, nil
 }

--- a/pkg/commands/fill/fill_test.go
+++ b/pkg/commands/fill/fill_test.go
@@ -111,14 +111,18 @@ func TestFillPack(t *testing.T) {
 			require.NotNil(t, result)
 
 			// Check result
-			assert.Equal(t, "testpack", result.PackName)
-			assert.Equal(t, len(tt.expectedFiles), len(result.FilesCreated),
-				"Expected %d files, got %d: %v", len(tt.expectedFiles), len(result.FilesCreated), result.FilesCreated)
+			assert.Equal(t, "fill", result.Command, "command should be fill")
+			assert.Equal(t, len(tt.expectedFiles), result.Metadata.FilesCreated,
+				"Expected %d files, got %d: %v", len(tt.expectedFiles), result.Metadata.FilesCreated, result.Metadata.CreatedPaths)
+			assert.True(t, len(result.Packs) > 0, "should have pack status")
+			if len(result.Packs) > 0 {
+				assert.Equal(t, "testpack", result.Packs[0].Name, "pack name should match")
+			}
 
 			// Verify files were created
 			for _, expectedFile := range tt.expectedFiles {
 				found := false
-				for _, createdFile := range result.FilesCreated {
+				for _, createdFile := range result.Metadata.CreatedPaths {
 					if createdFile == expectedFile {
 						found = true
 						break

--- a/pkg/commands/initialize/init.go
+++ b/pkg/commands/initialize/init.go
@@ -1,6 +1,10 @@
 package initialize
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/arthur-debert/dodot/pkg/commands/status"
 	"github.com/arthur-debert/dodot/pkg/filesystem"
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/pack"
@@ -17,7 +21,7 @@ type InitPackOptions struct {
 	FileSystem types.FS
 }
 
-func InitPack(opts InitPackOptions) (*types.InitResult, error) {
+func InitPack(opts InitPackOptions) (*types.PackCommandResult, error) {
 	log := logging.GetLogger("core.commands")
 	log.Debug().Str("command", "InitPack").Str("pack", opts.PackName).Msg("Executing command")
 
@@ -28,8 +32,44 @@ func InitPack(opts InitPackOptions) (*types.InitResult, error) {
 	}
 
 	// Delegate to pack.Initialize
-	return pack.Initialize(fs, pack.InitOptions{
+	initResult, err := pack.Initialize(fs, pack.InitOptions{
 		PackName:     opts.PackName,
 		DotfilesRoot: opts.DotfilesRoot,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current pack status
+	statusOpts := status.StatusPacksOptions{
+		DotfilesRoot: opts.DotfilesRoot,
+		PackNames:    []string{opts.PackName},
+		FileSystem:   fs,
+	}
+	packStatus, statusErr := status.StatusPacks(statusOpts)
+	if statusErr != nil {
+		log.Error().Err(statusErr).Msg("Failed to get pack status")
+	}
+
+	// Build result
+	result := &types.PackCommandResult{
+		Command:   "init",
+		Timestamp: time.Now(),
+		DryRun:    false,
+		Packs:     []types.DisplayPack{},
+		Metadata: types.CommandMetadata{
+			FilesCreated: len(initResult.FilesCreated),
+			CreatedPaths: initResult.FilesCreated,
+		},
+	}
+
+	// Copy packs from status if available
+	if packStatus != nil {
+		result.Packs = packStatus.Packs
+	}
+
+	// Generate message
+	result.Message = fmt.Sprintf("The pack %s has been initialized with %d files.", opts.PackName, len(initResult.FilesCreated))
+
+	return result, nil
 }

--- a/pkg/commands/initialize/init.go
+++ b/pkg/commands/initialize/init.go
@@ -1,11 +1,7 @@
 package initialize
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/arthur-debert/dodot/pkg/commands/status"
-	"github.com/arthur-debert/dodot/pkg/filesystem"
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/pack"
 	"github.com/arthur-debert/dodot/pkg/types"
@@ -25,51 +21,25 @@ func InitPack(opts InitPackOptions) (*types.PackCommandResult, error) {
 	log := logging.GetLogger("core.commands")
 	log.Debug().Str("command", "InitPack").Str("pack", opts.PackName).Msg("Executing command")
 
-	// Use provided filesystem or default
-	fs := opts.FileSystem
-	if fs == nil {
-		fs = filesystem.NewOS()
+	// Create status function that wraps the status command
+	getStatusFunc := func(packName, dotfilesRoot string, fs types.FS) ([]types.DisplayPack, error) {
+		statusOpts := status.StatusPacksOptions{
+			DotfilesRoot: dotfilesRoot,
+			PackNames:    []string{packName},
+			FileSystem:   fs,
+		}
+		result, err := status.StatusPacks(statusOpts)
+		if err != nil {
+			return nil, err
+		}
+		return result.Packs, nil
 	}
 
 	// Delegate to pack.Initialize
-	initResult, err := pack.Initialize(fs, pack.InitOptions{
-		PackName:     opts.PackName,
-		DotfilesRoot: opts.DotfilesRoot,
+	return pack.Initialize(pack.InitOptions{
+		PackName:      opts.PackName,
+		DotfilesRoot:  opts.DotfilesRoot,
+		FileSystem:    opts.FileSystem,
+		GetPackStatus: getStatusFunc,
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Get current pack status
-	statusOpts := status.StatusPacksOptions{
-		DotfilesRoot: opts.DotfilesRoot,
-		PackNames:    []string{opts.PackName},
-		FileSystem:   fs,
-	}
-	packStatus, statusErr := status.StatusPacks(statusOpts)
-	if statusErr != nil {
-		log.Error().Err(statusErr).Msg("Failed to get pack status")
-	}
-
-	// Build result
-	result := &types.PackCommandResult{
-		Command:   "init",
-		Timestamp: time.Now(),
-		DryRun:    false,
-		Packs:     []types.DisplayPack{},
-		Metadata: types.CommandMetadata{
-			FilesCreated: len(initResult.FilesCreated),
-			CreatedPaths: initResult.FilesCreated,
-		},
-	}
-
-	// Copy packs from status if available
-	if packStatus != nil {
-		result.Packs = packStatus.Packs
-	}
-
-	// Generate message
-	result.Message = fmt.Sprintf("The pack %s has been initialized with %d files.", opts.PackName, len(initResult.FilesCreated))
-
-	return result, nil
 }

--- a/pkg/commands/initialize/init_test.go
+++ b/pkg/commands/initialize/init_test.go
@@ -80,18 +80,21 @@ func TestInitPack(t *testing.T) {
 			require.NotNil(t, result)
 
 			// Check result
-			assert.Equal(t, tt.packName, result.PackName)
-			assert.Equal(t, filepath.Join(env.DotfilesRoot, tt.packName), result.Path)
+			assert.Equal(t, "init", result.Command, "command should be init")
+			assert.True(t, len(result.Packs) > 0, "should have pack status")
+			if len(result.Packs) > 0 {
+				assert.Equal(t, tt.packName, result.Packs[0].Name, "pack name should match")
+			}
 
 			// Check expected files were created
-			assert.Equal(t, len(tt.expectedFiles), len(result.FilesCreated),
-				"Expected %d files, got %d: %v", len(tt.expectedFiles), len(result.FilesCreated), result.FilesCreated)
+			assert.Equal(t, len(tt.expectedFiles), result.Metadata.FilesCreated,
+				"Expected %d files, got %d: %v", len(tt.expectedFiles), result.Metadata.FilesCreated, result.Metadata.CreatedPaths)
 
 			// Verify each expected file
 			packPath := filepath.Join(env.DotfilesRoot, tt.packName)
 			for _, expectedFile := range tt.expectedFiles {
 				found := false
-				for _, createdFile := range result.FilesCreated {
+				for _, createdFile := range result.Metadata.CreatedPaths {
 					if createdFile == expectedFile {
 						found = true
 						break

--- a/pkg/commands/off/off.go
+++ b/pkg/commands/off/off.go
@@ -121,9 +121,7 @@ func OffPacks(opts OffPacksOptions) (*types.PackCommandResult, error) {
 
 		// Track pack-level errors
 		if len(packResult.Errors) > 0 {
-			for _, err := range packResult.Errors {
-				errors = append(errors, err)
-			}
+			errors = append(errors, packResult.Errors...)
 		}
 	}
 

--- a/pkg/commands/status/status.go
+++ b/pkg/commands/status/status.go
@@ -36,7 +36,7 @@ type StatusPacksOptions struct {
 }
 
 // StatusPacks shows the deployment status of specified packs
-func StatusPacks(opts StatusPacksOptions) (*types.DisplayResult, error) {
+func StatusPacks(opts StatusPacksOptions) (*types.PackCommandResult, error) {
 	logger := logging.GetLogger("commands.status")
 	logger.Debug().
 		Str("dotfilesRoot", opts.DotfilesRoot).
@@ -70,12 +70,14 @@ func StatusPacks(opts StatusPacksOptions) (*types.DisplayResult, error) {
 	// Create datastore for status checking
 	dataStore := datastore.New(opts.FileSystem, opts.Paths.(paths.Paths))
 
-	// Build display result
-	result := &types.DisplayResult{
+	// Build command result
+	result := &types.PackCommandResult{
 		Command:   "status",
 		DryRun:    false,
 		Timestamp: time.Now(),
 		Packs:     make([]types.DisplayPack, 0, len(selectedPacks)),
+		// Status command doesn't have a message
+		Message: "",
 	}
 
 	// Process each pack

--- a/pkg/pack/addignore.go
+++ b/pkg/pack/addignore.go
@@ -2,37 +2,68 @@ package pack
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/arthur-debert/dodot/pkg/config"
+	"github.com/arthur-debert/dodot/pkg/errors"
+	"github.com/arthur-debert/dodot/pkg/filesystem"
 	"github.com/arthur-debert/dodot/pkg/logging"
+	"github.com/arthur-debert/dodot/pkg/statustype"
 	"github.com/arthur-debert/dodot/pkg/types"
 )
 
-// AddIgnoreResult represents the result of adding an ignore file to a pack
-type AddIgnoreResult struct {
-	PackName       string `json:"packName"`
-	IgnoreFilePath string `json:"ignoreFilePath"`
-	Created        bool   `json:"created"`
-	AlreadyExisted bool   `json:"alreadyExisted"`
+// AddIgnoreOptions contains options for the AddIgnore operation
+type AddIgnoreOptions struct {
+	// PackName is the name of the pack to add ignore file to
+	PackName string
+	// DotfilesRoot is the root directory for dotfiles
+	DotfilesRoot string
+	// FileSystem is the filesystem to use (optional, defaults to OS filesystem)
+	FileSystem types.FS
+	// GetPackStatus is a function to get pack status to avoid circular imports
+	GetPackStatus statustype.GetPackStatusFunc
 }
 
 // AddIgnore creates a .dodotignore file for the pack if it doesn't already exist.
 // Returns information about whether the file was created or already existed.
-func (p *Pack) AddIgnore(fs types.FS, cfg *config.Config) (*AddIgnoreResult, error) {
+func AddIgnore(opts AddIgnoreOptions) (*types.PackCommandResult, error) {
 	logger := logging.GetLogger("pack.addignore")
 	logger.Debug().
-		Str("pack", p.Name).
+		Str("pack", opts.PackName).
 		Msg("Checking for ignore file")
 
-	// Use default config if not provided
-	if cfg == nil {
-		cfg = config.Default()
+	// Use provided filesystem or default
+	fs := opts.FileSystem
+	if fs == nil {
+		fs = filesystem.NewOS()
 	}
+
+	// Validate pack name
+	if opts.PackName == "" {
+		return nil, errors.New(errors.ErrPackNotFound, "pack name cannot be empty")
+	}
+
+	// Find the pack
+	packPath := opts.DotfilesRoot + "/" + opts.PackName
+	if _, err := fs.Stat(packPath); err != nil {
+		return nil, errors.New(errors.ErrPackNotFound, fmt.Sprintf("pack %s not found", opts.PackName))
+	}
+
+	// Create pack instance
+	p := &Pack{
+		Pack: &types.Pack{
+			Name: opts.PackName,
+			Path: packPath,
+		},
+	}
+
+	// Get default configuration
+	cfg := config.Default()
 
 	// Check if ignore file already exists using the embedded Pack's method
 	exists, err := p.HasIgnoreFile(fs, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check for ignore file: %w", err)
+		return nil, errors.Wrapf(err, errors.ErrInternal, "failed to check for ignore file")
 	}
 
 	ignoreFilePath := p.GetFilePath(cfg.Patterns.SpecialFiles.IgnoreFile)
@@ -43,17 +74,14 @@ func (p *Pack) AddIgnore(fs types.FS, cfg *config.Config) (*AddIgnoreResult, err
 			Str("path", ignoreFilePath).
 			Msg("Ignore file already exists")
 
-		return &AddIgnoreResult{
-			PackName:       p.Name,
-			IgnoreFilePath: ignoreFilePath,
-			Created:        false,
-			AlreadyExisted: true,
-		}, nil
+		// File already exists, build result
+		result := buildAddIgnoreResult(opts, ignoreFilePath, false, true, fs)
+		return result, nil
 	}
 
 	// Create the ignore file using the embedded Pack's method
 	if err := p.CreateIgnoreFile(fs, cfg); err != nil {
-		return nil, fmt.Errorf("failed to create ignore file: %w", err)
+		return nil, errors.Wrapf(err, errors.ErrInternal, "failed to create ignore file")
 	}
 
 	logger.Info().
@@ -61,10 +89,48 @@ func (p *Pack) AddIgnore(fs types.FS, cfg *config.Config) (*AddIgnoreResult, err
 		Str("path", ignoreFilePath).
 		Msg("Successfully created ignore file")
 
-	return &AddIgnoreResult{
-		PackName:       p.Name,
-		IgnoreFilePath: ignoreFilePath,
-		Created:        true,
-		AlreadyExisted: false,
-	}, nil
+	// File created, build result
+	result := buildAddIgnoreResult(opts, ignoreFilePath, true, false, fs)
+	return result, nil
+}
+
+// buildAddIgnoreResult creates a PackCommandResult for addignore operations
+func buildAddIgnoreResult(opts AddIgnoreOptions, ignoreFilePath string, created, alreadyExisted bool, fs types.FS) *types.PackCommandResult {
+	logger := logging.GetLogger("pack.addignore")
+
+	// Get current pack status if function provided
+	var packStatus []types.DisplayPack
+	if opts.GetPackStatus != nil {
+		var statusErr error
+		packStatus, statusErr = opts.GetPackStatus(opts.PackName, opts.DotfilesRoot, fs)
+		if statusErr != nil {
+			logger.Error().Err(statusErr).Msg("Failed to get pack status")
+		}
+	}
+
+	// Build result
+	result := &types.PackCommandResult{
+		Command:   "add-ignore",
+		Timestamp: time.Now(),
+		DryRun:    false,
+		Packs:     []types.DisplayPack{},
+		Metadata: types.CommandMetadata{
+			IgnoreCreated:  created,
+			AlreadyExisted: alreadyExisted,
+		},
+	}
+
+	// Copy packs from status if available
+	if packStatus != nil {
+		result.Packs = packStatus
+	}
+
+	// Generate message
+	if alreadyExisted {
+		result.Message = "A .dodotignore file already exists in the pack " + opts.PackName + "."
+	} else {
+		result.Message = "A .dodotignore file has been added to the pack " + opts.PackName + "."
+	}
+
+	return result
 }

--- a/pkg/pack/addignore.go
+++ b/pkg/pack/addignore.go
@@ -8,9 +8,17 @@ import (
 	"github.com/arthur-debert/dodot/pkg/types"
 )
 
+// AddIgnoreResult represents the result of adding an ignore file to a pack
+type AddIgnoreResult struct {
+	PackName       string `json:"packName"`
+	IgnoreFilePath string `json:"ignoreFilePath"`
+	Created        bool   `json:"created"`
+	AlreadyExisted bool   `json:"alreadyExisted"`
+}
+
 // AddIgnore creates a .dodotignore file for the pack if it doesn't already exist.
 // Returns information about whether the file was created or already existed.
-func (p *Pack) AddIgnore(fs types.FS, cfg *config.Config) (*types.AddIgnoreResult, error) {
+func (p *Pack) AddIgnore(fs types.FS, cfg *config.Config) (*AddIgnoreResult, error) {
 	logger := logging.GetLogger("pack.addignore")
 	logger.Debug().
 		Str("pack", p.Name).
@@ -35,7 +43,7 @@ func (p *Pack) AddIgnore(fs types.FS, cfg *config.Config) (*types.AddIgnoreResul
 			Str("path", ignoreFilePath).
 			Msg("Ignore file already exists")
 
-		return &types.AddIgnoreResult{
+		return &AddIgnoreResult{
 			PackName:       p.Name,
 			IgnoreFilePath: ignoreFilePath,
 			Created:        false,
@@ -53,7 +61,7 @@ func (p *Pack) AddIgnore(fs types.FS, cfg *config.Config) (*types.AddIgnoreResul
 		Str("path", ignoreFilePath).
 		Msg("Successfully created ignore file")
 
-	return &types.AddIgnoreResult{
+	return &AddIgnoreResult{
 		PackName:       p.Name,
 		IgnoreFilePath: ignoreFilePath,
 		Created:        true,

--- a/pkg/pack/adopt.go
+++ b/pkg/pack/adopt.go
@@ -5,10 +5,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/arthur-debert/dodot/pkg/errors"
+	"github.com/arthur-debert/dodot/pkg/filesystem"
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/paths"
+	"github.com/arthur-debert/dodot/pkg/statustype"
 	"github.com/arthur-debert/dodot/pkg/types"
 	"github.com/rs/zerolog"
 )
@@ -21,36 +24,66 @@ type AdoptOptions struct {
 	Force bool
 	// DotfilesRoot is the root directory for dotfiles
 	DotfilesRoot string
+	// PackName is the name of the pack to adopt files into
+	PackName string
+	// FileSystem is the filesystem to use (optional, defaults to OS filesystem)
+	FileSystem types.FS
+	// GetPackStatus is a function to get pack status to avoid circular imports
+	GetPackStatus statustype.GetPackStatusFunc
 }
 
-// AdoptResult represents the result of adopting files into a pack
-type AdoptResult struct {
-	PackName     string        `json:"packName"`
-	AdoptedFiles []AdoptedFile `json:"adoptedFiles"`
-}
-
-// AdoptedFile represents a file that was adopted into a pack
+// AdoptedFile represents a file that was adopted into a pack (local to pack package)
 type AdoptedFile struct {
-	OriginalPath string `json:"originalPath"`
-	NewPath      string `json:"newPath"`
-	SymlinkPath  string `json:"symlinkPath"`
+	OriginalPath string
+	NewPath      string
+	SymlinkPath  string
 }
 
 // Adopt moves existing files into the pack and creates symlinks back to their original locations.
 // This allows existing configuration files to be managed by dodot without disrupting their use.
-func (p *Pack) Adopt(fs types.FS, opts AdoptOptions) (*AdoptResult, error) {
+func Adopt(opts AdoptOptions) (*types.PackCommandResult, error) {
 	logger := logging.GetLogger("pack.adopt")
 	logger.Info().
-		Str("pack", p.Name).
+		Str("pack", opts.PackName).
 		Strs("source_paths", opts.SourcePaths).
 		Bool("force", opts.Force).
 		Msg("Adopting files into pack")
 
-	// Prepare result
-	result := &AdoptResult{
-		PackName:     p.Name,
-		AdoptedFiles: []AdoptedFile{},
+	// Use provided filesystem or default
+	fs := opts.FileSystem
+	if fs == nil {
+		fs = filesystem.NewOS()
 	}
+
+	// Validate pack name
+	packName := strings.TrimRight(opts.PackName, "/")
+	if packName == "" {
+		return nil, errors.New(errors.ErrPackNotFound, "pack name cannot be empty")
+	}
+	if err := paths.ValidatePackName(packName); err != nil {
+		return nil, errors.Wrap(err, errors.ErrPackNotFound, "invalid pack name")
+	}
+
+	// Check if pack exists or create it
+	packPath := filepath.Join(opts.DotfilesRoot, packName)
+	if _, err := fs.Stat(packPath); os.IsNotExist(err) {
+		// Create pack directory
+		if err := fs.MkdirAll(packPath, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create pack directory: %w", err)
+		}
+		logger.Info().Str("pack", packName).Msg("Created pack directory")
+	}
+
+	// Create pack instance
+	p := &Pack{
+		Pack: &types.Pack{
+			Name: packName,
+			Path: packPath,
+		},
+	}
+
+	// Track adopted files
+	var adoptedFiles []AdoptedFile
 
 	// Process each source path
 	for _, sourcePath := range opts.SourcePaths {
@@ -59,14 +92,53 @@ func (p *Pack) Adopt(fs types.FS, opts AdoptOptions) (*AdoptResult, error) {
 			return nil, fmt.Errorf("failed to adopt %s: %w", sourcePath, err)
 		}
 		if adopted != nil {
-			result.AdoptedFiles = append(result.AdoptedFiles, *adopted)
+			adoptedFiles = append(adoptedFiles, *adopted)
 		}
 	}
 
 	logger.Info().
 		Str("pack", p.Name).
-		Int("files_adopted", len(result.AdoptedFiles)).
+		Int("files_adopted", len(adoptedFiles)).
 		Msg("Adopt operation completed")
+
+	// Get current pack status if function provided
+	var packStatus []types.DisplayPack
+	if opts.GetPackStatus != nil {
+		var statusErr error
+		packStatus, statusErr = opts.GetPackStatus(opts.PackName, opts.DotfilesRoot, fs)
+		if statusErr != nil {
+			logger.Error().Err(statusErr).Msg("Failed to get pack status")
+		}
+	}
+
+	// Build result
+	result := &types.PackCommandResult{
+		Command:   "adopt",
+		Timestamp: time.Now(),
+		DryRun:    false,
+		Packs:     []types.DisplayPack{},
+		Metadata: types.CommandMetadata{
+			FilesAdopted: len(adoptedFiles),
+			AdoptedPaths: make([]string, 0, len(adoptedFiles)),
+		},
+	}
+
+	// Collect adopted paths
+	for _, file := range adoptedFiles {
+		result.Metadata.AdoptedPaths = append(result.Metadata.AdoptedPaths, file.OriginalPath)
+	}
+
+	// Copy packs from status if available
+	if packStatus != nil {
+		result.Packs = packStatus
+	}
+
+	// Generate message
+	if len(adoptedFiles) == 1 {
+		result.Message = "1 file has been adopted into the pack " + opts.PackName + "."
+	} else {
+		result.Message = fmt.Sprintf("%d files have been adopted into the pack %s.", len(adoptedFiles), opts.PackName)
+	}
 
 	return result, nil
 }
@@ -152,7 +224,7 @@ func (p *Pack) adoptSingleFile(fs types.FS, logger zerolog.Logger, sourcePath st
 
 // AdoptOrCreate creates a pack if it doesn't exist before adopting files.
 // This is a static method since we might need to create the pack first.
-func AdoptOrCreate(fs types.FS, dotfilesRoot, packName string, opts AdoptOptions) (*AdoptResult, error) {
+func AdoptOrCreate(fs types.FS, dotfilesRoot, packName string, opts AdoptOptions) (*types.PackCommandResult, error) {
 	logger := logging.GetLogger("pack.adopt")
 
 	// Normalize and validate pack name
@@ -174,14 +246,14 @@ func AdoptOrCreate(fs types.FS, dotfilesRoot, packName string, opts AdoptOptions
 		logger.Info().Str("pack", packName).Msg("Created pack directory")
 	}
 
-	// Create pack instance
-	p := &Pack{
-		Pack: &types.Pack{
-			Name: packName,
-			Path: packPath,
-		},
+	// Delegate to Adopt function with updated options
+	updatedOpts := AdoptOptions{
+		SourcePaths:   opts.SourcePaths,
+		Force:         opts.Force,
+		DotfilesRoot:  dotfilesRoot,
+		PackName:      packName,
+		FileSystem:    fs,
+		GetPackStatus: opts.GetPackStatus,
 	}
-
-	// Delegate to Adopt method
-	return p.Adopt(fs, opts)
+	return Adopt(updatedOpts)
 }

--- a/pkg/pack/fill.go
+++ b/pkg/pack/fill.go
@@ -1,26 +1,52 @@
 package pack
 
 import (
+	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/arthur-debert/dodot/pkg/errors"
+	"github.com/arthur-debert/dodot/pkg/filesystem"
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/rules"
+	"github.com/arthur-debert/dodot/pkg/statustype"
 	"github.com/arthur-debert/dodot/pkg/types"
 )
 
-// FillResult represents the result of filling a pack with template files
-type FillResult struct {
-	FilesCreated []string `json:"filesCreated"`
+// FillOptions contains options for the Fill operation
+type FillOptions struct {
+	// PackName is the name of the pack to fill
+	PackName string
+	// DotfilesRoot is the root directory for dotfiles
+	DotfilesRoot string
+	// FileSystem is the filesystem to use (optional, defaults to OS filesystem)
+	FileSystem types.FS
+	// GetPackStatus is a function to get pack status to avoid circular imports
+	GetPackStatus statustype.GetPackStatusFunc
 }
 
 // Fill adds template files for handlers that need them in the pack.
 // It identifies which handlers need files but don't have them, and creates
 // appropriate template files for each handler.
-func (p *Pack) Fill(fs types.FS) (*FillResult, error) {
+func Fill(opts FillOptions) (*types.PackCommandResult, error) {
 	log := logging.GetLogger("pack.fill")
-	log.Debug().Str("pack", p.Name).Msg("Starting fill operation")
+	log.Debug().Str("pack", opts.PackName).Msg("Starting fill operation")
+
+	// Use provided filesystem or default
+	fs := opts.FileSystem
+	if fs == nil {
+		fs = filesystem.NewOS()
+	}
+
+	// Find the specific pack
+	targetPack, err := findPack(opts.DotfilesRoot, opts.PackName, fs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap in our enhanced Pack type
+	p := New(targetPack)
 
 	// Get handlers that need files - note we pass the embedded types.Pack
 	handlersNeeding, err := rules.GetHandlersNeedingFiles(*p.Pack, fs)
@@ -124,16 +150,67 @@ func (p *Pack) Fill(fs types.FS) (*FillResult, error) {
 		filesCreated = append(filesCreated, template.Filename)
 	}
 
-	// Return result
-	result := &FillResult{
-		FilesCreated: filesCreated,
-	}
-
 	log.Info().
 		Str("pack", p.Name).
 		Str("path", p.Path).
 		Int("filesCreated", len(filesCreated)).
 		Msg("Fill operation completed")
 
+	// Get current pack status if function provided
+	var packStatus []types.DisplayPack
+	if opts.GetPackStatus != nil {
+		var statusErr error
+		packStatus, statusErr = opts.GetPackStatus(opts.PackName, opts.DotfilesRoot, fs)
+		if statusErr != nil {
+			log.Error().Err(statusErr).Msg("Failed to get pack status")
+		}
+	}
+
+	// Build result
+	result := &types.PackCommandResult{
+		Command:   "fill",
+		Timestamp: time.Now(),
+		DryRun:    false,
+		Packs:     []types.DisplayPack{},
+		Metadata: types.CommandMetadata{
+			FilesCreated: len(filesCreated),
+			CreatedPaths: filesCreated,
+		},
+	}
+
+	// Copy packs from status if available
+	if packStatus != nil {
+		result.Packs = packStatus
+	}
+
+	// Generate message
+	if len(filesCreated) == 1 {
+		result.Message = "The pack " + opts.PackName + " has been filled with 1 placeholder file."
+	} else {
+		result.Message = fmt.Sprintf("The pack %s has been filled with %d placeholder files.", opts.PackName, len(filesCreated))
+	}
+
 	return result, nil
+}
+
+// findPack is a helper to find a pack by name without importing core package
+func findPack(dotfilesRoot, packName string, fs types.FS) (*types.Pack, error) {
+	if packName == "" {
+		return nil, fmt.Errorf("pack(s) not found")
+	}
+
+	packPath := dotfilesRoot + "/" + packName
+	info, err := fs.Stat(packPath)
+	if err != nil {
+		return nil, fmt.Errorf("pack(s) not found")
+	}
+
+	if !info.IsDir() {
+		return nil, fmt.Errorf("pack(s) not found")
+	}
+
+	return &types.Pack{
+		Name: packName,
+		Path: packPath,
+	}, nil
 }

--- a/pkg/pack/fill.go
+++ b/pkg/pack/fill.go
@@ -10,10 +10,15 @@ import (
 	"github.com/arthur-debert/dodot/pkg/types"
 )
 
+// FillResult represents the result of filling a pack with template files
+type FillResult struct {
+	FilesCreated []string `json:"filesCreated"`
+}
+
 // Fill adds template files for handlers that need them in the pack.
 // It identifies which handlers need files but don't have them, and creates
 // appropriate template files for each handler.
-func (p *Pack) Fill(fs types.FS) (*types.FillResult, error) {
+func (p *Pack) Fill(fs types.FS) (*FillResult, error) {
 	log := logging.GetLogger("pack.fill")
 	log.Debug().Str("pack", p.Name).Msg("Starting fill operation")
 
@@ -120,8 +125,7 @@ func (p *Pack) Fill(fs types.FS) (*types.FillResult, error) {
 	}
 
 	// Return result
-	result := &types.FillResult{
-		PackName:     p.Name,
+	result := &FillResult{
 		FilesCreated: filesCreated,
 	}
 

--- a/pkg/pack/init.go
+++ b/pkg/pack/init.go
@@ -19,9 +19,16 @@ type InitOptions struct {
 	DotfilesRoot string
 }
 
+// InitResult represents the result of initializing a new pack
+type InitResult struct {
+	PackName     string   `json:"packName"`
+	Path         string   `json:"path"`
+	FilesCreated []string `json:"filesCreated"`
+}
+
 // Initialize creates a new pack with the standard structure and template files.
 // This is a static method since we're creating a new pack, not operating on an existing one.
-func Initialize(fs types.FS, opts InitOptions) (*types.InitResult, error) {
+func Initialize(fs types.FS, opts InitOptions) (*InitResult, error) {
 	log := logging.GetLogger("pack.init")
 	log.Debug().Str("pack", opts.PackName).Msg("Initializing new pack")
 
@@ -93,7 +100,7 @@ func Initialize(fs types.FS, opts InitOptions) (*types.InitResult, error) {
 	filesCreated = append(filesCreated, fillResult.FilesCreated...)
 
 	// Return result
-	result := &types.InitResult{
+	result := &InitResult{
 		PackName:     opts.PackName,
 		Path:         packPath,
 		FilesCreated: filesCreated,

--- a/pkg/pack/init.go
+++ b/pkg/pack/init.go
@@ -86,25 +86,23 @@ func Initialize(opts InitOptions) (*types.PackCommandResult, error) {
 	}
 	filesCreated = append(filesCreated, "README.txt")
 
-	// Now we need to create a Pack instance to use Fill
-	// First, load the configuration we just wrote
-	packConfig := config.PackConfig{} // Use default config for new pack
-	p := &types.Pack{
-		Name:   opts.PackName,
-		Path:   packPath,
-		Config: packConfig,
-	}
+	// Pack configuration will be loaded automatically by Fill function
 
-	// Wrap in our enhanced Pack type and fill with template files
-	enhancedPack := New(p)
+	// Fill the pack with template files using the static function
 	log.Info().Msg("Creating template files")
-	fillResult, err := enhancedPack.Fill(fs)
+	fillOpts := FillOptions{
+		PackName:     opts.PackName,
+		DotfilesRoot: opts.DotfilesRoot,
+		FileSystem:   fs,
+		// Don't pass GetPackStatus here to avoid duplication
+	}
+	fillResult, err := Fill(fillOpts)
 	if err != nil {
 		return nil, errors.Wrapf(err, errors.ErrInternal, "failed to fill pack with template files")
 	}
 
 	// Add the files created by fill
-	filesCreated = append(filesCreated, fillResult.FilesCreated...)
+	filesCreated = append(filesCreated, fillResult.Metadata.CreatedPaths...)
 
 	log.Info().
 		Str("pack", opts.PackName).

--- a/pkg/statustype/types.go
+++ b/pkg/statustype/types.go
@@ -1,0 +1,10 @@
+// Package statustype provides common types and utilities for status operations
+// without importing other dodot packages, preventing circular dependencies.
+package statustype
+
+import (
+	"github.com/arthur-debert/dodot/pkg/types"
+)
+
+// GetPackStatusFunc is a function type for getting pack status to avoid circular imports
+type GetPackStatusFunc func(packName, dotfilesRoot string, fs types.FS) ([]types.DisplayPack, error)

--- a/pkg/types/results.go
+++ b/pkg/types/results.go
@@ -36,6 +36,52 @@ type CommandResult struct {
 	Result  *DisplayResult `json:"result"`            // The pack status display
 }
 
+// PackCommandResult is the unified result type for all pack-related commands.
+// It combines pack status display with command-specific metadata.
+type PackCommandResult struct {
+	// Command that was executed
+	Command string `json:"command"` // "on", "off", "status", "adopt", "fill", "add-ignore"
+
+	// Packs affected by the command with their current status
+	Packs []DisplayPack `json:"packs"`
+
+	// Optional message for the command (e.g., "The pack vim has been turned on.")
+	Message string `json:"message,omitempty"`
+
+	// Metadata specific to the command
+	Metadata CommandMetadata `json:"metadata,omitempty"`
+
+	// Whether this was a dry run
+	DryRun bool `json:"dryRun"`
+
+	// When the command was executed
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// CommandMetadata contains command-specific information
+type CommandMetadata struct {
+	// For 'on' command
+	TotalDeployed  int  `json:"totalDeployed,omitempty"`
+	NoProvision    bool `json:"noProvision,omitempty"`
+	ProvisionRerun bool `json:"provisionRerun,omitempty"`
+
+	// For 'off' command
+	TotalCleared int      `json:"totalCleared,omitempty"`
+	HandlersRun  []string `json:"handlersRun,omitempty"`
+
+	// For 'adopt' command
+	FilesAdopted int      `json:"filesAdopted,omitempty"`
+	AdoptedPaths []string `json:"adoptedPaths,omitempty"`
+
+	// For 'fill' command
+	FilesCreated int      `json:"filesCreated,omitempty"`
+	CreatedPaths []string `json:"createdPaths,omitempty"`
+
+	// For 'add-ignore' command
+	IgnoreCreated  bool `json:"ignoreCreated,omitempty"`
+	AlreadyExisted bool `json:"alreadyExisted,omitempty"`
+}
+
 // FormatCommandMessage generates a standard message for command results.
 // It handles pluralization and pack name listing appropriately.
 // Returns empty string if there are no packs (message will be omitted).
@@ -129,46 +175,11 @@ func (dp *DisplayPack) GetPackStatus() string {
 	return "queue"
 }
 
-// FillResult holds the result of the 'fill' command.
-type FillResult struct {
-	PackName     string   `json:"packName"`
-	FilesCreated []string `json:"filesCreated"`
-	// Operations field removed - part of Operation layer elimination
-}
-
-// InitResult holds the result of the 'init' command.
-type InitResult struct {
-	PackName     string   `json:"packName"`
-	Path         string   `json:"path"`
-	FilesCreated []string `json:"filesCreated"`
-	// Operations field removed - part of Operation layer elimination
-}
-
-// AddIgnoreResult holds the result of the 'add-ignore' command.
-type AddIgnoreResult struct {
-	PackName       string `json:"packName"`
-	IgnoreFilePath string `json:"ignoreFilePath"`
-	Created        bool   `json:"created"`
-	AlreadyExisted bool   `json:"alreadyExisted"`
-}
-
 // GenConfigResult holds the result of the 'gen-config' command.
+// This is kept separate as it doesn't follow the pack command pattern.
 type GenConfigResult struct {
 	ConfigContent string   `json:"configContent"`
 	FilesWritten  []string `json:"filesWritten"`
-}
-
-// AdoptResult holds the result of the 'adopt' command.
-type AdoptResult struct {
-	PackName     string        `json:"packName"`
-	AdoptedFiles []AdoptedFile `json:"adoptedFiles"`
-}
-
-// AdoptedFile represents a single file that was adopted.
-type AdoptedFile struct {
-	OriginalPath string `json:"originalPath"` // Original file path (e.g., ~/.gitconfig)
-	NewPath      string `json:"newPath"`      // New path in pack (e.g., /path/to/dotfiles/git/gitconfig)
-	SymlinkPath  string `json:"symlinkPath"`  // Symlink path (usually same as OriginalPath)
 }
 
 // GetHandlerSymbol returns the Unicode symbol for a given Handler

--- a/pkg/ui/terminal/renderer.go
+++ b/pkg/ui/terminal/renderer.go
@@ -33,7 +33,29 @@ func New(w io.Writer) (*Renderer, error) {
 func (r *Renderer) RenderResult(result interface{}) error {
 	// For now, delegate to the legacy renderer based on type
 	switch v := result.(type) {
+	case *types.PackCommandResult:
+		// Convert PackCommandResult to DisplayResult for rendering
+		displayResult := &types.DisplayResult{
+			Command:   v.Command,
+			Packs:     v.Packs,
+			DryRun:    v.DryRun,
+			Timestamp: v.Timestamp,
+		}
+
+		// Render the optional message first
+		if v.Message != "" {
+			if err := r.legacyRenderer.RenderMessage("Info", v.Message); err != nil {
+				return err
+			}
+			// Add a blank line between message and pack status
+			if _, err := fmt.Fprintln(r.output); err != nil {
+				return err
+			}
+		}
+		// Then render the pack status
+		return r.legacyRenderer.Render(displayResult)
 	case *types.CommandResult:
+		// Legacy CommandResult support
 		// Render the optional message first
 		if v.Message != "" {
 			if err := r.legacyRenderer.RenderMessage("Info", v.Message); err != nil {

--- a/pkg/ui/text/renderer.go
+++ b/pkg/ui/text/renderer.go
@@ -27,7 +27,29 @@ func New(output io.Writer) (*Renderer, error) {
 func (r *Renderer) RenderResult(result interface{}) error {
 	// For now, delegate to the legacy renderer based on type
 	switch v := result.(type) {
+	case *types.PackCommandResult:
+		// Convert PackCommandResult to DisplayResult for rendering
+		displayResult := &types.DisplayResult{
+			Command:   v.Command,
+			Packs:     v.Packs,
+			DryRun:    v.DryRun,
+			Timestamp: v.Timestamp,
+		}
+
+		// Render the optional message first
+		if v.Message != "" {
+			if _, err := fmt.Fprintln(r.output, v.Message); err != nil {
+				return err
+			}
+			// Add a blank line between message and pack status
+			if _, err := fmt.Fprintln(r.output); err != nil {
+				return err
+			}
+		}
+		// Then render the pack status
+		return r.legacyRenderer.Render(displayResult)
 	case *types.CommandResult:
+		// Legacy CommandResult support
 		// Render the optional message first
 		if v.Message != "" {
 			if _, err := fmt.Fprintln(r.output, v.Message); err != nil {


### PR DESCRIPTION
## Summary
- Replace multiple separate result types with unified PackCommandResult for consistent output format
- All pack commands now show full status for each pack + command summary message
- Preserve command-specific information in metadata field

## Changes Made
- Added unified PackCommandResult type with CommandMetadata for command-specific data
- Updated all pack commands (on, off, status, adopt, fill, add-ignore, init) to return PackCommandResult
- Updated rendering system to handle unified result type
- Removed old result types from types package and defined local types in pack package
- Updated all tests to use new result structure

## Test Plan
- [x] All existing tests pass
- [x] Build succeeds without errors
- [x] Linting passes
- [x] Commands maintain backward compatibility in output format

🤖 Generated with [Claude Code](https://claude.ai/code)