### PR TITLE
Add E2E testing infrastructure with BATS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,26 @@ jobs:
 
       - name: Run checks
         run: scripts/check
+
+  e2e:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: ./.github/actions/rust-setup
+
+      - name: Build dodot
+        run: cargo build --release -p dodot
+
+      - name: Install BATS
+        run: |
+          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats
+          sudo /tmp/bats/install.sh /usr/local
+
+      - name: Run E2E tests
+        run: |
+          export DODOT_BIN="$PWD/target/release/dodot"
+          bats tests/e2e/bats/

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -11,19 +11,29 @@ use standout::cli::{CommandContext, HandlerResult, Output};
 use dodot_lib::commands;
 use dodot_lib::packs::orchestration::ExecutionContext;
 
+/// Read a boolean flag, returning false if the flag is not defined
+/// for this subcommand.
+fn flag_or_false(matches: &clap::ArgMatches, name: &str) -> bool {
+    matches
+        .try_get_one::<bool>(name)
+        .ok()
+        .flatten()
+        .copied()
+        .unwrap_or(false)
+}
+
 /// Build an ExecutionContext from the current environment.
 ///
 /// Uses `ExecutionContext::production()` with the dotfiles root
-/// discovered from env/git. Overrides dry_run and no_provision
-/// based on CLI flags.
+/// discovered from env/git. Reads CLI flags when present, defaulting
+/// to false for flags not defined on the current subcommand.
 fn build_ctx(matches: &clap::ArgMatches) -> Result<ExecutionContext, anyhow::Error> {
-    // Discover dotfiles root from environment
     let dotfiles_root = discover_dotfiles_root()?;
     let mut ctx = ExecutionContext::production(&dotfiles_root)?;
 
-    ctx.dry_run = matches.get_flag("dry-run");
-    ctx.no_provision = matches.get_flag("no-provision");
-    ctx.provision_rerun = matches.get_flag("provision-rerun");
+    ctx.dry_run = flag_or_false(matches, "dry-run");
+    ctx.no_provision = flag_or_false(matches, "no-provision");
+    ctx.provision_rerun = flag_or_false(matches, "provision-rerun");
 
     Ok(ctx)
 }
@@ -95,9 +105,7 @@ pub fn down_handler(
     matches: &clap::ArgMatches,
     _ctx: &CommandContext,
 ) -> HandlerResult<commands::PackStatusResult> {
-    let dotfiles_root = discover_dotfiles_root()?;
-    let mut ctx = ExecutionContext::production(&dotfiles_root)?;
-    ctx.dry_run = matches.get_flag("dry-run");
+    let ctx = build_ctx(matches)?;
     let filter = pack_filter(matches);
     let result = commands::down::down(filter.as_deref(), &ctx)?;
     Ok(Output::Render(result))

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -95,7 +95,9 @@ pub fn down_handler(
     matches: &clap::ArgMatches,
     _ctx: &CommandContext,
 ) -> HandlerResult<commands::PackStatusResult> {
-    let ctx = build_ctx(matches)?;
+    let dotfiles_root = discover_dotfiles_root()?;
+    let mut ctx = ExecutionContext::production(&dotfiles_root)?;
+    ctx.dry_run = matches.get_flag("dry-run");
     let filter = pack_filter(matches);
     let result = commands::down::down(filter.as_deref(), &ctx)?;
     Ok(Output::Render(result))

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# E2E test runner for dodot.
+#
+# Usage:
+#   scripts/e2e                    Run all E2E tests in Docker
+#   scripts/e2e --shell            Drop into interactive container
+#   scripts/e2e --local            Run locally (no Docker, uses temp-dir isolation)
+#   scripts/e2e --rebuild          Force rebuild of Docker image
+#   scripts/e2e test_up.bats       Run a specific test file
+#   scripts/e2e --local test_up.bats   Run specific test file locally
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IMAGE_NAME="dodot-e2e"
+
+mode="docker"
+rebuild=false
+test_target=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --shell)
+            mode="shell"
+            shift
+            ;;
+        --local)
+            mode="local"
+            shift
+            ;;
+        --rebuild)
+            rebuild=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: scripts/e2e [OPTIONS] [TEST_FILE]"
+            echo ""
+            echo "Options:"
+            echo "  --shell     Drop into interactive container with dodot on PATH"
+            echo "  --local     Run locally without Docker (temp-dir isolation)"
+            echo "  --rebuild   Force rebuild of Docker image"
+            echo "  -h, --help  Show this help"
+            echo ""
+            echo "Examples:"
+            echo "  scripts/e2e                       Run all tests in Docker"
+            echo "  scripts/e2e test_up.bats           Run specific test file in Docker"
+            echo "  scripts/e2e --local                Run all tests locally"
+            echo "  scripts/e2e --local test_up.bats   Run specific test file locally"
+            echo "  scripts/e2e --shell                Interactive container shell"
+            exit 0
+            ;;
+        *.bats)
+            test_target="$1"
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Local mode ──────────────────────────────────────────────────
+
+run_local() {
+    if ! command -v bats >/dev/null 2>&1; then
+        echo "Error: bats not found. Install with: brew install bats-core" >&2
+        exit 1
+    fi
+
+    # Build the release binary
+    echo "Building dodot..."
+    cargo build --release -p dodot --manifest-path "$PROJECT_ROOT/Cargo.toml"
+
+    export DODOT_BIN="$PROJECT_ROOT/target/release/dodot"
+
+    if [[ -n "$test_target" ]]; then
+        bats "$PROJECT_ROOT/tests/e2e/bats/$test_target"
+    else
+        bats "$PROJECT_ROOT/tests/e2e/bats/"
+    fi
+}
+
+# ── Docker mode ─────────────────────────────────────────────────
+
+ensure_image() {
+    if $rebuild || ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+        echo "Building Docker image..."
+        docker build \
+            -t "$IMAGE_NAME" \
+            -f "$PROJECT_ROOT/tests/e2e/Dockerfile" \
+            "$PROJECT_ROOT"
+    fi
+}
+
+run_docker() {
+    ensure_image
+
+    if [[ -n "$test_target" ]]; then
+        docker run --rm "$IMAGE_NAME" "/tests/$test_target"
+    else
+        docker run --rm "$IMAGE_NAME"
+    fi
+}
+
+run_shell() {
+    ensure_image
+
+    echo "Entering interactive container..."
+    echo "  dodot is at /usr/local/bin/dodot"
+    echo "  Test helpers: source /tests/helpers/setup.bash"
+    echo "  Run tests:    bats /tests/"
+    echo ""
+
+    docker run --rm -it \
+        --entrypoint bash \
+        "$IMAGE_NAME"
+}
+
+# ── Dispatch ────────────────────────────────────────────────────
+
+case "$mode" in
+    local)  run_local ;;
+    docker) run_docker ;;
+    shell)  run_shell ;;
+esac

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -1,0 +1,46 @@
+# Multi-stage Dockerfile for dodot E2E testing.
+#
+# Stage 1: Build the dodot binary from source.
+# Stage 2: Minimal runtime with BATS for test execution.
+#
+# Usage:
+#   docker build -t dodot-e2e -f tests/e2e/Dockerfile .
+#   docker run --rm dodot-e2e                    # run all tests
+#   docker run --rm -it dodot-e2e bash            # interactive shell
+#   docker run --rm dodot-e2e bats /tests/test_up.bats  # single test file
+
+# ── Stage 1: Builder ────────────────────────────────────────────
+FROM rust:1.94.1-slim AS builder
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates/ crates/
+
+RUN cargo build --release -p dodot && \
+    strip target/release/dodot
+
+# ── Stage 2: Runtime ────────────────────────────────────────────
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install bats-core + helpers
+RUN git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats && \
+    /tmp/bats/install.sh /usr/local && \
+    rm -rf /tmp/bats
+
+# Copy dodot binary from builder
+COPY --from=builder /build/target/release/dodot /usr/local/bin/dodot
+
+# Copy test suite
+COPY tests/e2e/bats/ /tests/
+
+ENV DODOT_BIN=/usr/local/bin/dodot
+WORKDIR /tests
+
+ENTRYPOINT ["bats"]
+CMD ["/tests/"]

