### PR TITLE
Add --explore mode for interactive E2E sandbox

### DIFF
--- a/scripts/e2e
+++ b/scripts/e2e
@@ -25,6 +25,10 @@ while [[ $# -gt 0 ]]; do
             mode="shell"
             shift
             ;;
+        --explore)
+            mode="explore"
+            shift
+            ;;
         --local)
             mode="local"
             shift
@@ -37,7 +41,8 @@ while [[ $# -gt 0 ]]; do
             echo "Usage: scripts/e2e [OPTIONS] [TEST_FILE]"
             echo ""
             echo "Options:"
-            echo "  --shell     Drop into interactive container with dodot on PATH"
+            echo "  --explore   Pre-built sandbox with fixtures + pre-existing home files"
+            echo "  --shell     Bare interactive container (for helper/BATS development)"
             echo "  --local     Run locally without Docker (temp-dir isolation)"
             echo "  --rebuild   Force rebuild of Docker image"
             echo "  -h, --help  Show this help"
@@ -47,7 +52,8 @@ while [[ $# -gt 0 ]]; do
             echo "  scripts/e2e test_up.bats           Run specific test file in Docker"
             echo "  scripts/e2e --local                Run all tests locally"
             echo "  scripts/e2e --local test_up.bats   Run specific test file locally"
-            echo "  scripts/e2e --shell                Interactive container shell"
+            echo "  scripts/e2e --explore              Explore sandbox with conflicts/adoptable files"
+            echo "  scripts/e2e --shell                Bare container shell"
             exit 0
             ;;
         *.bats)
@@ -118,10 +124,20 @@ run_shell() {
         "$IMAGE_NAME"
 }
 
+run_explore() {
+    ensure_image
+
+    docker run --rm -it \
+        --entrypoint bash \
+        "$IMAGE_NAME" \
+        /tests/interactive.bash
+}
+
 # ── Dispatch ────────────────────────────────────────────────────
 
 case "$mode" in
     local)  run_local ;;
     docker) run_docker ;;
     shell)  run_shell ;;
+    explore) run_explore ;;
 esac

