### PR TITLE
refactor: decouple handlers from RuleMatch (#702)

### DIFF
--- a/pkg/core/match.go
+++ b/pkg/core/match.go
@@ -8,18 +8,18 @@ import (
 )
 
 // GetMatches processes packs and returns all files that match rules
-func GetMatches(packs []types.Pack) ([]types.RuleMatch, error) {
+func GetMatches(packs []types.Pack) ([]handlerpipeline.RuleMatch, error) {
 	return GetMatchesFS(packs, filesystem.NewOS())
 }
 
 // GetMatchesFS processes packs and returns all files that match rules using the provided filesystem
-func GetMatchesFS(packs []types.Pack, filesystem types.FS) ([]types.RuleMatch, error) {
+func GetMatchesFS(packs []types.Pack, filesystem types.FS) ([]handlerpipeline.RuleMatch, error) {
 	return handlerpipeline.GetMatchesFS(packs, filesystem)
 }
 
 // FilterMatchesByHandlerCategory filters rule matches based on handler category
-func FilterMatchesByHandlerCategory(matches []types.RuleMatch, allowConfiguration, allowCodeExecution bool) []types.RuleMatch {
-	var filtered []types.RuleMatch
+func FilterMatchesByHandlerCategory(matches []handlerpipeline.RuleMatch, allowConfiguration, allowCodeExecution bool) []handlerpipeline.RuleMatch {
+	var filtered []handlerpipeline.RuleMatch
 
 	for _, match := range matches {
 		// Check if handler is configuration type

--- a/pkg/core/matching_test.go
+++ b/pkg/core/matching_test.go
@@ -97,15 +97,15 @@ handler = "symlink"`,
 
 func TestFilterMatchesByHandlerCategory(t *testing.T) {
 	// Create test matches
-	createMatch := func(pack, handler string) types.RuleMatch {
-		return types.RuleMatch{
+	createMatch := func(pack, handler string) handlerpipeline.RuleMatch {
+		return handlerpipeline.RuleMatch{
 			Pack:        pack,
 			HandlerName: handler,
 			Path:        "test",
 		}
 	}
 
-	allMatches := []types.RuleMatch{
+	allMatches := []handlerpipeline.RuleMatch{
 		createMatch("vim", "symlink"),    // configuration
 		createMatch("vim", "shell"),      // configuration
 		createMatch("vim", "path"),       // configuration

--- a/pkg/handlerpipeline/execute_test.go
+++ b/pkg/handlerpipeline/execute_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/arthur-debert/dodot/pkg/testutil"
-	"github.com/arthur-debert/dodot/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,19 +12,19 @@ import (
 func TestExecuteMatches(t *testing.T) {
 	tests := []struct {
 		name           string
-		matches        []types.RuleMatch
+		matches        []RuleMatch
 		expectSuccess  bool
 		expectHandlers []string
 	}{
 		{
 			name:           "empty matches",
-			matches:        []types.RuleMatch{},
+			matches:        []RuleMatch{},
 			expectSuccess:  true,
 			expectHandlers: []string{},
 		},
 		{
 			name: "single symlink match",
-			matches: []types.RuleMatch{
+			matches: []RuleMatch{
 				{
 					Pack:         "test-pack",
 					Path:         "vimrc",
@@ -38,7 +37,7 @@ func TestExecuteMatches(t *testing.T) {
 		},
 		{
 			name: "multiple symlink handlers",
-			matches: []types.RuleMatch{
+			matches: []RuleMatch{
 				{
 					Pack:         "test-pack",
 					Path:         "vimrc",
@@ -111,7 +110,7 @@ func TestExecuteMatchesDryRun(t *testing.T) {
 	defer env.Cleanup()
 
 	// Create test matches
-	matches := []types.RuleMatch{
+	matches := []RuleMatch{
 		{
 			Pack:         "test-pack",
 			Path:         "vimrc",

--- a/pkg/handlerpipeline/internal_test.go
+++ b/pkg/handlerpipeline/internal_test.go
@@ -4,12 +4,11 @@ import (
 	"testing"
 
 	"github.com/arthur-debert/dodot/pkg/operations"
-	"github.com/arthur-debert/dodot/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGroupMatchesByHandler(t *testing.T) {
-	matches := []types.RuleMatch{
+	matches := []RuleMatch{
 		{HandlerName: "symlink", Pack: "vim", Path: "vimrc"},
 		{HandlerName: "symlink", Pack: "vim", Path: "gvimrc"},
 		{HandlerName: "shell", Pack: "bash", Path: "profile.sh"},
@@ -38,4 +37,30 @@ func TestCountSuccessfulResults(t *testing.T) {
 	// Test empty results
 	assert.Equal(t, 0, countSuccessfulResults(nil))
 	assert.Equal(t, 0, countSuccessfulResults([]operations.OperationResult{}))
+}
+
+func TestRuleMatch_Structure(t *testing.T) {
+	match := RuleMatch{
+		RuleName:     "filename",
+		Pack:         "test-pack",
+		Path:         "file.txt",
+		AbsolutePath: "/test/file.txt",
+		Priority:     10,
+		Metadata: map[string]interface{}{
+			"pattern": "*.txt",
+		},
+		HandlerName:    "symlink",
+		HandlerOptions: map[string]interface{}{},
+	}
+
+	assert.Equal(t, "test-pack", match.Pack)
+	assert.Equal(t, "file.txt", match.Path)
+	assert.Equal(t, "/test/file.txt", match.AbsolutePath)
+	assert.Equal(t, 10, match.Priority)
+	assert.Equal(t, "filename", match.RuleName)
+	assert.Equal(t, "symlink", match.HandlerName)
+
+	// Check metadata
+	assert.Contains(t, match.Metadata, "pattern")
+	assert.Equal(t, "*.txt", match.Metadata["pattern"])
 }

--- a/pkg/handlerpipeline/rule_match.go
+++ b/pkg/handlerpipeline/rule_match.go
@@ -1,4 +1,4 @@
-package types
+package handlerpipeline
 
 // RuleMatch represents a successful rule match on a file or directory
 // This is the output from the rules system that gets passed to handlers

--- a/pkg/handlers/homebrew/integration_test.go
+++ b/pkg/handlers/homebrew/integration_test.go
@@ -75,12 +75,11 @@ cask "visual-studio-code"
 	handler := homebrew.NewHandler()
 
 	// Create test matches
-	matches := []types.RuleMatch{
+	matches := []operations.FileInput{
 		{
-			Pack:         "dev-tools",
-			Path:         "Brewfile",
-			AbsolutePath: brewfilePath,
-			HandlerName:  "homebrew",
+			PackName:     "dev-tools",
+			RelativePath: "Brewfile",
+			SourcePath:   brewfilePath,
 		},
 	}
 
@@ -124,12 +123,11 @@ func TestHomebrewHandler_ExecuteWithDataStore(t *testing.T) {
 
 	handler := homebrew.NewHandler()
 
-	matches := []types.RuleMatch{
+	matches := []operations.FileInput{
 		{
-			Pack:         "tools",
-			Path:         "Brewfile",
-			AbsolutePath: brewfilePath,
-			HandlerName:  "homebrew",
+			PackName:     "tools",
+			RelativePath: "Brewfile",
+			SourcePath:   brewfilePath,
 		},
 	}
 
@@ -238,18 +236,16 @@ func TestHomebrewHandler_MultipleBrewfiles(t *testing.T) {
 
 	handler := homebrew.NewHandler()
 
-	matches := []types.RuleMatch{
+	matches := []operations.FileInput{
 		{
-			Pack:         "tools",
-			Path:         "Brewfile",
-			AbsolutePath: brewfile1,
-			HandlerName:  "homebrew",
+			PackName:     "tools",
+			RelativePath: "Brewfile",
+			SourcePath:   brewfile1,
 		},
 		{
-			Pack:         "tools",
-			Path:         "apps/Brewfile",
-			AbsolutePath: brewfile2,
-			HandlerName:  "homebrew",
+			PackName:     "tools",
+			RelativePath: "apps/Brewfile",
+			SourcePath:   brewfile2,
 		},
 	}
 

--- a/pkg/handlers/install/integration_test.go
+++ b/pkg/handlers/install/integration_test.go
@@ -72,12 +72,11 @@ func TestInstallHandler_OperationIntegration(t *testing.T) {
 	handler := install.NewHandler()
 
 	// Create test matches
-	matches := []types.RuleMatch{
+	matches := []operations.FileInput{
 		{
-			Pack:         "testpack",
-			Path:         "install.sh",
-			AbsolutePath: scriptPath,
-			HandlerName:  "install",
+			PackName:     "testpack",
+			RelativePath: "install.sh",
+			SourcePath:   scriptPath,
 		},
 	}
 
@@ -120,12 +119,11 @@ func TestInstallHandler_ExecuteWithDataStore(t *testing.T) {
 
 	handler := install.NewHandler()
 
-	matches := []types.RuleMatch{
+	matches := []operations.FileInput{
 		{
-			Pack:         "testpack",
-			Path:         "install.sh",
-			AbsolutePath: scriptPath,
-			HandlerName:  "install",
+			PackName:     "testpack",
+			RelativePath: "install.sh",
+			SourcePath:   scriptPath,
 		},
 	}
 
@@ -236,18 +234,17 @@ func TestInstallHandler_IdempotentExecution(t *testing.T) {
 
 	handler := install.NewHandler()
 
-	match := types.RuleMatch{
-		Pack:         "test",
-		Path:         "install.sh",
-		AbsolutePath: scriptPath,
-		HandlerName:  "install",
+	match := operations.FileInput{
+		PackName:     "test",
+		RelativePath: "install.sh",
+		SourcePath:   scriptPath,
 	}
 
 	// Generate operations twice
-	ops1, err := handler.ToOperations([]types.RuleMatch{match})
+	ops1, err := handler.ToOperations([]operations.FileInput{match})
 	require.NoError(t, err)
 
-	ops2, err := handler.ToOperations([]types.RuleMatch{match})
+	ops2, err := handler.ToOperations([]operations.FileInput{match})
 	require.NoError(t, err)
 
 	// Same content should produce same sentinel

--- a/pkg/handlers/path/path.go
+++ b/pkg/handlers/path/path.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/arthur-debert/dodot/pkg/handlers"
 	"github.com/arthur-debert/dodot/pkg/operations"
-	"github.com/arthur-debert/dodot/pkg/types"
 )
 
 // Handler demonstrates how the path handler looks in the new architecture.
@@ -45,17 +44,17 @@ func (h *Handler) GetMetadata() operations.HandlerMetadata {
 	}
 }
 
-// ToOperations converts rule matches to operations.
+// ToOperations converts file inputs to operations.
 // This is the core simplification - the handler just declares what it wants,
 // not how to do it. The executor handles the complexity.
-func (h *Handler) ToOperations(matches []types.RuleMatch) ([]operations.Operation, error) {
+func (h *Handler) ToOperations(files []operations.FileInput) ([]operations.Operation, error) {
 	var ops []operations.Operation
 
 	// Deduplicate paths - same logic as current handler but simpler
 	seen := make(map[string]bool)
 
-	for _, match := range matches {
-		key := fmt.Sprintf("%s:%s", match.Pack, match.Path)
+	for _, file := range files {
+		key := fmt.Sprintf("%s:%s", file.PackName, file.RelativePath)
 		if seen[key] {
 			continue // Skip duplicates
 		}
@@ -65,9 +64,9 @@ func (h *Handler) ToOperations(matches []types.RuleMatch) ([]operations.Operatio
 		// Create a link in the datastore that shell init will read
 		ops = append(ops, operations.Operation{
 			Type:    operations.CreateDataLink,
-			Pack:    match.Pack,
+			Pack:    file.PackName,
 			Handler: "path",
-			Source:  match.Path,
+			Source:  file.RelativePath,
 			// No Target needed - shell init handles PATH management
 			// No Command needed - this is a linking operation
 			// No Sentinel needed - links are their own state

--- a/pkg/handlers/shell/integration_test.go
+++ b/pkg/handlers/shell/integration_test.go
@@ -62,24 +62,21 @@ func TestShellHandler_OperationIntegration(t *testing.T) {
 	handler := shell.NewHandler()
 
 	// Create test matches
-	matches := []types.RuleMatch{
+	matches := []operations.FileInput{
 		{
-			Pack:         "bash",
-			Path:         "aliases.sh",
-			AbsolutePath: "/dotfiles/bash/aliases.sh",
-			HandlerName:  "shell",
+			PackName:     "bash",
+			RelativePath: "aliases.sh",
+			SourcePath:   "/dotfiles/bash/aliases.sh",
 		},
 		{
-			Pack:         "bash",
-			Path:         "functions.sh",
-			AbsolutePath: "/dotfiles/bash/functions.sh",
-			HandlerName:  "shell",
+			PackName:     "bash",
+			RelativePath: "functions.sh",
+			SourcePath:   "/dotfiles/bash/functions.sh",
 		},
 		{
-			Pack:         "zsh",
-			Path:         "config.zsh",
-			AbsolutePath: "/dotfiles/zsh/config.zsh",
-			HandlerName:  "shell",
+			PackName:     "zsh",
+			RelativePath: "config.zsh",
+			SourcePath:   "/dotfiles/zsh/config.zsh",
 		},
 	}
 
@@ -92,8 +89,8 @@ func TestShellHandler_OperationIntegration(t *testing.T) {
 	for i, op := range ops {
 		assert.Equal(t, operations.CreateDataLink, op.Type)
 		assert.Equal(t, "shell", op.Handler)
-		assert.Equal(t, matches[i].Pack, op.Pack)
-		assert.Equal(t, matches[i].AbsolutePath, op.Source)
+		assert.Equal(t, matches[i].PackName, op.Pack)
+		assert.Equal(t, matches[i].SourcePath, op.Source)
 	}
 
 	// Test with executor in dry-run mode
@@ -117,12 +114,11 @@ func TestShellHandler_ExecuteWithDataStore(t *testing.T) {
 
 	handler := shell.NewHandler()
 
-	matches := []types.RuleMatch{
+	matches := []operations.FileInput{
 		{
-			Pack:         "bash",
-			Path:         "aliases.sh",
-			AbsolutePath: "/dotfiles/bash/aliases.sh",
-			HandlerName:  "shell",
+			PackName:     "bash",
+			RelativePath: "aliases.sh",
+			SourcePath:   "/dotfiles/bash/aliases.sh",
 		},
 	}
 

--- a/pkg/handlers/shell/shell.go
+++ b/pkg/handlers/shell/shell.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/arthur-debert/dodot/pkg/handlers"
 	"github.com/arthur-debert/dodot/pkg/operations"
-	"github.com/arthur-debert/dodot/pkg/types"
 )
 
 const ShellHandlerName = "shell"
@@ -26,19 +25,19 @@ func NewHandler() *Handler {
 	}
 }
 
-// ToOperations converts rule matches to shell operations.
+// ToOperations converts file inputs to shell operations.
 // Shell scripts require only CreateDataLink - shell initialization handles sourcing.
-func (h *Handler) ToOperations(matches []types.RuleMatch) ([]operations.Operation, error) {
+func (h *Handler) ToOperations(files []operations.FileInput) ([]operations.Operation, error) {
 	var ops []operations.Operation
 
-	for _, match := range matches {
+	for _, file := range files {
 		// Shell scripts only need to be linked in the datastore
 		// The shell initialization script will source them automatically
 		ops = append(ops, operations.Operation{
 			Type:    operations.CreateDataLink,
-			Pack:    match.Pack,
+			Pack:    file.PackName,
 			Handler: ShellHandlerName,
-			Source:  match.AbsolutePath,
+			Source:  file.SourcePath,
 		})
 	}
 

--- a/pkg/handlers/shell/shell_test.go
+++ b/pkg/handlers/shell/shell_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/arthur-debert/dodot/pkg/handlers/shell"
 	"github.com/arthur-debert/dodot/pkg/operations"
-	"github.com/arthur-debert/dodot/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,18 +14,17 @@ func TestHandler_ToOperations(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		matches  []types.RuleMatch
+		matches  []operations.FileInput
 		wantOps  int
 		checkOps func(*testing.T, []operations.Operation)
 	}{
 		{
 			name: "single shell script creates one operation",
-			matches: []types.RuleMatch{
+			matches: []operations.FileInput{
 				{
-					Pack:         "bash",
-					Path:         "aliases.sh",
-					AbsolutePath: "/dotfiles/bash/aliases.sh",
-					HandlerName:  "shell",
+					PackName:     "bash",
+					RelativePath: "aliases.sh",
+					SourcePath:   "/dotfiles/bash/aliases.sh",
 				},
 			},
 			wantOps: 1,
@@ -39,24 +37,21 @@ func TestHandler_ToOperations(t *testing.T) {
 		},
 		{
 			name: "multiple shell scripts create multiple operations",
-			matches: []types.RuleMatch{
+			matches: []operations.FileInput{
 				{
-					Pack:         "bash",
-					Path:         "aliases.sh",
-					AbsolutePath: "/dotfiles/bash/aliases.sh",
-					HandlerName:  "shell",
+					PackName:     "bash",
+					RelativePath: "aliases.sh",
+					SourcePath:   "/dotfiles/bash/aliases.sh",
 				},
 				{
-					Pack:         "bash",
-					Path:         "functions.sh",
-					AbsolutePath: "/dotfiles/bash/functions.sh",
-					HandlerName:  "shell",
+					PackName:     "bash",
+					RelativePath: "functions.sh",
+					SourcePath:   "/dotfiles/bash/functions.sh",
 				},
 				{
-					Pack:         "zsh",
-					Path:         "config.zsh",
-					AbsolutePath: "/dotfiles/zsh/config.zsh",
-					HandlerName:  "shell",
+					PackName:     "zsh",
+					RelativePath: "config.zsh",
+					SourcePath:   "/dotfiles/zsh/config.zsh",
 				},
 			},
 			wantOps: 3,
@@ -80,7 +75,7 @@ func TestHandler_ToOperations(t *testing.T) {
 		},
 		{
 			name:    "empty matches returns empty operations",
-			matches: []types.RuleMatch{},
+			matches: []operations.FileInput{},
 			wantOps: 0,
 		},
 	}

--- a/pkg/handlers/symlink/integration_test.go
+++ b/pkg/handlers/symlink/integration_test.go
@@ -68,18 +68,16 @@ func TestSymlinkHandler_OperationIntegration(t *testing.T) {
 	handler := symlink.NewHandler()
 
 	// Create test matches
-	matches := []types.RuleMatch{
+	matches := []operations.FileInput{
 		{
-			Pack:         "vim",
-			Path:         ".vimrc",
-			AbsolutePath: "/dotfiles/vim/.vimrc",
-			HandlerName:  "symlink",
+			PackName:     "vim",
+			RelativePath: ".vimrc",
+			SourcePath:   "/dotfiles/vim/.vimrc",
 		},
 		{
-			Pack:         "vim",
-			Path:         ".vim/colors/theme.vim",
-			AbsolutePath: "/dotfiles/vim/.vim/colors/theme.vim",
-			HandlerName:  "symlink",
+			PackName:     "vim",
+			RelativePath: ".vim/colors/theme.vim",
+			SourcePath:   "/dotfiles/vim/.vim/colors/theme.vim",
 		},
 	}
 
@@ -120,12 +118,11 @@ func TestSymlinkHandler_ExecuteWithDataStore(t *testing.T) {
 
 	handler := symlink.NewHandler()
 
-	matches := []types.RuleMatch{
+	matches := []operations.FileInput{
 		{
-			Pack:         "vim",
-			Path:         ".vimrc",
-			AbsolutePath: "/dotfiles/vim/.vimrc",
-			HandlerName:  "symlink",
+			PackName:     "vim",
+			RelativePath: ".vimrc",
+			SourcePath:   "/dotfiles/vim/.vimrc",
 		},
 	}
 

--- a/pkg/operations/executor_test.go
+++ b/pkg/operations/executor_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/arthur-debert/dodot/pkg/operations"
-	"github.com/arthur-debert/dodot/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -62,8 +61,8 @@ type MockHandler struct {
 	mock.Mock
 }
 
-func (m *MockHandler) ToOperations(matches []types.RuleMatch) ([]operations.Operation, error) {
-	args := m.Called(matches)
+func (m *MockHandler) ToOperations(files []operations.FileInput) ([]operations.Operation, error) {
+	args := m.Called(files)
 	return args.Get(0).([]operations.Operation), args.Error(1)
 }
 

--- a/pkg/operations/handler_integration_test.go
+++ b/pkg/operations/handler_integration_test.go
@@ -16,27 +16,27 @@ func TestPathHandler_OperationIntegration(t *testing.T) {
 	// Create simplified handler
 	handler := path.NewHandler()
 
-	// Create test matches
-	matches := []types.RuleMatch{
+	// Create test file inputs
+	files := []operations.FileInput{
 		{
-			Pack:        "tools",
-			Path:        "bin",
-			HandlerName: "path",
+			PackName:     "tools",
+			SourcePath:   "/test/tools/bin",
+			RelativePath: "bin",
 		},
 		{
-			Pack:        "tools",
-			Path:        "scripts",
-			HandlerName: "path",
+			PackName:     "tools",
+			SourcePath:   "/test/tools/scripts",
+			RelativePath: "scripts",
 		},
 		{
-			Pack:        "dev",
-			Path:        "bin",
-			HandlerName: "path",
+			PackName:     "dev",
+			SourcePath:   "/test/dev/bin",
+			RelativePath: "bin",
 		},
 	}
 
 	// Convert to operations
-	ops, err := handler.ToOperations(matches)
+	ops, err := handler.ToOperations(files)
 	require.NoError(t, err)
 	assert.Len(t, ops, 3)
 

--- a/pkg/operations/types.go
+++ b/pkg/operations/types.go
@@ -5,6 +5,15 @@ import (
 	"github.com/arthur-debert/dodot/pkg/types"
 )
 
+// FileInput represents the minimal information handlers need about a file.
+// This decouples handlers from the matching/rules system.
+type FileInput struct {
+	PackName     string                 // Name of the pack containing this file
+	SourcePath   string                 // Absolute path to the file
+	RelativePath string                 // Path relative to pack root
+	Options      map[string]interface{} // Handler-specific options from rules
+}
+
 // OperationType represents the fundamental operations that dodot performs.
 // This is the core insight: dodot only does 4 things, everything else is orchestration.
 type OperationType int
@@ -65,10 +74,10 @@ type Handler interface {
 	Name() string
 	Category() handlers.HandlerCategory
 
-	// Core responsibility: transform file matches to operations
+	// Core responsibility: transform file inputs to operations
 	// This is the heart of the simplification - handlers just declare
 	// what operations they need, not how to perform them.
-	ToOperations(matches []types.RuleMatch) ([]Operation, error)
+	ToOperations(files []FileInput) ([]Operation, error)
 
 	// Metadata for UI/UX
 	GetMetadata() HandlerMetadata

--- a/pkg/packcommands/status.go
+++ b/pkg/packcommands/status.go
@@ -216,7 +216,7 @@ func checkSpecialFiles(pack types.Pack, result *StatusResult, fs types.FS) error
 }
 
 // getHandlerStatus checks the deployment status for a specific match
-func getHandlerStatus(match types.RuleMatch, pack types.Pack, dataStore types.DataStore, fs types.FS, pathsInstance paths.Paths) (Status, error) {
+func getHandlerStatus(match handlerpipeline.RuleMatch, pack types.Pack, dataStore types.DataStore, fs types.FS, pathsInstance paths.Paths) (Status, error) {
 	// Check handler category to determine how to check status
 	category := handlers.HandlerRegistry.GetHandlerCategory(match.HandlerName)
 
@@ -236,7 +236,7 @@ func getHandlerStatus(match types.RuleMatch, pack types.Pack, dataStore types.Da
 }
 
 // getConfigurationHandlerStatus checks status for configuration handlers
-func getConfigurationHandlerStatus(match types.RuleMatch, pack types.Pack, dataStore types.DataStore, fs types.FS, pathsInstance paths.Paths) (Status, error) {
+func getConfigurationHandlerStatus(match handlerpipeline.RuleMatch, pack types.Pack, dataStore types.DataStore, fs types.FS, pathsInstance paths.Paths) (Status, error) {
 	baseName := filepath.Base(match.Path)
 	intermediateLinkPath := filepath.Join(pathsInstance.PackHandlerDir(pack.Name, match.HandlerName), baseName)
 
@@ -315,7 +315,7 @@ func getConfigurationHandlerStatus(match types.RuleMatch, pack types.Pack, dataS
 }
 
 // getCodeExecutionHandlerStatus checks status for code execution handlers
-func getCodeExecutionHandlerStatus(match types.RuleMatch, pack types.Pack, dataStore types.DataStore, fs types.FS) (Status, error) {
+func getCodeExecutionHandlerStatus(match handlerpipeline.RuleMatch, pack types.Pack, dataStore types.DataStore, fs types.FS) (Status, error) {
 	// Calculate current checksum
 	currentChecksum, err := utils.CalculateFileChecksum(match.AbsolutePath)
 	if err != nil {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -29,29 +29,3 @@ func TestPack_Structure(t *testing.T) {
 	assert.Len(t, pack.Config.Ignore, 1)
 	assert.Equal(t, "*.bak", pack.Config.Ignore[0].Path)
 }
-
-func TestRuleMatch_Structure(t *testing.T) {
-	match := types.RuleMatch{
-		RuleName:     "filename",
-		Pack:         "test-pack",
-		Path:         "file.txt",
-		AbsolutePath: "/test/file.txt",
-		Priority:     10,
-		Metadata: map[string]interface{}{
-			"pattern": "*.txt",
-		},
-		HandlerName:    "symlink",
-		HandlerOptions: map[string]interface{}{},
-	}
-
-	assert.Equal(t, "test-pack", match.Pack)
-	assert.Equal(t, "file.txt", match.Path)
-	assert.Equal(t, "/test/file.txt", match.AbsolutePath)
-	assert.Equal(t, 10, match.Priority)
-	assert.Equal(t, "filename", match.RuleName)
-	assert.Equal(t, "symlink", match.HandlerName)
-
-	// Check metadata
-	assert.Contains(t, match.Metadata, "pattern")
-	assert.Equal(t, "*.txt", match.Metadata["pattern"])
-}


### PR DESCRIPTION
## Summary

This PR completes the decoupling of handlers from the RuleMatch type by introducing a new FileInput type. This creates better separation of concerns between the matching/rules system and the execution system.

## Changes

- Added `FileInput` type to operations package as minimal data structure for handlers
- Updated `Handler` interface to use `[]FileInput` instead of `[]RuleMatch`
- Moved `RuleMatch` from `pkg/types` to `pkg/handlerpipeline` where it conceptually belongs
- Added transformation function in handlerpipeline to convert RuleMatch to FileInput
- Updated all handler implementations (symlink, shell, path, homebrew, install)
- Updated all handler tests to use FileInput instead of RuleMatch

## Motivation

As discussed in #702, handlers shouldn't need to understand the matching/rules concepts. They should focus solely on transforming file inputs to operations. This refactoring achieves that separation by:

1. Moving RuleMatch to handlerpipeline where it's created and used
2. Providing handlers with only the minimal data they need (FileInput)
3. Keeping the transformation logic in the pipeline where it belongs

## Test Plan

- [x] All existing handler tests pass
- [x] All handlerpipeline tests pass
- [x] Pre-commit hooks pass (formatting, linting, tests)
- [x] No import cycles introduced

This is part of Phase 5 of the pipeline refactoring.

🤖 Generated with [Claude Code](https://claude.ai/code)