### PR TITLE
feat: add structured logging with tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2026-04-16
+
+### Added
+- Structured logging via `tracing` with daily-rotating file output to `~/.cache/dodot/logs/`
+- `--verbose` flag: show INFO-level log messages on stderr
+- `--debug` flag: show DEBUG-level log messages on stderr
+- INFO and DEBUG events across orchestration pipeline and executor subsystems
+- Automatic cleanup of log files older than 7 days
+
 ## [0.9.2] - 2026-04-16
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +518,15 @@ name = "dconf_rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7046468a81e6a002061c01e6a7c83139daf91b11c30e66795b13217c2d885c8b"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derivative"
@@ -600,6 +618,9 @@ dependencies = [
  "dodot-lib",
  "serde",
  "standout",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -616,6 +637,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
+ "tracing",
 ]
 
 [[package]]
@@ -951,6 +973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1033,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1092,21 @@ dependencies = [
  "libc",
  "memoffset 0.7.1",
 ]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "objc"
@@ -1197,6 +1249,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1528,6 +1586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,6 +1830,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +1972,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +2001,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1930,6 +2079,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "dodot"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "dodot-lib"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "clapfig",
  "confique",

--- a/crates/dodot-cli/Cargo.toml
+++ b/crates/dodot-cli/Cargo.toml
@@ -17,3 +17,6 @@ clap = { version = "4", features = ["derive"] }
 dodot-lib = { version = "0.9.2", path = "../dodot-lib" }
 serde = { version = "1", features = ["derive"] }
 standout = "7.3"
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/dodot-cli/Cargo.toml
+++ b/crates/dodot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dodot"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 license = "MIT"
 description = "A dotfiles manager that uses symlinks for live editing"
@@ -14,7 +14,7 @@ path = "src/main.rs"
 anyhow = "1"
 clapfig = "0.16"
 clap = { version = "4", features = ["derive"] }
-dodot-lib = { version = "0.9.2", path = "../dodot-lib" }
+dodot-lib = { version = "0.9.3", path = "../dodot-lib" }
 serde = { version = "1", features = ["derive"] }
 standout = "7.3"
 tracing = "0.1"

--- a/crates/dodot-cli/src/logging.rs
+++ b/crates/dodot-cli/src/logging.rs
@@ -1,0 +1,117 @@
+//! Logging setup — file + optional stdout subscriber.
+//!
+//! By default, dodot logs to a daily-rotating file under
+//! `~/.cache/dodot/logs/`. The `--verbose` and `--debug` flags
+//! additionally enable stdout output at the respective level.
+
+use std::fs;
+use std::path::Path;
+use std::time::SystemTime;
+
+use tracing_appender::rolling;
+use tracing_subscriber::fmt;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Layer;
+
+/// Verbosity level requested via CLI flags.
+pub enum Verbosity {
+    /// No stdout logging (file only).
+    Quiet,
+    /// INFO and above to stdout.
+    Verbose,
+    /// DEBUG and above to stdout.
+    Debug,
+}
+
+/// Initialize the tracing subscriber.
+///
+/// Always logs to a daily-rotating file. Optionally also logs to
+/// stdout based on `verbosity`.
+pub fn init(log_dir: &Path, verbosity: Verbosity) {
+    // Ensure the log directory exists
+    let _ = fs::create_dir_all(log_dir);
+
+    // File layer: always active, DEBUG level (captures everything)
+    let file_appender = rolling::daily(log_dir, "dodot.log");
+    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+
+    // Leak the guard so the writer lives for the process lifetime.
+    // This is fine for a CLI that runs and exits.
+    std::mem::forget(_guard);
+
+    let file_layer = fmt::layer()
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_target(true);
+
+    let file_filter = EnvFilter::new("dodot_lib=debug,dodot=debug");
+
+    match verbosity {
+        Verbosity::Quiet => {
+            tracing_subscriber::registry()
+                .with(file_layer.with_filter(file_filter))
+                .init();
+        }
+        Verbosity::Verbose => {
+            let stdout_layer = fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_target(false)
+                .compact();
+            let stdout_filter = EnvFilter::new("dodot_lib=info,dodot=info");
+
+            tracing_subscriber::registry()
+                .with(file_layer.with_filter(file_filter))
+                .with(stdout_layer.with_filter(stdout_filter))
+                .init();
+        }
+        Verbosity::Debug => {
+            let stdout_layer = fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_target(true)
+                .compact();
+            let stdout_filter = EnvFilter::new("dodot_lib=debug,dodot=debug");
+
+            tracing_subscriber::registry()
+                .with(file_layer.with_filter(file_filter))
+                .with(stdout_layer.with_filter(stdout_filter))
+                .init();
+        }
+    }
+
+    cleanup_old_logs(log_dir, 7);
+}
+
+/// Remove log files older than `max_age_days` days.
+fn cleanup_old_logs(log_dir: &Path, max_age_days: u64) {
+    let cutoff = SystemTime::now() - std::time::Duration::from_secs(max_age_days * 24 * 60 * 60);
+
+    let entries = match fs::read_dir(log_dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+
+        // Only clean up dodot log files
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if n.starts_with("dodot.log") => n,
+            _ => continue,
+        };
+
+        // Don't remove the base file name (current day's log)
+        if name == "dodot.log" {
+            continue;
+        }
+
+        if let Ok(meta) = fs::metadata(&path) {
+            if let Ok(modified) = meta.modified() {
+                if modified < cutoff {
+                    let _ = fs::remove_file(&path);
+                }
+            }
+        }
+    }
+}