--- a/tests/e2e/bats/interactive.bash
+++ b/tests/e2e/bats/interactive.bash
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Interactive exploration environment for dodot.
+#
+# Sets up a realistic sandbox with pre-existing home files,
+# so you can immediately experiment with all commands:
+#
+#   dodot status          — see pending packs
+#   dodot up              — deploy (hits conflicts on pre-existing files)
+#   dodot up --dry-run    — preview what would happen
+#   dodot adopt vim ~/.vimrc  — adopt an existing file into a pack
+#   dodot down            — tear down
+#
+# The sandbox is at $HOME. DOTFILES_ROOT points to ~/dotfiles.
+# Everything is isolated — nothing escapes the container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export DODOT_BIN="${DODOT_BIN:-/usr/local/bin/dodot}"
+
+# Source helpers
+source "$SCRIPT_DIR/helpers/setup.bash"
+
+# ── Build sandbox ───────────────────────────────────────────────
+
+sandbox_setup
+
+# Build the full dotfiles repo
+create_realistic_dotfiles
+
+# Also add a dot. prefix pack for testing that convention
+instrumented_shell "shell" "dot.bashrc" 'alias reload="source ~/.bashrc"'
+instrumented_shell "shell" "dot.zshrc" 'alias reload="source ~/.zshrc"'
+create_pack_file "shell" "dot.inputrc" 'set editing-mode vi'
+
+# Install the brew mock so homebrew handler works
+install_brew_mock
+
+# ── Pre-populate HOME (simulating a real system) ────────────────
+
+# Existing dotfiles that will CONFLICT with dodot up
+create_home_file ".bashrc" '# System bashrc — pre-existing
+export PATH="/usr/local/bin:$PATH"
+echo "Welcome to the explore sandbox!"
+'
+
+create_home_file ".gitconfig" '[user]
+    name = Explorer
+    email = explorer@example.com
+[core]
+    editor = vim
+'
+
+# Existing config files — will conflict with nvim pack
+mkdir -p "$HOME/.config/nvim"
+cat > "$HOME/.config/nvim/init.lua" << 'LUA'
+-- Pre-existing nvim config (will conflict with nvim pack)
+vim.opt.number = true
+vim.opt.relativenumber = true
+LUA
+
+# Existing ssh config — will conflict with ssh pack
+mkdir -p "$HOME/.ssh"
+cat > "$HOME/.ssh/config" << 'SSH'
+# Pre-existing SSH config
+Host github.com
+    IdentityFile ~/.ssh/id_ed25519
+SSH
+
+# Files that are good candidates for `dodot adopt`
+create_home_file ".tmux.conf" 'set -g mouse on
+set -g default-terminal "screen-256color"
+'
+
+create_home_file ".config/starship.toml" '[character]
+success_symbol = "[➜](bold green)"
+error_symbol = "[✗](bold red)"
+'
+
+create_home_file ".config/alacritty/alacritty.toml" '[font]
+size = 14.0
+[font.normal]
+family = "JetBrains Mono"
+'
+
+# ── Print welcome ───────────────────────────────────────────────
+
+cat << 'WELCOME'
+
+┌─────────────────────────────────────────────────┐
+│           dodot explore sandbox                  │
+├─────────────────────────────────────────────────┤
+│                                                  │
+│  Dotfiles repo:  ~/dotfiles                      │
+│  Home dir:       ~ (sandboxed)                   │
+│                                                  │
+│  Packs available:                                │
+│    vim/    git/    zsh/    nvim/    tools/        │
+│    ssh/    shell/  disabled/                      │
+│                                                  │
+│  Pre-existing files (will cause conflicts):      │
+│    ~/.bashrc  ~/.gitconfig  ~/.ssh/config         │
+│    ~/.config/nvim/init.lua                        │
+│                                                  │
+│  Adoptable files (no pack yet):                  │
+│    ~/.tmux.conf  ~/.config/starship.toml          │
+│    ~/.config/alacritty/alacritty.toml             │
+│                                                  │
+│  Try:                                            │
+│    dodot status                                  │
+│    dodot up --dry-run                            │
+│    dodot adopt vim ~/.tmux.conf                  │
+│    dodot init mypack                             │
+│    eval "$(dodot init-sh)"                       │
+│                                                  │
+│  Helpers available:                              │
+│    source /tests/helpers/setup.bash              │
+│    create_pack_file, assert_symlink, etc.        │
+│                                                  │
+└─────────────────────────────────────────────────┘
+
+WELCOME
+
+# Show current state
+echo "Current status:"
+echo ""
+dodot status 2>&1 | head -30
+echo ""
+echo "---"
+echo ""
+
+# Drop into interactive shell (only when stdin is a terminal)
+if [ -t 0 ]; then
+    export PS1="[dodot-explore] \w \$ "
+    cd "$HOME"
+    exec bash --norc --noprofile -i
+fi


### PR DESCRIPTION
## Summary

- Add `scripts/e2e --explore` — drops into a Docker container with a pre-built sandbox simulating a real system, ready for hands-on experimentation with all dodot commands
- The sandbox has a realistic dotfiles repo (8 packs, all 5 handlers), pre-existing home files that create conflicts, and orphan dotfiles ready for adoption
- Complements `--shell` (bare container for BATS/helper development) with a higher-level "just play with dodot" experience for humans and agents

### What the sandbox contains

**Dotfiles repo** (~/dotfiles):
- `vim/` — symlink (vimrc) + shell (aliases.sh)
- `git/` — symlink (gitconfig)
- `zsh/` — all 3 shell file types (aliases.sh, profile.sh, login.sh)
- `nvim/` — subdirectory files routed to XDG (nvim/init.lua, nvim/lua/plugins.lua)
- `tools/` — install handler + path handler (bin/devtool) + Brewfile (with brew mock)
- `ssh/` — force_home routing (ssh/config → ~/.ssh/config)
- `shell/` — dot. prefix convention (dot.bashrc, dot.zshrc, dot.inputrc)
- `disabled/` — ignored pack

**Pre-existing home files** (will conflict on `dodot up`):
- `~/.bashrc`, `~/.gitconfig`, `~/.ssh/config`, `~/.config/nvim/init.lua`

**Adoptable orphans** (no pack yet):
- `~/.tmux.conf`, `~/.config/starship.toml`, `~/.config/alacritty/alacritty.toml`

### Usage

```bash
scripts/e2e --explore        # enter sandbox
dodot status                 # see all packs pending
dodot up --dry-run           # preview deployment
dodot up vim                 # deploy a pack
dodot adopt vim ~/.tmux.conf # adopt an orphan file
eval "$(dodot init-sh)"      # wire up shell integration
```

## Test plan

- [x] `scripts/e2e --explore` builds image and launches sandbox with welcome banner + status
- [x] All 99 existing E2E tests pass (no regressions)
- [x] 158 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)