--- a/tests/e2e/bats/helpers/assertions.bash
+++ b/tests/e2e/bats/helpers/assertions.bash
@@ -124,7 +124,7 @@ assert_sentinel_exists() {
 
     # shellcheck disable=SC2086
     local matches
-    matches=$(find "$sentinel_dir" -name "$pattern" -maxdepth 1 2>/dev/null)
+    matches=$(find "$sentinel_dir" -maxdepth 1 -name "$pattern" 2>/dev/null)
     if [[ -z "$matches" ]]; then
         echo "no sentinel matching '$pattern' in $sentinel_dir" >&2
         echo "contents:" >&2

--- a/tests/e2e/bats/helpers/assertions.bash
+++ b/tests/e2e/bats/helpers/assertions.bash
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Custom assertion helpers for dodot E2E tests.
+#
+# Mirror the assertion API from TempEnvironment in the Rust test suite.
+
+# Assert that a symlink exists and points to the expected target.
+# Usage: assert_symlink "/path/to/link" "/path/to/target"
+assert_symlink() {
+    local link="$1"
+    local target="$2"
+
+    if [[ ! -L "$link" ]]; then
+        echo "expected symlink at $link, but it is not a symlink" >&2
+        if [[ -e "$link" ]]; then
+            echo "  (exists as regular file/dir)" >&2
+        else
+            echo "  (does not exist)" >&2
+        fi
+        return 1
+    fi
+
+    local actual_target
+    actual_target="$(readlink "$link")"
+    if [[ "$actual_target" != "$target" ]]; then
+        echo "symlink $link points to $actual_target, expected $target" >&2
+        return 1
+    fi
+}
+
+# Assert the full dodot double-link chain:
+#   source (pack file) -> datastore link -> user-visible path
+#
+# Usage: assert_double_link "vim" "symlink" "vimrc" "/path/to/source" "/path/to/user/file"
+assert_double_link() {
+    local pack="$1"
+    local handler="$2"
+    local filename="$3"
+    local source="$4"
+    local user_path="$5"
+
+    local datastore_link="$XDG_DATA_HOME/dodot/packs/$pack/$handler/$filename"
+
+    # Datastore link -> source
+    assert_symlink "$datastore_link" "$source"
+
+    # User link -> datastore link
+    assert_symlink "$user_path" "$datastore_link"
+}
+
+# Assert that a file exists.
+# Usage: assert_exists "/path/to/file"
+assert_exists() {
+    local path="$1"
+    if [[ ! -e "$path" ]]; then
+        echo "expected $path to exist, but it does not" >&2
+        return 1
+    fi
+}
+
+# Assert that nothing exists at the given path.
+# Usage: assert_not_exists "/path/to/file"
+assert_not_exists() {
+    local path="$1"
+    if [[ -e "$path" || -L "$path" ]]; then
+        echo "expected $path to not exist, but it does" >&2
+        return 1
+    fi
+}
+
+# Assert that a directory exists.
+# Usage: assert_dir_exists "/path/to/dir"
+assert_dir_exists() {
+    local path="$1"
+    if [[ ! -d "$path" ]]; then
+        echo "expected $path to be a directory" >&2
+        return 1
+    fi
+}
+
+# Assert a file exists and contains a pattern.
+# Usage: assert_file_contains "/path/to/file" "pattern"
+assert_file_contains() {
+    local path="$1"
+    local pattern="$2"
+
+    assert_exists "$path"
+    if ! grep -q "$pattern" "$path"; then
+        echo "expected $path to contain '$pattern'" >&2
+        echo "actual contents:" >&2
+        cat "$path" >&2
+        return 1
+    fi
+}
+
+# Assert a file exists with exactly the given contents.
+# Usage: assert_file_contents "/path/to/file" "expected content"
+assert_file_contents() {
+    local path="$1"
+    local expected="$2"
+
+    assert_exists "$path"
+    local actual
+    actual="$(cat "$path")"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "file $path has unexpected contents" >&2
+        echo "expected: $expected" >&2
+        echo "actual:   $actual" >&2
+        return 1
+    fi
+}
+
+# Assert that a sentinel file matching a glob pattern exists.
+# Usage: assert_sentinel_exists "tools" "install" "install.sh-*"
+assert_sentinel_exists() {
+    local pack="$1"
+    local handler="$2"
+    local pattern="$3"
+
+    local sentinel_dir="$XDG_DATA_HOME/dodot/packs/$pack/$handler"
+    if [[ ! -d "$sentinel_dir" ]]; then
+        echo "sentinel dir $sentinel_dir does not exist" >&2
+        return 1
+    fi
+
+    # shellcheck disable=SC2086
+    local matches
+    matches=$(find "$sentinel_dir" -name "$pattern" -maxdepth 1 2>/dev/null)
+    if [[ -z "$matches" ]]; then
+        echo "no sentinel matching '$pattern' in $sentinel_dir" >&2
+        echo "contents:" >&2
+        ls -la "$sentinel_dir" >&2
+        return 1
+    fi
+}
+
+# Assert no handler state exists for a pack/handler pair.
+# Usage: assert_no_handler_state "vim" "symlink"
+assert_no_handler_state() {
+    local pack="$1"
+    local handler="$2"
+    local dir="$XDG_DATA_HOME/dodot/packs/$pack/$handler"
+
+    if [[ -d "$dir" ]]; then
+        local count
+        count=$(find "$dir" -mindepth 1 -maxdepth 1 | wc -l)
+        if [[ "$count" -gt 0 ]]; then
+            echo "expected no state for $pack/$handler, but found $count entries in $dir" >&2
+            ls -la "$dir" >&2
+            return 1
+        fi
+    fi
+}
+
+# Assert that dodot output (from $output) contains a string.
+# Usage: run dodot status
+#        assert_output_contains "vim"
+assert_output_contains() {
+    local pattern="$1"
+    if [[ "$output" != *"$pattern"* ]]; then
+        echo "expected output to contain '$pattern'" >&2
+        echo "actual output:" >&2
+        echo "$output" >&2
+        return 1
+    fi
+}
+
+# Assert that dodot output does NOT contain a string.
+# Usage: run dodot status
+#        assert_output_not_contains "error"
+assert_output_not_contains() {
+    local pattern="$1"
+    if [[ "$output" == *"$pattern"* ]]; then
+        echo "expected output to NOT contain '$pattern'" >&2
+        echo "actual output:" >&2
+        echo "$output" >&2
+        return 1
+    fi
+}

--- a/tests/e2e/bats/helpers/fixtures.bash
+++ b/tests/e2e/bats/helpers/fixtures.bash
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Fixture creation helpers — shell equivalent of TempEnvironment builder.
+#
+# All paths are relative to the current sandbox's DOTFILES_ROOT and HOME.
+
+# Create a pack directory.
+# Usage: create_pack "vim"
+create_pack() {
+    local pack="$1"
+    mkdir -p "$DOTFILES_ROOT/$pack"
+}
+
+# Create a file inside a pack.
+# Usage: create_pack_file "vim" "vimrc" "set nocompatible"
+# Handles nested paths (creates parent dirs).
+create_pack_file() {
+    local pack="$1"
+    local rel_path="$2"
+    local contents="${3:-}"
+    local full_path="$DOTFILES_ROOT/$pack/$rel_path"
+
+    mkdir -p "$(dirname "$full_path")"
+    printf '%b' "$contents" > "$full_path"
+}
+
+# Write a .dodot.toml config for a specific pack.
+# Usage: create_pack_config "vim" '[pack]\nignore = ["*.bak"]'
+create_pack_config() {
+    local pack="$1"
+    local toml="$2"
+
+    printf '%b' "$toml" > "$DOTFILES_ROOT/$pack/.dodot.toml"
+}
+
+# Write a .dodot.toml at the dotfiles root.
+# Usage: create_root_config '[symlink]\nstrip_dot_prefix = true'
+create_root_config() {
+    local toml="$1"
+    printf '%b' "$toml" > "$DOTFILES_ROOT/.dodot.toml"
+}
+
+# Mark a pack as ignored by creating .dodotignore.
+# Usage: mark_ignored "disabled-pack"
+mark_ignored() {
+    local pack="$1"
+    mkdir -p "$DOTFILES_ROOT/$pack"
+    touch "$DOTFILES_ROOT/$pack/.dodotignore"
+}
+
+# Create a file under the simulated HOME directory.
+# Useful for testing adopt.
+# Usage: create_home_file ".vimrc" "set nocompatible"
+create_home_file() {
+    local rel_path="$1"
+    local contents="${2:-}"
+    local full_path="$HOME/$rel_path"
+
+    mkdir -p "$(dirname "$full_path")"
+    printf '%b' "$contents" > "$full_path"
+}
+
+# Create an executable script inside a pack.
+# Usage: create_pack_script "tools" "install.sh" '#!/bin/sh
+# echo "installed" > "$HOME/.tools-installed"'
+create_pack_script() {
+    local pack="$1"
+    local rel_path="$2"
+    local contents="$3"
+
+    create_pack_file "$pack" "$rel_path" "$contents"
+    chmod +x "$DOTFILES_ROOT/$pack/$rel_path"
+}
+
+# Create a bin directory inside a pack with executable scripts.
+# Usage: create_pack_bin "tools" "myscript" '#!/bin/sh
+# echo hello'
+create_pack_bin() {
+    local pack="$1"
+    local script_name="$2"
+    local contents="$3"
+
+    create_pack_file "$pack" "bin/$script_name" "$contents"
+    chmod +x "$DOTFILES_ROOT/$pack/bin/$script_name"
+}

--- a/tests/e2e/bats/helpers/setup.bash
+++ b/tests/e2e/bats/helpers/setup.bash
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# E2E test harness — sandbox lifecycle and dodot wrapper.
+#
+# Every BATS test gets an isolated filesystem sandbox mirroring
+# the structure that TempEnvironment creates in the Rust test suite.
+#
+# Usage in .bats files:
+#   setup()    { load helpers/setup; sandbox_setup; }
+#   teardown() { sandbox_teardown; }
+
+# Resolve the project root relative to BATS_TEST_DIRNAME
+_E2E_HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_E2E_PROJECT_ROOT="$(cd "$_E2E_HELPERS_DIR/../../../.." && pwd)"
+
+# Where the compiled dodot binary lives.
+# Set DODOT_BIN externally to override (e.g. in CI or Docker).
+DODOT_BIN="${DODOT_BIN:-$_E2E_PROJECT_ROOT/target/release/dodot}"
+
+# Source sibling helpers
+# shellcheck source=fixtures.bash
+source "$_E2E_HELPERS_DIR/fixtures.bash"
+# shellcheck source=assertions.bash
+source "$_E2E_HELPERS_DIR/assertions.bash"
+
+# ── Sandbox lifecycle ───────────────────────────────────────────
+
+sandbox_setup() {
+    SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/dodot-e2e-XXXXXXXXXX")"
+
+    # Mirror TempEnvironment layout
+    SANDBOX_HOME="$SANDBOX/home"
+    SANDBOX_DOTFILES="$SANDBOX_HOME/dotfiles"
+    SANDBOX_CONFIG_HOME="$SANDBOX_HOME/.config"
+    SANDBOX_DATA_HOME="$SANDBOX_HOME/.local/share"
+    SANDBOX_CACHE_HOME="$SANDBOX_HOME/.cache"
+
+    mkdir -p \
+        "$SANDBOX_HOME" \
+        "$SANDBOX_DOTFILES" \
+        "$SANDBOX_CONFIG_HOME" \
+        "$SANDBOX_DATA_HOME/dodot/packs" \
+        "$SANDBOX_DATA_HOME/dodot/shell" \
+        "$SANDBOX_CACHE_HOME/dodot"
+
+    # Redirect all env vars into the sandbox
+    export HOME="$SANDBOX_HOME"
+    export DOTFILES_ROOT="$SANDBOX_DOTFILES"
+    export XDG_CONFIG_HOME="$SANDBOX_CONFIG_HOME"
+    export XDG_DATA_HOME="$SANDBOX_DATA_HOME"
+    export XDG_CACHE_HOME="$SANDBOX_CACHE_HOME"
+
+    # Prevent git from escaping the sandbox
+    export GIT_CEILING_DIRECTORIES="$SANDBOX"
+
+    # Initialize a git repo in the dotfiles root so that
+    # discover_dotfiles_root()'s git-toplevel fallback stays contained
+    git init -q "$SANDBOX_DOTFILES"
+
+    # Plain text output for reliable grep/assertion matching
+    export NO_COLOR=1
+}
+
+sandbox_teardown() {
+    if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+        rm -rf "$SANDBOX"
+    fi
+}
+
+# ── dodot wrapper ───────────────────────────────────────────────
+
+# Run the dodot binary.
+# Usage:  dodot status
+#         dodot up --dry-run
+#         dodot up vim
+dodot() {
+    "$DODOT_BIN" "$@"
+}

--- a/tests/e2e/bats/test_addignore.bats
+++ b/tests/e2e/bats/test_addignore.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot addignore`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "addignore creates .dodotignore file" {
+    create_pack_file "scratch" "notes" "x"
+
+    run dodot addignore scratch
+    [ "$status" -eq 0 ]
+    assert_output_contains "ignored"
+
+    assert_exists "$DOTFILES_ROOT/scratch/.dodotignore"
+}
+
+@test "addignore is idempotent" {
+    create_pack_file "scratch" "notes" "x"
+    mark_ignored "scratch"
+
+    run dodot addignore scratch
+    [ "$status" -eq 0 ]
+    assert_output_contains "already ignored"
+}
+
+@test "addignore makes pack show as ignored in list" {
+    create_pack_file "scratch" "notes" "x"
+
+    dodot addignore scratch
+    run dodot list
+    [ "$status" -eq 0 ]
+    assert_output_contains "scratch"
+    assert_output_contains "(ignored)"
+}
+
+@test "addignore makes pack skipped by status" {
+    create_pack_file "scratch" "notes" "x"
+
+    dodot addignore scratch
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_not_contains "scratch"
+}

--- a/tests/e2e/bats/test_adopt.bats
+++ b/tests/e2e/bats/test_adopt.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot adopt`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "adopt moves file into pack and creates symlink" {
+    create_pack "vim"
+    create_home_file ".vimrc" "set nocompatible"
+
+    run dodot adopt vim "$HOME/.vimrc"
+    [ "$status" -eq 0 ]
+    assert_output_contains "1 file"
+
+    # File should be in the pack (dot prefix stripped)
+    assert_exists "$DOTFILES_ROOT/vim/vimrc"
+    assert_file_contents "$DOTFILES_ROOT/vim/vimrc" "set nocompatible"
+
+    # Original location should be a symlink
+    [ -L "$HOME/.vimrc" ]
+}
+
+@test "adopt with --force overwrites existing pack file" {
+    create_pack_file "vim" "vimrc" "old content"
+    create_home_file ".vimrc" "new content"
+
+    run dodot adopt vim --force "$HOME/.vimrc"
+    [ "$status" -eq 0 ]
+
+    assert_file_contents "$DOTFILES_ROOT/vim/vimrc" "new content"
+}
+
+@test "adopt reports error without --force when file exists in pack" {
+    create_pack_file "vim" "vimrc" "old content"
+    create_home_file ".vimrc" "new content"
+
+    run dodot adopt vim "$HOME/.vimrc"
+    assert_output_contains "already exists"
+
+    # Original pack file should be unchanged
+    assert_file_contents "$DOTFILES_ROOT/vim/vimrc" "old content"
+}
+
+@test "adopt multiple files" {
+    create_pack "shell"
+    create_home_file ".bashrc" "# bashrc"
+    create_home_file ".zshrc" "# zshrc"
+
+    run dodot adopt shell "$HOME/.bashrc" "$HOME/.zshrc"
+    [ "$status" -eq 0 ]
+    assert_output_contains "2 file"
+
+    assert_exists "$DOTFILES_ROOT/shell/bashrc"
+    assert_exists "$DOTFILES_ROOT/shell/zshrc"
+}

--- a/tests/e2e/bats/test_down.bats
+++ b/tests/e2e/bats/test_down.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot down`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "down removes deployed state" {
+    create_pack_file "vim" "vimrc" "x"
+
+    dodot up
+    assert_exists "$XDG_DATA_HOME/dodot/packs/vim/symlink/vimrc"
+
+    run dodot down
+    [ "$status" -eq 0 ]
+    assert_output_contains "deactivated"
+
+    # Datastore state should be gone
+    assert_no_handler_state "vim" "symlink"
+}
+
+@test "down makes status return to pending" {
+    create_pack_file "vim" "vimrc" "x"
+
+    dodot up
+    dodot down
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "pending"
+    assert_output_not_contains "deployed"
+}
+
+@test "down --dry-run shows plan without changes" {
+    create_pack_file "vim" "vimrc" "x"
+
+    dodot up
+    run dodot down --dry-run
+    [ "$status" -eq 0 ]
+    assert_output_contains "dry run"
+
+    # State should still be deployed
+    run dodot status
+    assert_output_contains "deployed"
+}
+
+@test "down removes selected packs only" {
+    create_pack_file "vim" "vimrc" "x"
+    create_pack_file "git" "gitconfig" "x"
+
+    dodot up
+    dodot down vim
+
+    # vim should be pending, git still deployed
+    run dodot status vim
+    assert_output_contains "pending"
+    run dodot status git
+    assert_output_contains "deployed"
+}
+
+@test "down on already-inactive packs is safe" {
+    create_pack_file "vim" "vimrc" "x"
+
+    # Never deployed — down should succeed
+    run dodot down
+    [ "$status" -eq 0 ]
+}
+
+@test "down removes shell handler state" {
+    create_pack_file "zsh" "aliases.sh" "alias ll='ls -la'"
+
+    dodot up
+    assert_exists "$XDG_DATA_HOME/dodot/packs/zsh/shell/aliases.sh"
+
+    dodot down
+    assert_no_handler_state "zsh" "shell"
+}
+
+@test "down removes path handler state" {
+    create_pack "tools"
+    create_pack_bin "tools" "mytool" '#!/bin/sh\necho hello'
+
+    dodot up
+    assert_exists "$XDG_DATA_HOME/dodot/packs/tools/path/bin"
+
+    dodot down
+    assert_no_handler_state "tools" "path"
+}

--- a/tests/e2e/bats/test_genconfig.bats
+++ b/tests/e2e/bats/test_genconfig.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot genconfig`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "genconfig returns TOML template" {
+    run dodot genconfig
+    [ "$status" -eq 0 ]
+    assert_output_contains "[pack]"
+    assert_output_contains "[symlink]"
+    assert_output_contains "[mappings]"
+}
+
+@test "genconfig --write creates file at dotfiles root" {
+    run dodot genconfig --write
+    [ "$status" -eq 0 ]
+
+    assert_exists "$DOTFILES_ROOT/.dodot.toml"
+    assert_file_contains "$DOTFILES_ROOT/.dodot.toml" "[pack]"
+}
+
+@test "genconfig --write does not overwrite existing config" {
+    create_root_config "[pack]\nignore = [\"scratch\"]"
+
+    run dodot genconfig --write
+    # Should either fail or report that config exists
+    # The file should still have original content
+    assert_file_contains "$DOTFILES_ROOT/.dodot.toml" "scratch"
+}

--- a/tests/e2e/bats/test_init.bats
+++ b/tests/e2e/bats/test_init.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot init`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "init creates pack directory with config" {
+    run dodot init newpack
+    [ "$status" -eq 0 ]
+    assert_output_contains "newpack"
+
+    assert_dir_exists "$DOTFILES_ROOT/newpack"
+    assert_exists "$DOTFILES_ROOT/newpack/.dodot.toml"
+}
+
+@test "init reports error if pack already exists" {
+    create_pack "existing"
+    create_pack_file "existing" "file" "x"
+
+    run dodot init existing
+    assert_output_contains "already exists"
+}
+
+@test "init creates pack that shows in list" {
+    dodot init mypack
+
+    run dodot list
+    [ "$status" -eq 0 ]
+    assert_output_contains "mypack"
+}

--- a/tests/e2e/bats/test_init_sh.bats
+++ b/tests/e2e/bats/test_init_sh.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot init-sh`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "init-sh outputs valid shell script" {
+    run dodot init-sh
+    [ "$status" -eq 0 ]
+    # Should have a shebang or be sourceable
+    assert_output_contains "#!/bin/sh"
+}
+
+@test "init-sh includes shell file source lines after up" {
+    create_pack_file "zsh" "aliases.sh" "alias ll='ls -la'"
+    dodot up
+
+    run dodot init-sh
+    [ "$status" -eq 0 ]
+    assert_output_contains "aliases.sh"
+    # Should use `. "path"` or `source "path"` syntax
+    assert_output_contains ". \""
+}
+
+@test "init-sh includes PATH additions after up" {
+    create_pack "tools"
+    create_pack_bin "tools" "mytool" '#!/bin/sh\necho hello'
+    dodot up
+
+    run dodot init-sh
+    [ "$status" -eq 0 ]
+    assert_output_contains "PATH="
+    assert_output_contains "bin"
+}
+
+@test "init-sh is empty when no packs deployed" {
+    create_pack_file "vim" "vimrc" "x"
+    # Don't deploy
+
+    run dodot init-sh
+    [ "$status" -eq 0 ]
+    # Should still be a valid script but have no source/PATH lines
+    assert_output_contains "#!/bin/sh"
+}
+
+@test "init-sh reflects changes after down" {
+    create_pack_file "zsh" "aliases.sh" "alias ll='ls -la'"
+    dodot up
+
+    run dodot init-sh
+    assert_output_contains "aliases.sh"
+
+    dodot down
+
+    run dodot init-sh
+    assert_output_not_contains "aliases.sh"
+}

--- a/tests/e2e/bats/test_install.bats
+++ b/tests/e2e/bats/test_install.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# E2E tests for the install handler (real script execution).
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "install.sh runs and creates marker" {
+    create_pack_script "tools" "install.sh" '#!/bin/sh
+echo "installed" > "$HOME/.tools-installed"'
+
+    dodot up
+    assert_exists "$HOME/.tools-installed"
+    assert_file_contains "$HOME/.tools-installed" "installed"
+}
+
+@test "install.sh creates sentinel after run" {
+    create_pack_script "tools" "install.sh" '#!/bin/sh
+echo done'
+
+    dodot up
+    assert_sentinel_exists "tools" "install" "install.sh-*"
+}
+
+@test "install.sh does not re-run on second up" {
+    create_pack_script "tools" "install.sh" '#!/bin/sh
+echo "$(date +%s%N)" > "$HOME/.install-timestamp"'
+
+    dodot up
+    local first_ts
+    first_ts="$(cat "$HOME/.install-timestamp")"
+
+    # Small delay to ensure different timestamp
+    sleep 1
+
+    dodot up
+    local second_ts
+    second_ts="$(cat "$HOME/.install-timestamp")"
+
+    # Should be the same — script didn't re-run
+    [ "$first_ts" = "$second_ts" ]
+}
+
+@test "install.sh re-runs with --provision-rerun" {
+    # TODO: provision_rerun is wired to CLI but not checked in execution pipeline.
+    # The sentinel check in execution/mod.rs always short-circuits regardless of this flag.
+    skip "provision_rerun not yet implemented in execution layer"
+
+    create_pack_script "tools" "install.sh" '#!/bin/sh
+echo "$(date +%s%N)" > "$HOME/.install-timestamp"'
+
+    dodot up
+    local first_ts
+    first_ts="$(cat "$HOME/.install-timestamp")"
+
+    sleep 1
+
+    dodot up --provision-rerun
+    local second_ts
+    second_ts="$(cat "$HOME/.install-timestamp")"
+
+    # Should be different — script re-ran
+    [ "$first_ts" != "$second_ts" ]
+}
+
+@test "install handler shows installed/never run in status" {
+    create_pack_script "tools" "install.sh" '#!/bin/sh
+echo done'
+
+    run dodot status
+    assert_output_contains "never run"
+
+    dodot up
+    run dodot status
+    assert_output_contains "installed"
+}
+
+@test "up --no-provision skips install.sh" {
+    create_pack_script "tools" "install.sh" '#!/bin/sh
+touch "$HOME/.should-not-exist"'
+
+    dodot up --no-provision
+
+    assert_not_exists "$HOME/.should-not-exist"
+
+    run dodot status
+    assert_output_contains "never run"
+}

--- a/tests/e2e/bats/test_install.bats
+++ b/tests/e2e/bats/test_install.bats
@@ -29,7 +29,7 @@ echo done'
 
 @test "install.sh does not re-run on second up" {
     create_pack_script "tools" "install.sh" '#!/bin/sh
-echo "$(date +%s%N)" > "$HOME/.install-timestamp"'
+echo "$(date +%s)" > "$HOME/.install-timestamp"'
 
     dodot up
     local first_ts
@@ -52,7 +52,7 @@ echo "$(date +%s%N)" > "$HOME/.install-timestamp"'
     skip "provision_rerun not yet implemented in execution layer"
 
     create_pack_script "tools" "install.sh" '#!/bin/sh
-echo "$(date +%s%N)" > "$HOME/.install-timestamp"'
+echo "$(date +%s)" > "$HOME/.install-timestamp"'
 
     dodot up
     local first_ts

--- a/tests/e2e/bats/test_lifecycle.bats
+++ b/tests/e2e/bats/test_lifecycle.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# E2E tests for full dodot lifecycle (up → status → down → status).
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "full lifecycle: up → status → down → status" {
+    create_pack_file "vim" "vimrc" "set nocompatible"
+    create_pack_file "git" "gitconfig" "[user]\n  name = test"
+
+    # 1. Status before up — all pending
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "pending"
+    assert_output_not_contains "deployed"
+
+    # 2. Up
+    run dodot up
+    [ "$status" -eq 0 ]
+    assert_output_contains "deployed"
+
+    # 3. Status after up — deployed
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "deployed"
+
+    # Symlinks exist
+    assert_exists "$HOME/.vimrc"
+    assert_exists "$HOME/.gitconfig"
+
+    # 4. Down
+    run dodot down
+    [ "$status" -eq 0 ]
+    assert_output_contains "deactivated"
+
+    # 5. Status after down — pending again
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "pending"
+    assert_output_not_contains "deployed"
+}
+
+@test "lifecycle with re-deploy is idempotent" {
+    create_pack_file "vim" "vimrc" "set nocompatible"
+
+    dodot up
+    run dodot status
+    assert_output_contains "deployed"
+
+    dodot down
+    run dodot status
+    assert_output_contains "pending"
+
+    # Re-deploy
+    dodot up
+    run dodot status
+    assert_output_contains "deployed"
+
+    # Symlink chain works
+    assert_file_contains "$HOME/.vimrc" "set nocompatible"
+}
+
+@test "lifecycle with mixed handlers" {
+    create_pack_file "dev" "vimrc" "set nocompatible"
+    create_pack_file "dev" "aliases.sh" "alias g=git"
+    create_pack "dev"
+    create_pack_bin "dev" "devtool" '#!/bin/sh\necho dev'
+
+    dodot up
+
+    # All handlers should be active
+    run dodot status
+    assert_output_contains "deployed"
+    assert_output_contains "sourced"
+    assert_output_contains "in PATH"
+
+    dodot down
+
+    run dodot status
+    assert_output_contains "pending"
+    assert_output_contains "not sourced"
+    assert_output_contains "not in PATH"
+}
+
+@test "selective up then full down" {
+    create_pack_file "vim" "vimrc" "x"
+    create_pack_file "git" "gitconfig" "x"
+
+    # Deploy only vim
+    dodot up vim
+    run dodot status vim
+    assert_output_contains "deployed"
+    run dodot status git
+    assert_output_contains "pending"
+
+    # Down everything
+    dodot down
+    run dodot status
+    assert_output_not_contains "deployed"
+}

--- a/tests/e2e/bats/test_list.bats
+++ b/tests/e2e/bats/test_list.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot list`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "list shows all packs" {
+    create_pack "git"
+    create_pack_file "git" "gitconfig" "[user]\n  name = test"
+    create_pack "vim"
+    create_pack_file "vim" "vimrc" "set nocompatible"
+
+    run dodot list
+    [ "$status" -eq 0 ]
+    assert_output_contains "git"
+    assert_output_contains "vim"
+}
+
+@test "list shows ignored packs with marker" {
+    create_pack "active"
+    create_pack_file "active" "file" "content"
+    create_pack "disabled"
+    create_pack_file "disabled" "file" "content"
+    mark_ignored "disabled"
+
+    run dodot list
+    [ "$status" -eq 0 ]
+    assert_output_contains "active"
+    assert_output_contains "disabled"
+    assert_output_contains "(ignored)"
+}
+
+@test "list with no packs shows nothing" {
+    run dodot list
+    [ "$status" -eq 0 ]
+    # Output should be empty or just whitespace
+    [[ -z "$(echo "$output" | tr -d '[:space:]')" ]]
+}
+
+@test "list ignores dotfiles and hidden directories" {
+    create_pack "vim"
+    create_pack_file "vim" "vimrc" "x"
+    # .dodot.toml and .git should not appear as packs
+    create_root_config '[pack]\nignore = []'
+
+    run dodot list
+    [ "$status" -eq 0 ]
+    assert_output_contains "vim"
+    assert_output_not_contains ".dodot.toml"
+    assert_output_not_contains ".git"
+}

--- a/tests/e2e/bats/test_shell_integration.bats
+++ b/tests/e2e/bats/test_shell_integration.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# E2E tests for shell integration (eval "$(dodot init-sh)").
+#
+# These tests verify that sourcing dodot's init script in a
+# real shell actually makes aliases and PATH changes take effect.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "sourcing init-sh makes shell aliases available" {
+    create_pack_file "zsh" "aliases.sh" 'alias dodot_test_alias="echo it works"'
+    dodot up
+
+    # Source the init script in a subshell and check the alias
+    result="$(bash -c "
+        export HOME='$HOME'
+        export XDG_DATA_HOME='$XDG_DATA_HOME'
+        export DOTFILES_ROOT='$DOTFILES_ROOT'
+        export XDG_CONFIG_HOME='$XDG_CONFIG_HOME'
+        export XDG_CACHE_HOME='$XDG_CACHE_HOME'
+        shopt -s expand_aliases
+        eval \"\$($DODOT_BIN init-sh)\"
+        dodot_test_alias
+    " 2>&1)"
+
+    [ "$result" = "it works" ]
+}
+
+@test "sourcing init-sh adds bin dirs to PATH" {
+    create_pack "tools"
+    create_pack_bin "tools" "dodot-test-tool" '#!/bin/sh
+echo "tool output"'
+    dodot up
+
+    # Source init-sh and check PATH
+    result="$(bash -c "
+        export HOME='$HOME'
+        export XDG_DATA_HOME='$XDG_DATA_HOME'
+        export DOTFILES_ROOT='$DOTFILES_ROOT'
+        export XDG_CONFIG_HOME='$XDG_CONFIG_HOME'
+        export XDG_CACHE_HOME='$XDG_CACHE_HOME'
+        eval \"\$($DODOT_BIN init-sh)\"
+        dodot-test-tool
+    " 2>&1)"
+
+    [ "$result" = "tool output" ]
+}
+
+@test "shell integration handles multiple packs" {
+    create_pack_file "shell1" "aliases.sh" 'alias test_a="echo a"'
+    create_pack_file "shell2" "aliases.sh" 'alias test_b="echo b"'
+    dodot up
+
+    result="$(bash -c "
+        export HOME='$HOME'
+        export XDG_DATA_HOME='$XDG_DATA_HOME'
+        export DOTFILES_ROOT='$DOTFILES_ROOT'
+        export XDG_CONFIG_HOME='$XDG_CONFIG_HOME'
+        export XDG_CACHE_HOME='$XDG_CACHE_HOME'
+        shopt -s expand_aliases
+        eval \"\$($DODOT_BIN init-sh)\"
+        test_a
+        test_b
+    " 2>&1)"
+
+    echo "$result" | grep -q "a"
+    echo "$result" | grep -q "b"
+}

--- a/tests/e2e/bats/test_status.bats
+++ b/tests/e2e/bats/test_status.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot status`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "status shows pending before up" {
+    create_pack_file "vim" "vimrc" "set nocompatible"
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "vim"
+    assert_output_contains "vimrc"
+    assert_output_contains "pending"
+}
+
+@test "status shows deployed after up" {
+    create_pack_file "vim" "vimrc" "set nocompatible"
+
+    dodot up
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "vim"
+    assert_output_contains "vimrc"
+    assert_output_contains "deployed"
+}
+
+@test "status filters by pack name" {
+    create_pack_file "vim" "vimrc" "x"
+    create_pack_file "git" "gitconfig" "x"
+
+    run dodot status vim
+    [ "$status" -eq 0 ]
+    assert_output_contains "vim"
+    assert_output_not_contains "git"
+}
+
+@test "status shows shell handler as sourced/not sourced" {
+    create_pack_file "zsh" "aliases.sh" "alias ll='ls -la'"
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "not sourced"
+
+    dodot up
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "sourced"
+    assert_output_not_contains "not sourced"
+}
+
+@test "status shows path handler as in PATH/not in PATH" {
+    create_pack "tools"
+    create_pack_bin "tools" "mytool" '#!/bin/sh\necho hello'
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "not in PATH"
+
+    dodot up
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "in PATH"
+}
+
+@test "status shows install handler as never run" {
+    create_pack_script "tools" "install.sh" '#!/bin/sh\necho done'
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "never run"
+}
+
+@test "status skips ignored packs" {
+    create_pack_file "vim" "vimrc" "x"
+    create_pack_file "disabled" "file" "x"
+    mark_ignored "disabled"
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "vim"
+    assert_output_not_contains "disabled"
+}
+
+@test "status returns pending after down" {
+    create_pack_file "vim" "vimrc" "x"
+
+    dodot up
+    dodot down
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "pending"
+    assert_output_not_contains "deployed"
+}

--- a/tests/e2e/bats/test_up.bats
+++ b/tests/e2e/bats/test_up.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot up`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "up deploys symlink files" {
+    create_pack_file "vim" "vimrc" "set nocompatible"
+
+    run dodot up
+    [ "$status" -eq 0 ]
+    assert_output_contains "Packs deployed"
+
+    # Double-link chain: source -> datastore -> ~/.vimrc
+    assert_double_link "vim" "symlink" "vimrc" \
+        "$DOTFILES_ROOT/vim/vimrc" \
+        "$HOME/.vimrc"
+
+    # Content should be readable through the symlink chain
+    assert_file_contains "$HOME/.vimrc" "set nocompatible"
+}
+
+@test "up deploys multiple files in a pack" {
+    create_pack_file "vim" "vimrc" "set nocompatible"
+    create_pack_file "vim" "gvimrc" "set guifont=Mono"
+
+    dodot up
+    assert_symlink "$HOME/.vimrc" "$XDG_DATA_HOME/dodot/packs/vim/symlink/vimrc"
+    assert_symlink "$HOME/.gvimrc" "$XDG_DATA_HOME/dodot/packs/vim/symlink/gvimrc"
+}
+
+@test "up deploys shell files" {
+    create_pack_file "zsh" "aliases.sh" "alias ll='ls -la'"
+
+    dodot up
+
+    # Shell file should be staged in datastore
+    assert_exists "$XDG_DATA_HOME/dodot/packs/zsh/shell/aliases.sh"
+
+    # Shell init script should reference it
+    assert_file_contains "$XDG_DATA_HOME/dodot/shell/dodot-init.sh" "aliases.sh"
+}
+
+@test "up deploys path directories" {
+    create_pack "tools"
+    create_pack_bin "tools" "mytool" '#!/bin/sh\necho hello'
+
+    dodot up
+
+    # Path dir should be staged in datastore
+    assert_exists "$XDG_DATA_HOME/dodot/packs/tools/path/bin"
+
+    # Init script should add bin to PATH
+    assert_file_contains "$XDG_DATA_HOME/dodot/shell/dodot-init.sh" "PATH="
+}
+
+@test "up --dry-run shows plan without changes" {
+    create_pack_file "vim" "vimrc" "x"
+
+    run dodot up --dry-run
+    [ "$status" -eq 0 ]
+    assert_output_contains "dry run"
+
+    # Nothing should actually be deployed
+    assert_not_exists "$HOME/.vimrc"
+    assert_no_handler_state "vim" "symlink"
+}
+
+@test "up --no-provision skips install scripts" {
+    create_pack_file "tools" "vimrc" "x"
+    create_pack_script "tools" "install.sh" '#!/bin/sh\ntouch "$HOME/.tools-installed"'
+
+    dodot up --no-provision
+
+    # Install script should NOT have run
+    assert_not_exists "$HOME/.tools-installed"
+}
+
+@test "up deploys selected packs only" {
+    create_pack_file "vim" "vimrc" "x"
+    create_pack_file "git" "gitconfig" "x"
+
+    dodot up vim
+
+    # vim should be deployed
+    assert_exists "$HOME/.vimrc"
+    # git should NOT be deployed
+    assert_not_exists "$HOME/.gitconfig"
+}
+
+@test "up is idempotent" {
+    create_pack_file "vim" "vimrc" "set nocompatible"
+
+    dodot up
+    assert_exists "$HOME/.vimrc"
+
+    # Second up should succeed without error
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    # Symlink should still work
+    assert_file_contains "$HOME/.vimrc" "set nocompatible"
+}
+
+@test "up deploys multiple packs" {
+    create_pack_file "vim" "vimrc" "x"
+    create_pack_file "git" "gitconfig" "x"
+
+    dodot up
+    assert_exists "$HOME/.vimrc"
+    assert_exists "$HOME/.gitconfig"
+}
+
+@test "up skips ignored packs" {
+    create_pack_file "vim" "vimrc" "x"
+    create_pack_file "disabled" "file" "x"
+    mark_ignored "disabled"
+
+    dodot up
+
+    assert_exists "$HOME/.vimrc"
+    assert_not_exists "$HOME/.file"
+}


### PR DESCRIPTION
## Summary

- Add containerized BATS E2E test suite (61 tests) that safely exercises the dodot CLI against real filesystems using isolated sandboxes
- Each test gets a fresh temp dir with `HOME`, `DOTFILES_ROOT`, and `XDG_*` redirected + `GIT_CEILING_DIRECTORIES` set to prevent sandbox escape
- Cover all commands (status, up, down, list, init, adopt, addignore, genconfig), all handlers (symlink, shell, path, install), and full shell integration (`eval "$(dodot init-sh)"`)
- Add Docker support (`scripts/e2e`) for safe local testing on macOS, plus a new `e2e` CI job on ubuntu-latest
- Fix panic in `dodot down` where `build_ctx` read `--no-provision`/`--provision-rerun` flags not defined for the down subcommand

## Test plan

- [x] `scripts/e2e --local` passes all 61 tests (60 pass, 1 skipped: `provision_rerun` not yet wired in execution layer)
- [x] `scripts/check` passes (158 Rust tests, clippy, fmt)
- [x] CI `check` job passes
- [x] CI `e2e` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)