--- a/crates/dodot-cli/src/logging.rs
+++ b/crates/dodot-cli/src/logging.rs
@@ -1,8 +1,8 @@
-//! Logging setup — file + optional stdout subscriber.
+//! Logging setup — file + optional stderr subscriber.
 //!
 //! By default, dodot logs to a daily-rotating file under
 //! `~/.cache/dodot/logs/`. The `--verbose` and `--debug` flags
-//! additionally enable stdout output at the respective level.
+//! additionally enable stderr output at the respective level.
 
 use std::fs;
 use std::path::Path;
@@ -17,29 +17,34 @@ use tracing_subscriber::Layer;
 
 /// Verbosity level requested via CLI flags.
 pub enum Verbosity {
-    /// No stdout logging (file only).
+    /// No stderr logging (file only).
     Quiet,
-    /// INFO and above to stdout.
+    /// INFO and above to stderr.
     Verbose,
-    /// DEBUG and above to stdout.
+    /// DEBUG and above to stderr.
     Debug,
 }
 
 /// Initialize the tracing subscriber.
 ///
 /// Always logs to a daily-rotating file. Optionally also logs to
-/// stdout based on `verbosity`.
-pub fn init(log_dir: &Path, verbosity: Verbosity) {
-    // Ensure the log directory exists
-    let _ = fs::create_dir_all(log_dir);
+/// stderr based on `verbosity`.
+///
+/// Returns a `WorkerGuard` that must be kept alive until process exit to
+/// ensure buffered log lines are flushed on shutdown.
+pub fn init(log_dir: &Path, verbosity: Verbosity) -> tracing_appender::non_blocking::WorkerGuard {
+    // Ensure the log directory exists; fall back to a temp dir on failure.
+    let log_dir = if fs::create_dir_all(log_dir).is_ok() {
+        log_dir.to_path_buf()
+    } else {
+        let fallback = std::env::temp_dir().join("dodot-logs");
+        let _ = fs::create_dir_all(&fallback);
+        fallback
+    };
 
     // File layer: always active, DEBUG level (captures everything)
-    let file_appender = rolling::daily(log_dir, "dodot.log");
-    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
-
-    // Leak the guard so the writer lives for the process lifetime.
-    // This is fine for a CLI that runs and exits.
-    std::mem::forget(_guard);
+    let file_appender = rolling::daily(&log_dir, "dodot.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
     let file_layer = fmt::layer()
         .with_writer(non_blocking)
@@ -55,32 +60,34 @@ pub fn init(log_dir: &Path, verbosity: Verbosity) {
                 .init();
         }
         Verbosity::Verbose => {
-            let stdout_layer = fmt::layer()
+            let stderr_layer = fmt::layer()
                 .with_writer(std::io::stderr)
                 .with_target(false)
                 .compact();
-            let stdout_filter = EnvFilter::new("dodot_lib=info,dodot=info");
+            let stderr_filter = EnvFilter::new("dodot_lib=info,dodot=info");
 
             tracing_subscriber::registry()
                 .with(file_layer.with_filter(file_filter))
-                .with(stdout_layer.with_filter(stdout_filter))
+                .with(stderr_layer.with_filter(stderr_filter))
                 .init();
         }
         Verbosity::Debug => {
-            let stdout_layer = fmt::layer()
+            let stderr_layer = fmt::layer()
                 .with_writer(std::io::stderr)
                 .with_target(true)
                 .compact();
-            let stdout_filter = EnvFilter::new("dodot_lib=debug,dodot=debug");
+            let stderr_filter = EnvFilter::new("dodot_lib=debug,dodot=debug");
 
             tracing_subscriber::registry()
                 .with(file_layer.with_filter(file_filter))
-                .with(stdout_layer.with_filter(stdout_filter))
+                .with(stderr_layer.with_filter(stderr_filter))
                 .init();
         }
     }
 
-    cleanup_old_logs(log_dir, 7);
+    cleanup_old_logs(&log_dir, 7);
+
+    guard
 }
 
 /// Remove log files older than `max_age_days` days.

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -20,8 +20,8 @@ fn main() {
     };
     let log_dir = dodot_lib::paths::XdgPather::from_env()
         .map(|p| dodot_lib::paths::Pather::log_dir(&p))
-        .unwrap_or_else(|_| std::path::PathBuf::from("/tmp/dodot-logs"));
-    logging::init(&log_dir, verbosity);
+        .unwrap_or_else(|_| std::env::temp_dir().join("dodot-logs"));
+    let _log_guard = logging::init(&log_dir, verbosity);
 
     // Passthrough: config (clapfig handles its own output)
     if let Some(("config", sub_matches)) = matches.subcommand() {

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -2,12 +2,26 @@ use clap::{Arg, ArgAction, Command as ClapCommand};
 use standout::cli::{App, CommandGroup};
 
 mod handlers;
+mod logging;
 
 fn main() {
     let app = build_app();
 
     // parse_with handles help rendering (with command groups) and exits if help requested
     let matches = app.parse_with(build_clap_command());
+
+    // Initialize logging based on CLI flags
+    let verbosity = if matches.get_flag("debug") {
+        logging::Verbosity::Debug
+    } else if matches.get_flag("verbose") {
+        logging::Verbosity::Verbose
+    } else {
+        logging::Verbosity::Quiet
+    };
+    let log_dir = dodot_lib::paths::XdgPather::from_env()
+        .map(|p| dodot_lib::paths::Pather::log_dir(&p))
+        .unwrap_or_else(|_| std::path::PathBuf::from("/tmp/dodot-logs"));
+    logging::init(&log_dir, verbosity);
 
     // Passthrough: config (clapfig handles its own output)
     if let Some(("config", sub_matches)) = matches.subcommand() {
@@ -123,6 +137,20 @@ fn build_clap_command() -> ClapCommand {
     ClapCommand::new("dodot")
         .about("A dotfiles manager that uses symlinks for live editing")
         .version(env!("CARGO_PKG_VERSION"))
+        .arg(
+            Arg::new("verbose")
+                .long("verbose")
+                .help("Enable verbose logging to stderr")
+                .global(true)
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("debug")
+                .long("debug")
+                .help("Enable debug logging to stderr (implies --verbose)")
+                .global(true)
+                .action(ArgAction::SetTrue),
+        )
         .subcommand(
             ClapCommand::new("status")
                 .about("Show deployment status of packs")

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -17,6 +17,7 @@ standout-render = "7.3"
 tempfile = { version = "3", optional = true }
 thiserror = "2"
 toml = "0.8"
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dodot-lib"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 license = "MIT"
 description = "Core library for dodot dotfiles manager"

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -1,5 +1,7 @@
 //! `down` command — remove all deployed state for packs.
 
+use tracing::{debug, info};
+
 use crate::commands::{handler_symbol, DisplayFile, DisplayPack, PackStatusResult};
 use crate::handlers::HANDLER_SYMLINK;
 use crate::packs;
@@ -9,6 +11,8 @@ use crate::Result;
 
 /// Run the `down` command: remove all state for specified (or all) packs.
 pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<PackStatusResult> {
+    info!(dry_run = ctx.dry_run, "starting down command");
+
     // Validate pack names before doing anything
     let mut warnings = Vec::new();
     if let Some(names) = pack_filter {
@@ -21,6 +25,7 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         ctx.paths.dotfiles_root(),
         &root_config.pack.ignore,
     )?;
+    info!(count = all_packs.len(), "discovered packs");
 
     if let Some(names) = pack_filter {
         all_packs.retain(|p| names.iter().any(|n| n == &p.name));
@@ -33,10 +38,11 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         let handlers = ctx.datastore.list_pack_handlers(&pack.name)?;
 
         if handlers.is_empty() {
-            // Already-down pack (#17): don't print misleading output
+            debug!(pack = %pack.name, "already down, skipping");
             continue;
         }
 
+        info!(pack = %pack.name, handlers = ?handlers, "removing pack state");
         any_removed = true;
         let mut files = Vec::new();
 
@@ -97,6 +103,7 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
 
     // Regenerate shell init script (now empty for removed packs)
     if !ctx.dry_run {
+        info!("regenerating shell init script");
         shell::write_init_script(ctx.fs.as_ref(), ctx.paths.as_ref())?;
     }
 

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -8,6 +8,8 @@
 //! potential conflicts as warnings — even for packs that aren't deployed
 //! yet. This lets users see problems before they run `up`.
 
+use tracing::{debug, info};
+
 use crate::commands::{
     handler_description, handler_symbol, DisplayFile, DisplayPack, PackStatusResult,
 };
@@ -212,6 +214,8 @@ fn conflict_warnings(conflicts: &[conflicts::Conflict], home: &std::path::Path) 
 /// Also performs cross-pack conflict detection and surfaces potential
 /// conflicts as warnings.
 pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<PackStatusResult> {
+    info!("starting status command");
+
     // Validate pack names before doing anything
     let mut warnings = Vec::new();
     if let Some(names) = pack_filter {
@@ -224,6 +228,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         ctx.paths.dotfiles_root(),
         &root_config.pack.ignore,
     )?;
+    info!(count = all_packs.len(), "discovered packs");
 
     if let Some(names) = pack_filter {
         all_packs.retain(|p| names.iter().any(|n| n == &p.name));
@@ -236,6 +241,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
     let mut pack_intents = Vec::new();
 
     for mut pack in all_packs {
+        info!(pack = %pack.name, "checking pack status");
         let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
         pack.config = pack_config.to_handler_config();
         let rules = mappings_to_rules(&pack_config.mappings);
@@ -323,8 +329,14 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
     // Detect and surface cross-pack conflicts as warnings
     let detected_conflicts = conflicts::detect_cross_pack_conflicts(&pack_intents, ctx.fs.as_ref());
     if !detected_conflicts.is_empty() {
+        info!(
+            count = detected_conflicts.len(),
+            "cross-pack conflicts detected"
+        );
         let home = ctx.paths.home_dir();
         warnings.extend(conflict_warnings(&detected_conflicts, home));
+    } else {
+        debug!("no cross-pack conflicts");
     }
 
     Ok(PackStatusResult {

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -8,6 +8,8 @@
 //! This prevents partial deployments where one pack silently overwrites
 //! another pack's symlinks.
 
+use tracing::{debug, info};
+
 use crate::commands::{
     handler_description, handler_symbol, status_style, DisplayFile, DisplayPack, PackStatusResult,
 };
@@ -26,6 +28,13 @@ use crate::Result;
 /// `--force` is set, because cross-pack conflicts are a configuration
 /// problem, not a deployment problem.
 pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<PackStatusResult> {
+    info!(
+        dry_run = ctx.dry_run,
+        force = ctx.force,
+        no_provision = ctx.no_provision,
+        "starting up command"
+    );
+
     // Phase 1: Discover packs and collect intents
     let packs = orchestration::prepare_packs(pack_filter, ctx)?;
 
@@ -38,6 +47,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
                 pack_intents.push((pack.name.clone(), intents));
             }
             Err(e) => {
+                info!(pack = %pack.name, error = %e, "intent collection failed");
                 intent_errors.push(PackResult {
                     pack_name: pack.name.clone(),
                     success: false,
@@ -49,18 +59,25 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     }
 
     // Phase 2: Detect cross-pack conflicts
+    info!("checking for cross-pack conflicts");
     let conflicts = conflicts::detect_cross_pack_conflicts(&pack_intents, ctx.fs.as_ref());
     if !conflicts.is_empty() {
+        info!(count = conflicts.len(), "cross-pack conflicts detected");
         return Err(crate::DodotError::CrossPackConflict { conflicts });
     }
+    debug!("no cross-pack conflicts");
 
     // Phase 3: Execute intents for each pack
     let mut pack_results: Vec<PackResult> = intent_errors;
 
     for (pack_name, intents) in pack_intents {
+        info!(pack = %pack_name, intents = intents.len(), "executing pack");
         match orchestration::execute_intents(intents, ctx) {
             Ok(operations) => {
                 let success = operations.iter().all(|r| r.success);
+                let succeeded = operations.iter().filter(|o| o.success).count();
+                let failed = operations.iter().filter(|o| !o.success).count();
+                debug!(pack = %pack_name, succeeded, failed, "pack execution complete");
                 pack_results.push(PackResult {
                     pack_name,
                     success,
@@ -69,6 +86,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
                 });
             }
             Err(e) => {
+                info!(pack = %pack_name, error = %e, "pack execution failed");
                 pack_results.push(PackResult {
                     pack_name,
                     success: false,
@@ -81,6 +99,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
 
     // Regenerate shell init script
     if !ctx.dry_run {
+        info!("regenerating shell init script");
         shell::write_init_script(ctx.fs.as_ref(), ctx.paths.as_ref())?;
     }
 

--- a/crates/dodot-lib/src/execution/mod.rs
+++ b/crates/dodot-lib/src/execution/mod.rs
@@ -16,6 +16,8 @@
 //! `$PATH`, it just won't be directly runnable until the user fixes
 //! permissions manually.
 
+use tracing::{debug, info};
+
 use crate::datastore::DataStore;
 use crate::fs::Fs;
 use crate::handlers::HANDLER_PATH;
@@ -60,6 +62,12 @@ impl<'a> Executor<'a> {
     /// execution immediately via `?`.
     /// In dry-run mode, all intents are simulated regardless of errors.
     pub fn execute(&self, intents: Vec<HandlerIntent>) -> Result<Vec<OperationResult>> {
+        debug!(
+            count = intents.len(),
+            dry_run = self.dry_run,
+            force = self.force,
+            "executor starting"
+        );
         let mut results = Vec::new();
 
         for intent in intents {
@@ -70,6 +78,10 @@ impl<'a> Executor<'a> {
             };
             results.extend(intent_results);
         }
+
+        let succeeded = results.iter().filter(|r| r.success).count();
+        let failed = results.iter().filter(|r| !r.success).count();
+        debug!(succeeded, failed, "executor finished");
 
         Ok(results)
     }
@@ -83,11 +95,24 @@ impl<'a> Executor<'a> {
                 source,
                 user_path,
             } => {
+                debug!(
+                    pack,
+                    handler,
+                    source = %source.display(),
+                    user_path = %user_path.display(),
+                    "executing link intent"
+                );
+
                 // Pre-check: does a non-symlink file exist at user_path?
                 // We check BEFORE creating the data link to avoid leaving
                 // dangling state when the user link would fail.
                 if !self.fs.is_symlink(user_path) && self.fs.exists(user_path) {
                     if self.force {
+                        info!(
+                            pack,
+                            path = %user_path.display(),
+                            "force-removing existing file"
+                        );
                         // Remove the existing path before creating the symlink
                         if self.fs.is_dir(user_path) {
                             self.fs.remove_dir_all(user_path)?;
@@ -95,6 +120,11 @@ impl<'a> Executor<'a> {
                             self.fs.remove_file(user_path)?;
                         }
                     } else {
+                        info!(
+                            pack,
+                            path = %user_path.display(),
+                            "conflict: file already exists"
+                        );
                         // Return a failed result — non-fatal so other files
                         // in the pack can still be processed.
                         let op = Operation::CreateUserLink {
@@ -115,10 +145,23 @@ impl<'a> Executor<'a> {
 
                 // Step 1: Create data link (source → datastore)
                 let datastore_path = self.datastore.create_data_link(pack, handler, source)?;
+                debug!(
+                    pack,
+                    datastore_path = %datastore_path.display(),
+                    "created data link"
+                );
 
                 // Step 2: Create user link (datastore → user location)
                 self.datastore
                     .create_user_link(&datastore_path, user_path)?;
+
+                let filename = source.file_name().unwrap_or_default().to_string_lossy();
+                info!(
+                    pack,
+                    file = %filename,
+                    target = %user_path.display(),
+                    "created symlink"
+                );
 
                 let op = Operation::CreateUserLink {
                     pack: pack.clone(),
@@ -129,11 +172,7 @@ impl<'a> Executor<'a> {
 
                 Ok(vec![OperationResult::ok(
                     op,
-                    format!(
-                        "{} → {}",
-                        source.file_name().unwrap_or_default().to_string_lossy(),
-                        user_path.display()
-                    ),
+                    format!("{} → {}", filename, user_path.display()),
                 )])
             }
 
@@ -142,6 +181,9 @@ impl<'a> Executor<'a> {
                 handler,
                 source,
             } => {
+                let filename = source.file_name().unwrap_or_default().to_string_lossy();
+                info!(pack, handler = handler.as_str(), file = %filename, "staging file");
+
                 self.datastore.create_data_link(pack, handler, source)?;
 
                 let op = Operation::CreateDataLink {
@@ -150,16 +192,11 @@ impl<'a> Executor<'a> {
                     source: source.clone(),
                 };
 
-                let mut results = vec![OperationResult::ok(
-                    op,
-                    format!(
-                        "staged {}",
-                        source.file_name().unwrap_or_default().to_string_lossy(),
-                    ),
-                )];
+                let mut results = vec![OperationResult::ok(op, format!("staged {}", filename))];
 
                 // Auto-chmod +x for path handler directories
                 if handler == HANDLER_PATH && self.auto_chmod_exec {
+                    debug!(pack, source = %source.display(), "checking executable permissions");
                     results.extend(self.ensure_executable(pack, source));
                 }
 
@@ -178,6 +215,12 @@ impl<'a> Executor<'a> {
                     let already_done = self.datastore.has_sentinel(pack, handler, sentinel)?;
 
                     if already_done {
+                        info!(
+                            pack,
+                            handler = handler.as_str(),
+                            sentinel,
+                            "sentinel found, skipping"
+                        );
                         let op = Operation::CheckSentinel {
                             pack: pack.clone(),
                             handler: handler.clone(),
@@ -186,6 +229,9 @@ impl<'a> Executor<'a> {
                         return Ok(vec![OperationResult::ok(op, "already completed")]);
                     }
                 }
+
+                let cmd_str = format!("{} {}", executable, arguments.join(" "));
+                info!(pack, handler = handler.as_str(), command = %cmd_str.trim(), "running command");
 
                 // Run the command
                 self.datastore.run_and_record(
@@ -197,7 +243,7 @@ impl<'a> Executor<'a> {
                     self.provision_rerun,
                 )?;
 
-                let cmd_str = format!("{} {}", executable, arguments.join(" "));
+                info!(pack, sentinel, "command completed, sentinel recorded");
 
                 let op = Operation::RunCommand {
                     pack: pack.clone(),
@@ -284,9 +330,11 @@ impl<'a> Executor<'a> {
 
             match self.fs.set_permissions(&entry.path, new_mode) {
                 Ok(()) => {
+                    info!(pack, file = %entry.name, mode = format!("{:o}", new_mode), "chmod +x");
                     results.push(OperationResult::ok(op, format!("chmod +x {}", entry.name)));
                 }
                 Err(e) => {
+                    info!(pack, file = %entry.name, error = %e, "chmod +x failed");
                     // Warning, not failure — don't mark the pack as failed
                     // just because chmod didn't work.
                     results.push(OperationResult::ok(

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 
 use serde::Serialize;
+use tracing::{debug, info};
 
 use crate::config::ConfigManager;
 use crate::datastore::DataStore;
@@ -122,8 +123,14 @@ pub fn execute(
     pack_filter: Option<&[String]>,
     ctx: &ExecutionContext,
 ) -> Result<ExecuteResult> {
+    info!(command = command.name(), "starting command");
+
     // Load root config for pack-level ignore patterns
     let root_config = ctx.config_manager.root_config()?;
+    debug!(
+        ignore_patterns = ?root_config.pack.ignore,
+        "loaded root config"
+    );
 
     // Discover packs
     let mut all_packs = packs::discover_packs(
@@ -131,12 +138,19 @@ pub fn execute(
         ctx.paths.dotfiles_root(),
         &root_config.pack.ignore,
     )?;
+    info!(
+        count = all_packs.len(),
+        root = %ctx.paths.dotfiles_root().display(),
+        "discovered packs"
+    );
 
     // Validate and apply name filter
     if let Some(names) = pack_filter {
         let _warnings = validate_pack_names(names, ctx)?;
         // Warnings are handled by the calling command (status/up/down)
+        debug!(filter = ?names, "applying pack filter");
         all_packs.retain(|p| names.iter().any(|n| n == &p.name));
+        info!(count = all_packs.len(), "packs after filter");
     }
 
     let total_packs = all_packs.len();
@@ -145,12 +159,16 @@ pub fn execute(
     let mut failed = 0;
 
     for mut pack in all_packs {
+        info!(pack = %pack.name, "processing pack");
+
         // Load pack-specific merged config
         match ctx.config_manager.config_for_pack(&pack.path) {
             Ok(pack_config) => {
+                debug!(pack = %pack.name, "loaded pack config");
                 pack.config = pack_config.to_handler_config();
             }
             Err(e) => {
+                info!(pack = %pack.name, error = %e, "pack config error, skipping");
                 failed += 1;
                 pack_results.push(PackResult {
                     pack_name: pack.name.clone(),
@@ -165,13 +183,16 @@ pub fn execute(
         match command.execute_for_pack(&pack, ctx) {
             Ok(result) => {
                 if result.success {
+                    info!(pack = %pack.name, ops = result.operations.len(), "pack succeeded");
                     successful += 1;
                 } else {
+                    info!(pack = %pack.name, ops = result.operations.len(), "pack completed with errors");
                     failed += 1;
                 }
                 pack_results.push(result);
             }
             Err(e) => {
+                info!(pack = %pack.name, error = %e, "pack failed");
                 failed += 1;
                 pack_results.push(PackResult {
                     pack_name: pack.name.clone(),
@@ -182,6 +203,13 @@ pub fn execute(
             }
         }
     }
+
+    info!(
+        total = total_packs,
+        successful = successful,
+        failed = failed,
+        "command complete"
+    );
 
     Ok(ExecuteResult {
         pack_results,
@@ -206,16 +234,20 @@ pub fn prepare_packs(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> 
         ctx.paths.dotfiles_root(),
         &root_config.pack.ignore,
     )?;
+    info!(count = all_packs.len(), "discovered packs");
 
     if let Some(names) = pack_filter {
         let _warnings = validate_pack_names(names, ctx)?;
+        debug!(filter = ?names, "applying pack filter");
         all_packs.retain(|p| names.iter().any(|n| n == &p.name));
+        info!(count = all_packs.len(), "packs after filter");
     }
 
     // Load per-pack config
     let mut configured = Vec::with_capacity(all_packs.len());
     for mut pack in all_packs {
         let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
+        debug!(pack = %pack.name, "loaded pack config");
         pack.config = pack_config.to_handler_config();
         configured.push(pack);
     }
@@ -241,10 +273,12 @@ pub fn collect_pack_intents(
     // Scan pack files
     let scanner = Scanner::new(ctx.fs.as_ref());
     let matches = scanner.scan_pack(pack, &rules, &root_config.pack.ignore)?;
+    debug!(pack = %pack.name, files = matches.len(), "scanned pack files");
 
     // Group by handler
     let groups = rules::group_by_handler(&matches);
     let order = rules::handler_execution_order(&groups);
+    debug!(pack = %pack.name, handlers = ?order, "handler execution order");
 
     // Build handler registry
     let registry = handlers::create_registry(ctx.fs.as_ref());
@@ -254,20 +288,31 @@ pub fn collect_pack_intents(
     for handler_name in &order {
         let handler = match registry.get(handler_name.as_str()) {
             Some(h) => h,
-            None => continue, // skip unknown handlers (e.g. "exclude")
+            None => {
+                debug!(pack = %pack.name, handler = %handler_name, "skipping unknown handler");
+                continue;
+            }
         };
 
         // Skip code execution handlers if --no-provision
         if ctx.no_provision && handler.category() == handlers::HandlerCategory::CodeExecution {
+            debug!(pack = %pack.name, handler = %handler_name, "skipping code-execution handler (--no-provision)");
             continue;
         }
 
         if let Some(handler_matches) = groups.get(handler_name) {
             let intents = handler.to_intents(handler_matches, &pack.config, ctx.paths.as_ref())?;
+            debug!(
+                pack = %pack.name,
+                handler = %handler_name,
+                intents = intents.len(),
+                "generated intents"
+            );
             all_intents.extend(intents);
         }
     }
 
+    info!(pack = %pack.name, intents = all_intents.len(), "collected intents");
     Ok(all_intents)
 }
 
@@ -280,6 +325,13 @@ pub fn execute_intents(
     intents: Vec<crate::operations::HandlerIntent>,
     ctx: &ExecutionContext,
 ) -> Result<Vec<OperationResult>> {
+    let count = intents.len();
+    info!(
+        intents = count,
+        dry_run = ctx.dry_run,
+        force = ctx.force,
+        "executing intents"
+    );
     let auto_chmod = ctx.config_manager.root_config()?.path.auto_chmod_exec;
     let executor = Executor::new(
         ctx.datastore.as_ref(),

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -49,6 +49,11 @@ pub trait Pather: Send + Sync {
         self.pack_data_dir(pack).join(handler)
     }
 
+    /// Log directory for dodot (e.g. `~/.cache/dodot/logs`).
+    fn log_dir(&self) -> PathBuf {
+        self.cache_dir().join("logs")
+    }
+
     /// Path to the generated shell init script.
     fn init_script_path(&self) -> PathBuf {
         self.shell_dir().join("dodot-init.sh")


### PR DESCRIPTION
## Summary

- Add structured logging via `tracing` with daily-rotating file output to `~/.cache/dodot/logs/`
- Add `--verbose` and `--debug` global CLI flags for stderr output at INFO/DEBUG levels
- Instrument orchestration pipeline (pack discovery, intent collection, conflict detection, shell init) and executor (symlink creation, staging, command execution, chmod) with INFO and DEBUG events
- Auto-cleanup of log files older than 7 days on startup

## Test plan

- [x] All 229 existing tests pass
- [x] Pre-commit hooks pass (rustfmt, clippy, nextest)
- [x] `dodot --verbose status` shows INFO events on stderr
- [x] `dodot --debug status` shows DEBUG events on stderr (with module paths)
- [x] File log created at `~/.cache/dodot/logs/dodot.log.YYYY-MM-DD`
- [x] Quiet mode (no flags) produces no stderr output

🤖 Generated with [Claude Code](https://claude.com/claude-code)