### PR TITLE
Add instrumented E2E fixtures, close coverage gaps, fix dot. prefix display bug

### DIFF
--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -68,7 +68,13 @@ pub fn handler_description(handler: &str, rel_path: &str, user_target: Option<&s
             if let Some(target) = user_target {
                 target.to_string()
             } else {
-                format!("~/.{rel_path}")
+                // Apply dot. prefix convention: dot.bashrc → ~/.bashrc
+                let display_path = if !rel_path.contains('/') && rel_path.starts_with("dot.") {
+                    format!(".{}", &rel_path[4..])
+                } else {
+                    format!(".{rel_path}")
+                };
+                format!("~/{display_path}")
             }
         }
         "shell" => "shell profile".into(),

--- a/tests/e2e/bats/helpers/assertions.bash
+++ b/tests/e2e/bats/helpers/assertions.bash
@@ -2,6 +2,12 @@
 # Custom assertion helpers for dodot E2E tests.
 #
 # Mirror the assertion API from TempEnvironment in the Rust test suite.
+#
+# ## Instrumented assertions
+#
+# These work with fixtures created by instrumented_* helpers in fixtures.bash.
+# They check env vars, stdout markers, marker files, and brew mock logs
+# that instrumented fixtures produce when loaded/executed.
 
 # Assert that a symlink exists and points to the expected target.
 # Usage: assert_symlink "/path/to/link" "/path/to/target"
