### PR TITLE
fix: improve resource file handling for distribution

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,8 @@ archives:
         dst: "man/man1"
       - src: "pkg/shell/*"
         dst: "shell"
+      - src: "pkg/ui/output/styles/styles.yaml"
+        dst: "styles/styles.yaml"
 
 checksum:
   name_template: "checksums.txt"
@@ -83,6 +85,12 @@ brews:
       
       # Install man page
       man1.install "man/man1/dodot.1.gz" if File.exist?("man/man1/dodot.1.gz")
+      
+      # Install shell integration scripts
+      pkgshare.install "shell" if Dir.exist?("shell")
+      
+      # Install styles configuration
+      pkgshare.install "styles" if Dir.exist?("styles")
 
 # nFPM packages (deb, rpm, etc.)
 # https://goreleaser.com/customization/nfpm/
@@ -117,6 +125,20 @@ nfpms:
       # Fish completion
       - src: completions/dodot.fish
         dst: /usr/share/fish/vendor_completions.d/dodot.fish
+        file_info:
+          mode: 0644
+      # Shell integration scripts
+      - src: shell/dodot-init.sh
+        dst: /usr/share/dodot/shell/dodot-init.sh
+        file_info:
+          mode: 0755
+      - src: shell/dodot-init.fish
+        dst: /usr/share/dodot/shell/dodot-init.fish
+        file_info:
+          mode: 0755
+      # Styles configuration
+      - src: styles/styles.yaml
+        dst: /usr/share/dodot/styles/styles.yaml
         file_info:
           mode: 0644
 

--- a/pkg/paths/shell.go
+++ b/pkg/paths/shell.go
@@ -15,9 +15,13 @@ func ResolveShellScriptPath(scriptName string) (string, error) {
 	if err == nil {
 		// Look for shell scripts in various installed locations
 		installedPaths := []string{
-			filepath.Join(filepath.Dir(exePath), "..", "share", "shell", scriptName), // Standard Unix layout
-			filepath.Join(filepath.Dir(exePath), "shell", scriptName),                // Same directory as binary
-			filepath.Join(filepath.Dir(exePath), "..", "shell", scriptName),          // Parent directory
+			// Homebrew installs to pkgshare: /opt/homebrew/share/dodot/shell/
+			"/opt/homebrew/share/dodot/shell/" + scriptName,
+			"/usr/local/share/dodot/shell/" + scriptName,                                      // Intel Mac homebrew
+			filepath.Join(filepath.Dir(exePath), "..", "share", "dodot", "shell", scriptName), // Standard Unix layout
+			filepath.Join(filepath.Dir(exePath), "..", "share", "shell", scriptName),          // Alternative Unix layout
+			filepath.Join(filepath.Dir(exePath), "shell", scriptName),                         // Same directory as binary
+			filepath.Join(filepath.Dir(exePath), "..", "shell", scriptName),                   // Parent directory
 		}
 
 		for _, path := range installedPaths {


### PR DESCRIPTION
## Summary
Fixes the panic when running dodot installed from homebrew due to missing resource files.

## Problem
When installed via homebrew, dodot couldn't find:
- `styles.yaml` - causing a panic on startup
- `dodot-init.sh` - preventing shell integration from working

## Solution
1. **Include resources in distribution**:
   - Added shell scripts and styles.yaml to goreleaser archives
   - Updated homebrew formula to install to `pkgshare`
   - Updated debian/rpm packages to install to `/usr/share/dodot/`

2. **Improve path resolution**:
   - Check common installation locations (homebrew, system packages)
   - Maintain file-based loading for development (hot reload)
   - Add embedded fallback for styles using `//go:embed`

3. **Graceful degradation**:
   - Default styles if styles.yaml is missing (no panic)
   - Warning if shell scripts not found (no crash)

## Test Plan
- [x] Local build works with file-based resources
- [x] Embedded styles compile correctly
- [ ] Homebrew installation finds resources in pkgshare
- [ ] Shell integration scripts are copied correctly

🤖 Generated with [Claude Code](https://claude.ai/code)