### PR TITLE
Clean up pkg/types package organization

### DIFF
--- a/cmd/dodot/root.go
+++ b/cmd/dodot/root.go
@@ -571,7 +571,7 @@ func newSnippetCmd() *cobra.Command {
 		}
 
 		// Get the appropriate snippet for the shell using the actual data directory
-		snippetText := types.GetShellIntegrationSnippet(shell, dataDir)
+		snippetText := shellpkg.GetShellIntegrationSnippet(shell, dataDir)
 
 		// Create a result structure for the snippet
 		snippetResult := struct {

--- a/pkg/commands/on/on.go
+++ b/pkg/commands/on/on.go
@@ -111,7 +111,7 @@ func OnPacks(opts OnPacksOptions) (*types.PackCommandResult, error) {
 					logger.Info().Str("dataDir", dataDir).Msg("Shell integration installed successfully")
 
 					// Show user what was installed and how to enable it
-					snippet := types.GetShellIntegrationSnippet("bash", dataDir)
+					snippet := shell.GetShellIntegrationSnippet("bash", dataDir)
 
 					fmt.Println("✅ Shell integration installed successfully!")
 					fmt.Printf("📁 Scripts installed to: %s/shell/\n", dataDir)

--- a/pkg/shell/snippets.go
+++ b/pkg/shell/snippets.go
@@ -1,4 +1,4 @@
-package types
+package shell
 
 import (
 	"fmt"

--- a/pkg/shell/snippets_test.go
+++ b/pkg/shell/snippets_test.go
@@ -1,14 +1,14 @@
-// pkg/types/shell_test.go
+// pkg/shell/snippets_test.go
 // TEST TYPE: Unit Tests
 // DEPENDENCIES: None
 // PURPOSE: Test shell integration snippet generation
 
-package types_test
+package shell_test
 
 import (
 	"testing"
 
-	"github.com/arthur-debert/dodot/pkg/types"
+	"github.com/arthur-debert/dodot/pkg/shell"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,7 +75,7 @@ end`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := types.GetShellIntegrationSnippet(tt.shell, tt.customDataDir)
+			result := shell.GetShellIntegrationSnippet(tt.shell, tt.customDataDir)
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
@@ -107,7 +107,7 @@ func TestGetShellIntegrationSnippet_PathsWithSpecialChars(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := types.GetShellIntegrationSnippet(tt.shell, tt.dataDir)
+			result := shell.GetShellIntegrationSnippet(tt.shell, tt.dataDir)
 			assert.Contains(t, result, tt.dataDir)
 		})
 	}
@@ -120,7 +120,7 @@ func TestGetShellIntegrationSnippet_Constants(t *testing.T) {
     source "$HOME/.local/share/dodot/shell/dodot-init.fish"
 end`
 
-	assert.Equal(t, bashExpected, types.GetShellIntegrationSnippet("bash", ""))
-	assert.Equal(t, bashExpected, types.GetShellIntegrationSnippet("zsh", ""))
-	assert.Equal(t, fishExpected, types.GetShellIntegrationSnippet("fish", ""))
+	assert.Equal(t, bashExpected, shell.GetShellIntegrationSnippet("bash", ""))
+	assert.Equal(t, bashExpected, shell.GetShellIntegrationSnippet("zsh", ""))
+	assert.Equal(t, fishExpected, shell.GetShellIntegrationSnippet("fish", ""))
 }


### PR DESCRIPTION
## Summary
Clean up and reorganize the pkg/types package by moving misplaced code and fixing test conventions.

## Changes Made

### 1. Move shell integration functionality to proper location
- **Move** `pkg/types/shell.go` → `pkg/shell/snippets.go`
- **Move** `pkg/types/shell_test.go` → `pkg/shell/snippets_test.go`
- **Update** package declarations and import references
- **Update** `cmd/dodot/root.go` to use `shellpkg.GetShellIntegrationSnippet`
- **Update** `pkg/commands/on/on.go` to use `shell.GetShellIntegrationSnippet`

### 2. Fix test conventions in pack_provisioning_test.go
- **Change** from `package types` to `package types_test` for proper separation
- **Replace** custom MockDataStore with the standardized one from `pkg/testutil`
- **Update** tests to use sentinel-based state tracking instead of custom state logic
- **Add** proper test documentation headers
- **Simplify** test assertions using testify/assert

### 3. Verify remaining test files are correctly placed
Confirmed that the remaining test files in pkg/types are testing core types and belong there:
- `execution_context_test.go` - Tests ExecutionContext, PackExecutionResult, HandlerResult
- `results_test.go` - Tests DisplayPack, DisplayResult, FormatCommandMessage
- `pack_test.go` - Tests Pack.GetFilePath method
- `types_test.go` - Tests basic Pack and RuleMatch structures

## Test Results
- ✅ All tests pass locally
- ✅ Shell integration tests work with moved package
- ✅ Provisioning tests work with proper MockDataStore
- ✅ Pre-commit hooks pass (linting, formatting, tests)

## Why These Changes?
1. **Better package organization**: Shell integration functionality belongs in `pkg/shell`, not `pkg/types`
2. **Consistent test conventions**: All tests should follow `package xyz_test` pattern and use standardized test utilities
3. **Reduced duplication**: Eliminate custom MockDataStore in favor of the proper one in `pkg/testutil`
4. **Improved maintainability**: Clearer separation of concerns and consistent patterns

This completes the cleanup task requested in the previous conversation.

🤖 Generated with [Claude Code](https://claude.ai/code)