### PR TITLE
refactor: rename on/off commands to up/down

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ dodot manages your dotfiles through symlinks and simple conventions. Edit your c
 - **Live editing** - Edit anywhere, changes apply immediately  
 - **Modular packs** - Group related configs, enable/disable together
 - **Git-based** - Your repo structure is the only state
-- **Minimal commands** - Just `on`, `off`, and `status`
+- **Minimal commands** - Just `up`, `down`, and `status`
 
 ## Installation
 
@@ -27,8 +27,8 @@ Or download from [releases](https://github.com/arthur-debert/dodot/releases).
 ```bash
 cd ~/dotfiles
 dodot status          # See what dodot will do
-dodot on              # Deploy all packs
-dodot off git         # Remove git pack
+dodot up              # Deploy all packs
+dodot down git         # Remove git pack
 ```
 
 ## How It Works

--- a/cmd/dodot/commands/down/down.go
+++ b/cmd/dodot/commands/down/down.go
@@ -1,15 +1,15 @@
-package off
+package down
 
 import (
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates the off command
+// NewCommand creates the down command
 // The command logic is kept in the main commands file for now to avoid circular dependencies
 func NewCommand() *cobra.Command {
 	// This will be filled in by the root command
 	return &cobra.Command{
-		Use:     "off [packs...]",
+		Use:     "down [packs...]",
 		Short:   MsgShort,
 		Long:    MsgLong,
 		Example: MsgExample,

--- a/cmd/dodot/commands/down/msgs.go
+++ b/cmd/dodot/commands/down/msgs.go
@@ -1,20 +1,20 @@
-package off
+package down
 
 // Message constants
 const (
 	MsgShort = "Remove and uninstall pack(s)"
-	MsgLong  = `The 'off' command is dodot's primary removal command. It completely removes pack deployments:
+	MsgLong  = `The 'down' command is dodot's primary removal command. It completely removes pack deployments:
   - Removes all symlinks
   - Clears shell integrations and PATH entries
   - Removes all handler state from the data directory
 
 Note: This is a complete removal - no state is saved for restoration. Files in your dotfiles repository are never touched.`
 	MsgExample = `  # Remove all pack deployments
-  dodot off
+  dodot down
   
   # Remove specific packs
-  dodot off vim zsh
+  dodot down vim zsh
   
   # Preview what will be removed
-  dodot off --dry-run vim`
+  dodot down --dry-run vim`
 )

--- a/cmd/dodot/commands/up/msgs.go
+++ b/cmd/dodot/commands/up/msgs.go
@@ -1,9 +1,9 @@
-package on
+package up
 
 // Message constants
 const (
 	MsgShort = "Install and deploy pack(s)"
-	MsgLong  = `The 'on' command is dodot's primary deployment command. It handles all aspects of pack deployment:
+	MsgLong  = `The 'up' command is dodot's primary deployment command. It handles all aspects of pack deployment:
   - Creates symlinks for configuration files
   - Sets up shell integrations and PATH entries
   - Runs installation scripts and package managers (unless --no-provision is used)
@@ -15,17 +15,17 @@ Provisioning Options:
   --provision-rerun: Force re-run provisioning even if already done`
 
 	MsgExample = `  # Deploy all packs
-  dodot on
+  dodot up
   
   # Deploy specific packs
-  dodot on vim zsh
+  dodot up vim zsh
   
   # Preview what will be deployed
-  dodot on --dry-run vim
+  dodot up --dry-run vim
   
   # Only create symlinks, skip installations
-  dodot on --no-provision vim
+  dodot up --no-provision vim
   
   # Force re-run provisioning handlers
-  dodot on --provision-rerun vim`
+  dodot up --provision-rerun vim`
 )

--- a/cmd/dodot/commands/up/up.go
+++ b/cmd/dodot/commands/up/up.go
@@ -1,13 +1,13 @@
-package on
+package up
 
 import (
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates the on command
+// NewCommand creates the up command
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "on [packs...]",
+		Use:     "up [packs...]",
 		Short:   MsgShort,
 		Long:    MsgLong,
 		Example: MsgExample,

--- a/cmd/dodot/msgs.go
+++ b/cmd/dodot/msgs.go
@@ -7,14 +7,14 @@ import (
 	// Import messages from command packages
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/addignore"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/adopt"
+	"github.com/arthur-debert/dodot/cmd/dodot/commands/down"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/fill"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/genconfig"
 	initcmd "github.com/arthur-debert/dodot/cmd/dodot/commands/init"
-	"github.com/arthur-debert/dodot/cmd/dodot/commands/off"
-	"github.com/arthur-debert/dodot/cmd/dodot/commands/on"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/snippet"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/status"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/topics"
+	"github.com/arthur-debert/dodot/cmd/dodot/commands/up"
 )
 
 // Re-export command messages for backward compatibility
@@ -49,11 +49,11 @@ var (
 	// Gen-config command
 	MsgGenConfigShort = genconfig.MsgShort
 
-	// Off command (not currently used, but imported to avoid "imported and not used" error)
-	_ = off.MsgShort
+	// Down command (not currently used, but imported to avoid "imported and not used" error)
+	_ = down.MsgShort
 
-	// On command (not currently used, but imported to avoid "imported and not used" error)
-	_ = on.MsgShort
+	// Up command (not currently used, but imported to avoid "imported and not used" error)
+	_ = up.MsgShort
 )
 
 // General messages (not command-specific)

--- a/cmd/dodot/root.go
+++ b/cmd/dodot/root.go
@@ -9,26 +9,26 @@ import (
 
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/addignore"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/adopt"
+	"github.com/arthur-debert/dodot/cmd/dodot/commands/down"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/fill"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/genconfig"
 	initcmd "github.com/arthur-debert/dodot/cmd/dodot/commands/init"
-	"github.com/arthur-debert/dodot/cmd/dodot/commands/off"
-	"github.com/arthur-debert/dodot/cmd/dodot/commands/on"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/snippet"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/status"
 	"github.com/arthur-debert/dodot/cmd/dodot/commands/topics"
+	"github.com/arthur-debert/dodot/cmd/dodot/commands/up"
 	topicspkg "github.com/arthur-debert/dodot/cmd/dodot/internal/topics"
 	"github.com/arthur-debert/dodot/internal/version"
 	"github.com/arthur-debert/dodot/pkg/dispatcher"
-	"github.com/arthur-debert/dodot/pkg/packs/discovery"
-	"github.com/arthur-debert/dodot/pkg/ui/output"
 	doerrors "github.com/arthur-debert/dodot/pkg/errors"
 	"github.com/arthur-debert/dodot/pkg/logging"
 	"github.com/arthur-debert/dodot/pkg/packs"
+	"github.com/arthur-debert/dodot/pkg/packs/discovery"
 	"github.com/arthur-debert/dodot/pkg/paths"
 	"github.com/arthur-debert/dodot/pkg/types"
 	"github.com/arthur-debert/dodot/pkg/ui"
 	"github.com/arthur-debert/dodot/pkg/ui/display"
+	"github.com/arthur-debert/dodot/pkg/ui/output"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -123,8 +123,8 @@ func NewRootCmd() *cobra.Command {
 
 	// Add all commands in the desired order
 	// Core commands
-	rootCmd.AddCommand(newOnCmd())
-	rootCmd.AddCommand(newOffCmd())
+	rootCmd.AddCommand(newUpCmd())
+	rootCmd.AddCommand(newDownCmd())
 	rootCmd.AddCommand(newStatusCmd())
 	// Single pack convenience commands
 	rootCmd.AddCommand(newAddIgnoreCmd())
@@ -687,8 +687,8 @@ func newGenConfigCmd() *cobra.Command {
 	return cmd
 }
 
-func newOffCmd() *cobra.Command {
-	cmd := off.NewCommand()
+func newDownCmd() *cobra.Command {
+	cmd := down.NewCommand()
 	cmd.ValidArgsFunction = packNamesCompletion
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		// Initialize paths (will show warning if using fallback)
@@ -704,10 +704,10 @@ func newOffCmd() *cobra.Command {
 			Str("dotfiles_root", p.DotfilesRoot()).
 			Bool("dry_run", dryRun).
 			Strs("packs", args).
-			Msg("Turning off packs")
+			Msg("Turning down packs")
 
 		// Turn off packs using the dispatcher
-		result, err := dispatcher.Dispatch(dispatcher.CommandOff, dispatcher.Options{
+		result, err := dispatcher.Dispatch(dispatcher.CommandDown, dispatcher.Options{
 			DotfilesRoot: p.DotfilesRoot(),
 			PackNames:    args,
 			DryRun:       dryRun,
@@ -716,7 +716,7 @@ func newOffCmd() *cobra.Command {
 			// Check if this is a pack not found error and provide detailed help
 			var dodotErr *doerrors.DodotError
 			if errors.As(err, &dodotErr) && dodotErr.Code == doerrors.ErrPackNotFound {
-				return handlePackNotFoundError(dodotErr, p, "off")
+				return handlePackNotFoundError(dodotErr, p, "down")
 			}
 			return fmt.Errorf("failed to turn off packs: %w", err)
 		}
@@ -737,8 +737,8 @@ func newOffCmd() *cobra.Command {
 	return cmd
 }
 
-func newOnCmd() *cobra.Command {
-	cmd := on.NewCommand()
+func newUpCmd() *cobra.Command {
+	cmd := up.NewCommand()
 	cmd.ValidArgsFunction = packNamesCompletion
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		// Initialize paths (will show warning if using fallback)
@@ -758,10 +758,10 @@ func newOnCmd() *cobra.Command {
 			Bool("dry_run", dryRun).
 			Bool("force", force).
 			Strs("packs", args).
-			Msg("Turning on packs")
+			Msg("Turning up packs")
 
 		// Turn on packs using the dispatcher
-		result, err := dispatcher.Dispatch(dispatcher.CommandOn, dispatcher.Options{
+		result, err := dispatcher.Dispatch(dispatcher.CommandUp, dispatcher.Options{
 			DotfilesRoot:   p.DotfilesRoot(),
 			PackNames:      args,
 			DryRun:         dryRun,
@@ -773,7 +773,7 @@ func newOnCmd() *cobra.Command {
 			// Check if this is a pack not found error and provide detailed help
 			var dodotErr *doerrors.DodotError
 			if errors.As(err, &dodotErr) && dodotErr.Code == doerrors.ErrPackNotFound {
-				return handlePackNotFoundError(dodotErr, p, "on")
+				return handlePackNotFoundError(dodotErr, p, "up")
 			}
 			return fmt.Errorf("failed to turn on packs: %w", err)
 		}

--- a/cmd/dodot/root_test.go
+++ b/cmd/dodot/root_test.go
@@ -25,7 +25,7 @@ func TestDeployCmd(t *testing.T) {
 	rootCmd := NewRootCmd()
 
 	// Execute the on command
-	rootCmd.SetArgs([]string{"on"})
+	rootCmd.SetArgs([]string{"up"})
 	err := rootCmd.Execute()
 
 	// Assert no error occurred
@@ -56,7 +56,7 @@ func TestDeployCmd_NoDotfilesRoot(t *testing.T) {
 	rootCmd := NewRootCmd()
 
 	// Execute the on command - should succeed with fallback warning
-	rootCmd.SetArgs([]string{"on"})
+	rootCmd.SetArgs([]string{"up"})
 	err = rootCmd.Execute()
 
 	// The command should succeed but with a fallback warning

--- a/docs/reference/cli-output.txxt
+++ b/docs/reference/cli-output.txxt
@@ -30,7 +30,7 @@ The message describes what action was taken, while the pack status shows the res
 Example Output
 ==============
 
-After running ``dodot on vim``::
+After running ``dodot up vim``::
 
     The pack vim has been turned on.
 

--- a/docs/reference/commands.txxt
+++ b/docs/reference/commands.txxt
@@ -50,13 +50,13 @@ Discovers and lists all available packs in the dotfiles root directory. Simple c
 **Status**: Working  
 **Usage**: `dodot list`
 
-### off
+### down
 The primary pack removal command. Completely removes pack deployments including all symlinks, shell integrations, PATH entries, and handler state from the data directory. This is a complete removal - no state is saved for restoration. Files in your dotfiles repository are never touched.
 
 **Status**: Working  
-**Usage**: `dodot off [pack-names...]`
+**Usage**: `dodot down [pack-names...]`
 
-### on
+### up
 The primary pack deployment command. Handles all aspects of pack deployment including creating symlinks for configuration files, setting up shell integrations and PATH entries, and running installation scripts and package managers. By default, provisioning handlers only run once per pack.
 
 **Options**:
@@ -64,7 +64,7 @@ The primary pack deployment command. Handles all aspects of pack deployment incl
 - `--provision-rerun`: Force re-run provisioning even if already done
 
 **Status**: Working  
-**Usage**: `dodot on [pack-names...] [--no-provision | --provision-rerun]`
+**Usage**: `dodot up [pack-names...] [--no-provision | --provision-rerun]`
 
 
 ### status
@@ -77,11 +77,11 @@ Shows deployment state of packs including special files, handler matches, and cu
 ## Command Relationships
 
 ### Activation Flow
-- `init` → `fill` → `on`
-- `on` handles both configuration and provisioning
+- `init` → `fill` → `up`
+- `up` handles both configuration and provisioning
 
 ### Deactivation Flow
-- `off` performs complete removal
+- `down` performs complete removal
 - All handler state is cleared
 
 ### Handler Types

--- a/docs/reference/getting-started.txxt
+++ b/docs/reference/getting-started.txxt
@@ -64,9 +64,9 @@ files, or remap dodot:
 Now that everything looks good, we're ready:
 
     # Preview what will happen without making changes
-    $ dodot on git --dry-run
+    $ dodot up git --dry-run
 
-    $ dodot on git
+    $ dodot up git
     ... homebrew:  git/Brewfile: installed
     ... shell:     git/alias.sh: sourced
     ... symlink:   git/gitconfig -> ~/.gitconfig: linked
@@ -80,9 +80,9 @@ Now that everything looks good, we're ready:
     # Edit your config - changes are immediate!
     $ vim ~/.gitconfig  # or ~/dotfiles/git/gitconfig - same file!
 
-And $ dodot off git would do the reverse.
+And $ dodot down git would do the reverse.
 
-All dodot commands can specify one or more packs ($ dodot on git nvim) or,
+All dodot commands can specify one or more packs ($ dodot up git nvim) or,
 when run without arguments, all packs.
 
 By using directory grouping into packs, and file naming conventions, dodot can
@@ -93,8 +93,8 @@ Quick Start Guide:
 1. cd ~/dotfiles (or wherever your dotfiles live)
 2. Run `dodot status` to see what dodot will do
 3. Fine-tune by renaming files or creating .dodot.toml configs
-4. Run `dodot on [pack]` to deploy (or `dodot on` for all packs)
-5. Use `dodot off [pack]` to cleanly remove
+4. Run `dodot up [pack]` to deploy (or `dodot up` for all packs)
+5. Use `dodot down [pack]` to cleanly remove
 
 What's Next?
 - Run `dodot --help` for all commands

--- a/docs/reference/handlers.txxt
+++ b/docs/reference/handlers.txxt
@@ -49,7 +49,7 @@ Handlers are divided into two categories based on their operation types:
 - Install Handler: Runs setup scripts once
 - Homebrew Handler: Installs packages once
 - Operations are tracked to prevent re-execution
-- Run by default with `dodot on`, skip with `--no-provision`
+- Run by default with `dodot up`, skip with `--no-provision`
 
 ### Configuration Handlers (always run)
 - Generate **CreateDataLink** and **CreateUserLink** operations
@@ -57,7 +57,7 @@ Handlers are divided into two categories based on their operation types:
 - Path Handler: Manages PATH entries
 - Shell Handler: Sources shell configuration
 - Operations are idempotent (safe to run multiple times)
-- Always run with `dodot on`
+- Always run with `dodot up`
 
 ## Quick Reference
 

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -20,8 +20,8 @@ type CommandType string
 
 const (
 	// Core commands
-	CommandOn     CommandType = "on"
-	CommandOff    CommandType = "off"
+	CommandUp     CommandType = "up"
+	CommandDown   CommandType = "down"
 	CommandStatus CommandType = "status"
 
 	// Single pack convenience commands
@@ -70,9 +70,9 @@ func Dispatch(cmdType CommandType, opts Options) (*display.PackCommandResult, er
 		Msg("Dispatching pack command")
 
 	switch cmdType {
-	case CommandOn:
+	case CommandUp:
 		// Use pack pipeline for on command
-		onCmd := &packcommands.OnCommand{
+		onCmd := &packcommands.UpCommand{
 			NoProvision: opts.NoProvision,
 			Force:       opts.Force,
 		}
@@ -86,9 +86,9 @@ func Dispatch(cmdType CommandType, opts Options) (*display.PackCommandResult, er
 		}
 		return convertPipelineResult(pipelineResult), nil
 
-	case CommandOff:
+	case CommandDown:
 		// Use pack pipeline for off command
-		offCmd := &packcommands.OffCommand{}
+		offCmd := &packcommands.DownCommand{}
 		pipelineResult, err := orchestration.Execute(offCmd, opts.PackNames, orchestration.Options{
 			DotfilesRoot: opts.DotfilesRoot,
 			DryRun:       opts.DryRun,
@@ -253,9 +253,9 @@ func convertPipelineResult(pipelineResult *orchestration.Result) *display.PackCo
 	}
 
 	switch pipelineResult.Command {
-	case "on":
+	case "up":
 		result.Message = display.FormatCommandMessage("turned on", packNames)
-	case "off":
+	case "down":
 		result.Message = display.FormatCommandMessage("turned off", packNames)
 	case "status":
 		result.Message = "" // Status command doesn't have a message

--- a/pkg/execution/context/manager_test.go
+++ b/pkg/execution/context/manager_test.go
@@ -15,7 +15,7 @@ func TestManager_CreateContext(t *testing.T) {
 	}{
 		{
 			name:    "create context for on command",
-			command: "on",
+			command: "up",
 			dryRun:  false,
 		},
 		{
@@ -42,7 +42,7 @@ func TestManager_CreateContext(t *testing.T) {
 
 func TestManager_AddPackResult(t *testing.T) {
 	m := NewManager()
-	ctx := m.CreateContext("on", false)
+	ctx := m.CreateContext("up", false)
 
 	// Create pack results with different stats
 	packResult1 := &PackExecutionResult{
@@ -91,7 +91,7 @@ func TestManager_AddPackResult(t *testing.T) {
 
 func TestManager_CompleteContext(t *testing.T) {
 	m := NewManager()
-	ctx := m.CreateContext("on", false)
+	ctx := m.CreateContext("up", false)
 
 	// Initially EndTime should be zero
 	assert.Zero(t, ctx.EndTime)

--- a/pkg/packs/commands/down.go
+++ b/pkg/packs/commands/down.go
@@ -12,21 +12,21 @@ import (
 	"github.com/arthur-debert/dodot/pkg/types"
 )
 
-// OffCommand implements the "off" command using the pack orchestration.
-type OffCommand struct{}
+// DownCommand implements the "down" command using the pack orchestration.
+type DownCommand struct{}
 
 // Name returns the command name.
-func (c *OffCommand) Name() string {
-	return "off"
+func (c *DownCommand) Name() string {
+	return "down"
 }
 
-// ExecuteForPack executes the "off" command for a single pack.
-func (c *OffCommand) ExecuteForPack(pack types.Pack, opts orchestration.Options) (*orchestration.PackResult, error) {
-	logger := logging.GetLogger("orchestration.off")
+// ExecuteForPack executes the "down" command for a single pack.
+func (c *DownCommand) ExecuteForPack(pack types.Pack, opts orchestration.Options) (*orchestration.PackResult, error) {
+	logger := logging.GetLogger("orchestration.down")
 	logger.Debug().
 		Str("pack", pack.Name).
 		Bool("dryRun", opts.DryRun).
-		Msg("Executing off command for pack")
+		Msg("Executing down command for pack")
 
 	// Initialize filesystem
 	fs := opts.FileSystem
@@ -118,7 +118,7 @@ func (c *OffCommand) ExecuteForPack(pack types.Pack, opts orchestration.Options)
 		Int("totalCleared", totalCleared).
 		Int("errors", len(errors)).
 		Bool("success", success).
-		Msg("Off command completed for pack")
+		Msg("Down command completed for pack")
 
 	// Aggregate errors if any
 	var finalError error

--- a/pkg/packs/commands/up.go
+++ b/pkg/packs/commands/up.go
@@ -12,8 +12,8 @@ import (
 	"github.com/arthur-debert/dodot/pkg/types"
 )
 
-// OnCommand implements the "on" command using the pack orchestration.
-type OnCommand struct {
+// UpCommand implements the "up" command using the pack orchestration.
+type UpCommand struct {
 	// NoProvision skips the provisioning phase
 	NoProvision bool
 
@@ -22,18 +22,18 @@ type OnCommand struct {
 }
 
 // Name returns the command name.
-func (c *OnCommand) Name() string {
-	return "on"
+func (c *UpCommand) Name() string {
+	return "up"
 }
 
-// ExecuteForPack executes the "on" command for a single pack.
-func (c *OnCommand) ExecuteForPack(pack types.Pack, opts orchestration.Options) (*orchestration.PackResult, error) {
-	logger := logging.GetLogger("orchestration.on")
+// ExecuteForPack executes the "up" command for a single pack.
+func (c *UpCommand) ExecuteForPack(pack types.Pack, opts orchestration.Options) (*orchestration.PackResult, error) {
+	logger := logging.GetLogger("orchestration.up")
 	logger.Debug().
 		Str("pack", pack.Name).
 		Bool("noProvision", c.NoProvision).
 		Bool("force", c.Force).
-		Msg("Executing on command for pack")
+		Msg("Executing up command for pack")
 
 	// Initialize filesystem
 	fs := opts.FileSystem
@@ -129,7 +129,7 @@ func (c *OnCommand) ExecuteForPack(pack types.Pack, opts orchestration.Options) 
 		Int("provisionSuccess", provisionSuccessCount).
 		Int("provisionFailure", provisionFailureCount).
 		Bool("success", success).
-		Msg("On command completed for pack")
+		Msg("Up command completed for pack")
 
 	return &orchestration.PackResult{
 		Pack:                  pack,

--- a/pkg/packs/commands/up_test.go
+++ b/pkg/packs/commands/up_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOnCommand_Name(t *testing.T) {
-	cmd := &commands.OnCommand{}
-	assert.Equal(t, "on", cmd.Name())
+func TestUpCommand_Name(t *testing.T) {
+	cmd := &commands.UpCommand{}
+	assert.Equal(t, "up", cmd.Name())
 }
 
-func TestOnCommand_ExecuteForPack_Success(t *testing.T) {
+func TestUpCommand_ExecuteForPack_Success(t *testing.T) {
 	env := testutil.NewTestEnvironment(t, testutil.EnvMemoryOnly)
 	defer env.Cleanup()
 
@@ -38,7 +38,7 @@ func TestOnCommand_ExecuteForPack_Success(t *testing.T) {
 		Path: env.DotfilesRoot + "/vim",
 	}
 
-	cmd := &commands.OnCommand{
+	cmd := &commands.UpCommand{
 		NoProvision: false,
 		Force:       false,
 	}
@@ -57,7 +57,7 @@ func TestOnCommand_ExecuteForPack_Success(t *testing.T) {
 	assert.Equal(t, "vim", result.Pack.Name)
 }
 
-func TestOnCommand_ExecuteForPack_NoProvision(t *testing.T) {
+func TestUpCommand_ExecuteForPack_NoProvision(t *testing.T) {
 	env := testutil.NewTestEnvironment(t, testutil.EnvMemoryOnly)
 	defer env.Cleanup()
 
@@ -78,7 +78,7 @@ func TestOnCommand_ExecuteForPack_NoProvision(t *testing.T) {
 		Path: env.DotfilesRoot + "/config",
 	}
 
-	cmd := &commands.OnCommand{
+	cmd := &commands.UpCommand{
 		NoProvision: true, // Skip provisioning
 		Force:       false,
 	}
@@ -98,7 +98,7 @@ func TestOnCommand_ExecuteForPack_NoProvision(t *testing.T) {
 	assert.True(t, result.Success)
 }
 
-func TestOnCommand_ExecuteForPack_InvalidPack(t *testing.T) {
+func TestUpCommand_ExecuteForPack_InvalidPack(t *testing.T) {
 	env := testutil.NewTestEnvironment(t, testutil.EnvMemoryOnly)
 	defer env.Cleanup()
 
@@ -108,7 +108,7 @@ func TestOnCommand_ExecuteForPack_InvalidPack(t *testing.T) {
 		Path: "/nonexistent/path",
 	}
 
-	cmd := &commands.OnCommand{}
+	cmd := &commands.UpCommand{}
 
 	// Execute command
 	result, err := cmd.ExecuteForPack(pack, orchestration.Options{

--- a/pkg/ui/display/types.go
+++ b/pkg/ui/display/types.go
@@ -29,7 +29,7 @@ type CommandResult struct {
 // It combines pack status display with command-specific metadata.
 type PackCommandResult struct {
 	// Command that was executed
-	Command string `json:"command"` // "on", "off", "status", "adopt", "fill", "add-ignore"
+	Command string `json:"command"` // "up", "down", "status", "adopt", "fill", "add-ignore"
 
 	// Packs affected by the command with their current status
 	Packs []DisplayPack `json:"packs"`

--- a/pkg/ui/display/types_test.go
+++ b/pkg/ui/display/types_test.go
@@ -339,7 +339,7 @@ func TestPackCommandResult(t *testing.T) {
 	now := time.Now()
 
 	result := display.PackCommandResult{
-		Command: "on",
+		Command: "up",
 		Packs: []display.DisplayPack{
 			{
 				Name:   "vim",
@@ -354,7 +354,7 @@ func TestPackCommandResult(t *testing.T) {
 		Timestamp: now,
 	}
 
-	assert.Equal(t, "on", result.Command)
+	assert.Equal(t, "up", result.Command)
 	assert.Len(t, result.Packs, 1)
 	assert.Equal(t, "vim", result.Packs[0].Name)
 	assert.Equal(t, "The pack vim has been turned on.", result.Message)


### PR DESCRIPTION
## Summary
- Renamed primary commands from `on`/`off` to `up`/`down`
- Better aligns with tools like docker-compose and vagrant
- Maintains same behavior and functionality

## Motivation
The `up`/`down` naming pattern is more intuitive for commands that combine provisioning and deployment:
- **up**: Brings a pack "up" - installs dependencies and deploys configurations
- **down**: Takes a pack "down" - removes everything completely

This follows established patterns in tools like:
- `docker-compose up/down`
- `vagrant up/destroy`
- `terraform apply/destroy`

## Changes
- Renamed command directories: `on` → `up`, `off` → `down`
- Updated all code references: `OnCommand` → `UpCommand`, etc.
- Updated documentation and examples
- All tests passing

## Test Plan
- [x] All existing tests pass
- [x] Manual testing of `dodot up` and `dodot down` commands
- [x] Documentation updated with new command names
- [x] Help text reflects new commands

🤖 Generated with [Claude Code](https://claude.ai/code)