### PR TITLE
refactor: move checksum to utils and rename pack to packcommands

### DIFF
--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/arthur-debert/dodot/pkg/logging"
-	"github.com/arthur-debert/dodot/pkg/pack"
+	"github.com/arthur-debert/dodot/pkg/packcommands"
 	"github.com/arthur-debert/dodot/pkg/paths"
 	"github.com/arthur-debert/dodot/pkg/types"
 )
@@ -71,7 +71,7 @@ func Dispatch(cmdType CommandType, opts Options) (*types.PackCommandResult, erro
 
 	switch cmdType {
 	case CommandOn:
-		result, err = pack.TurnOn(pack.OnOptions{
+		result, err = packcommands.TurnOn(packcommands.OnOptions{
 			DotfilesRoot:   opts.DotfilesRoot,
 			PackNames:      opts.PackNames,
 			DryRun:         opts.DryRun,
@@ -82,7 +82,7 @@ func Dispatch(cmdType CommandType, opts Options) (*types.PackCommandResult, erro
 		})
 
 	case CommandOff:
-		result, err = pack.TurnOff(pack.OffOptions{
+		result, err = packcommands.TurnOff(packcommands.OffOptions{
 			DotfilesRoot: opts.DotfilesRoot,
 			PackNames:    opts.PackNames,
 			DryRun:       opts.DryRun,
@@ -90,7 +90,7 @@ func Dispatch(cmdType CommandType, opts Options) (*types.PackCommandResult, erro
 		})
 
 	case CommandStatus:
-		result, err = pack.GetPacksStatus(pack.StatusCommandOptions{
+		result, err = packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 			DotfilesRoot: opts.DotfilesRoot,
 			PackNames:    opts.PackNames,
 			Paths:        opts.Paths,
@@ -100,7 +100,7 @@ func Dispatch(cmdType CommandType, opts Options) (*types.PackCommandResult, erro
 	case CommandInit:
 		// For init, we need to create a status function
 		getPackStatus := func(packName, dotfilesRoot string, fs types.FS) ([]types.DisplayPack, error) {
-			statusResult, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+			statusResult, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 				DotfilesRoot: dotfilesRoot,
 				PackNames:    []string{packName},
 				FileSystem:   fs,
@@ -111,7 +111,7 @@ func Dispatch(cmdType CommandType, opts Options) (*types.PackCommandResult, erro
 			return statusResult.Packs, nil
 		}
 
-		result, err = pack.Initialize(pack.InitOptions{
+		result, err = packcommands.Initialize(packcommands.InitOptions{
 			PackName:      opts.PackName,
 			DotfilesRoot:  opts.DotfilesRoot,
 			FileSystem:    opts.FileSystem,
@@ -125,7 +125,7 @@ func Dispatch(cmdType CommandType, opts Options) (*types.PackCommandResult, erro
 			packName = opts.PackNames[0]
 		}
 
-		result, err = pack.Fill(pack.FillOptions{
+		result, err = packcommands.Fill(packcommands.FillOptions{
 			PackName:     packName,
 			DotfilesRoot: opts.DotfilesRoot,
 			FileSystem:   opts.FileSystem,
@@ -138,12 +138,12 @@ func Dispatch(cmdType CommandType, opts Options) (*types.PackCommandResult, erro
 			packName = opts.PackNames[0]
 		}
 
-		// Skip pack validation here - it will be handled by pack.Adopt
+		// Skip pack validation here - it will be handled by packcommands.Adopt
 		// This avoids circular dependency issues
 
 		// Create status function
 		getPackStatus := func(packName, dotfilesRoot string, fs types.FS) ([]types.DisplayPack, error) {
-			statusResult, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+			statusResult, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 				DotfilesRoot: dotfilesRoot,
 				PackNames:    []string{packName},
 				FileSystem:   fs,
@@ -154,7 +154,7 @@ func Dispatch(cmdType CommandType, opts Options) (*types.PackCommandResult, erro
 			return statusResult.Packs, nil
 		}
 
-		result, err = pack.Adopt(pack.AdoptOptions{
+		result, err = packcommands.Adopt(packcommands.AdoptOptions{
 			SourcePaths:   opts.SourcePaths,
 			Force:         opts.Force,
 			DotfilesRoot:  opts.DotfilesRoot,
@@ -172,7 +172,7 @@ func Dispatch(cmdType CommandType, opts Options) (*types.PackCommandResult, erro
 
 		// Create status function
 		getPackStatus := func(packName, dotfilesRoot string, fs types.FS) ([]types.DisplayPack, error) {
-			statusResult, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+			statusResult, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 				DotfilesRoot: dotfilesRoot,
 				PackNames:    []string{packName},
 				FileSystem:   fs,
@@ -183,7 +183,7 @@ func Dispatch(cmdType CommandType, opts Options) (*types.PackCommandResult, erro
 			return statusResult.Packs, nil
 		}
 
-		result, err = pack.AddIgnore(pack.AddIgnoreOptions{
+		result, err = packcommands.AddIgnore(packcommands.AddIgnoreOptions{
 			PackName:      packName,
 			DotfilesRoot:  opts.DotfilesRoot,
 			FileSystem:    opts.FileSystem,

--- a/pkg/handlers/homebrew/homebrew.go
+++ b/pkg/handlers/homebrew/homebrew.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 
 	"github.com/arthur-debert/dodot/pkg/handlers"
-	"github.com/arthur-debert/dodot/pkg/internal/hashutil"
 	"github.com/arthur-debert/dodot/pkg/operations"
 	"github.com/arthur-debert/dodot/pkg/types"
+	"github.com/arthur-debert/dodot/pkg/utils"
 )
 
 const HomebrewHandlerName = "homebrew"
@@ -37,7 +37,7 @@ func (h *Handler) ToOperations(matches []types.RuleMatch) ([]operations.Operatio
 
 	for _, match := range matches {
 		// Calculate checksum for idempotency
-		checksum, err := hashutil.CalculateFileChecksum(match.AbsolutePath)
+		checksum, err := utils.CalculateFileChecksum(match.AbsolutePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate checksum for %s: %w", match.AbsolutePath, err)
 		}

--- a/pkg/handlers/install/install.go
+++ b/pkg/handlers/install/install.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 
 	"github.com/arthur-debert/dodot/pkg/handlers"
-	"github.com/arthur-debert/dodot/pkg/internal/hashutil"
 	"github.com/arthur-debert/dodot/pkg/operations"
 	"github.com/arthur-debert/dodot/pkg/types"
+	"github.com/arthur-debert/dodot/pkg/utils"
 )
 
 const InstallHandlerName = "install"
@@ -36,7 +36,7 @@ func (h *Handler) ToOperations(matches []types.RuleMatch) ([]operations.Operatio
 
 	for _, match := range matches {
 		// Calculate checksum for idempotency
-		checksum, err := hashutil.CalculateFileChecksum(match.AbsolutePath)
+		checksum, err := utils.CalculateFileChecksum(match.AbsolutePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate checksum for %s: %w", match.AbsolutePath, err)
 		}

--- a/pkg/pack/status.go
+++ b/pkg/pack/status.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/arthur-debert/dodot/pkg/handlers"
-	"github.com/arthur-debert/dodot/pkg/internal/hashutil"
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/paths"
 	"github.com/arthur-debert/dodot/pkg/rules"
 	"github.com/arthur-debert/dodot/pkg/types"
+	"github.com/arthur-debert/dodot/pkg/utils"
 )
 
 // StatusState represents the state of a deployment
@@ -317,7 +317,7 @@ func getConfigurationHandlerStatus(match types.RuleMatch, pack types.Pack, dataS
 // getCodeExecutionHandlerStatus checks status for code execution handlers
 func getCodeExecutionHandlerStatus(match types.RuleMatch, pack types.Pack, dataStore types.DataStore, fs types.FS) (Status, error) {
 	// Calculate current checksum
-	currentChecksum, err := hashutil.CalculateFileChecksum(match.AbsolutePath)
+	currentChecksum, err := utils.CalculateFileChecksum(match.AbsolutePath)
 	if err != nil {
 		return Status{}, fmt.Errorf("failed to calculate checksum: %w", err)
 	}

--- a/pkg/packcommands/addignore.go
+++ b/pkg/packcommands/addignore.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"fmt"

--- a/pkg/packcommands/addignore_test.go
+++ b/pkg/packcommands/addignore_test.go
@@ -3,13 +3,13 @@
 // DEPENDENCIES: Memory FS
 // PURPOSE: Test addignore command orchestration for creating ignore files
 
-package pack_test
+package packcommands_test
 
 import (
 	"path/filepath"
 	"testing"
 
-	"github.com/arthur-debert/dodot/pkg/pack"
+	"github.com/arthur-debert/dodot/pkg/packcommands"
 	"github.com/arthur-debert/dodot/pkg/config"
 	"github.com/arthur-debert/dodot/pkg/errors"
 	"github.com/arthur-debert/dodot/pkg/testutil"
@@ -29,14 +29,14 @@ func TestAddIgnore_CreateIgnoreFile_Orchestration(t *testing.T) {
 		},
 	})
 
-	opts := pack.AddIgnoreOptions{
+	opts := packcommands.AddIgnoreOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "vim",
 		FileSystem:   env.FS,
 	}
 
 	// Execute
-	result, err := pack.AddIgnore(opts)
+	result, err := packcommands.AddIgnore(opts)
 
 	// Verify orchestration behavior
 	require.NoError(t, err)
@@ -64,14 +64,14 @@ func TestAddIgnore_AlreadyExists_Orchestration(t *testing.T) {
 	}
 	env.SetupPack("vim", testutil.PackConfig{Files: packFiles})
 
-	opts := pack.AddIgnoreOptions{
+	opts := packcommands.AddIgnoreOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "vim",
 		FileSystem:   env.FS,
 	}
 
 	// Execute
-	result, err := pack.AddIgnore(opts)
+	result, err := packcommands.AddIgnore(opts)
 
 	// Verify already exists behavior
 	require.NoError(t, err)
@@ -94,14 +94,14 @@ func TestAddIgnore_PackNameNormalization_Orchestration(t *testing.T) {
 		},
 	})
 
-	opts := pack.AddIgnoreOptions{
+	opts := packcommands.AddIgnoreOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "vim/", // Trailing slash should be normalized
 		FileSystem:   env.FS,
 	}
 
 	// Execute
-	result, err := pack.AddIgnore(opts)
+	result, err := packcommands.AddIgnore(opts)
 
 	// Verify pack name normalization
 	require.NoError(t, err)
@@ -117,14 +117,14 @@ func TestAddIgnore_NonExistentPack_Orchestration(t *testing.T) {
 	env := testutil.NewTestEnvironment(t, testutil.EnvIsolated)
 
 	// Don't create any pack - test non-existent pack behavior
-	opts := pack.AddIgnoreOptions{
+	opts := packcommands.AddIgnoreOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "nonexistent",
 		FileSystem:   env.FS,
 	}
 
 	// Execute
-	result, err := pack.AddIgnore(opts)
+	result, err := packcommands.AddIgnore(opts)
 
 	// Verify error handling for non-existent pack
 	assert.Error(t, err, "should return error for non-existent pack")
@@ -140,14 +140,14 @@ func TestAddIgnore_EmptyPackName_Orchestration(t *testing.T) {
 	// Setup
 	env := testutil.NewTestEnvironment(t, testutil.EnvIsolated)
 
-	opts := pack.AddIgnoreOptions{
+	opts := packcommands.AddIgnoreOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "", // Empty pack name
 		FileSystem:   env.FS,
 	}
 
 	// Execute
-	result, err := pack.AddIgnore(opts)
+	result, err := packcommands.AddIgnore(opts)
 
 	// Verify validation error for empty pack name
 	assert.Error(t, err, "should return error for empty pack name")
@@ -173,14 +173,14 @@ func TestAddIgnore_InvalidPackName_Orchestration(t *testing.T) {
 
 	for _, packName := range invalidPackNames {
 		t.Run("invalid_name_"+packName, func(t *testing.T) {
-			opts := pack.AddIgnoreOptions{
+			opts := packcommands.AddIgnoreOptions{
 				DotfilesRoot: env.DotfilesRoot,
 				PackName:     packName,
 				FileSystem:   env.FS,
 			}
 
 			// Execute
-			result, err := pack.AddIgnore(opts)
+			result, err := packcommands.AddIgnore(opts)
 
 			// Verify validation catches invalid pack names
 			assert.Error(t, err, "should return error for invalid pack name: %s", packName)
@@ -203,14 +203,14 @@ func TestAddIgnore_ResultStructure_Orchestration(t *testing.T) {
 		},
 	})
 
-	opts := pack.AddIgnoreOptions{
+	opts := packcommands.AddIgnoreOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "vim",
 		FileSystem:   env.FS,
 	}
 
 	// Execute
-	result, err := pack.AddIgnore(opts)
+	result, err := packcommands.AddIgnore(opts)
 
 	// Verify complete result structure
 	require.NoError(t, err)
@@ -241,13 +241,13 @@ func TestAddIgnore_MultiplePacksOrchestration_Integration(t *testing.T) {
 	// Execute addignore for each pack
 	for _, packName := range packNames {
 		t.Run("pack_"+packName, func(t *testing.T) {
-			opts := pack.AddIgnoreOptions{
+			opts := packcommands.AddIgnoreOptions{
 				DotfilesRoot: env.DotfilesRoot,
 				PackName:     packName,
 				FileSystem:   env.FS,
 			}
 
-			result, err := pack.AddIgnore(opts)
+			result, err := packcommands.AddIgnore(opts)
 
 			// Verify each pack gets its own ignore file
 			require.NoError(t, err)
@@ -276,14 +276,14 @@ func TestAddIgnore_FileSystemIntegration_Orchestration(t *testing.T) {
 		},
 	})
 
-	opts := pack.AddIgnoreOptions{
+	opts := packcommands.AddIgnoreOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "complex-pack",
 		FileSystem:   env.FS,
 	}
 
 	// Execute
-	result, err := pack.AddIgnore(opts)
+	result, err := packcommands.AddIgnore(opts)
 
 	// Verify ignore file creation integrates with pack structure
 	require.NoError(t, err)

--- a/pkg/packcommands/adopt.go
+++ b/pkg/packcommands/adopt.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"fmt"

--- a/pkg/packcommands/adopt_file.go
+++ b/pkg/packcommands/adopt_file.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"fmt"

--- a/pkg/packcommands/adopt_test.go
+++ b/pkg/packcommands/adopt_test.go
@@ -3,7 +3,7 @@
 // DEPENDENCIES: Mock DataStore, Memory FS
 // PURPOSE: Test adopt command orchestration for file adoption and pack management
 
-package pack_test
+package packcommands_test
 
 import (
 	"os"
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/arthur-debert/dodot/pkg/pack"
+	"github.com/arthur-debert/dodot/pkg/packcommands"
 	"github.com/arthur-debert/dodot/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +24,7 @@ func TestAdopt_EmptySourcePaths_Orchestration(t *testing.T) {
 	// Create the pack first
 	env.SetupPack("test-pack", testutil.PackConfig{})
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "test-pack",
 		SourcePaths:  []string{},
@@ -33,7 +33,7 @@ func TestAdopt_EmptySourcePaths_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify empty sources handling - adopt succeeds but adopts nothing
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func TestAdopt_SingleFile_Orchestration(t *testing.T) {
 	err := env.FS.WriteFile(homeFile, []byte("user.name = Test User"), 0644)
 	require.NoError(t, err)
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "git",
 		SourcePaths:  []string{homeFile},
@@ -63,7 +63,7 @@ func TestAdopt_SingleFile_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify single file adoption orchestration
 	require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestAdopt_MultipleFiles_Orchestration(t *testing.T) {
 		sourcePaths = append(sourcePaths, filePath)
 	}
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "shell",
 		SourcePaths:  sourcePaths,
@@ -117,7 +117,7 @@ func TestAdopt_MultipleFiles_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify multiple file adoption orchestration
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestAdopt_NonExistentFile_Orchestration(t *testing.T) {
 
 	nonExistentFile := filepath.Join(env.HomeDir, ".nonexistent")
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "test",
 		SourcePaths:  []string{nonExistentFile},
@@ -156,7 +156,7 @@ func TestAdopt_NonExistentFile_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify error handling for non-existent files
 	assert.Error(t, err, "should return error for non-existent file")
@@ -174,7 +174,7 @@ func TestAdopt_NewPackCreation_Orchestration(t *testing.T) {
 	err := env.FS.WriteFile(sourceFile, []byte("set number"), 0644)
 	require.NoError(t, err)
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "newpack", // Pack doesn't exist yet
 		SourcePaths:  []string{sourceFile},
@@ -183,7 +183,7 @@ func TestAdopt_NewPackCreation_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify error for non-existent pack
 	require.Error(t, err)
@@ -210,7 +210,7 @@ func TestAdopt_ForceOverwrite_Orchestration(t *testing.T) {
 	err = env.FS.WriteFile(sourceFile, []byte("new content"), 0644)
 	require.NoError(t, err)
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "git",
 		SourcePaths:  []string{sourceFile},
@@ -219,7 +219,7 @@ func TestAdopt_ForceOverwrite_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify force overwrite orchestration
 	require.NoError(t, err)
@@ -251,7 +251,7 @@ func TestAdopt_ConflictWithoutForce_Orchestration(t *testing.T) {
 	err = env.FS.WriteFile(sourceFile, []byte("new content"), 0644)
 	require.NoError(t, err)
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "git",
 		SourcePaths:  []string{sourceFile},
@@ -260,7 +260,7 @@ func TestAdopt_ConflictWithoutForce_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify conflict handling without force
 	assert.Error(t, err, "should return error for existing destination")
@@ -283,7 +283,7 @@ func TestAdopt_InvalidPackName_Orchestration(t *testing.T) {
 	err := env.FS.WriteFile(sourceFile, []byte("test content"), 0644)
 	require.NoError(t, err)
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "", // Invalid: empty pack name
 		SourcePaths:  []string{sourceFile},
@@ -292,7 +292,7 @@ func TestAdopt_InvalidPackName_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify pack name validation
 	assert.Error(t, err, "should return error for empty pack name")
@@ -312,7 +312,7 @@ func TestAdopt_PackNameTrailingSlash_Orchestration(t *testing.T) {
 	err := env.FS.WriteFile(sourceFile, []byte("test content"), 0644)
 	require.NoError(t, err)
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "test/", // Trailing slash (from shell completion)
 		SourcePaths:  []string{sourceFile},
@@ -321,7 +321,7 @@ func TestAdopt_PackNameTrailingSlash_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify trailing slash handling
 	require.NoError(t, err)
@@ -352,7 +352,7 @@ func TestAdopt_IdempotentBehavior_Orchestration(t *testing.T) {
 	err = env.FS.Symlink(managedFile, symlinkPath)
 	require.NoError(t, err)
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "git",
 		SourcePaths:  []string{symlinkPath},
@@ -361,7 +361,7 @@ func TestAdopt_IdempotentBehavior_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify idempotent behavior (already managed files are skipped)
 	require.NoError(t, err)
@@ -397,7 +397,7 @@ func TestAdopt_XDGConfigFile_Orchestration(t *testing.T) {
 		}
 	}()
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "starship",
 		SourcePaths:  []string{configFile},
@@ -406,7 +406,7 @@ func TestAdopt_XDGConfigFile_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify XDG config adoption orchestration
 	require.NoError(t, err)
@@ -435,7 +435,7 @@ func TestAdopt_PartialFailure_Orchestration(t *testing.T) {
 
 	invalidFile := filepath.Join(env.HomeDir, ".nonexistent")
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "mixed",
 		SourcePaths:  []string{validFile, invalidFile}, // Mix of valid and invalid
@@ -444,7 +444,7 @@ func TestAdopt_PartialFailure_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify partial failure handling
 	assert.Error(t, err, "should return error for invalid file")
@@ -469,7 +469,7 @@ func TestAdopt_ResultStructure_Orchestration(t *testing.T) {
 	err := env.FS.WriteFile(sourceFile, []byte("test content"), 0644)
 	require.NoError(t, err)
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "structure-test",
 		SourcePaths:  []string{sourceFile},
@@ -478,7 +478,7 @@ func TestAdopt_ResultStructure_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify result structure completeness
 	require.NoError(t, err)
@@ -512,7 +512,7 @@ func TestAdopt_FileSystemIntegration_Orchestration(t *testing.T) {
 	err = env.FS.WriteFile(nestedFile, []byte("{\"setting\": \"value\"}"), 0644)
 	require.NoError(t, err)
 
-	opts := pack.AdoptOptions{
+	opts := packcommands.AdoptOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     "app",
 		SourcePaths:  []string{nestedFile},
@@ -521,7 +521,7 @@ func TestAdopt_FileSystemIntegration_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.Adopt(opts)
+	result, err := packcommands.Adopt(opts)
 
 	// Verify complex filesystem operation orchestration
 	require.NoError(t, err)

--- a/pkg/packcommands/file_operations.go
+++ b/pkg/packcommands/file_operations.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"os"

--- a/pkg/packcommands/fill.go
+++ b/pkg/packcommands/fill.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"fmt"

--- a/pkg/packcommands/fill_test.go
+++ b/pkg/packcommands/fill_test.go
@@ -1,4 +1,4 @@
-package pack_test
+package packcommands_test
 
 import (
 	"os"
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/arthur-debert/dodot/pkg/pack"
+	"github.com/arthur-debert/dodot/pkg/packcommands"
 	"github.com/arthur-debert/dodot/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,13 +93,13 @@ func TestFill(t *testing.T) {
 			}
 
 			// Run fill command
-			opts := pack.FillOptions{
+			opts := packcommands.FillOptions{
 				DotfilesRoot: env.DotfilesRoot,
 				PackName:     "testpack",
 				FileSystem:   fs,
 			}
 
-			result, err := pack.Fill(opts)
+			result, err := packcommands.Fill(opts)
 
 			// Check error
 			if tt.expectedError != "" {
@@ -188,13 +188,13 @@ func TestFillErrors(t *testing.T) {
 			}
 
 			// Run fill command
-			opts := pack.FillOptions{
+			opts := packcommands.FillOptions{
 				DotfilesRoot: env.DotfilesRoot,
 				PackName:     tt.packName,
 				FileSystem:   env.FS,
 			}
 
-			result, err := pack.Fill(opts)
+			result, err := packcommands.Fill(opts)
 
 			// Should error
 			require.Error(t, err)

--- a/pkg/packcommands/ignore_file.go
+++ b/pkg/packcommands/ignore_file.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"github.com/arthur-debert/dodot/pkg/config"

--- a/pkg/packcommands/init.go
+++ b/pkg/packcommands/init.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"fmt"

--- a/pkg/packcommands/init_test.go
+++ b/pkg/packcommands/init_test.go
@@ -1,4 +1,4 @@
-package pack_test
+package packcommands_test
 
 import (
 	"os"
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/arthur-debert/dodot/pkg/pack"
+	"github.com/arthur-debert/dodot/pkg/packcommands"
 	"github.com/arthur-debert/dodot/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,13 +62,13 @@ func TestInitialize(t *testing.T) {
 			defer env.Cleanup()
 
 			// Run init command
-			opts := pack.InitOptions{
+			opts := packcommands.InitOptions{
 				DotfilesRoot: env.DotfilesRoot,
 				PackName:     tt.packName,
 				FileSystem:   env.FS,
 			}
 
-			result, err := pack.Initialize(opts)
+			result, err := packcommands.Initialize(opts)
 
 			// Check error
 			if tt.expectedError != "" {
@@ -156,13 +156,13 @@ func TestInitializeExistingPack(t *testing.T) {
 	require.NoError(t, env.FS.MkdirAll(packPath, 0755))
 
 	// Try to init over existing pack
-	opts := pack.InitOptions{
+	opts := packcommands.InitOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackName:     packName,
 		FileSystem:   env.FS,
 	}
 
-	result, err := pack.Initialize(opts)
+	result, err := packcommands.Initialize(opts)
 
 	// Should error
 	require.Error(t, err)
@@ -179,13 +179,13 @@ func TestInitializeIntegration(t *testing.T) {
 
 		// Init a new pack
 		packName := "integration"
-		opts := pack.InitOptions{
+		opts := packcommands.InitOptions{
 			DotfilesRoot: env.DotfilesRoot,
 			PackName:     packName,
 			FileSystem:   env.FS,
 		}
 
-		result, err := pack.Initialize(opts)
+		result, err := packcommands.Initialize(opts)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 

--- a/pkg/packcommands/off.go
+++ b/pkg/packcommands/off.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"fmt"

--- a/pkg/packcommands/on.go
+++ b/pkg/packcommands/on.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"fmt"

--- a/pkg/packcommands/on_provisioning_test.go
+++ b/pkg/packcommands/on_provisioning_test.go
@@ -3,12 +3,12 @@
 // DEPENDENCIES: Mock DataStore, Memory FS
 // PURPOSE: Test on command with new provisioning options
 
-package pack_test
+package packcommands_test
 
 import (
 	"testing"
 
-	"github.com/arthur-debert/dodot/pkg/pack"
+	"github.com/arthur-debert/dodot/pkg/packcommands"
 	"github.com/arthur-debert/dodot/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,7 +34,7 @@ handler = "install"`,
 		},
 	})
 
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{"mixed"},
 		DryRun:       false,
@@ -44,7 +44,7 @@ handler = "install"`,
 	}
 
 	// Execute
-	result, err := pack.TurnOn(opts)
+	result, err := packcommands.TurnOn(opts)
 
 	// Verify only link was executed, not provision
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ handler = "install"`,
 	}
 
 	// First run - should skip already provisioned
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot:   env.DotfilesRoot,
 		PackNames:      []string{"tools"},
 		DryRun:         false,
@@ -89,7 +89,7 @@ handler = "install"`,
 		FileSystem:     env.FS,
 	}
 
-	result, err := pack.TurnOn(opts)
+	result, err := packcommands.TurnOn(opts)
 	require.NoError(t, err)
 
 	// Verify pack was turned on but install was skipped
@@ -101,7 +101,7 @@ handler = "install"`,
 	// Second run with ProvisionRerun - should re-run provisioning
 	opts.ProvisionRerun = true
 
-	result2, err := pack.TurnOn(opts)
+	result2, err := packcommands.TurnOn(opts)
 	require.NoError(t, err)
 
 	// Verify provisioning was re-run
@@ -124,7 +124,7 @@ handler = "install"`,
 		},
 	})
 
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{"broken"},
 		DryRun:       false,
@@ -134,7 +134,7 @@ handler = "install"`,
 	}
 
 	// Execute
-	result, err := pack.TurnOn(opts)
+	result, err := packcommands.TurnOn(opts)
 
 	// Should handle provisioning errors gracefully
 	// The error handling might vary based on implementation
@@ -185,7 +185,7 @@ handler = "shell"`,
 		mockDS.SetSentinel("complex", "install", "install.sh", true)
 	}
 
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot:   env.DotfilesRoot,
 		PackNames:      []string{"complex"},
 		DryRun:         false,
@@ -196,7 +196,7 @@ handler = "shell"`,
 	}
 
 	// Execute
-	result, err := pack.TurnOn(opts)
+	result, err := packcommands.TurnOn(opts)
 
 	// Verify mixed provisioning behavior
 	require.NoError(t, err)

--- a/pkg/packcommands/on_test.go
+++ b/pkg/packcommands/on_test.go
@@ -3,13 +3,13 @@
 // DEPENDENCIES: Mock DataStore, Memory FS
 // PURPOSE: Test on command orchestration without filesystem dependencies
 
-package pack_test
+package packcommands_test
 
 import (
 	"path/filepath"
 	"testing"
 
-	"github.com/arthur-debert/dodot/pkg/pack"
+	"github.com/arthur-debert/dodot/pkg/packcommands"
 	"github.com/arthur-debert/dodot/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,7 +19,7 @@ func TestTurnOn_EmptyPackNames_Orchestration(t *testing.T) {
 	// Setup
 	env := testutil.NewTestEnvironment(t, testutil.EnvIsolated)
 
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		DryRun:       false,
@@ -28,7 +28,7 @@ func TestTurnOn_EmptyPackNames_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.TurnOn(opts)
+	result, err := packcommands.TurnOn(opts)
 
 	// Verify orchestration behavior
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ handler = "symlink"`,
 		},
 	})
 
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{"testpack"},
 		DryRun:       true,
@@ -60,7 +60,7 @@ handler = "symlink"`,
 	}
 
 	// Execute
-	result, err := pack.TurnOn(opts)
+	result, err := packcommands.TurnOn(opts)
 
 	// Verify orchestration behavior
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestTurnOn_ForceFlag_Orchestration(t *testing.T) {
 	err := env.FS.WriteFile(filepath.Join(env.HomeDir, ".conflicted.conf"), []byte("user content"), 0644)
 	require.NoError(t, err)
 
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{"force-test"},
 		DryRun:       false,
@@ -97,7 +97,7 @@ func TestTurnOn_ForceFlag_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.TurnOn(opts)
+	result, err := packcommands.TurnOn(opts)
 
 	// Verify orchestration behavior
 	require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestTurnOn_SpecificPacks_Orchestration(t *testing.T) {
 	})
 
 	// Only turn on specific packs
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{"pack1", "pack3"},
 		DryRun:       false,
@@ -137,7 +137,7 @@ func TestTurnOn_SpecificPacks_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.TurnOn(opts)
+	result, err := packcommands.TurnOn(opts)
 
 	// Verify orchestration behavior
 	require.NoError(t, err)
@@ -158,7 +158,7 @@ func TestTurnOn_InvalidPack_Orchestration(t *testing.T) {
 	// Setup
 	env := testutil.NewTestEnvironment(t, testutil.EnvIsolated)
 
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{"non-existent"},
 		DryRun:       false,
@@ -167,7 +167,7 @@ func TestTurnOn_InvalidPack_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	_, err := pack.TurnOn(opts)
+	_, err := packcommands.TurnOn(opts)
 
 	// Verify error handling
 	require.Error(t, err)
@@ -188,7 +188,7 @@ func TestTurnOn_MultipleHandlers_Orchestration(t *testing.T) {
 		},
 	})
 
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{"multi"},
 		DryRun:       false,
@@ -197,7 +197,7 @@ func TestTurnOn_MultipleHandlers_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.TurnOn(opts)
+	result, err := packcommands.TurnOn(opts)
 
 	// Verify orchestration behavior
 	require.NoError(t, err)
@@ -215,7 +215,7 @@ func TestTurnOn_EmptyDotfilesDirectory_Orchestration(t *testing.T) {
 
 	// No packs created
 
-	opts := pack.OnOptions{
+	opts := packcommands.OnOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{}, // Empty = all packs
 		DryRun:       false,
@@ -224,7 +224,7 @@ func TestTurnOn_EmptyDotfilesDirectory_Orchestration(t *testing.T) {
 	}
 
 	// Execute
-	result, err := pack.TurnOn(opts)
+	result, err := packcommands.TurnOn(opts)
 
 	// Verify behavior with no packs
 	require.NoError(t, err)

--- a/pkg/packcommands/pack.go
+++ b/pkg/packcommands/pack.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"github.com/arthur-debert/dodot/pkg/types"

--- a/pkg/packcommands/provisioning.go
+++ b/pkg/packcommands/provisioning.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"fmt"

--- a/pkg/packcommands/status.go
+++ b/pkg/packcommands/status.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"fmt"

--- a/pkg/packcommands/status_command.go
+++ b/pkg/packcommands/status_command.go
@@ -1,4 +1,4 @@
-package pack
+package packcommands
 
 import (
 	"fmt"

--- a/pkg/packcommands/status_command_test.go
+++ b/pkg/packcommands/status_command_test.go
@@ -1,11 +1,11 @@
-package pack_test
+package packcommands_test
 
 import (
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/arthur-debert/dodot/pkg/pack"
+	"github.com/arthur-debert/dodot/pkg/packcommands"
 	"github.com/arthur-debert/dodot/pkg/paths"
 	"github.com/arthur-debert/dodot/pkg/testutil"
 	"github.com/arthur-debert/dodot/pkg/types"
@@ -16,7 +16,7 @@ import (
 func TestGetPacksStatus_NoPacksReturnsEmptyResult(t *testing.T) {
 	env := testutil.NewTestEnvironment(t, testutil.EnvMemoryOnly)
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -36,7 +36,7 @@ func TestGetPacksStatus_SinglePackWithNoFiles(t *testing.T) {
 		Files: map[string]string{},
 	})
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -60,7 +60,7 @@ func TestGetPacksStatus_PackWithIgnoredFile(t *testing.T) {
 		},
 	})
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -86,7 +86,7 @@ func TestGetPacksStatus_PackWithConfigFile(t *testing.T) {
 		},
 	})
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -112,7 +112,7 @@ func TestGetPacksStatus_PackWithUnlinkedSymlinkFiles(t *testing.T) {
 		},
 	})
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -164,7 +164,7 @@ func TestGetPacksStatus_PackWithLinkedSymlinkFiles(t *testing.T) {
 	intermediateLinkPath := filepath.Join(intermediateLinkDir, ".vimrc")
 	require.NoError(t, env.FS.Symlink(vimrcPath, intermediateLinkPath))
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -203,7 +203,7 @@ func TestGetPacksStatus_PackWithPathHandlerFiles(t *testing.T) {
 	toolPath := filepath.Join(binDir, "tool1")
 	require.NoError(t, env.FS.WriteFile(toolPath, []byte("#!/bin/bash\necho tool1"), 0755))
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -247,7 +247,7 @@ func TestGetPacksStatus_PackWithShellProfileFiles(t *testing.T) {
 		},
 	})
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -292,7 +292,7 @@ func TestGetPacksStatus_PackWithInstallScript(t *testing.T) {
 		},
 	})
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -322,7 +322,7 @@ func TestGetPacksStatus_PackWithBrewfile(t *testing.T) {
 		},
 	})
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -367,7 +367,7 @@ func TestGetPacksStatus_MixedPackWithMultipleHandlers(t *testing.T) {
 	// Note: In isolated environment, we could create actual symlinks, but following
 	// testing guidelines, we'll test without pre-existing links
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -420,7 +420,7 @@ func TestGetPacksStatus_SpecificPackSelection(t *testing.T) {
 		},
 	})
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{"vim"},
 		Paths:        env.Paths,
@@ -449,7 +449,7 @@ func TestGetPacksStatus_ErrorStatusWhenIntermediateLinkPointsToWrongSource(t *te
 	linkPath := filepath.Join(packHandlerDir, ".config")
 	require.NoError(t, env.FS.Symlink(wrongSource, linkPath))
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -490,7 +490,7 @@ func TestGetPacksStatus_ProvisioningStatusWithChangedFile(t *testing.T) {
 	err := env.FS.WriteFile(installPath, []byte("#!/bin/bash\necho v2"), 0755)
 	require.NoError(t, err)
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{},
 		Paths:        env.Paths,
@@ -535,7 +535,7 @@ func TestGetPacksStatus_Timestamp(t *testing.T) {
 	})
 
 	before := time.Now()
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		Paths:        env.Paths,
 		FileSystem:   env.FS,
@@ -553,7 +553,7 @@ func TestGetPacksStatus_WithInvalidPack(t *testing.T) {
 		Files: map[string]string{},
 	})
 
-	result, err := pack.GetPacksStatus(pack.StatusCommandOptions{
+	result, err := packcommands.GetPacksStatus(packcommands.StatusCommandOptions{
 		DotfilesRoot: env.DotfilesRoot,
 		PackNames:    []string{"valid", "nonexistent"},
 		Paths:        env.Paths,

--- a/pkg/utils/checksum.go
+++ b/pkg/utils/checksum.go
@@ -1,4 +1,4 @@
-package hashutil
+package utils
 
 import (
 	"crypto/sha256"

--- a/pkg/utils/checksum_test.go
+++ b/pkg/utils/checksum_test.go
@@ -1,14 +1,14 @@
 // Test Type: Unit Test
 // Description: Tests for the hashutil package - checksum calculation with minimal filesystem dependency
 
-package hashutil_test
+package utils_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/arthur-debert/dodot/pkg/internal/hashutil"
+	"github.com/arthur-debert/dodot/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -57,7 +57,7 @@ func TestCalculateFileChecksum_Success(t *testing.T) {
 			require.NoError(t, err)
 
 			// Calculate checksum
-			checksum, err := hashutil.CalculateFileChecksum(testFile)
+			checksum, err := utils.CalculateFileChecksum(testFile)
 			require.NoError(t, err)
 
 			// Verify checksum format
@@ -84,7 +84,7 @@ func TestCalculateFileChecksum_Consistency(t *testing.T) {
 	// Calculate checksum multiple times
 	checksums := make([]string, 5)
 	for i := 0; i < 5; i++ {
-		checksum, err := hashutil.CalculateFileChecksum(testFile)
+		checksum, err := utils.CalculateFileChecksum(testFile)
 		require.NoError(t, err)
 		checksums[i] = checksum
 	}
@@ -131,7 +131,7 @@ func TestCalculateFileChecksum_Errors(t *testing.T) {
 			}
 
 			// Attempt to calculate checksum
-			_, err := hashutil.CalculateFileChecksum(path)
+			_, err := utils.CalculateFileChecksum(path)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -163,7 +163,7 @@ func TestCalculateFileChecksum_LargeFile(t *testing.T) {
 	require.NoError(t, err)
 
 	// Calculate checksum
-	checksum, err := hashutil.CalculateFileChecksum(largeFile)
+	checksum, err := utils.CalculateFileChecksum(largeFile)
 	require.NoError(t, err)
 
 	// Verify format


### PR DESCRIPTION
## Summary
- Moved `pkg/internal/hashutil/checksum.go` to `pkg/utils/checksum.go` for better visibility
- Renamed `pkg/pack` to `pkg/packcommands` for clarity and to distinguish from the `Pack` type
- Updated all imports and references throughout the codebase

## Test plan
- [x] All existing tests pass
- [x] No functionality changes, only package reorganization
- [x] Pre-commit hooks pass (formatting, linting, tests)

🤖 Generated with [Claude Code](https://claude.ai/code)