@@ -84,7 +90,7 @@ assert_file_contains() {
     local pattern="$2"
 
     assert_exists "$path"
-    if ! grep -q "$pattern" "$path"; then
+    if ! grep -q -e "$pattern" "$path"; then
         echo "expected $path to contain '$pattern'" >&2
         echo "actual contents:" >&2
         cat "$path" >&2
@@ -173,6 +179,163 @@ assert_output_not_contains() {
         echo "expected output to NOT contain '$pattern'" >&2
         echo "actual output:" >&2
         echo "$output" >&2
+        return 1
+    fi
+}
+
+# ── Instrumented assertions ─────────────────────────────────────
+#
+# These require eval_init_sh to have been called first (for shell/path),
+# or dodot up to have run (for install/brew).
+
+# Assert that an instrumented shell file was loaded via init-sh.
+# Checks the DODOT_LOADED_{PACK}_{FILE} env var is set.
+# Usage: dodot up && eval_init_sh
+#        assert_shell_loaded "vim" "aliases.sh"
+assert_shell_loaded() {
+    local pack="$1"
+    local filename="$2"
+    local var_name="DODOT_LOADED_$(_normalize "$pack" "$filename")"
+
+    local val="${!var_name:-}"
+    if [[ "$val" != "1" ]]; then
+        echo "expected $var_name=1 (shell file $pack/$filename loaded)" >&2
+        echo "  actual: ${var_name}=${val:-<unset>}" >&2
+        echo "  hint: did you call eval_init_sh after dodot up?" >&2
+        return 1
+    fi
+}
+
+# Assert that an instrumented shell file was NOT loaded.
+# Usage: assert_shell_not_loaded "vim" "aliases.sh"
+assert_shell_not_loaded() {
+    local pack="$1"
+    local filename="$2"
+    local var_name="DODOT_LOADED_$(_normalize "$pack" "$filename")"
+
+    local val="${!var_name:-}"
+    if [[ "$val" == "1" ]]; then
+        echo "expected $var_name to be unset (shell file $pack/$filename should not be loaded)" >&2
+        return 1
+    fi
+}
+
+# Assert that an instrumented bin script is callable and produces the expected marker.
+# Usage: dodot up && eval_init_sh
+#        assert_bin_available "tools" "devtool"
+assert_bin_available() {
+    local pack="$1"
+    local script_name="$2"
+    local marker="DODOT_BIN_$(_normalize "$pack" "$script_name")"
+
+    if ! command -v "$script_name" >/dev/null 2>&1; then
+        echo "expected '$script_name' to be on PATH" >&2
+        echo "  PATH=$PATH" >&2
+        echo "  hint: did you call eval_init_sh after dodot up?" >&2
+        return 1
+    fi
+
+    local actual
+    actual="$("$script_name" 2>&1)"
+    if [[ "$actual" != *"$marker"* ]]; then
+        echo "expected running '$script_name' to output '$marker'" >&2
+        echo "  actual output: $actual" >&2
+        return 1
+    fi
+}
+
+# Assert that an instrumented bin script is NOT on PATH.
+# Usage: assert_bin_not_available "tools" "devtool"
+assert_bin_not_available() {
+    local script_name="$2"
+
+    if command -v "$script_name" >/dev/null 2>&1; then
+        echo "expected '$script_name' to NOT be on PATH, but found: $(command -v "$script_name")" >&2
+        return 1
+    fi
+}
+
+# Assert that an instrumented install script has run.
+# Checks marker file at $HOME/.dodot-markers/{pack}.install.
+# Usage: dodot up
+#        assert_install_ran "tools"
+assert_install_ran() {
+    local pack="$1"
+    local marker="$HOME/.dodot-markers/${pack}.install"
+
+    if [[ ! -f "$marker" ]]; then
+        echo "expected install marker at $marker (install.sh for pack '$pack' should have run)" >&2
+        echo "  contents of $HOME/.dodot-markers/:" >&2
+        ls -la "$HOME/.dodot-markers/" 2>&1 >&2 || echo "  (directory does not exist)" >&2
+        return 1
+    fi
+}
+
+# Assert that an instrumented install script has NOT run.
+# Usage: assert_install_not_ran "tools"
+assert_install_not_ran() {
+    local pack="$1"
+    local marker="$HOME/.dodot-markers/${pack}.install"
+
+    if [[ -f "$marker" ]]; then
+        echo "expected no install marker at $marker (install.sh for pack '$pack' should NOT have run)" >&2
+        return 1
+    fi
+}
+
+# Assert that the brew mock was invoked.
+# Usage: install_brew_mock; dodot up
+#        assert_brew_invoked
+assert_brew_invoked() {
+    local log="$HOME/.dodot-markers/brew.log"
+
+    if [[ ! -f "$log" ]]; then
+        echo "expected brew mock log at $log, but it does not exist" >&2
+        echo "  hint: did you call install_brew_mock before dodot up?" >&2
+        return 1
+    fi
+}
+
+# Assert that the brew mock was invoked with specific arguments.
+# Usage: assert_brew_invoked_with "bundle" "--file="
+assert_brew_invoked_with() {
+    local log="$HOME/.dodot-markers/brew.log"
+
+    assert_brew_invoked
+
+    for pattern in "$@"; do
+        if ! grep -q -F -- "$pattern" "$log"; then
+            echo "expected brew log to contain '$pattern'" >&2
+            echo "  actual log:" >&2
+            cat "$log" >&2
+            return 1
+        fi
+    done
+}
+
+# Assert that the brew mock was NOT invoked.
+# Usage: assert_brew_not_invoked
+assert_brew_not_invoked() {
+    local log="$HOME/.dodot-markers/brew.log"
+
+    if [[ -f "$log" ]]; then
+        echo "expected brew mock log to not exist, but found:" >&2
+        cat "$log" >&2
+        return 1
+    fi
+}
+
+# Assert that a specific env var is set to a specific value.
+# Useful for checking custom exports from shell fixtures.
+# Usage: assert_env_var "ZSH_PROFILE_LOADED" "1"
+assert_env_var() {
+    local var_name="$1"
+    local expected="$2"
+
+    local val="${!var_name:-}"
+    if [[ "$val" != "$expected" ]]; then
+        echo "expected $var_name='$expected'" >&2
+        echo "  actual: ${var_name}='${val:-<unset>}'" >&2
         return 1
     fi
 }

--- a/tests/e2e/bats/helpers/assertions.bash
+++ b/tests/e2e/bats/helpers/assertions.bash
@@ -266,7 +266,7 @@ assert_install_ran() {
     if [[ ! -f "$marker" ]]; then
         echo "expected install marker at $marker (install.sh for pack '$pack' should have run)" >&2
         echo "  contents of $HOME/.dodot-markers/:" >&2
-        ls -la "$HOME/.dodot-markers/" 2>&1 >&2 || echo "  (directory does not exist)" >&2
+        ls -la "$HOME/.dodot-markers/" >&2 2>&1 || echo "  (directory does not exist)" >&2
         return 1
     fi
 }
@@ -297,7 +297,8 @@ assert_brew_invoked() {
 }
 
 # Assert that the brew mock was invoked with specific arguments.
-# Usage: assert_brew_invoked_with "bundle" "--file="
+# Each argument is matched as a fixed-string substring against the log.
+# Usage: assert_brew_invoked_with "bundle" "--file"
 assert_brew_invoked_with() {
     local log="$HOME/.dodot-markers/brew.log"
 

--- a/tests/e2e/bats/helpers/fixtures.bash
+++ b/tests/e2e/bats/helpers/fixtures.bash
@@ -2,6 +2,19 @@
 # Fixture creation helpers — shell equivalent of TempEnvironment builder.
 #
 # All paths are relative to the current sandbox's DOTFILES_ROOT and HOME.
+#
+# ## Instrumented fixtures
+#
+# Functions prefixed with `instrumented_` create self-reporting fixtures.
+# When loaded/executed, they set detectable markers:
+#
+#   Shell files:  export DODOT_LOADED_{PACK}_{FILE}=1   (env var)
+#   Bin scripts:  echo DODOT_BIN_{PACK}_{SCRIPT}        (stdout)
+#   Install:      write to $HOME/.dodot-markers/{pack}   (file)
+#   Brew mock:    log args to $HOME/.dodot-markers/brew.log
+#
+# The naming convention normalizes pack/file names:
+#   "vim" + "aliases.sh" → DODOT_LOADED_VIM_ALIASES_SH
 
 # Create a pack directory.
 # Usage: create_pack "vim"
@@ -81,4 +94,166 @@ create_pack_bin() {
 
     create_pack_file "$pack" "bin/$script_name" "$contents"
     chmod +x "$DOTFILES_ROOT/$pack/bin/$script_name"
+}
+
+# ── Naming convention ───────────────────────────────────────────
+
+# Normalize a string to an env-var-safe identifier.
+# Replaces dots, hyphens, slashes with underscores, uppercases.
+# Usage: _normalize "vim" "aliases.sh"  →  VIM_ALIASES_SH
+_normalize() {
+    local result=""
+    for part in "$@"; do
+        [[ -n "$result" ]] && result="${result}_"
+        result="${result}${part}"
+    done
+    echo "$result" | tr '[:lower:]' '[:upper:]' | tr './-' '___'
+}
+
+# ── Instrumented fixture generators ─────────────────────────────
+
+# Create an instrumented shell file that exports a marker env var when sourced.
+# Usage: instrumented_shell "vim" "aliases.sh"
+# Creates: dotfiles/vim/aliases.sh containing:
+#   export DODOT_LOADED_VIM_ALIASES_SH=1
+# Optionally append extra content:
+#   instrumented_shell "vim" "aliases.sh" 'alias vi=vim'
+instrumented_shell() {
+    local pack="$1"
+    local filename="$2"
+    local extra="${3:-}"
+    local var_name="DODOT_LOADED_$(_normalize "$pack" "$filename")"
+
+    local contents="export ${var_name}=1"
+    [[ -n "$extra" ]] && contents="${contents}
+${extra}"
+
+    create_pack_file "$pack" "$filename" "$contents"
+}
+
+# Create an instrumented bin script that echoes a marker when run.
+# Usage: instrumented_bin "tools" "mytool"
+# Creates: dotfiles/tools/bin/mytool containing:
+#   #!/bin/sh
+#   echo DODOT_BIN_TOOLS_MYTOOL
+# Optionally append extra content:
+#   instrumented_bin "tools" "mytool" 'echo "extra output"'
+instrumented_bin() {
+    local pack="$1"
+    local script_name="$2"
+    local extra="${3:-}"
+    local marker="DODOT_BIN_$(_normalize "$pack" "$script_name")"
+
+    local contents="#!/bin/sh
+echo ${marker}"
+    [[ -n "$extra" ]] && contents="${contents}
+${extra}"
+
+    create_pack_bin "$pack" "$script_name" "$contents"
+}
+
+# Create an instrumented install script that writes a marker file.
+# Usage: instrumented_install "tools"
+# Creates: dotfiles/tools/install.sh that writes to:
+#   $HOME/.dodot-markers/tools.install
+# Optionally append extra content:
+#   instrumented_install "tools" 'apt-get update'
+instrumented_install() {
+    local pack="$1"
+    local extra="${2:-}"
+
+    local contents='#!/bin/sh
+mkdir -p "$HOME/.dodot-markers"
+echo "executed" > "$HOME/.dodot-markers/'"${pack}"'.install"'
+    [[ -n "$extra" ]] && contents="${contents}
+${extra}"
+
+    create_pack_script "$pack" "install.sh" "$contents"
+}
+
+# Create a Brewfile in a pack.
+# Usage: instrumented_brewfile "dev"
+# Creates: dotfiles/dev/Brewfile with tap/brew lines.
+# The actual brew command will be intercepted by the brew mock.
+instrumented_brewfile() {
+    local pack="$1"
+    local contents="${2:-brew \"ripgrep\"}"
+
+    create_pack_file "$pack" "Brewfile" "$contents"
+}
+
+# Install a mock `brew` script that logs all invocations.
+# Must be called during setup before `dodot up`.
+# Usage: install_brew_mock
+# Creates: $HOME/.dodot-markers/brew-mock/brew on PATH
+# Logs to: $HOME/.dodot-markers/brew.log
+install_brew_mock() {
+    local mock_dir="$HOME/.dodot-markers/brew-mock"
+    mkdir -p "$mock_dir"
+
+    cat > "$mock_dir/brew" <<'MOCK'
+#!/bin/sh
+mkdir -p "$HOME/.dodot-markers"
+echo "$@" >> "$HOME/.dodot-markers/brew.log"
+MOCK
+    chmod +x "$mock_dir/brew"
+
+    export PATH="$mock_dir:$PATH"
+}
+
+# ── Eval helper ─────────────────────────────────────────────────
+
+# Eval dodot init-sh in the current shell and return the output.
+# After calling this, env vars from shell files and PATH changes are live.
+# Usage: eval_init_sh
+eval_init_sh() {
+    eval "$("$DODOT_BIN" init-sh)"
+}
+
+# ── Realistic dotfiles fixture ──────────────────────────────────
+
+# Build a complete multi-pack dotfiles repo exercising all handlers.
+# Usage: create_realistic_dotfiles
+#
+# Packs created:
+#   vim/      - symlink (vimrc), shell (aliases.sh)
+#   git/      - symlink (gitconfig)
+#   zsh/      - shell (aliases.sh, profile.sh, login.sh)
+#   nvim/     - symlink with subdirs (nvim/init.lua, nvim/lua/plugins.lua) → XDG
+#   tools/    - install (install.sh), path (bin/devtool), Brewfile
+#   ssh/      - symlink with force_home (ssh/config) — tests force_home routing
+#   disabled/ - ignored pack
+#
+# Also creates root .dodot.toml with target_overrides for vim/vimrc.
+create_realistic_dotfiles() {
+    # vim: symlink + shell
+    instrumented_shell "vim" "aliases.sh" 'alias vi=vim'
+    create_pack_file "vim" "vimrc" "set nocompatible"
+
+    # git: symlink
+    create_pack_file "git" "gitconfig" "[user]\n  name = testuser\n  email = test@example.com"
+
+    # zsh: all three shell file types
+    instrumented_shell "zsh" "aliases.sh" 'alias ll="ls -la"'
+    instrumented_shell "zsh" "profile.sh" 'export ZSH_PROFILE_LOADED=1'
+    instrumented_shell "zsh" "login.sh" 'export ZSH_LOGIN_LOADED=1'
+
+    # nvim: subdirectory files → XDG config
+    create_pack_file "nvim" "nvim/init.lua" '-- nvim config\nrequire("plugins")'
+    create_pack_file "nvim" "nvim/lua/plugins.lua" '-- plugin list\nreturn {}'
+
+    # tools: install + path + brew
+    instrumented_install "tools"
+    instrumented_bin "tools" "devtool"
+    instrumented_brewfile "tools"
+
+    # ssh: tests force_home routing (ssh is in default force_home list)
+    create_pack_file "ssh" "ssh/config" "Host *\n  ServerAliveInterval 60"
+
+    # disabled: ignored pack
+    create_pack_file "disabled" "notes.txt" "scratch"
+    mark_ignored "disabled"
+
+    # Root config — keep defaults, just ensure config file is loadable
+    create_root_config '[pack]\nignore = []'
 }

--- a/tests/e2e/bats/helpers/fixtures.bash
+++ b/tests/e2e/bats/helpers/fixtures.bash
@@ -10,7 +10,7 @@
 #
 #   Shell files:  export DODOT_LOADED_{PACK}_{FILE}=1   (env var)
 #   Bin scripts:  echo DODOT_BIN_{PACK}_{SCRIPT}        (stdout)
-#   Install:      write to $HOME/.dodot-markers/{pack}   (file)
+#   Install:      write to $HOME/.dodot-markers/{pack}.install   (file)
 #   Brew mock:    log args to $HOME/.dodot-markers/brew.log
 #
 # The naming convention normalizes pack/file names:
@@ -224,7 +224,7 @@ eval_init_sh() {
 #   ssh/      - symlink with force_home (ssh/config) — tests force_home routing
 #   disabled/ - ignored pack
 #
-# Also creates root .dodot.toml with target_overrides for vim/vimrc.
+# Also creates a minimal root .dodot.toml so the config file is loadable.
 create_realistic_dotfiles() {
     # vim: symlink + shell
     instrumented_shell "vim" "aliases.sh" 'alias vi=vim'

--- a/tests/e2e/bats/test_config.bats
+++ b/tests/e2e/bats/test_config.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot config` subcommands.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "config list displays merged config" {
+    create_root_config '[pack]\nignore = ["scratch"]'
+
+    run dodot config list
+    [ "$status" -eq 0 ]
+    assert_output_contains "pack"
+    assert_output_contains "symlink"
+}
+
+@test "config get retrieves specific values" {
+    create_root_config '[mappings]\ninstall = "setup.sh"'
+
+    run dodot config get mappings.install
+    [ "$status" -eq 0 ]
+    assert_output_contains "setup.sh"
+}
+
+@test "config list with pack override shows merged result" {
+    create_root_config '[mappings]\ninstall = "install.sh"'
+    create_pack "vim"
+    create_pack_config "vim" '[mappings]\ninstall = "vim-setup.sh"'
+
+    # Root config should still show install.sh
+    run dodot config list
+    [ "$status" -eq 0 ]
+    assert_output_contains "install"
+}

--- a/tests/e2e/bats/test_config_behavior.bats
+++ b/tests/e2e/bats/test_config_behavior.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# E2E tests for config-driven behavior:
+# - [pack] ignore patterns
+# - [symlink] target_overrides (absolute paths)
+# - [symlink] force_home
+# - [symlink] protected_paths
+# - per-pack .dodot.toml overrides
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+# ── Pack ignore patterns ────────────────────────────────────────
+
+@test "pack ignore excludes matching files from processing" {
+    create_pack_file "vim" "vimrc" "set nocompatible"
+    create_pack_file "vim" "notes.bak" "scratch"
+    create_pack_config "vim" '[pack]\nignore = ["*.bak"]'
+
+    dodot up
+    assert_exists "$HOME/.vimrc"
+
+    # .bak file should not be symlinked
+    run dodot status vim
+    assert_output_not_contains "notes.bak"
+}
+
+# ── Target overrides ───────────────────────────────────────────
+
+@test "target_overrides with absolute path places symlink at exact location" {
+    create_pack_file "custom" "myconfig" "custom content"
+    create_pack_config "custom" "[symlink]\ntargets = { \"myconfig\" = \"$HOME/custom-location/myconfig\" }"
+
+    dodot up
+
+    assert_exists "$HOME/custom-location/myconfig"
+    assert_file_contains "$HOME/custom-location/myconfig" "custom content"
+}
+
+@test "target_overrides with relative path resolves from XDG_CONFIG_HOME" {
+    create_pack_file "app" "settings.toml" "key = value"
+    create_pack_config "app" '[symlink]\ntargets = { "settings.toml" = "myapp/settings.toml" }'
+
+    dodot up
+
+    assert_exists "$XDG_CONFIG_HOME/myapp/settings.toml"
+    assert_file_contains "$XDG_CONFIG_HOME/myapp/settings.toml" "key = value"
+}
+
+# ── Force home ─────────────────────────────────────────────────
+
+@test "force_home routes subdirectory to HOME instead of XDG" {
+    # Default force_home includes "ssh", so ssh/config → ~/.ssh/config
+    create_pack_file "mypack" "ssh/config" "Host *"
+
+    # Add "ssh" to force_home via root config (it's in defaults, but explicit is clearer)
+    create_root_config '[symlink]\nforce_home = ["ssh"]'
+
+    dodot up
+    assert_exists "$HOME/.ssh/config"
+    assert_file_contains "$HOME/.ssh/config" "Host"
+}
+
+@test "custom force_home entry routes to HOME" {
+    create_pack_file "mypack" "mytool/config.yml" "setting: true"
+    create_root_config '[symlink]\nforce_home = ["mytool"]'
+
+    dodot up
+    assert_exists "$HOME/.mytool/config.yml"
+}
+
+# ── Protected paths ────────────────────────────────────────────
+
+@test "protected paths are refused" {
+    # .ssh/id_rsa is in the default protected list
+    create_pack_file "keys" "ssh/id_rsa" "secret key"
+
+    run dodot up
+    # Should report error or skip the protected file
+    run dodot status keys
+    # The protected file should NOT be deployed
+    assert_not_exists "$HOME/.ssh/id_rsa"
+}
+
+# ── Per-pack config overrides ──────────────────────────────────
+
+@test "per-pack config overrides root config" {
+    create_pack_file "vim" "vimrc" "set nocompatible"
+    create_pack_file "vim" "cache.tmp" "temporary"
+
+    # Root config has no ignores
+    create_root_config '[pack]\nignore = []'
+
+    # Pack config adds ignore
+    create_pack_config "vim" '[pack]\nignore = ["*.tmp"]'
+
+    dodot up
+
+    assert_exists "$HOME/.vimrc"
+    # .tmp should be excluded by pack-level ignore
+    run dodot status vim
+    assert_output_not_contains "cache.tmp"
+}
+
+@test "per-pack mapping override changes handler assignment" {
+    # Root uses default install.sh
+    create_root_config '[mappings]\ninstall = "install.sh"'
+
+    # This pack uses setup.sh instead
+    create_pack_script "custom" "setup.sh" '#!/bin/sh
+mkdir -p "$HOME/.dodot-markers"
+echo "executed" > "$HOME/.dodot-markers/custom.install"'
+    create_pack_config "custom" '[mappings]\ninstall = "setup.sh"'
+
+    dodot up
+    assert_install_ran "custom"
+}

--- a/tests/e2e/bats/test_dot_prefix.bats
+++ b/tests/e2e/bats/test_dot_prefix.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+# E2E tests for the dot. prefix convention.
+#
+# Files named `dot.something` in a pack become `.something` when deployed.
+# This keeps them visible in editors/file browsers while in the repo,
+# but they become proper hidden dotfiles at the target location.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+# ── Basic dot. prefix stripping ─────────────────────────────────
+
+@test "dot.bashrc deploys to ~/.bashrc" {
+    create_pack_file "shell" "dot.bashrc" "# my bashrc"
+
+    dodot up
+    assert_exists "$HOME/.bashrc"
+    assert_file_contains "$HOME/.bashrc" "my bashrc"
+}
+
+@test "dot.zshrc deploys to ~/.zshrc" {
+    create_pack_file "shell" "dot.zshrc" "# my zshrc"
+
+    dodot up
+    assert_exists "$HOME/.zshrc"
+}
+
+@test "multiple dot. files in same pack" {
+    create_pack_file "shell" "dot.bashrc" "# bashrc"
+    create_pack_file "shell" "dot.zshrc" "# zshrc"
+    create_pack_file "shell" "dot.inputrc" "# inputrc"
+
+    dodot up
+    assert_exists "$HOME/.bashrc"
+    assert_exists "$HOME/.zshrc"
+    assert_exists "$HOME/.inputrc"
+}
+
+# ── Status display ──────────────────────────────────────────────
+
+@test "status shows ~/.bashrc not ~/.dot.bashrc" {
+    create_pack_file "shell" "dot.bashrc" "# bashrc"
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "~/.bashrc"
+    assert_output_not_contains "~/.dot.bashrc"
+}
+
+@test "status shows correct target for mix of dot. and regular files" {
+    create_pack_file "vim" "dot.vimrc" "set nocompatible"
+    create_pack_file "vim" "gvimrc" "set guifont=Mono"
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "~/.vimrc"
+    assert_output_contains "~/.gvimrc"
+    assert_output_not_contains "~/.dot.vimrc"
+}
+
+# ── Subdirectory files are NOT stripped ──────────────────────────
+
+@test "dot. prefix not stripped for subdirectory files" {
+    create_pack_file "app" "subdir/dot.conf" "config"
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    # Subdirectory files keep the dot. prefix
+    assert_output_contains "dot.conf"
+}
+
+# ── Full lifecycle ──────────────────────────────────────────────
+
+@test "dot. prefix lifecycle: up → verify → down → verify" {
+    create_pack_file "shell" "dot.bashrc" "# my bashrc"
+
+    # Status before deploy
+    run dodot status
+    assert_output_contains "~/.bashrc"
+    assert_output_contains "pending"
+
+    # Deploy
+    dodot up
+    assert_exists "$HOME/.bashrc"
+
+    # Status after deploy
+    run dodot status
+    assert_output_contains "deployed"
+
+    # Down
+    dodot down
+
+    # Status after down
+    run dodot status
+    assert_output_contains "pending"
+
+    # Source file still in pack (unchanged)
+    assert_exists "$DOTFILES_ROOT/shell/dot.bashrc"
+}
+
+# ── Coexists with regular files ─────────────────────────────────
+
+@test "dot. and regular files deploy correctly together" {
+    create_pack_file "mixed" "dot.bashrc" "# bashrc"
+    create_pack_file "mixed" "vimrc" "set nocompatible"
+
+    dodot up
+
+    # dot.bashrc → ~/.bashrc
+    assert_exists "$HOME/.bashrc"
+    assert_file_contains "$HOME/.bashrc" "bashrc"
+
+    # vimrc → ~/.vimrc (regular dot-prefix behavior)
+    assert_exists "$HOME/.vimrc"
+    assert_file_contains "$HOME/.vimrc" "nocompatible"
+}
+
+@test "dot. prefix works with double-link chain" {
+    create_pack_file "shell" "dot.bashrc" "# bashrc"
+
+    dodot up
+
+    # Datastore link should use the original filename (dot.bashrc)
+    assert_symlink \
+        "$XDG_DATA_HOME/dodot/packs/shell/symlink/dot.bashrc" \
+        "$DOTFILES_ROOT/shell/dot.bashrc"
+
+    # User link should point to the datastore
+    assert_symlink \
+        "$HOME/.bashrc" \
+        "$XDG_DATA_HOME/dodot/packs/shell/symlink/dot.bashrc"
+}

--- a/tests/e2e/bats/test_fill.bats
+++ b/tests/e2e/bats/test_fill.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot fill`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "fill adds template files to empty pack" {
+    create_pack "mypack"
+
+    run dodot fill mypack
+    [ "$status" -eq 0 ]
+
+    # Should have created placeholder files
+    assert_exists "$DOTFILES_ROOT/mypack"
+    # fill creates .dodot.toml and placeholder files
+    local file_count
+    file_count=$(find "$DOTFILES_ROOT/mypack" -type f | wc -l | tr -d ' ')
+    [ "$file_count" -gt 0 ]
+}
+
+@test "fill skips existing files" {
+    create_pack_file "mypack" "vimrc" "my custom content"
+
+    run dodot fill mypack
+    [ "$status" -eq 0 ]
+
+    # Existing file should be untouched
+    assert_file_contents "$DOTFILES_ROOT/mypack/vimrc" "my custom content"
+}
+
+@test "fill on nonexistent pack reports error" {
+    run dodot fill nonexistent
+    assert_output_contains "Error"
+}

--- a/tests/e2e/bats/test_realistic.bats
+++ b/tests/e2e/bats/test_realistic.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# E2E tests using the realistic multi-pack dotfiles fixture.
+# Exercises all handlers, subdirectory routing, force_home, and
+# the full deploy/source/verify cycle.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+    create_realistic_dotfiles
+    install_brew_mock
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+# ── Shell handler ───────────────────────────────────────────────
+
+@test "all shell files are sourced after up" {
+    dodot up
+    eval_init_sh
+
+    assert_shell_loaded "vim" "aliases.sh"
+    assert_shell_loaded "zsh" "aliases.sh"
+    assert_shell_loaded "zsh" "profile.sh"
+    assert_shell_loaded "zsh" "login.sh"
+}
+
+@test "shell files export custom env vars" {
+    dodot up
+    eval_init_sh
+
+    assert_env_var "ZSH_PROFILE_LOADED" "1"
+    assert_env_var "ZSH_LOGIN_LOADED" "1"
+}
+
+@test "shell files are not sourced after down" {
+    dodot up
+    dodot down
+
+    # Fresh eval should not load anything
+    eval_init_sh
+    assert_shell_not_loaded "vim" "aliases.sh"
+    assert_shell_not_loaded "zsh" "aliases.sh"
+}
+
+# ── Path handler ────────────────────────────────────────────────
+
+@test "bin scripts are on PATH after up" {
+    dodot up
+    eval_init_sh
+
+    assert_bin_available "tools" "devtool"
+}
+
+@test "bin scripts are not on PATH after down" {
+    dodot up
+    dodot down
+    eval_init_sh
+
+    assert_bin_not_available "tools" "devtool"
+}
+
+# ── Install handler ─────────────────────────────────────────────
+
+@test "install.sh executes on up" {
+    dodot up
+    assert_install_ran "tools"
+}
+
+@test "install.sh skipped with --no-provision" {
+    dodot up --no-provision
+    assert_install_not_ran "tools"
+}
+
+# ── Homebrew handler ────────────────────────────────────────────
+
+@test "brew mock receives bundle command on up" {
+    dodot up
+
+    assert_brew_invoked
+    assert_brew_invoked_with "bundle" "--file"
+}
+
+@test "brew skipped with --no-provision" {
+    dodot up --no-provision
+    assert_brew_not_invoked
+}
+
+@test "Brewfile shows in status as not installed / installed" {
+    run dodot status tools
+    assert_output_contains "not installed"
+
+    dodot up
+    run dodot status tools
+    assert_output_contains "installed"
+}
+
+# ── Symlink handler: top-level files ───────────────────────────
+
+@test "top-level dotfiles land in HOME" {
+    dodot up
+
+    assert_exists "$HOME/.vimrc"
+    assert_file_contains "$HOME/.vimrc" "set nocompatible"
+    assert_exists "$HOME/.gitconfig"
+    assert_file_contains "$HOME/.gitconfig" "testuser"
+}
+
+# ── Symlink handler: subdirectory → XDG ────────────────────────
+
+@test "subdirectory files route to XDG_CONFIG_HOME" {
+    dodot up
+
+    assert_exists "$XDG_CONFIG_HOME/nvim/init.lua"
+    assert_exists "$XDG_CONFIG_HOME/nvim/lua/plugins.lua"
+}
+
+# ── Symlink handler: force_home ─────────────────────────────────
+
+@test "force_home routes ssh/ to HOME instead of XDG" {
+    dodot up
+
+    # ssh is in the default force_home list, so ssh/config → ~/.ssh/config
+    assert_exists "$HOME/.ssh/config"
+    assert_file_contains "$HOME/.ssh/config" "ServerAliveInterval"
+}
+
+# ── Ignored packs ──────────────────────────────────────────────
+
+@test "ignored packs excluded from status and up" {
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_not_contains "disabled"
+
+    dodot up
+    assert_not_exists "$HOME/.notes.txt"
+}
+
+# ── Full lifecycle with realistic fixture ──────────────────────
+
+@test "full lifecycle: up → verify → down → verify" {
+    # Deploy
+    dodot up
+    eval_init_sh
+
+    # All handlers active
+    assert_shell_loaded "vim" "aliases.sh"
+    assert_bin_available "tools" "devtool"
+    assert_install_ran "tools"
+    assert_brew_invoked
+    assert_exists "$HOME/.vimrc"
+    assert_exists "$XDG_CONFIG_HOME/nvim/init.lua"
+    assert_exists "$HOME/.ssh/config"
+
+    # Tear down
+    dodot down
+
+    # Status should show everything pending/not sourced
+    run dodot status
+    assert_output_contains "pending"
+    assert_output_contains "not sourced"
+    assert_output_contains "not in PATH"
+}


### PR DESCRIPTION
## Summary

- **Bugfix**: `dodot status` displayed wrong target for `dot.` prefix files (`~/.dot.bashrc` instead of `~/.bashrc`). The symlink handler deployed correctly but `handler_description()` didn't apply the same `dot.` → `.` transform. Found by the new E2E tests.
- **Instrumented fixture library**: self-reporting test artifacts that set env vars, write marker files, or log invocations when loaded — making assertions trivial and composable across all 5 handlers.
- **38 new E2E tests** covering previously untested areas: all shell file variants (`profile.sh`, `login.sh`), Brewfile/homebrew handler (via mock), subdirectory→XDG routing, `force_home`, `protected_paths`, `target_overrides`, per-pack config overrides, `fill` command, `config` subcommands, and `dot.` prefix convention.

### Instrumented fixture convention

| Handler | Generator | Marker | Assertion |
|---|---|---|---|
| shell | `instrumented_shell "vim" "aliases.sh"` | `DODOT_LOADED_VIM_ALIASES_SH=1` | `assert_shell_loaded` |
| path | `instrumented_bin "tools" "devtool"` | `echo DODOT_BIN_TOOLS_DEVTOOL` | `assert_bin_available` |
| install | `instrumented_install "tools"` | `$HOME/.dodot-markers/tools.install` | `assert_install_ran` |
| homebrew | `instrumented_brewfile` + `install_brew_mock` | `$HOME/.dodot-markers/brew.log` | `assert_brew_invoked_with` |

Each has a negative variant (`assert_shell_not_loaded`, `assert_brew_not_invoked`, etc).

`create_realistic_dotfiles()` builds a 7-pack repo exercising every handler and routing rule in a single call.

## Test plan

- [x] 99 E2E tests pass locally (`scripts/e2e --local`) — 98 pass, 1 skipped (`provision_rerun`)
- [x] 158 Rust tests pass (`scripts/check`)
- [x] CI `check` + `e2e` jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)