### PR TITLE
feat: preprocessing pipeline for file transformations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +434,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,11 +644,13 @@ version = "0.10.0"
 dependencies = [
  "clapfig",
  "confique",
+ "flate2",
  "glob",
  "serde",
  "serde_json",
  "sha2",
  "standout-render",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
@@ -750,6 +767,27 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -996,7 +1034,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1079,6 +1120,16 @@ checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
 dependencies = [
  "memo-map",
  "serde",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1221,6 +1272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "polling"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1404,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1605,6 +1671,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1836,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2515,6 +2598,16 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -9,11 +9,13 @@ repository = "https://github.com/arthur-debert/dodot"
 [dependencies]
 clapfig = "0.16"
 confique = "0.4"
+flate2 = "1"
 glob = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 standout-render = "7.3"
+tar = "0.4"
 tempfile = { version = "3", optional = true }
 thiserror = "2"
 toml = "0.8"

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -37,6 +37,9 @@ pub struct DodotConfig {
 
     #[config(nested)]
     pub mappings: MappingsSection,
+
+    #[config(nested)]
+    pub preprocessor: PreprocessorSection,
 }
 
 /// Pack-level settings.
@@ -108,6 +111,14 @@ pub struct PathSection {
     /// sourced by other scripts).
     #[config(default = true)]
     pub auto_chmod_exec: bool,
+}
+
+/// Preprocessing pipeline settings.
+#[derive(Config, Debug, Clone, Serialize, Deserialize)]
+pub struct PreprocessorSection {
+    /// Global kill switch for all preprocessing.
+    #[config(default = true)]
+    pub enabled: bool,
 }
 
 /// File-to-handler mapping patterns.

--- a/crates/dodot-lib/src/datastore/filesystem.rs
+++ b/crates/dodot-lib/src/datastore/filesystem.rs
@@ -169,8 +169,13 @@ impl DataStore for FilesystemDataStore {
         content: &[u8],
     ) -> Result<PathBuf> {
         let dir = self.paths.handler_data_dir(pack, handler);
-        self.fs.mkdir_all(&dir)?;
         let path = dir.join(filename);
+        // Create the full parent chain (supports nested filenames like "sub/file.txt")
+        if let Some(parent) = path.parent() {
+            self.fs.mkdir_all(parent)?;
+        } else {
+            self.fs.mkdir_all(&dir)?;
+        }
         self.fs.write_file(&path, content)?;
         Ok(path)
     }
@@ -684,6 +689,28 @@ mod tests {
 
         assert!(env.fs.exists(&path));
         assert_eq!(env.fs.read_to_string(&path).unwrap(), "hello");
+    }
+
+    #[test]
+    fn write_rendered_file_supports_nested_filename() {
+        // A filename containing `/` should be written to the corresponding
+        // nested directory under the handler data dir, creating any needed
+        // parents. This preserves source structure for preprocessor output.
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        let path = ds
+            .write_rendered_file("app", "preprocessed", "sub/nested/file.txt", b"deep")
+            .unwrap();
+
+        assert!(env.fs.exists(&path));
+        assert!(!env.fs.is_symlink(&path));
+        assert_eq!(env.fs.read_to_string(&path).unwrap(), "deep");
+        assert!(
+            path.to_string_lossy().contains("sub/nested/file.txt"),
+            "path should contain nested structure: {}",
+            path.display()
+        );
     }
 
     // ── Object safety ───────────────────────────────────────────

--- a/crates/dodot-lib/src/datastore/filesystem.rs
+++ b/crates/dodot-lib/src/datastore/filesystem.rs
@@ -161,6 +161,20 @@ impl DataStore for FilesystemDataStore {
             .collect())
     }
 
+    fn write_rendered_file(
+        &self,
+        pack: &str,
+        handler: &str,
+        filename: &str,
+        content: &[u8],
+    ) -> Result<PathBuf> {
+        let dir = self.paths.handler_data_dir(pack, handler);
+        self.fs.mkdir_all(&dir)?;
+        let path = dir.join(filename);
+        self.fs.write_file(&path, content)?;
+        Ok(path)
+    }
+
     fn sentinel_path(&self, pack: &str, handler: &str, sentinel: &str) -> PathBuf {
         self.paths.handler_data_dir(pack, handler).join(sentinel)
     }
@@ -595,6 +609,81 @@ mod tests {
 
         let sentinels = ds.list_handler_sentinels("vim", "install").unwrap();
         assert!(sentinels.is_empty());
+    }
+
+    // ── write_rendered_file ───────────────────────────────────────
+
+    #[test]
+    fn write_rendered_file_creates_regular_file() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        let path = ds
+            .write_rendered_file("app", "preprocessed", "config.toml", b"host = localhost")
+            .unwrap();
+
+        assert!(env.fs.exists(&path));
+        assert!(!env.fs.is_symlink(&path));
+        assert_eq!(env.fs.read_to_string(&path).unwrap(), "host = localhost");
+    }
+
+    #[test]
+    fn write_rendered_file_overwrites_existing() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        let path1 = ds
+            .write_rendered_file("app", "preprocessed", "config.toml", b"version 1")
+            .unwrap();
+        let path2 = ds
+            .write_rendered_file("app", "preprocessed", "config.toml", b"version 2")
+            .unwrap();
+
+        assert_eq!(path1, path2);
+        assert_eq!(env.fs.read_to_string(&path1).unwrap(), "version 2");
+    }
+
+    #[test]
+    fn write_rendered_file_empty_content() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        let path = ds
+            .write_rendered_file("app", "preprocessed", "empty.conf", b"")
+            .unwrap();
+
+        assert!(env.fs.exists(&path));
+        assert_eq!(env.fs.read_to_string(&path).unwrap(), "");
+    }
+
+    #[test]
+    fn write_rendered_file_binary_content() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        let binary = vec![0u8, 1, 2, 255, 254, 253];
+        let path = ds
+            .write_rendered_file("app", "preprocessed", "data.bin", &binary)
+            .unwrap();
+
+        assert_eq!(env.fs.read_file(&path).unwrap(), binary);
+    }
+
+    #[test]
+    fn write_rendered_file_creates_parent_dirs() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        // handler_data_dir doesn't exist yet — write_rendered_file should create it
+        let handler_dir = env.paths.handler_data_dir("newpack", "preprocessed");
+        assert!(!env.fs.exists(&handler_dir));
+
+        let path = ds
+            .write_rendered_file("newpack", "preprocessed", "file.txt", b"hello")
+            .unwrap();
+
+        assert!(env.fs.exists(&path));
+        assert_eq!(env.fs.read_to_string(&path).unwrap(), "hello");
     }
 
     // ── Object safety ───────────────────────────────────────────

--- a/crates/dodot-lib/src/datastore/filesystem.rs
+++ b/crates/dodot-lib/src/datastore/filesystem.rs
@@ -1,10 +1,39 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use crate::datastore::{CommandRunner, DataStore};
 use crate::fs::Fs;
 use crate::paths::Pather;
-use crate::Result;
+use crate::{DodotError, Result};
+
+/// Validate that `raw` is a safe relative path to be used under `base`.
+///
+/// Defense-in-depth against path traversal: rejects absolute paths, `..`
+/// components, and anything that would escape `base`. Returns the
+/// normalised relative `PathBuf` on success.
+fn validate_safe_relative(raw: &str, base: &Path) -> Result<PathBuf> {
+    let candidate = Path::new(raw);
+    let mut cleaned = PathBuf::new();
+    for component in candidate.components() {
+        match component {
+            Component::Normal(n) => cleaned.push(n),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(DodotError::Other(format!(
+                    "unsafe datastore path: {} (would escape {})",
+                    raw,
+                    base.display()
+                )));
+            }
+        }
+    }
+    if cleaned.as_os_str().is_empty() {
+        return Err(DodotError::Other(format!(
+            "empty datastore path (from {raw:?})"
+        )));
+    }
+    Ok(cleaned)
+}
 
 /// [`DataStore`] implementation backed by the real filesystem.
 ///
@@ -169,7 +198,8 @@ impl DataStore for FilesystemDataStore {
         content: &[u8],
     ) -> Result<PathBuf> {
         let dir = self.paths.handler_data_dir(pack, handler);
-        let path = dir.join(filename);
+        let relative = validate_safe_relative(filename, &dir)?;
+        let path = dir.join(&relative);
         // Create the full parent chain (supports nested filenames like "sub/file.txt")
         if let Some(parent) = path.parent() {
             self.fs.mkdir_all(parent)?;
@@ -177,6 +207,14 @@ impl DataStore for FilesystemDataStore {
             self.fs.mkdir_all(&dir)?;
         }
         self.fs.write_file(&path, content)?;
+        Ok(path)
+    }
+
+    fn write_rendered_dir(&self, pack: &str, handler: &str, relative: &str) -> Result<PathBuf> {
+        let dir = self.paths.handler_data_dir(pack, handler);
+        let rel = validate_safe_relative(relative, &dir)?;
+        let path = dir.join(&rel);
+        self.fs.mkdir_all(&path)?;
         Ok(path)
     }
 
@@ -689,6 +727,71 @@ mod tests {
 
         assert!(env.fs.exists(&path));
         assert_eq!(env.fs.read_to_string(&path).unwrap(), "hello");
+    }
+
+    #[test]
+    fn write_rendered_file_rejects_absolute_path() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        let err = ds
+            .write_rendered_file("app", "preprocessed", "/etc/passwd", b"x")
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::DodotError::Other(ref m) if m.contains("unsafe")),
+            "expected unsafe-path error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn write_rendered_file_rejects_parent_dir() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        let err = ds
+            .write_rendered_file("app", "preprocessed", "../escape.txt", b"x")
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::DodotError::Other(ref m) if m.contains("unsafe")),
+            "expected unsafe-path error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn write_rendered_dir_creates_dir() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        let path = ds
+            .write_rendered_dir("app", "preprocessed", "sub/nested")
+            .unwrap();
+
+        assert!(env.fs.is_dir(&path));
+        assert!(!env.fs.is_symlink(&path));
+    }
+
+    #[test]
+    fn write_rendered_dir_is_idempotent() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        let p1 = ds.write_rendered_dir("app", "preprocessed", "d").unwrap();
+        let p2 = ds.write_rendered_dir("app", "preprocessed", "d").unwrap();
+        assert_eq!(p1, p2);
+        assert!(env.fs.is_dir(&p1));
+    }
+
+    #[test]
+    fn write_rendered_dir_rejects_unsafe_paths() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        assert!(ds
+            .write_rendered_dir("app", "preprocessed", "/abs")
+            .is_err());
+        assert!(ds
+            .write_rendered_dir("app", "preprocessed", "../esc")
+            .is_err());
     }
 
     #[test]

--- a/crates/dodot-lib/src/datastore/mod.rs
+++ b/crates/dodot-lib/src/datastore/mod.rs
@@ -87,6 +87,11 @@ pub trait DataStore: Send + Sync {
     /// rendered content rather than a symlink to the source.
     /// Returns the absolute path of the written file.
     /// Idempotent: overwrites if the file already exists.
+    ///
+    /// `filename` must be a safe relative path — no absolute paths, no
+    /// `..` components. Callers (typically the preprocessing pipeline)
+    /// are expected to validate before calling. Implementations should
+    /// also reject unsafe paths as defense-in-depth.
     fn write_rendered_file(
         &self,
         pack: &str,
@@ -94,6 +99,13 @@ pub trait DataStore: Send + Sync {
         filename: &str,
         content: &[u8],
     ) -> Result<PathBuf>;
+
+    /// Creates a directory (mkdir -p) inside the datastore and returns
+    /// its absolute path. Used for preprocessor-expanded directory
+    /// entries (e.g. directory markers from tar archives).
+    ///
+    /// Same path-safety constraints as [`write_rendered_file`].
+    fn write_rendered_dir(&self, pack: &str, handler: &str, relative: &str) -> Result<PathBuf>;
 
     /// Returns the absolute path where a sentinel file would be stored.
     fn sentinel_path(&self, pack: &str, handler: &str, sentinel: &str) -> std::path::PathBuf;

--- a/crates/dodot-lib/src/datastore/mod.rs
+++ b/crates/dodot-lib/src/datastore/mod.rs
@@ -81,6 +81,20 @@ pub trait DataStore: Send + Sync {
     /// Lists sentinel file names for a pack/handler.
     fn list_handler_sentinels(&self, pack: &str, handler: &str) -> Result<Vec<String>>;
 
+    /// Writes a regular file (not a symlink) into the datastore.
+    ///
+    /// Used for preprocessor-expanded files where the datastore holds
+    /// rendered content rather than a symlink to the source.
+    /// Returns the absolute path of the written file.
+    /// Idempotent: overwrites if the file already exists.
+    fn write_rendered_file(
+        &self,
+        pack: &str,
+        handler: &str,
+        filename: &str,
+        content: &[u8],
+    ) -> Result<PathBuf>;
+
     /// Returns the absolute path where a sentinel file would be stored.
     fn sentinel_path(&self, pack: &str, handler: &str, sentinel: &str) -> std::path::PathBuf;
 }

--- a/crates/dodot-lib/src/error.rs
+++ b/crates/dodot-lib/src/error.rs
@@ -54,7 +54,7 @@ pub enum DodotError {
         message: String,
     },
 
-    #[error("preprocessing collision in pack \"{pack}\": {source_file} expands to {expanded_name}, which already exists as a regular file")]
+    #[error("preprocessing collision in pack \"{pack}\": {source_file} expands to {expanded_name}, which conflicts with an existing pack file or another preprocessor's output")]
     PreprocessorCollision {
         pack: String,
         source_file: String,

--- a/crates/dodot-lib/src/error.rs
+++ b/crates/dodot-lib/src/error.rs
@@ -47,6 +47,20 @@ pub enum DodotError {
         conflicts: Vec<crate::conflicts::Conflict>,
     },
 
+    #[error("preprocessing failed for {source_file} ({preprocessor}): {message}")]
+    PreprocessorError {
+        preprocessor: String,
+        source_file: PathBuf,
+        message: String,
+    },
+
+    #[error("preprocessing collision in pack \"{pack}\": {source_file} expands to {expanded_name}, which already exists as a regular file")]
+    PreprocessorCollision {
+        pack: String,
+        source_file: String,
+        expanded_name: String,
+    },
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/dodot-lib/src/handlers/install.rs
+++ b/crates/dodot-lib/src/handlers/install.rs
@@ -166,6 +166,7 @@ mod tests {
             handler: "install".into(),
             is_dir: false,
             options: std::collections::HashMap::new(),
+            preprocessor_source: None,
         }];
 
         let pather = crate::paths::XdgPather::builder()

--- a/crates/dodot-lib/src/lib.rs
+++ b/crates/dodot-lib/src/lib.rs
@@ -9,6 +9,7 @@ pub mod handlers;
 pub mod operations;
 pub mod packs;
 pub mod paths;
+pub mod preprocessing;
 pub mod render;
 pub mod rules;
 pub mod shell;

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -259,23 +259,65 @@ pub fn prepare_packs(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> 
 
 /// Collect handler intents for a pack **without** executing them.
 ///
-/// Runs the scan → match rules → group by handler → to_intents
-/// pipeline and returns the generated intents. This is the first half
-/// of the two-phase execution model that enables cross-pack conflict
-/// detection before any mutations happen.
+/// Runs the scan → preprocess → match rules → group by handler →
+/// to_intents pipeline and returns the generated intents. This is the
+/// first half of the two-phase execution model that enables cross-pack
+/// conflict detection before any mutations happen.
 pub fn collect_pack_intents(
     pack: &Pack,
     ctx: &ExecutionContext,
 ) -> Result<Vec<crate::operations::HandlerIntent>> {
+    collect_pack_intents_with_preprocessors(pack, ctx, None)
+}
+
+/// Like [`collect_pack_intents`], but accepts an explicit preprocessor
+/// registry. If `None`, no preprocessing occurs.
+///
+/// This variant exists for testing: callers can inject a registry with
+/// test preprocessors without requiring config-driven registration.
+pub fn collect_pack_intents_with_preprocessors(
+    pack: &Pack,
+    ctx: &ExecutionContext,
+    preprocessors: Option<&crate::preprocessing::PreprocessorRegistry>,
+) -> Result<Vec<crate::operations::HandlerIntent>> {
     let root_config = ctx.config_manager.config_for_pack(&pack.path)?;
     let rules = crate::config::mappings_to_rules(&root_config.mappings);
 
-    // Scan pack files
+    // Phase 1: Walk pack directory
     let scanner = Scanner::new(ctx.fs.as_ref());
-    let matches = scanner.scan_pack(pack, &rules, &root_config.pack.ignore)?;
-    debug!(pack = %pack.name, files = matches.len(), "scanned pack files");
+    let entries = scanner.walk_pack(&pack.path, &root_config.pack.ignore)?;
+    debug!(pack = %pack.name, entries = entries.len(), "walked pack directory");
 
-    // Group by handler
+    // Phase 2: Preprocessing
+    let preprocess_result = if let Some(registry) = preprocessors {
+        if !registry.is_empty() && root_config.preprocessor.enabled {
+            crate::preprocessing::pipeline::preprocess_pack(
+                entries,
+                registry,
+                pack,
+                ctx.fs.as_ref(),
+                ctx.datastore.as_ref(),
+            )?
+        } else {
+            crate::preprocessing::pipeline::PreprocessResult::passthrough(entries)
+        }
+    } else {
+        crate::preprocessing::pipeline::PreprocessResult::passthrough(entries)
+    };
+
+    // Phase 3: Merge and match rules
+    let all_entries = preprocess_result.merged_entries();
+    let mut matches = scanner.match_entries(&all_entries, &rules, &pack.name);
+    debug!(pack = %pack.name, files = matches.len(), "matched rules");
+
+    // Propagate preprocessor source info into matches
+    for m in &mut matches {
+        if let Some(source) = preprocess_result.source_map.get(&m.absolute_path) {
+            m.preprocessor_source = Some(source.clone());
+        }
+    }
+
+    // Phase 4: Group by handler
     let groups = rules::group_by_handler(&matches);
     let order = rules::handler_execution_order(&groups);
     debug!(pack = %pack.name, handlers = ?order, "handler execution order");
@@ -614,6 +656,376 @@ mod tests {
                 !matches!(r.operation, crate::operations::Operation::RunCommand { .. }),
                 "RunCommand should be skipped with no_provision"
             );
+        }
+    }
+
+    // ── Preprocessing integration tests ────────────────────────
+
+    #[test]
+    fn preprocessing_identity_file_deploys_via_symlink_handler() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "host = localhost")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let mut registry = crate::preprocessing::PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::new(),
+        ));
+
+        let intents =
+            collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap();
+
+        // Should produce a Link intent for "config.toml" (not "config.toml.identity")
+        assert_eq!(intents.len(), 1, "intents: {intents:?}");
+
+        match &intents[0] {
+            crate::operations::HandlerIntent::Link {
+                pack: p,
+                handler,
+                source,
+                user_path,
+            } => {
+                assert_eq!(p, "app");
+                assert_eq!(handler, "symlink");
+                // The source should be in the datastore (preprocessed handler dir)
+                assert!(
+                    source.to_string_lossy().contains("preprocessed"),
+                    "source should be in preprocessed dir: {}",
+                    source.display()
+                );
+                // The user_path should NOT contain .identity extension
+                let user_str = user_path.to_string_lossy();
+                assert!(
+                    !user_str.contains("identity"),
+                    "user_path should not have .identity: {user_str}"
+                );
+            }
+            other => panic!("expected Link intent, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preprocessing_mixed_pack_deploys_both() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "preprocessed content")
+            .file("readme.txt", "regular content")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let mut registry = crate::preprocessing::PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::new(),
+        ));
+
+        let intents =
+            collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap();
+
+        // Should have 2 Link intents: one for config.toml (preprocessed), one for readme.txt (regular)
+        assert_eq!(intents.len(), 2, "intents: {intents:?}");
+
+        let intent_sources: Vec<String> = intents
+            .iter()
+            .filter_map(|i| match i {
+                crate::operations::HandlerIntent::Link { source, .. } => {
+                    Some(source.to_string_lossy().to_string())
+                }
+                _ => None,
+            })
+            .collect();
+
+        // One should be in the preprocessed dir, the other in the pack dir
+        let has_preprocessed = intent_sources.iter().any(|s| s.contains("preprocessed"));
+        let has_regular = intent_sources
+            .iter()
+            .any(|s| s.contains("dotfiles/app/readme.txt"));
+        assert!(
+            has_preprocessed,
+            "should have a preprocessed source: {intent_sources:?}"
+        );
+        assert!(
+            has_regular,
+            "should have a regular source: {intent_sources:?}"
+        );
+    }
+
+    #[test]
+    fn preprocessing_collision_detected() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "preprocessed")
+            .file("config.toml", "regular")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let mut registry = crate::preprocessing::PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::new(),
+        ));
+
+        let err =
+            collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap_err();
+        assert!(
+            matches!(err, crate::DodotError::PreprocessorCollision { .. }),
+            "expected PreprocessorCollision, got: {err}"
+        );
+    }
+
+    #[test]
+    fn preprocessing_disabled_via_config_treats_files_as_regular() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "content")
+            .done()
+            .build();
+
+        // Write config disabling preprocessing
+        env.fs
+            .write_file(
+                &env.dotfiles_root.join(".dodot.toml"),
+                b"[preprocessor]\nenabled = false\n",
+            )
+            .unwrap();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let mut registry = crate::preprocessing::PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::new(),
+        ));
+
+        let intents =
+            collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap();
+
+        // With preprocessing disabled, the .identity file is treated as regular
+        // and deployed as-is with the .identity extension preserved
+        assert_eq!(intents.len(), 1);
+        match &intents[0] {
+            crate::operations::HandlerIntent::Link { user_path, .. } => {
+                let user_str = user_path.to_string_lossy();
+                assert!(
+                    user_str.contains("identity"),
+                    "with preprocessing disabled, file should keep .identity extension: {user_str}"
+                );
+            }
+            other => panic!("expected Link intent, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preprocessing_no_registry_works_like_before() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("vimrc", "set nocompatible")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "vim".into(),
+            path: env.dotfiles_root.join("vim"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("vim"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        // No preprocessor registry at all
+        let intents = collect_pack_intents_with_preprocessors(&pack, &ctx, None).unwrap();
+
+        assert_eq!(intents.len(), 1);
+        match &intents[0] {
+            crate::operations::HandlerIntent::Link { source, .. } => {
+                assert!(
+                    source.to_string_lossy().contains("vim/vimrc"),
+                    "source should be the pack file: {}",
+                    source.display()
+                );
+            }
+            other => panic!("expected Link intent, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preprocessing_end_to_end_deploy_and_verify_content() {
+        // Full pipeline: preprocess → collect intents → execute → verify user file
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "host = localhost\nport = 5432")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let mut registry = crate::preprocessing::PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::new(),
+        ));
+
+        let intents =
+            collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap();
+
+        // Extract the user_path from the intent so we know where to check
+        let user_path = match &intents[0] {
+            crate::operations::HandlerIntent::Link { user_path, .. } => user_path.clone(),
+            other => panic!("expected Link intent, got: {other:?}"),
+        };
+
+        let results = execute_intents(intents, &ctx).unwrap();
+
+        assert!(
+            results.iter().all(|r| r.success),
+            "all operations should succeed: {results:?}"
+        );
+
+        // The user file should exist and have the preprocessed content
+        assert!(
+            ctx.fs.exists(&user_path),
+            "user file should exist at: {}",
+            user_path.display()
+        );
+        assert!(
+            ctx.fs.is_symlink(&user_path),
+            "user file should be a symlink"
+        );
+
+        // Content should be the preprocessed (identity = same) content
+        let content = ctx.fs.read_to_string(&user_path).unwrap();
+        assert_eq!(content, "host = localhost\nport = 5432");
+    }
+
+    #[test]
+    fn preprocessing_error_propagates_through_pipeline() {
+        // Expansion errors should propagate through the pipeline.
+        // We test this at the pipeline level (not orchestration) since
+        // the scanner won't see a file that doesn't exist. The pipeline
+        // tests in pipeline.rs cover this case directly. Here we verify
+        // that a valid preprocessor file that triggers an error during
+        // a lower-level operation still propagates correctly.
+        //
+        // Use the unarchive preprocessor with a corrupted archive.
+        let env = TempEnvironment::builder()
+            .pack("tools")
+            .file("bad.tar.gz", "this is not valid gzip data at all")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "tools".into(),
+            path: env.dotfiles_root.join("tools"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("tools"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let mut registry = crate::preprocessing::PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::unarchive::UnarchivePreprocessor::new(),
+        ));
+
+        let err =
+            collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap_err();
+        assert!(
+            matches!(err, crate::DodotError::PreprocessorError { .. }),
+            "expected PreprocessorError, got: {err}"
+        );
+    }
+
+    #[test]
+    fn preprocessing_multiple_types_in_registry() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "identity content")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        // Register both identity and unarchive preprocessors
+        let mut registry = crate::preprocessing::PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::new(),
+        ));
+        registry.register(Box::new(
+            crate::preprocessing::unarchive::UnarchivePreprocessor::new(),
+        ));
+
+        let intents =
+            collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap();
+
+        // The .identity file should still be handled by the identity preprocessor
+        assert_eq!(intents.len(), 1);
+        match &intents[0] {
+            crate::operations::HandlerIntent::Link { source, .. } => {
+                assert!(source.to_string_lossy().contains("preprocessed"));
+            }
+            other => panic!("expected Link intent, got: {other:?}"),
         }
     }
 }

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -263,11 +263,15 @@ pub fn prepare_packs(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> 
 /// to_intents pipeline and returns the generated intents. This is the
 /// first half of the two-phase execution model that enables cross-pack
 /// conflict detection before any mutations happen.
+///
+/// Uses the default preprocessor registry
+/// ([`crate::preprocessing::default_registry`]).
 pub fn collect_pack_intents(
     pack: &Pack,
     ctx: &ExecutionContext,
 ) -> Result<Vec<crate::operations::HandlerIntent>> {
-    collect_pack_intents_with_preprocessors(pack, ctx, None)
+    let registry = crate::preprocessing::default_registry();
+    collect_pack_intents_with_preprocessors(pack, ctx, Some(&registry))
 }
 
 /// Like [`collect_pack_intents`], but accepts an explicit preprocessor
@@ -1027,5 +1031,66 @@ mod tests {
             }
             other => panic!("expected Link intent, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn collect_pack_intents_uses_default_registry() {
+        // The normal `collect_pack_intents` entrypoint should wire the
+        // default preprocessor registry (not pass `None`). We verify
+        // this by putting a `.tar.gz` file in a pack — the default
+        // registry contains `UnarchivePreprocessor`, so the archive
+        // should be expanded rather than passed through.
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let env = TempEnvironment::builder()
+            .pack("tools")
+            .file("placeholder", "")
+            .done()
+            .build();
+
+        // Create a simple tar.gz at the pack's bin/ dir so it maps to
+        // the path handler after expansion.
+        let archive_path = env.dotfiles_root.join("tools/payload.tar.gz");
+        let file = std::fs::File::create(&archive_path).unwrap();
+        let enc = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(enc);
+        let content = b"#!/bin/sh\necho hi";
+        let mut header = tar::Header::new_gnu();
+        header.set_path("mytool").unwrap();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder.append(&header, &content[..]).unwrap();
+        let enc = builder.into_inner().unwrap();
+        enc.finish().unwrap();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "tools".into(),
+            path: env.dotfiles_root.join("tools"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("tools"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        // Call the real production entrypoint — no explicit registry.
+        let intents = collect_pack_intents(&pack, &ctx).unwrap();
+
+        // Should include a Link intent for the expanded `mytool` file,
+        // with its source in the preprocessed datastore directory.
+        let has_expanded_source = intents.iter().any(|i| match i {
+            crate::operations::HandlerIntent::Link { source, .. } => {
+                source.to_string_lossy().contains("preprocessed")
+                    && source.to_string_lossy().contains("mytool")
+            }
+            _ => false,
+        });
+        assert!(
+            has_expanded_source,
+            "production collect_pack_intents should expand .tar.gz via the default registry. Intents: {intents:?}"
+        );
     }
 }

--- a/crates/dodot-lib/src/preprocessing/identity.rs
+++ b/crates/dodot-lib/src/preprocessing/identity.rs
@@ -1,0 +1,210 @@
+//! Identity preprocessor — passes content through unchanged.
+//!
+//! This preprocessor exists for testing the preprocessing pipeline.
+//! It matches files with the `.identity` extension and returns their
+//! content unchanged.
+
+use std::path::{Path, PathBuf};
+
+use crate::fs::Fs;
+use crate::preprocessing::{ExpandedFile, Preprocessor, TransformType};
+use crate::Result;
+
+/// A preprocessor that passes content through unchanged.
+///
+/// Useful for testing the preprocessing pipeline without depending
+/// on any transformation engine.
+pub struct IdentityPreprocessor {
+    extension: String,
+}
+
+impl IdentityPreprocessor {
+    /// Create a new identity preprocessor with the default extension `.identity`.
+    pub fn new() -> Self {
+        Self {
+            extension: "identity".to_string(),
+        }
+    }
+
+    /// Create an identity preprocessor with a custom extension.
+    pub fn with_extension(ext: &str) -> Self {
+        Self {
+            extension: ext.to_string(),
+        }
+    }
+}
+
+impl Default for IdentityPreprocessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Preprocessor for IdentityPreprocessor {
+    fn name(&self) -> &str {
+        "identity"
+    }
+
+    fn transform_type(&self) -> TransformType {
+        TransformType::Generative
+    }
+
+    fn matches_extension(&self, filename: &str) -> bool {
+        let suffix = format!(".{}", self.extension);
+        filename.ends_with(&suffix)
+    }
+
+    fn stripped_name(&self, filename: &str) -> String {
+        let suffix = format!(".{}", self.extension);
+        filename
+            .strip_suffix(&suffix)
+            .unwrap_or(filename)
+            .to_string()
+    }
+
+    fn expand(&self, source: &Path, fs: &dyn Fs) -> Result<Vec<ExpandedFile>> {
+        let content = fs.read_file(source)?;
+        let stripped =
+            self.stripped_name(&source.file_name().unwrap_or_default().to_string_lossy());
+
+        Ok(vec![ExpandedFile {
+            relative_path: PathBuf::from(stripped),
+            content,
+            is_dir: false,
+        }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_identity_extension() {
+        let pp = IdentityPreprocessor::new();
+        assert!(pp.matches_extension("config.toml.identity"));
+        assert!(pp.matches_extension("aliases.sh.identity"));
+        assert!(!pp.matches_extension("config.toml"));
+        assert!(!pp.matches_extension("identity"));
+        assert!(!pp.matches_extension("config.identity.bak"));
+    }
+
+    #[test]
+    fn stripped_name_removes_extension() {
+        let pp = IdentityPreprocessor::new();
+        assert_eq!(pp.stripped_name("config.toml.identity"), "config.toml");
+        assert_eq!(pp.stripped_name("aliases.sh.identity"), "aliases.sh");
+        assert_eq!(pp.stripped_name("simple.identity"), "simple");
+    }
+
+    #[test]
+    fn custom_extension() {
+        let pp = IdentityPreprocessor::with_extension("test");
+        assert!(pp.matches_extension("config.toml.test"));
+        assert!(!pp.matches_extension("config.toml.identity"));
+        assert_eq!(pp.stripped_name("config.toml.test"), "config.toml");
+    }
+
+    #[test]
+    fn expand_returns_content_unchanged() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "host = localhost\nport = 5432")
+            .done()
+            .build();
+
+        let pp = IdentityPreprocessor::new();
+        let source = env.dotfiles_root.join("app/config.toml.identity");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].relative_path, PathBuf::from("config.toml"));
+        assert_eq!(
+            String::from_utf8_lossy(&result[0].content),
+            "host = localhost\nport = 5432"
+        );
+        assert!(!result[0].is_dir);
+    }
+
+    #[test]
+    fn trait_properties() {
+        let pp = IdentityPreprocessor::new();
+        assert_eq!(pp.name(), "identity");
+        assert_eq!(pp.transform_type(), TransformType::Generative);
+    }
+
+    #[test]
+    fn expand_empty_file() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("empty.conf.identity", "")
+            .done()
+            .build();
+
+        let pp = IdentityPreprocessor::new();
+        let source = env.dotfiles_root.join("app/empty.conf.identity");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].relative_path, PathBuf::from("empty.conf"));
+        assert!(result[0].content.is_empty());
+    }
+
+    #[test]
+    fn expand_binary_content() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("data.bin.identity", "")
+            .done()
+            .build();
+
+        // Write binary content directly
+        let source = env.dotfiles_root.join("app/data.bin.identity");
+        let binary = vec![0u8, 1, 2, 255, 128, 64];
+        env.fs.write_file(&source, &binary).unwrap();
+
+        let pp = IdentityPreprocessor::new();
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].content, binary);
+    }
+
+    #[test]
+    fn expand_missing_file_returns_error() {
+        let env = crate::testing::TempEnvironment::builder().build();
+
+        let pp = IdentityPreprocessor::new();
+        let source = env.dotfiles_root.join("nonexistent.identity");
+        let err = pp.expand(&source, env.fs.as_ref());
+
+        assert!(err.is_err(), "expanding a missing file should fail");
+    }
+
+    #[test]
+    fn double_extension_only_strips_last() {
+        let pp = IdentityPreprocessor::new();
+        // Only the outermost .identity is stripped
+        assert_eq!(pp.stripped_name("file.identity.identity"), "file.identity");
+        assert!(pp.matches_extension("file.identity.identity"));
+    }
+
+    #[test]
+    fn expand_is_idempotent() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "data")
+            .done()
+            .build();
+
+        let pp = IdentityPreprocessor::new();
+        let source = env.dotfiles_root.join("app/config.toml.identity");
+
+        let result1 = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let result2 = pp.expand(&source, env.fs.as_ref()).unwrap();
+
+        assert_eq!(result1.len(), result2.len());
+        assert_eq!(result1[0].relative_path, result2[0].relative_path);
+        assert_eq!(result1[0].content, result2[0].content);
+    }
+}

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -133,6 +133,17 @@ impl Default for PreprocessorRegistry {
     }
 }
 
+/// The default registry used on the normal execution path.
+///
+/// Contains all user-facing preprocessors. The [`identity`] preprocessor
+/// is test-only and is intentionally *not* registered here (it would
+/// match innocuous-looking `.identity` files in user dotfiles).
+pub fn default_registry() -> PreprocessorRegistry {
+    let mut registry = PreprocessorRegistry::new();
+    registry.register(Box::new(unarchive::UnarchivePreprocessor::new()));
+    registry
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -70,6 +70,15 @@ pub trait Preprocessor: Send + Sync {
     /// For multi-file preprocessors (archives): returns many entries.
     ///
     /// The `source` path points to the original file in the pack directory.
+    ///
+    /// # Memory
+    ///
+    /// Expanded content is held fully in memory via [`Vec<u8>`]. This is
+    /// appropriate for dotfile-sized payloads (configs, small scripts,
+    /// small archives). Preprocessors that may handle very large inputs
+    /// (e.g. multi-hundred-MB archives of pre-built toolchains) should
+    /// consider adding a streaming path rather than materialising the
+    /// entire decoded stream at once.
     fn expand(&self, source: &Path, fs: &dyn Fs) -> Result<Vec<ExpandedFile>>;
 }
 

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -1,0 +1,223 @@
+//! Preprocessing pipeline — transforms source files before handler dispatch.
+//!
+//! Preprocessors expand files whose version-controlled source differs from
+//! the deployed artifact (templates, plists, encrypted secrets). The
+//! preprocessing phase runs before handler dispatch, producing virtual
+//! entries that downstream handlers (symlink, shell, path, install,
+//! homebrew) consume transparently.
+//!
+//! See `docs/proposals/preprocessing-pipeline.lex` for the full design.
+
+pub mod identity;
+pub mod pipeline;
+pub mod unarchive;
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::fs::Fs;
+use crate::Result;
+
+/// The safety model for a preprocessor's transformation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum TransformType {
+    /// Source generates destination; reversal is heuristic (templates).
+    Generative,
+    /// Source and destination are lossless representations (plists).
+    Representational,
+    /// Source is decoded on deploy; no reverse path (GPG).
+    Opaque,
+}
+
+/// A single file produced by a preprocessor's expansion.
+#[derive(Debug, Clone)]
+pub struct ExpandedFile {
+    /// Path relative to the expansion output (usually just the filename).
+    pub relative_path: PathBuf,
+    /// The file content.
+    pub content: Vec<u8>,
+    /// Whether this entry is a directory marker.
+    pub is_dir: bool,
+}
+
+/// The core preprocessor abstraction.
+///
+/// Each preprocessor is a small struct that implements this trait.
+/// Preprocessors are stored in a [`PreprocessorRegistry`] and dispatched
+/// by file extension at preprocessing time.
+///
+/// Preprocessors are pure transformers — they read source files and
+/// produce expanded content. Writing to the datastore is handled by the
+/// pipeline, not by individual preprocessors.
+pub trait Preprocessor: Send + Sync {
+    /// Unique name for this preprocessor (e.g. `"template"`, `"plist"`).
+    fn name(&self) -> &str;
+
+    /// The safety model for this transformation.
+    fn transform_type(&self) -> TransformType;
+
+    /// Whether this preprocessor handles a file with the given name.
+    fn matches_extension(&self, filename: &str) -> bool;
+
+    /// Strip the preprocessor extension to get the logical filename.
+    /// e.g. `"config.toml.tmpl"` → `"config.toml"`.
+    fn stripped_name(&self, filename: &str) -> String;
+
+    /// Expand the source file into one or more output files.
+    ///
+    /// For single-file preprocessors (templates): returns one entry.
+    /// For multi-file preprocessors (archives): returns many entries.
+    ///
+    /// The `source` path points to the original file in the pack directory.
+    fn expand(&self, source: &Path, fs: &dyn Fs) -> Result<Vec<ExpandedFile>>;
+}
+
+/// Registry of available preprocessors.
+///
+/// Preprocessors are checked in registration order. The first preprocessor
+/// whose `matches_extension` returns true for a filename wins.
+pub struct PreprocessorRegistry {
+    preprocessors: Vec<Box<dyn Preprocessor>>,
+}
+
+impl PreprocessorRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            preprocessors: Vec::new(),
+        }
+    }
+
+    /// Register a preprocessor.
+    pub fn register(&mut self, preprocessor: Box<dyn Preprocessor>) {
+        self.preprocessors.push(preprocessor);
+    }
+
+    /// Find the preprocessor that handles a given filename, if any.
+    pub fn find_for_file(&self, filename: &str) -> Option<&dyn Preprocessor> {
+        self.preprocessors
+            .iter()
+            .find(|p| p.matches_extension(filename))
+            .map(|p| p.as_ref())
+    }
+
+    /// Whether any registered preprocessor handles this filename.
+    pub fn is_preprocessor_file(&self, filename: &str) -> bool {
+        self.find_for_file(filename).is_some()
+    }
+
+    /// Whether the registry has any preprocessors registered.
+    pub fn is_empty(&self) -> bool {
+        self.preprocessors.is_empty()
+    }
+
+    /// Number of registered preprocessors.
+    pub fn len(&self) -> usize {
+        self.preprocessors.len()
+    }
+}
+
+impl Default for PreprocessorRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile-time check: Preprocessor must be object-safe
+    #[allow(dead_code)]
+    fn assert_object_safe(_: &dyn Preprocessor) {}
+
+    #[allow(dead_code)]
+    fn assert_boxable(_: Box<dyn Preprocessor>) {}
+
+    #[test]
+    fn transform_type_eq() {
+        assert_eq!(TransformType::Generative, TransformType::Generative);
+        assert_ne!(TransformType::Generative, TransformType::Opaque);
+    }
+
+    #[test]
+    fn empty_registry() {
+        let registry = PreprocessorRegistry::new();
+        assert!(registry.is_empty());
+        assert_eq!(registry.len(), 0);
+        assert!(!registry.is_preprocessor_file("anything.txt"));
+        assert!(registry.find_for_file("anything.txt").is_none());
+    }
+
+    #[test]
+    fn registry_finds_preprocessor() {
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::new(),
+        ));
+
+        assert!(!registry.is_empty());
+        assert_eq!(registry.len(), 1);
+        assert!(registry.is_preprocessor_file("config.toml.identity"));
+        assert!(!registry.is_preprocessor_file("config.toml"));
+
+        let found = registry.find_for_file("config.toml.identity").unwrap();
+        assert_eq!(found.name(), "identity");
+    }
+
+    #[test]
+    fn registry_first_match_wins() {
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::new(),
+        ));
+        // Registering a second one that matches the same extension
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::with_extension("identity"),
+        ));
+
+        let found = registry.find_for_file("test.identity").unwrap();
+        assert_eq!(found.name(), "identity");
+    }
+
+    #[test]
+    fn registry_multiple_different_preprocessors() {
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::new(),
+        ));
+        registry.register(Box::new(
+            crate::preprocessing::unarchive::UnarchivePreprocessor::new(),
+        ));
+
+        assert_eq!(registry.len(), 2);
+
+        // Each matches its own extension
+        assert!(registry.is_preprocessor_file("config.toml.identity"));
+        assert!(registry.is_preprocessor_file("bin.tar.gz"));
+
+        // Neither matches the other
+        let identity = registry.find_for_file("config.toml.identity").unwrap();
+        assert_eq!(identity.name(), "identity");
+
+        let unarchive = registry.find_for_file("bin.tar.gz").unwrap();
+        assert_eq!(unarchive.name(), "unarchive");
+
+        // Non-preprocessor files still return None
+        assert!(registry.find_for_file("regular.txt").is_none());
+    }
+
+    #[test]
+    fn registry_does_not_match_partial_extension() {
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(
+            crate::preprocessing::identity::IdentityPreprocessor::new(),
+        ));
+
+        // "identity" alone is not ".identity"
+        assert!(!registry.is_preprocessor_file("identity"));
+        // File without the dot prefix shouldn't match
+        assert!(!registry.is_preprocessor_file("fileidentity"));
+    }
+}

--- a/crates/dodot-lib/src/preprocessing/pipeline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline.rs
@@ -102,8 +102,12 @@ pub fn preprocess_pack(
     let mut virtual_entries = Vec::new();
     let mut source_map = HashMap::new();
 
-    // Build a set of regular entry relative paths for collision detection
-    let regular_paths: std::collections::HashSet<PathBuf> = regular_entries
+    // Tracks claimed paths for collision detection. Seeded with regular
+    // entries; virtual entries are added as they're created so two
+    // preprocessors can't both produce the same virtual path (e.g.
+    // `config.toml.identity` and `config.toml.tmpl` both expanding to
+    // `config.toml`).
+    let mut claimed_paths: std::collections::HashSet<PathBuf> = regular_entries
         .iter()
         .map(|e| e.relative_path.clone())
         .collect();
@@ -143,8 +147,9 @@ pub fn preprocess_pack(
                 expanded.relative_path.clone()
             };
 
-            // Phase 4: Collision check
-            if regular_paths.contains(&virtual_relative) {
+            // Phase 4: Collision check (against both regular entries and
+            // previously-expanded virtual entries)
+            if claimed_paths.contains(&virtual_relative) {
                 return Err(DodotError::PreprocessorCollision {
                     pack: pack.name.clone(),
                     source_file: filename.clone(),
@@ -152,12 +157,13 @@ pub fn preprocess_pack(
                 });
             }
 
-            // Write expanded content to datastore
-            let expanded_filename = virtual_relative.to_string_lossy().replace('/', "__");
+            // Write expanded content to datastore, preserving directory
+            // structure. `write_rendered_file` creates any needed parent
+            // directories under the handler data dir.
             let datastore_path = datastore.write_rendered_file(
                 &pack.name,
                 PREPROCESSED_HANDLER,
-                &expanded_filename,
+                &virtual_relative.to_string_lossy(),
                 &expanded.content,
             )?;
 
@@ -168,6 +174,7 @@ pub fn preprocess_pack(
                 "wrote expanded file"
             );
 
+            claimed_paths.insert(virtual_relative.clone());
             source_map.insert(datastore_path.clone(), entry.absolute_path.clone());
 
             virtual_entries.push(PackEntry {
@@ -672,5 +679,144 @@ mod tests {
             matches!(err, DodotError::Fs { .. }),
             "expected Fs error for missing file, got: {err}"
         );
+    }
+
+    #[test]
+    fn inter_preprocessor_collision_detected() {
+        // Two preprocessors produce the same logical name.
+        // Set up: `config.toml.identity` and `config.toml.other` (custom
+        // extension) both strip to `config.toml`. The pipeline must
+        // detect this and refuse rather than silently overwriting.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "a")
+            .file("config.toml.other", "b")
+            .done()
+            .build();
+
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(IdentityPreprocessor::new()));
+        registry.register(Box::new(IdentityPreprocessor::with_extension("other")));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![
+            PackEntry {
+                relative_path: "config.toml.identity".into(),
+                absolute_path: env.dotfiles_root.join("app/config.toml.identity"),
+                is_dir: false,
+            },
+            PackEntry {
+                relative_path: "config.toml.other".into(),
+                absolute_path: env.dotfiles_root.join("app/config.toml.other"),
+                is_dir: false,
+            },
+        ];
+
+        let err =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        assert!(
+            matches!(err, DodotError::PreprocessorCollision { .. }),
+            "expected PreprocessorCollision for inter-preprocessor clash, got: {err}"
+        );
+    }
+
+    #[test]
+    fn datastore_preserves_directory_structure() {
+        // Preprocessor files in subdirectories should land in matching
+        // subdirectories under the datastore, not be flattened with `__`.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("sub/config.toml.identity", "nested")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "sub/config.toml.identity".into(),
+            absolute_path: env.dotfiles_root.join("app/sub/config.toml.identity"),
+            is_dir: false,
+        }];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert_eq!(result.virtual_entries.len(), 1);
+        let datastore_path = &result.virtual_entries[0].absolute_path;
+
+        // The datastore path should contain the subdirectory structure, not flattened
+        let ds_str = datastore_path.to_string_lossy();
+        assert!(
+            ds_str.contains("sub/config.toml"),
+            "datastore path should preserve directory structure, got: {ds_str}"
+        );
+        assert!(
+            !ds_str.contains("__"),
+            "datastore path should not contain flattening separator, got: {ds_str}"
+        );
+
+        // File should actually exist at that path
+        assert!(env.fs.exists(datastore_path));
+        let content = env.fs.read_to_string(datastore_path).unwrap();
+        assert_eq!(content, "nested");
+    }
+
+    #[test]
+    fn datastore_distinguishes_sibling_from_flattened_name() {
+        // Regression test for the flatten-with-`__` edge case: a user could
+        // have `a/b.txt` and `a__b.txt` both as preprocessor outputs, which
+        // would have collided under the old flattening scheme. With
+        // directory-preserving storage they live in distinct datastore paths.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("a/b.txt.identity", "nested")
+            .file("a__b.txt.identity", "flat")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![
+            PackEntry {
+                relative_path: "a/b.txt.identity".into(),
+                absolute_path: env.dotfiles_root.join("app/a/b.txt.identity"),
+                is_dir: false,
+            },
+            PackEntry {
+                relative_path: "a__b.txt.identity".into(),
+                absolute_path: env.dotfiles_root.join("app/a__b.txt.identity"),
+                is_dir: false,
+            },
+        ];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert_eq!(result.virtual_entries.len(), 2);
+
+        // Both files must exist with distinct content
+        let nested = result
+            .virtual_entries
+            .iter()
+            .find(|e| e.relative_path == std::path::Path::new("a/b.txt"))
+            .expect("nested entry");
+        let flat = result
+            .virtual_entries
+            .iter()
+            .find(|e| e.relative_path == std::path::Path::new("a__b.txt"))
+            .expect("flat entry");
+
+        assert_ne!(nested.absolute_path, flat.absolute_path);
+        assert_eq!(
+            env.fs.read_to_string(&nested.absolute_path).unwrap(),
+            "nested"
+        );
+        assert_eq!(env.fs.read_to_string(&flat.absolute_path).unwrap(), "flat");
     }
 }

--- a/crates/dodot-lib/src/preprocessing/pipeline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline.rs
@@ -6,7 +6,7 @@
 //! and produces virtual entries for the handler pipeline.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
 use tracing::{debug, info};
 
@@ -16,6 +16,31 @@ use crate::packs::Pack;
 use crate::preprocessing::PreprocessorRegistry;
 use crate::rules::PackEntry;
 use crate::{DodotError, Result};
+
+/// Validate that a preprocessor-produced path is safe to materialise in
+/// the datastore: relative, no root/prefix/parent-dir components.
+///
+/// Malicious or malformed preprocessor output (tar-slip, absolute paths,
+/// `..` segments) can escape the pack namespace and overwrite arbitrary
+/// files. We reject such paths before any disk write.
+fn validate_safe_relative_path(path: &Path, preprocessor: &str, source_file: &Path) -> Result<()> {
+    for component in path.components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(DodotError::PreprocessorError {
+                    preprocessor: preprocessor.into(),
+                    source_file: source_file.to_path_buf(),
+                    message: format!(
+                        "unsafe path in preprocessor output: {} (absolute or contains `..`)",
+                        path.display()
+                    ),
+                });
+            }
+        }
+    }
+    Ok(())
+}
 
 /// The result of preprocessing a pack's file entries.
 #[derive(Debug)]
@@ -134,11 +159,19 @@ pub fn preprocess_pack(
         let expanded_files = preprocessor.expand(&entry.absolute_path, fs)?;
 
         for expanded in expanded_files {
+            // Reject unsafe paths from the preprocessor (tar-slip,
+            // absolute paths, parent-dir escapes) before any disk write.
+            validate_safe_relative_path(
+                &expanded.relative_path,
+                preprocessor.name(),
+                &entry.absolute_path,
+            )?;
+
             // Compute the virtual relative path.
             // If the source was in a subdirectory (e.g., "subdir/config.toml.identity"),
             // the virtual entry should preserve the parent (e.g., "subdir/config.toml").
             let virtual_relative = if let Some(parent) = entry.relative_path.parent() {
-                if parent == std::path::Path::new("") {
+                if parent == Path::new("") {
                     expanded.relative_path.clone()
                 } else {
                     parent.join(&expanded.relative_path)
@@ -146,6 +179,14 @@ pub fn preprocess_pack(
             } else {
                 expanded.relative_path.clone()
             };
+
+            // Defense-in-depth: validate the joined path too (parent
+            // could only come from the pack scanner, but re-check).
+            validate_safe_relative_path(
+                &virtual_relative,
+                preprocessor.name(),
+                &entry.absolute_path,
+            )?;
 
             // Phase 4: Collision check (against both regular entries and
             // previously-expanded virtual entries)
@@ -158,20 +199,30 @@ pub fn preprocess_pack(
             }
 
             // Write expanded content to datastore, preserving directory
-            // structure. `write_rendered_file` creates any needed parent
-            // directories under the handler data dir.
-            let datastore_path = datastore.write_rendered_file(
-                &pack.name,
-                PREPROCESSED_HANDLER,
-                &virtual_relative.to_string_lossy(),
-                &expanded.content,
-            )?;
+            // structure. Directories get mkdir'd; files get their content
+            // written. `write_rendered_file` creates any needed parent
+            // directories.
+            let datastore_path = if expanded.is_dir {
+                datastore.write_rendered_dir(
+                    &pack.name,
+                    PREPROCESSED_HANDLER,
+                    &virtual_relative.to_string_lossy(),
+                )?
+            } else {
+                datastore.write_rendered_file(
+                    &pack.name,
+                    PREPROCESSED_HANDLER,
+                    &virtual_relative.to_string_lossy(),
+                    &expanded.content,
+                )?
+            };
 
             debug!(
                 pack = %pack.name,
                 virtual_path = %virtual_relative.display(),
                 datastore_path = %datastore_path.display(),
-                "wrote expanded file"
+                is_dir = expanded.is_dir,
+                "wrote expanded entry"
             );
 
             claimed_paths.insert(virtual_relative.clone());
@@ -818,5 +869,181 @@ mod tests {
             "nested"
         );
         assert_eq!(env.fs.read_to_string(&flat.absolute_path).unwrap(), "flat");
+    }
+
+    // ── Path-traversal defenses ─────────────────────────────────
+
+    /// Test-only preprocessor that emits a configurable set of
+    /// [`crate::preprocessing::ExpandedFile`]s — lets tests inject
+    /// unsafe paths or directory entries without needing a real archive.
+    struct ScriptedPreprocessor {
+        name: &'static str,
+        extension: &'static str,
+        outputs: Vec<crate::preprocessing::ExpandedFile>,
+    }
+
+    impl crate::preprocessing::Preprocessor for ScriptedPreprocessor {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn transform_type(&self) -> crate::preprocessing::TransformType {
+            crate::preprocessing::TransformType::Opaque
+        }
+        fn matches_extension(&self, filename: &str) -> bool {
+            filename.ends_with(self.extension)
+        }
+        fn stripped_name(&self, filename: &str) -> String {
+            filename
+                .strip_suffix(self.extension)
+                .unwrap_or(filename)
+                .to_string()
+        }
+        fn expand(
+            &self,
+            _source: &Path,
+            _fs: &dyn Fs,
+        ) -> Result<Vec<crate::preprocessing::ExpandedFile>> {
+            Ok(self.outputs.clone())
+        }
+    }
+
+    #[test]
+    fn rejects_absolute_path_from_preprocessor() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("bad.evil", "x")
+            .done()
+            .build();
+
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(ScriptedPreprocessor {
+            name: "evil",
+            extension: ".evil",
+            outputs: vec![crate::preprocessing::ExpandedFile {
+                relative_path: PathBuf::from("/etc/passwd"),
+                content: b"pwn".to_vec(),
+                is_dir: false,
+            }],
+        }));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "bad.evil".into(),
+            absolute_path: env.dotfiles_root.join("app/bad.evil"),
+            is_dir: false,
+        }];
+
+        let err =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        assert!(
+            matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("unsafe path")),
+            "expected unsafe-path error, got: {err}"
+        );
+        // Verify the malicious target was not written
+        assert!(!std::path::Path::new("/etc/passwd.dodot-would-have-written-here").exists());
+    }
+
+    #[test]
+    fn rejects_parent_dir_escape_from_preprocessor() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("bad.evil", "x")
+            .done()
+            .build();
+
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(ScriptedPreprocessor {
+            name: "evil",
+            extension: ".evil",
+            outputs: vec![crate::preprocessing::ExpandedFile {
+                relative_path: PathBuf::from("../../escape.txt"),
+                content: b"pwn".to_vec(),
+                is_dir: false,
+            }],
+        }));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "bad.evil".into(),
+            absolute_path: env.dotfiles_root.join("app/bad.evil"),
+            is_dir: false,
+        }];
+
+        let err =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        assert!(
+            matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("unsafe path")),
+            "expected unsafe-path error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn directory_entry_is_mkdird_not_written_as_file() {
+        // A preprocessor emits a directory marker followed by a file
+        // inside it. The pipeline must mkdir the directory rather than
+        // writing a file at the directory path (which would break the
+        // subsequent nested file write).
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("bundle.zz", "x")
+            .done()
+            .build();
+
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(ScriptedPreprocessor {
+            name: "scripted",
+            extension: ".zz",
+            outputs: vec![
+                crate::preprocessing::ExpandedFile {
+                    relative_path: PathBuf::from("sub"),
+                    content: Vec::new(),
+                    is_dir: true,
+                },
+                crate::preprocessing::ExpandedFile {
+                    relative_path: PathBuf::from("sub/nested.txt"),
+                    content: b"hello".to_vec(),
+                    is_dir: false,
+                },
+            ],
+        }));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "bundle.zz".into(),
+            absolute_path: env.dotfiles_root.join("app/bundle.zz"),
+            is_dir: false,
+        }];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert_eq!(result.virtual_entries.len(), 2);
+
+        let dir_entry = result
+            .virtual_entries
+            .iter()
+            .find(|e| e.is_dir)
+            .expect("directory entry");
+        assert!(
+            env.fs.is_dir(&dir_entry.absolute_path),
+            "directory entry should be a real directory: {}",
+            dir_entry.absolute_path.display()
+        );
+
+        let file_entry = result
+            .virtual_entries
+            .iter()
+            .find(|e| !e.is_dir)
+            .expect("file entry");
+        assert_eq!(
+            env.fs.read_to_string(&file_entry.absolute_path).unwrap(),
+            "hello"
+        );
     }
 }

--- a/crates/dodot-lib/src/preprocessing/pipeline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline.rs
@@ -1,0 +1,676 @@
+//! Preprocessing pipeline — partitions, expands, and merges entries.
+//!
+//! This module contains the core pipeline function that runs between
+//! directory walking and rule matching. It identifies preprocessor files,
+//! expands them, writes results to the datastore, checks for collisions,
+//! and produces virtual entries for the handler pipeline.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use tracing::{debug, info};
+
+use crate::datastore::DataStore;
+use crate::fs::Fs;
+use crate::packs::Pack;
+use crate::preprocessing::PreprocessorRegistry;
+use crate::rules::PackEntry;
+use crate::{DodotError, Result};
+
+/// The result of preprocessing a pack's file entries.
+#[derive(Debug)]
+pub struct PreprocessResult {
+    /// Entries that were NOT preprocessed (pass through unchanged).
+    pub regular_entries: Vec<PackEntry>,
+    /// Virtual entries created by preprocessing (point to datastore files).
+    pub virtual_entries: Vec<PackEntry>,
+    /// Maps virtual entry absolute_path → original source path in pack.
+    pub source_map: HashMap<PathBuf, PathBuf>,
+}
+
+impl PreprocessResult {
+    /// Create a passthrough result where all entries are regular (no preprocessing).
+    pub fn passthrough(entries: Vec<PackEntry>) -> Self {
+        Self {
+            regular_entries: entries,
+            virtual_entries: Vec::new(),
+            source_map: HashMap::new(),
+        }
+    }
+
+    /// Return all entries (regular + virtual) merged into one list, sorted by relative path.
+    pub fn merged_entries(&self) -> Vec<PackEntry> {
+        let mut all = Vec::with_capacity(self.regular_entries.len() + self.virtual_entries.len());
+        all.extend(self.regular_entries.iter().cloned());
+        all.extend(self.virtual_entries.iter().cloned());
+        all.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+        all
+    }
+}
+
+/// The handler name used for preprocessor-expanded files in the datastore.
+const PREPROCESSED_HANDLER: &str = "preprocessed";
+
+/// Run the preprocessing pipeline for a pack's file entries.
+///
+/// 1. Partition entries into preprocessor files vs regular files.
+/// 2. For each preprocessor file: expand, write results to datastore.
+/// 3. Create virtual PackEntries pointing to the datastore files.
+/// 4. Check for collisions between virtual and regular entries.
+/// 5. Return the result for merging into the handler pipeline.
+pub fn preprocess_pack(
+    entries: Vec<PackEntry>,
+    registry: &PreprocessorRegistry,
+    pack: &Pack,
+    fs: &dyn Fs,
+    datastore: &dyn DataStore,
+) -> Result<PreprocessResult> {
+    let mut regular_entries = Vec::new();
+    let mut preprocessor_entries = Vec::new();
+
+    // Phase 1: Partition
+    for entry in entries {
+        let filename = entry
+            .relative_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        if !entry.is_dir && registry.is_preprocessor_file(&filename) {
+            preprocessor_entries.push(entry);
+        } else {
+            regular_entries.push(entry);
+        }
+    }
+
+    debug!(
+        pack = %pack.name,
+        preprocessor = preprocessor_entries.len(),
+        regular = regular_entries.len(),
+        "partitioned entries"
+    );
+
+    if preprocessor_entries.is_empty() {
+        return Ok(PreprocessResult {
+            regular_entries,
+            virtual_entries: Vec::new(),
+            source_map: HashMap::new(),
+        });
+    }
+
+    // Phase 2 & 3: Expand and create virtual entries
+    let mut virtual_entries = Vec::new();
+    let mut source_map = HashMap::new();
+
+    // Build a set of regular entry relative paths for collision detection
+    let regular_paths: std::collections::HashSet<PathBuf> = regular_entries
+        .iter()
+        .map(|e| e.relative_path.clone())
+        .collect();
+
+    for entry in &preprocessor_entries {
+        let filename = entry
+            .relative_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        let preprocessor = registry
+            .find_for_file(&filename)
+            .expect("already checked in partition");
+
+        info!(
+            pack = %pack.name,
+            preprocessor = preprocessor.name(),
+            file = %filename,
+            "expanding"
+        );
+
+        // Expand the source file
+        let expanded_files = preprocessor.expand(&entry.absolute_path, fs)?;
+
+        for expanded in expanded_files {
+            // Compute the virtual relative path.
+            // If the source was in a subdirectory (e.g., "subdir/config.toml.identity"),
+            // the virtual entry should preserve the parent (e.g., "subdir/config.toml").
+            let virtual_relative = if let Some(parent) = entry.relative_path.parent() {
+                if parent == std::path::Path::new("") {
+                    expanded.relative_path.clone()
+                } else {
+                    parent.join(&expanded.relative_path)
+                }
+            } else {
+                expanded.relative_path.clone()
+            };
+
+            // Phase 4: Collision check
+            if regular_paths.contains(&virtual_relative) {
+                return Err(DodotError::PreprocessorCollision {
+                    pack: pack.name.clone(),
+                    source_file: filename.clone(),
+                    expanded_name: virtual_relative.to_string_lossy().into_owned(),
+                });
+            }
+
+            // Write expanded content to datastore
+            let expanded_filename = virtual_relative.to_string_lossy().replace('/', "__");
+            let datastore_path = datastore.write_rendered_file(
+                &pack.name,
+                PREPROCESSED_HANDLER,
+                &expanded_filename,
+                &expanded.content,
+            )?;
+
+            debug!(
+                pack = %pack.name,
+                virtual_path = %virtual_relative.display(),
+                datastore_path = %datastore_path.display(),
+                "wrote expanded file"
+            );
+
+            source_map.insert(datastore_path.clone(), entry.absolute_path.clone());
+
+            virtual_entries.push(PackEntry {
+                relative_path: virtual_relative,
+                absolute_path: datastore_path,
+                is_dir: expanded.is_dir,
+            });
+        }
+    }
+
+    info!(
+        pack = %pack.name,
+        virtual_count = virtual_entries.len(),
+        "preprocessing complete"
+    );
+
+    Ok(PreprocessResult {
+        regular_entries,
+        virtual_entries,
+        source_map,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datastore::FilesystemDataStore;
+    use crate::handlers::HandlerConfig;
+    use crate::preprocessing::identity::IdentityPreprocessor;
+    use crate::testing::TempEnvironment;
+    use std::sync::Arc;
+
+    fn make_pack(name: &str, path: PathBuf) -> Pack {
+        Pack {
+            name: name.into(),
+            path,
+            config: HandlerConfig::default(),
+        }
+    }
+
+    fn make_registry() -> PreprocessorRegistry {
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(IdentityPreprocessor::new()));
+        registry
+    }
+
+    fn make_datastore(env: &TempEnvironment) -> FilesystemDataStore {
+        let runner = Arc::new(crate::datastore::ShellCommandRunner);
+        FilesystemDataStore::new(env.fs.clone(), env.paths.clone(), runner)
+    }
+
+    #[test]
+    fn passthrough_when_no_preprocessor_files() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("vimrc", "set nocompatible")
+            .file("gvimrc", "set guifont=Mono")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("vim", env.dotfiles_root.join("vim"));
+
+        let entries = vec![
+            PackEntry {
+                relative_path: "vimrc".into(),
+                absolute_path: env.dotfiles_root.join("vim/vimrc"),
+                is_dir: false,
+            },
+            PackEntry {
+                relative_path: "gvimrc".into(),
+                absolute_path: env.dotfiles_root.join("vim/gvimrc"),
+                is_dir: false,
+            },
+        ];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert_eq!(result.regular_entries.len(), 2);
+        assert!(result.virtual_entries.is_empty());
+        assert!(result.source_map.is_empty());
+    }
+
+    #[test]
+    fn identity_preprocessor_creates_virtual_entry() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "host = localhost")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "config.toml.identity".into(),
+            absolute_path: env.dotfiles_root.join("app/config.toml.identity"),
+            is_dir: false,
+        }];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert!(result.regular_entries.is_empty());
+        assert_eq!(result.virtual_entries.len(), 1);
+
+        let virtual_entry = &result.virtual_entries[0];
+        assert_eq!(virtual_entry.relative_path, PathBuf::from("config.toml"));
+        assert!(!virtual_entry.is_dir);
+
+        // Verify the file was written to the datastore
+        let content = env.fs.read_to_string(&virtual_entry.absolute_path).unwrap();
+        assert_eq!(content, "host = localhost");
+
+        // Verify source map
+        assert_eq!(
+            result.source_map[&virtual_entry.absolute_path],
+            env.dotfiles_root.join("app/config.toml.identity")
+        );
+    }
+
+    #[test]
+    fn mixed_pack_partitions_correctly() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "host = localhost")
+            .file("readme.txt", "hello")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![
+            PackEntry {
+                relative_path: "config.toml.identity".into(),
+                absolute_path: env.dotfiles_root.join("app/config.toml.identity"),
+                is_dir: false,
+            },
+            PackEntry {
+                relative_path: "readme.txt".into(),
+                absolute_path: env.dotfiles_root.join("app/readme.txt"),
+                is_dir: false,
+            },
+        ];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert_eq!(result.regular_entries.len(), 1);
+        assert_eq!(
+            result.regular_entries[0].relative_path,
+            PathBuf::from("readme.txt")
+        );
+
+        assert_eq!(result.virtual_entries.len(), 1);
+        assert_eq!(
+            result.virtual_entries[0].relative_path,
+            PathBuf::from("config.toml")
+        );
+    }
+
+    #[test]
+    fn collision_detection_rejects_conflict() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "preprocessed")
+            .file("config.toml", "regular")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![
+            PackEntry {
+                relative_path: "config.toml.identity".into(),
+                absolute_path: env.dotfiles_root.join("app/config.toml.identity"),
+                is_dir: false,
+            },
+            PackEntry {
+                relative_path: "config.toml".into(),
+                absolute_path: env.dotfiles_root.join("app/config.toml"),
+                is_dir: false,
+            },
+        ];
+
+        let err =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        assert!(
+            matches!(err, DodotError::PreprocessorCollision { .. }),
+            "expected PreprocessorCollision, got: {err}"
+        );
+    }
+
+    #[test]
+    fn merged_entries_combines_and_sorts() {
+        let result = PreprocessResult {
+            regular_entries: vec![PackEntry {
+                relative_path: "zebra".into(),
+                absolute_path: "/z".into(),
+                is_dir: false,
+            }],
+            virtual_entries: vec![PackEntry {
+                relative_path: "alpha".into(),
+                absolute_path: "/a".into(),
+                is_dir: false,
+            }],
+            source_map: HashMap::new(),
+        };
+
+        let merged = result.merged_entries();
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].relative_path, PathBuf::from("alpha"));
+        assert_eq!(merged[1].relative_path, PathBuf::from("zebra"));
+    }
+
+    #[test]
+    fn empty_registry_passes_all_through() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "content")
+            .done()
+            .build();
+
+        let registry = PreprocessorRegistry::new(); // empty!
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "config.toml.identity".into(),
+            absolute_path: env.dotfiles_root.join("app/config.toml.identity"),
+            is_dir: false,
+        }];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        // With no preprocessors registered, the file is treated as regular
+        assert_eq!(result.regular_entries.len(), 1);
+        assert!(result.virtual_entries.is_empty());
+    }
+
+    #[test]
+    fn directories_are_never_preprocessed() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("bin.identity/tool", "#!/bin/sh")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "bin.identity".into(),
+            absolute_path: env.dotfiles_root.join("app/bin.identity"),
+            is_dir: true, // directory — should NOT be preprocessed
+        }];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert_eq!(result.regular_entries.len(), 1);
+        assert!(result.virtual_entries.is_empty());
+    }
+
+    #[test]
+    fn subdirectory_preprocessor_file_preserves_parent() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("subdir/config.toml.identity", "nested content")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "subdir/config.toml.identity".into(),
+            absolute_path: env.dotfiles_root.join("app/subdir/config.toml.identity"),
+            is_dir: false,
+        }];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert_eq!(result.virtual_entries.len(), 1);
+        assert_eq!(
+            result.virtual_entries[0].relative_path,
+            PathBuf::from("subdir/config.toml")
+        );
+    }
+
+    #[test]
+    fn multiple_preprocessor_files_in_one_pack() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "config content")
+            .file("settings.json.identity", "settings content")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![
+            PackEntry {
+                relative_path: "config.toml.identity".into(),
+                absolute_path: env.dotfiles_root.join("app/config.toml.identity"),
+                is_dir: false,
+            },
+            PackEntry {
+                relative_path: "settings.json.identity".into(),
+                absolute_path: env.dotfiles_root.join("app/settings.json.identity"),
+                is_dir: false,
+            },
+        ];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert!(result.regular_entries.is_empty());
+        assert_eq!(result.virtual_entries.len(), 2);
+
+        let names: Vec<String> = result
+            .virtual_entries
+            .iter()
+            .map(|e| e.relative_path.to_string_lossy().to_string())
+            .collect();
+        assert!(names.contains(&"config.toml".to_string()));
+        assert!(names.contains(&"settings.json".to_string()));
+
+        // Each should have a source_map entry
+        assert_eq!(result.source_map.len(), 2);
+    }
+
+    #[test]
+    fn pack_with_only_preprocessor_files() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("only.conf.identity", "the only file")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "only.conf.identity".into(),
+            absolute_path: env.dotfiles_root.join("app/only.conf.identity"),
+            is_dir: false,
+        }];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert!(result.regular_entries.is_empty());
+        assert_eq!(result.virtual_entries.len(), 1);
+        assert_eq!(result.merged_entries().len(), 1);
+    }
+
+    #[test]
+    fn source_map_is_complete() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("a.conf.identity", "aaa")
+            .file("b.conf.identity", "bbb")
+            .file("regular.txt", "ccc")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![
+            PackEntry {
+                relative_path: "a.conf.identity".into(),
+                absolute_path: env.dotfiles_root.join("app/a.conf.identity"),
+                is_dir: false,
+            },
+            PackEntry {
+                relative_path: "b.conf.identity".into(),
+                absolute_path: env.dotfiles_root.join("app/b.conf.identity"),
+                is_dir: false,
+            },
+            PackEntry {
+                relative_path: "regular.txt".into(),
+                absolute_path: env.dotfiles_root.join("app/regular.txt"),
+                is_dir: false,
+            },
+        ];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        // Every virtual entry must have a source_map entry
+        for ve in &result.virtual_entries {
+            assert!(
+                result.source_map.contains_key(&ve.absolute_path),
+                "virtual entry {} has no source_map entry",
+                ve.absolute_path.display()
+            );
+        }
+        // No regular entries in the source_map
+        for re in &result.regular_entries {
+            assert!(
+                !result.source_map.contains_key(&re.absolute_path),
+                "regular entry {} should not be in source_map",
+                re.absolute_path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn preprocessing_is_idempotent() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "content")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let make_entries = || {
+            vec![PackEntry {
+                relative_path: "config.toml.identity".into(),
+                absolute_path: env.dotfiles_root.join("app/config.toml.identity"),
+                is_dir: false,
+            }]
+        };
+
+        let result1 = preprocess_pack(
+            make_entries(),
+            &registry,
+            &pack,
+            env.fs.as_ref(),
+            &datastore,
+        )
+        .unwrap();
+        let result2 = preprocess_pack(
+            make_entries(),
+            &registry,
+            &pack,
+            env.fs.as_ref(),
+            &datastore,
+        )
+        .unwrap();
+
+        assert_eq!(result1.virtual_entries.len(), result2.virtual_entries.len());
+        assert_eq!(
+            result1.virtual_entries[0].relative_path,
+            result2.virtual_entries[0].relative_path
+        );
+
+        // Datastore file should be the same content
+        let content1 = env
+            .fs
+            .read_to_string(&result1.virtual_entries[0].absolute_path)
+            .unwrap();
+        let content2 = env
+            .fs
+            .read_to_string(&result2.virtual_entries[0].absolute_path)
+            .unwrap();
+        assert_eq!(content1, content2);
+    }
+
+    #[test]
+    fn expansion_error_propagates() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("placeholder", "")
+            .done()
+            .build();
+
+        let registry = make_registry();
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        // Point to a file that doesn't exist — expansion should fail
+        let entries = vec![PackEntry {
+            relative_path: "missing.conf.identity".into(),
+            absolute_path: env.dotfiles_root.join("app/missing.conf.identity"),
+            is_dir: false,
+        }];
+
+        let err =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        assert!(
+            matches!(err, DodotError::Fs { .. }),
+            "expected Fs error for missing file, got: {err}"
+        );
+    }
+}

--- a/crates/dodot-lib/src/preprocessing/unarchive.rs
+++ b/crates/dodot-lib/src/preprocessing/unarchive.rs
@@ -1,0 +1,343 @@
+//! Unarchive preprocessor — extracts tar.gz archives.
+//!
+//! Matches files with `.tar.gz` extension and extracts their contents.
+//! Each file in the archive becomes an [`ExpandedFile`].
+//!
+//! This is an Opaque transformation: there is no reverse path
+//! (you cannot re-archive deployed files back into the source).
+
+use std::io::Read;
+use std::path::Path;
+
+use crate::fs::Fs;
+use crate::preprocessing::{ExpandedFile, Preprocessor, TransformType};
+use crate::{DodotError, Result};
+
+/// A preprocessor that extracts `.tar.gz` archives.
+pub struct UnarchivePreprocessor;
+
+impl UnarchivePreprocessor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for UnarchivePreprocessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Preprocessor for UnarchivePreprocessor {
+    fn name(&self) -> &str {
+        "unarchive"
+    }
+
+    fn transform_type(&self) -> TransformType {
+        TransformType::Opaque
+    }
+
+    fn matches_extension(&self, filename: &str) -> bool {
+        filename.ends_with(".tar.gz")
+    }
+
+    fn stripped_name(&self, filename: &str) -> String {
+        filename
+            .strip_suffix(".tar.gz")
+            .unwrap_or(filename)
+            .to_string()
+    }
+
+    fn expand(&self, source: &Path, fs: &dyn Fs) -> Result<Vec<ExpandedFile>> {
+        let reader = fs.open_read(source)?;
+        let gz = flate2::read::GzDecoder::new(reader);
+        let mut archive = tar::Archive::new(gz);
+
+        let mut expanded = Vec::new();
+
+        let entries = archive
+            .entries()
+            .map_err(|e| DodotError::PreprocessorError {
+                preprocessor: "unarchive".into(),
+                source_file: source.to_path_buf(),
+                message: format!("failed to read archive entries: {e}"),
+            })?;
+
+        for entry_result in entries {
+            let mut entry = entry_result.map_err(|e| DodotError::PreprocessorError {
+                preprocessor: "unarchive".into(),
+                source_file: source.to_path_buf(),
+                message: format!("failed to read archive entry: {e}"),
+            })?;
+
+            let entry_path = entry
+                .path()
+                .map_err(|e| DodotError::PreprocessorError {
+                    preprocessor: "unarchive".into(),
+                    source_file: source.to_path_buf(),
+                    message: format!("invalid path in archive: {e}"),
+                })?
+                .into_owned();
+
+            let is_dir = entry.header().entry_type().is_dir();
+
+            if is_dir {
+                expanded.push(ExpandedFile {
+                    relative_path: entry_path,
+                    content: Vec::new(),
+                    is_dir: true,
+                });
+            } else {
+                let mut content = Vec::new();
+                entry
+                    .read_to_end(&mut content)
+                    .map_err(|e| DodotError::PreprocessorError {
+                        preprocessor: "unarchive".into(),
+                        source_file: source.to_path_buf(),
+                        message: format!("failed to read entry content: {e}"),
+                    })?;
+
+                expanded.push(ExpandedFile {
+                    relative_path: entry_path,
+                    content,
+                    is_dir: false,
+                });
+            }
+        }
+
+        Ok(expanded)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_tar_gz_extension() {
+        let pp = UnarchivePreprocessor::new();
+        assert!(pp.matches_extension("bin.tar.gz"));
+        assert!(pp.matches_extension("tools.tar.gz"));
+        assert!(!pp.matches_extension("file.tar"));
+        assert!(!pp.matches_extension("file.gz"));
+        assert!(!pp.matches_extension("file.zip"));
+        assert!(!pp.matches_extension("tar.gz")); // no base name before extension? still matches
+    }
+
+    #[test]
+    fn stripped_name_removes_extension() {
+        let pp = UnarchivePreprocessor::new();
+        assert_eq!(pp.stripped_name("bin.tar.gz"), "bin");
+        assert_eq!(pp.stripped_name("my-tools.tar.gz"), "my-tools");
+        assert_eq!(pp.stripped_name("nested.dir.tar.gz"), "nested.dir");
+    }
+
+    #[test]
+    fn trait_properties() {
+        let pp = UnarchivePreprocessor::new();
+        assert_eq!(pp.name(), "unarchive");
+        assert_eq!(pp.transform_type(), TransformType::Opaque);
+    }
+
+    #[test]
+    fn expand_extracts_tar_gz() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("tools")
+            .file("placeholder", "")
+            .done()
+            .build();
+
+        // Create a tar.gz archive programmatically
+        let archive_path = env.dotfiles_root.join("tools/bin.tar.gz");
+        let file = std::fs::File::create(&archive_path).unwrap();
+        let enc = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(enc);
+
+        // Add a file to the archive
+        let content = b"#!/bin/sh\necho hello";
+        let mut header = tar::Header::new_gnu();
+        header.set_path("mytool").unwrap();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder.append(&header, &content[..]).unwrap();
+
+        // Add another file
+        let content2 = b"#!/bin/sh\necho world";
+        let mut header2 = tar::Header::new_gnu();
+        header2.set_path("other-tool").unwrap();
+        header2.set_size(content2.len() as u64);
+        header2.set_mode(0o755);
+        header2.set_cksum();
+        builder.append(&header2, &content2[..]).unwrap();
+
+        let enc = builder.into_inner().unwrap();
+        enc.finish().unwrap();
+
+        // Now expand it
+        let pp = UnarchivePreprocessor::new();
+        let result = pp.expand(&archive_path, env.fs.as_ref()).unwrap();
+
+        assert_eq!(result.len(), 2);
+
+        let names: Vec<String> = result
+            .iter()
+            .map(|f| f.relative_path.to_string_lossy().to_string())
+            .collect();
+        assert!(names.contains(&"mytool".to_string()));
+        assert!(names.contains(&"other-tool".to_string()));
+
+        let mytool = result
+            .iter()
+            .find(|f| f.relative_path.to_str() == Some("mytool"))
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&mytool.content),
+            "#!/bin/sh\necho hello"
+        );
+        assert!(!mytool.is_dir);
+    }
+
+    #[test]
+    fn expand_tar_gz_with_directory() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("tools")
+            .file("placeholder", "")
+            .done()
+            .build();
+
+        let archive_path = env.dotfiles_root.join("tools/stuff.tar.gz");
+        let file = std::fs::File::create(&archive_path).unwrap();
+        let enc = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(enc);
+
+        // Add a directory entry
+        let mut dir_header = tar::Header::new_gnu();
+        dir_header.set_path("subdir/").unwrap();
+        dir_header.set_size(0);
+        dir_header.set_entry_type(tar::EntryType::Directory);
+        dir_header.set_mode(0o755);
+        dir_header.set_cksum();
+        builder.append(&dir_header, &[][..]).unwrap();
+
+        // Add a file inside the directory
+        let content = b"nested file";
+        let mut file_header = tar::Header::new_gnu();
+        file_header.set_path("subdir/nested.txt").unwrap();
+        file_header.set_size(content.len() as u64);
+        file_header.set_mode(0o644);
+        file_header.set_cksum();
+        builder.append(&file_header, &content[..]).unwrap();
+
+        let enc = builder.into_inner().unwrap();
+        enc.finish().unwrap();
+
+        let pp = UnarchivePreprocessor::new();
+        let result = pp.expand(&archive_path, env.fs.as_ref()).unwrap();
+
+        assert_eq!(result.len(), 2);
+
+        let dir_entry = result
+            .iter()
+            .find(|f| f.relative_path.to_str() == Some("subdir/"))
+            .expect("should have directory entry");
+        assert!(dir_entry.is_dir);
+
+        let file_entry = result
+            .iter()
+            .find(|f| f.relative_path.to_str() == Some("subdir/nested.txt"))
+            .expect("should have nested file");
+        assert!(!file_entry.is_dir);
+        assert_eq!(String::from_utf8_lossy(&file_entry.content), "nested file");
+    }
+
+    #[test]
+    fn expand_empty_tar_gz() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("tools")
+            .file("placeholder", "")
+            .done()
+            .build();
+
+        let archive_path = env.dotfiles_root.join("tools/empty.tar.gz");
+        let file = std::fs::File::create(&archive_path).unwrap();
+        let enc = GzEncoder::new(file, Compression::default());
+        let builder = tar::Builder::new(enc);
+        let enc = builder.into_inner().unwrap();
+        enc.finish().unwrap();
+
+        let pp = UnarchivePreprocessor::new();
+        let result = pp.expand(&archive_path, env.fs.as_ref()).unwrap();
+
+        assert!(result.is_empty(), "empty archive should expand to no files");
+    }
+
+    #[test]
+    fn expand_single_file_tar_gz() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("tools")
+            .file("placeholder", "")
+            .done()
+            .build();
+
+        let archive_path = env.dotfiles_root.join("tools/one.tar.gz");
+        let file = std::fs::File::create(&archive_path).unwrap();
+        let enc = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(enc);
+
+        let content = b"single file";
+        let mut header = tar::Header::new_gnu();
+        header.set_path("only.txt").unwrap();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, &content[..]).unwrap();
+
+        let enc = builder.into_inner().unwrap();
+        enc.finish().unwrap();
+
+        let pp = UnarchivePreprocessor::new();
+        let result = pp.expand(&archive_path, env.fs.as_ref()).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].relative_path.to_str(), Some("only.txt"));
+    }
+
+    #[test]
+    fn expand_corrupted_archive_returns_error() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("tools")
+            .file("bad.tar.gz", "this is not a valid gzip stream")
+            .done()
+            .build();
+
+        let pp = UnarchivePreprocessor::new();
+        let source = env.dotfiles_root.join("tools/bad.tar.gz");
+        let err = pp.expand(&source, env.fs.as_ref());
+
+        assert!(err.is_err(), "corrupted archive should produce an error");
+    }
+
+    #[test]
+    fn expand_missing_file_returns_error() {
+        let env = crate::testing::TempEnvironment::builder().build();
+
+        let pp = UnarchivePreprocessor::new();
+        let source = env.dotfiles_root.join("nonexistent.tar.gz");
+        let err = pp.expand(&source, env.fs.as_ref());
+
+        assert!(err.is_err(), "missing archive should produce an error");
+    }
+}

--- a/crates/dodot-lib/src/preprocessing/unarchive.rs
+++ b/crates/dodot-lib/src/preprocessing/unarchive.rs
@@ -7,11 +7,26 @@
 //! (you cannot re-archive deployed files back into the source).
 
 use std::io::Read;
-use std::path::Path;
+use std::path::{Component, Path};
 
 use crate::fs::Fs;
 use crate::preprocessing::{ExpandedFile, Preprocessor, TransformType};
 use crate::{DodotError, Result};
+
+/// Reject tar entries whose path is absolute, contains `..`, or has a
+/// drive/root prefix. Without this check an archive could write outside
+/// the pack's datastore namespace (tar-slip).
+fn entry_path_is_safe(path: &Path) -> bool {
+    for component in path.components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return false;
+            }
+        }
+    }
+    true
+}
 
 /// A preprocessor that extracts `.tar.gz` archives.
 pub struct UnarchivePreprocessor;
@@ -79,15 +94,30 @@ impl Preprocessor for UnarchivePreprocessor {
                 })?
                 .into_owned();
 
-            let is_dir = entry.header().entry_type().is_dir();
+            // Tar-slip guard: reject absolute paths and `..` components.
+            if !entry_path_is_safe(&entry_path) {
+                return Err(DodotError::PreprocessorError {
+                    preprocessor: "unarchive".into(),
+                    source_file: source.to_path_buf(),
+                    message: format!(
+                        "unsafe entry path in archive: {} (absolute or contains `..`)",
+                        entry_path.display()
+                    ),
+                });
+            }
 
-            if is_dir {
+            // Only regular files and directories are allowed. Symlinks,
+            // hardlinks, devices, fifos, and other special entry types
+            // are rejected to avoid surprising behavior in a dotfile
+            // deployment tool.
+            let entry_type = entry.header().entry_type();
+            if entry_type.is_dir() {
                 expanded.push(ExpandedFile {
                     relative_path: entry_path,
                     content: Vec::new(),
                     is_dir: true,
                 });
-            } else {
+            } else if entry_type.is_file() {
                 let mut content = Vec::new();
                 entry
                     .read_to_end(&mut content)
@@ -101,6 +131,16 @@ impl Preprocessor for UnarchivePreprocessor {
                     relative_path: entry_path,
                     content,
                     is_dir: false,
+                });
+            } else {
+                return Err(DodotError::PreprocessorError {
+                    preprocessor: "unarchive".into(),
+                    source_file: source.to_path_buf(),
+                    message: format!(
+                        "unsupported tar entry type {:?} for {} (only regular files and directories are allowed)",
+                        entry_type,
+                        entry_path.display()
+                    ),
                 });
             }
         }
@@ -339,5 +379,144 @@ mod tests {
         let err = pp.expand(&source, env.fs.as_ref());
 
         assert!(err.is_err(), "missing archive should produce an error");
+    }
+
+    /// Build a tar.gz archive containing a single file with a raw
+    /// (potentially unsafe) path written directly into the header bytes.
+    /// The `tar` crate's safe APIs reject absolute paths and `..`, but
+    /// real-world attackers can craft arbitrary bytes — this helper
+    /// simulates that.
+    fn write_malicious_tar_gz(archive_path: &Path, raw_path: &[u8], content: &[u8]) {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        // Manually craft a ustar header (512 bytes) with the path written
+        // at offset 0 without any sanitisation.
+        let mut header = [0u8; 512];
+
+        // Name (bytes 0..100): raw_path, null-terminated
+        let name_len = raw_path.len().min(99);
+        header[..name_len].copy_from_slice(&raw_path[..name_len]);
+
+        // Mode (100..108): "0000644\0"
+        header[100..108].copy_from_slice(b"0000644\0");
+
+        // UID/GID (108..124): zeros (8 octal chars + null, twice)
+        header[108..116].copy_from_slice(b"0000000\0");
+        header[116..124].copy_from_slice(b"0000000\0");
+
+        // Size (124..136): octal-padded
+        let size_str = format!("{:011o}\0", content.len());
+        header[124..136].copy_from_slice(size_str.as_bytes());
+
+        // MTime (136..148)
+        header[136..148].copy_from_slice(b"00000000000\0");
+
+        // Checksum placeholder — 8 spaces while computing
+        header[148..156].copy_from_slice(b"        ");
+
+        // TypeFlag (156): '0' for regular file
+        header[156] = b'0';
+
+        // Magic (257..263): "ustar\0"
+        header[257..263].copy_from_slice(b"ustar\0");
+        // Version (263..265): "00"
+        header[263..265].copy_from_slice(b"00");
+
+        // Compute checksum: sum of all bytes in header
+        let checksum: u32 = header.iter().map(|b| *b as u32).sum();
+        let cksum_str = format!("{checksum:06o}\0 ");
+        header[148..156].copy_from_slice(cksum_str.as_bytes());
+
+        let file = std::fs::File::create(archive_path).unwrap();
+        let mut enc = GzEncoder::new(file, Compression::default());
+        enc.write_all(&header).unwrap();
+
+        // Write content padded to 512-byte boundary
+        enc.write_all(content).unwrap();
+        let pad = (512 - content.len() % 512) % 512;
+        if pad > 0 {
+            enc.write_all(&vec![0u8; pad]).unwrap();
+        }
+
+        // Tar EOF: two 512-byte zero blocks
+        enc.write_all(&[0u8; 1024]).unwrap();
+
+        enc.finish().unwrap();
+    }
+
+    #[test]
+    fn rejects_tar_slip_absolute_path() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("tools")
+            .file("placeholder", "")
+            .done()
+            .build();
+
+        let archive_path = env.dotfiles_root.join("tools/evil.tar.gz");
+        write_malicious_tar_gz(&archive_path, b"/etc/passwd", b"pwn");
+
+        let pp = UnarchivePreprocessor::new();
+        let err = pp.expand(&archive_path, env.fs.as_ref()).unwrap_err();
+        assert!(
+            matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("unsafe entry path")),
+            "expected unsafe-path error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_tar_slip_parent_dir() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("tools")
+            .file("placeholder", "")
+            .done()
+            .build();
+
+        let archive_path = env.dotfiles_root.join("tools/evil.tar.gz");
+        write_malicious_tar_gz(&archive_path, b"../../escape.txt", b"pwn");
+
+        let pp = UnarchivePreprocessor::new();
+        let err = pp.expand(&archive_path, env.fs.as_ref()).unwrap_err();
+        assert!(
+            matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("unsafe entry path")),
+            "expected unsafe-path error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_symlink_entry() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("tools")
+            .file("placeholder", "")
+            .done()
+            .build();
+
+        let archive_path = env.dotfiles_root.join("tools/syms.tar.gz");
+        let file = std::fs::File::create(&archive_path).unwrap();
+        let enc = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(enc);
+
+        let mut header = tar::Header::new_gnu();
+        header.set_path("link").unwrap();
+        header.set_size(0);
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_link_name("/etc/passwd").unwrap();
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, &[][..]).unwrap();
+
+        let enc = builder.into_inner().unwrap();
+        enc.finish().unwrap();
+
+        let pp = UnarchivePreprocessor::new();
+        let err = pp.expand(&archive_path, env.fs.as_ref()).unwrap_err();
+        assert!(
+            matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("unsupported tar entry type")),
+            "expected unsupported-entry-type error, got: {err}"
+        );
     }
 }

--- a/crates/dodot-lib/src/rules/mod.rs
+++ b/crates/dodot-lib/src/rules/mod.rs
@@ -34,6 +34,17 @@ pub struct Rule {
     pub options: HashMap<String, String>,
 }
 
+/// A raw file entry discovered during directory walking (before rule matching).
+#[derive(Debug, Clone)]
+pub struct PackEntry {
+    /// Path relative to the pack root (e.g. `"vimrc"`, `"nvim/init.lua"`).
+    pub relative_path: PathBuf,
+    /// Absolute path to the file.
+    pub absolute_path: PathBuf,
+    /// Whether this entry is a directory.
+    pub is_dir: bool,
+}
+
 /// A file that matched a rule during pack scanning.
 #[derive(Debug, Clone, Serialize)]
 pub struct RuleMatch {
@@ -55,6 +66,11 @@ pub struct RuleMatch {
     /// Handler-specific options from the matched rule.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub options: HashMap<String, String>,
+
+    /// If this file was produced by a preprocessor, the original source path.
+    /// `None` for regular (non-preprocessed) files.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preprocessor_source: Option<PathBuf>,
 }
 
 // ── Grouping helpers ────────────────────────────────────────────
@@ -196,42 +212,68 @@ impl<'a> Scanner<'a> {
     /// single entries). Skips hidden files (except `.config`), special
     /// files (`.dodot.toml`, `.dodotignore`), and files matching
     /// pack-level ignore patterns.
+    ///
+    /// This is a convenience wrapper over [`walk_pack`] + [`match_entries`].
     pub fn scan_pack(
         &self,
         pack: &Pack,
         rules: &[Rule],
         pack_ignore: &[String],
     ) -> Result<Vec<RuleMatch>> {
-        let compiled = compile_rules(rules);
         let entries = self.walk_pack(&pack.path, pack_ignore)?;
+        Ok(self.match_entries(&entries, rules, &pack.name))
+    }
+
+    /// Walk a pack directory and return raw file entries.
+    ///
+    /// Skips hidden files (except `.config`), special files
+    /// (`.dodot.toml`, `.dodotignore`), and files matching
+    /// pack-level ignore patterns.
+    pub fn walk_pack(
+        &self,
+        pack_path: &Path,
+        ignore_patterns: &[String],
+    ) -> Result<Vec<PackEntry>> {
+        let mut results = Vec::new();
+        self.walk_dir(pack_path, pack_path, ignore_patterns, &mut results)?;
+        Ok(results)
+    }
+
+    /// Match a list of entries against rules, returning rule matches.
+    ///
+    /// This is the second half of the scan pipeline: given raw entries
+    /// (from [`walk_pack`] or from preprocessing), match each against
+    /// the rule set to determine which handler processes it.
+    pub fn match_entries(
+        &self,
+        entries: &[PackEntry],
+        rules: &[Rule],
+        pack_name: &str,
+    ) -> Vec<RuleMatch> {
+        let compiled = compile_rules(rules);
         let mut matches = Vec::new();
 
-        for (rel_path, abs_path, is_dir) in entries {
-            let filename = rel_path
+        for entry in entries {
+            let filename = entry
+                .relative_path
                 .file_name()
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_default();
 
-            if let Some(rule_match) = self.match_file(
-                &compiled, &filename, is_dir, &rel_path, &abs_path, &pack.name,
+            if let Some(rule_match) = match_file(
+                &compiled,
+                &filename,
+                entry.is_dir,
+                &entry.relative_path,
+                &entry.absolute_path,
+                pack_name,
             ) {
                 matches.push(rule_match);
             }
         }
 
         matches.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
-        Ok(matches)
-    }
-
-    /// Walk pack directory, returning (relative_path, absolute_path, is_dir).
-    fn walk_pack(
-        &self,
-        pack_path: &Path,
-        ignore_patterns: &[String],
-    ) -> Result<Vec<(PathBuf, PathBuf, bool)>> {
-        let mut results = Vec::new();
-        self.walk_dir(pack_path, pack_path, ignore_patterns, &mut results)?;
-        Ok(results)
+        matches
     }
 
     fn walk_dir(
@@ -239,7 +281,7 @@ impl<'a> Scanner<'a> {
         base: &Path,
         dir: &Path,
         ignore_patterns: &[String],
-        results: &mut Vec<(PathBuf, PathBuf, bool)>,
+        results: &mut Vec<PackEntry>,
     ) -> Result<()> {
         let entries = self.fs.read_dir(dir)?;
 
@@ -269,58 +311,66 @@ impl<'a> Scanner<'a> {
 
             if entry.is_dir {
                 // Add directory itself as a candidate (for path handler)
-                results.push((rel_path.clone(), entry.path.clone(), true));
+                results.push(PackEntry {
+                    relative_path: rel_path.clone(),
+                    absolute_path: entry.path.clone(),
+                    is_dir: true,
+                });
                 // Recurse into subdirectories
                 self.walk_dir(base, &entry.path, ignore_patterns, results)?;
             } else {
-                results.push((rel_path, entry.path.clone(), false));
+                results.push(PackEntry {
+                    relative_path: rel_path,
+                    absolute_path: entry.path.clone(),
+                    is_dir: false,
+                });
             }
         }
 
         Ok(())
     }
+}
 
-    /// Match a single file against the compiled rules.
-    ///
-    /// 1. Check exclusion rules first — if any match, file is skipped.
-    /// 2. Check inclusion rules by priority (descending), first match wins.
-    fn match_file(
-        &self,
-        compiled: &[CompiledRule],
-        filename: &str,
-        is_dir: bool,
-        rel_path: &Path,
-        abs_path: &Path,
-        pack: &str,
-    ) -> Option<RuleMatch> {
-        // Phase 1: check exclusions
-        for rule in compiled {
-            if rule.is_exclusion && matches_entry(&rule.pattern, filename, is_dir) {
-                return None;
-            }
+/// Match a single file against the compiled rules.
+///
+/// 1. Check exclusion rules first — if any match, file is skipped.
+/// 2. Check inclusion rules by priority (descending), first match wins.
+fn match_file(
+    compiled: &[CompiledRule],
+    filename: &str,
+    is_dir: bool,
+    rel_path: &Path,
+    abs_path: &Path,
+    pack: &str,
+) -> Option<RuleMatch> {
+    // Phase 1: check exclusions
+    for rule in compiled {
+        if rule.is_exclusion && matches_entry(&rule.pattern, filename, is_dir) {
+            return None;
         }
-
-        // Phase 2: find first matching inclusion rule (sorted by priority desc)
-        // We sort a copy so we don't modify the original
-        let mut inclusion_rules: Vec<&CompiledRule> =
-            compiled.iter().filter(|r| !r.is_exclusion).collect();
-        inclusion_rules.sort_by(|a, b| b.priority.cmp(&a.priority));
-
-        for rule in inclusion_rules {
-            if matches_entry(&rule.pattern, filename, is_dir) {
-                return Some(RuleMatch {
-                    relative_path: rel_path.to_path_buf(),
-                    absolute_path: abs_path.to_path_buf(),
-                    pack: pack.to_string(),
-                    handler: rule.handler.clone(),
-                    is_dir,
-                    options: rule.options.clone(),
-                });
-            }
-        }
-
-        None
     }
+
+    // Phase 2: find first matching inclusion rule (sorted by priority desc)
+    // We sort a copy so we don't modify the original
+    let mut inclusion_rules: Vec<&CompiledRule> =
+        compiled.iter().filter(|r| !r.is_exclusion).collect();
+    inclusion_rules.sort_by(|a, b| b.priority.cmp(&a.priority));
+
+    for rule in inclusion_rules {
+        if matches_entry(&rule.pattern, filename, is_dir) {
+            return Some(RuleMatch {
+                relative_path: rel_path.to_path_buf(),
+                absolute_path: abs_path.to_path_buf(),
+                pack: pack.to_string(),
+                handler: rule.handler.clone(),
+                is_dir,
+                options: rule.options.clone(),
+                preprocessor_source: None,
+            });
+        }
+    }
+
+    None
 }
 
 fn is_ignored(name: &str, patterns: &[String]) -> bool {
@@ -707,6 +757,7 @@ mod tests {
                 handler: "symlink".into(),
                 is_dir: false,
                 options: HashMap::new(),
+                preprocessor_source: None,
             },
             RuleMatch {
                 relative_path: "aliases.sh".into(),
@@ -715,6 +766,7 @@ mod tests {
                 handler: "shell".into(),
                 is_dir: false,
                 options: HashMap::new(),
+                preprocessor_source: None,
             },
             RuleMatch {
                 relative_path: "gvimrc".into(),
@@ -723,6 +775,7 @@ mod tests {
                 handler: "symlink".into(),
                 is_dir: false,
                 options: HashMap::new(),
+                preprocessor_source: None,
             },
         ];
 
@@ -766,6 +819,7 @@ mod tests {
             handler: "symlink".into(),
             is_dir: false,
             options: HashMap::new(),
+            preprocessor_source: None,
         };
         let json = serde_json::to_string(&m).unwrap();
         assert!(json.contains("vimrc"));

--- a/crates/dodot-lib/src/testing/mod.rs
+++ b/crates/dodot-lib/src/testing/mod.rs
@@ -178,6 +178,52 @@ impl TempEnvironment {
         );
     }
 
+    /// Assert a rendered (non-symlink) file exists in the datastore
+    /// with the expected content.
+    pub fn assert_rendered_file(&self, pack: &str, handler: &str, filename: &str, expected: &str) {
+        let path = self.paths.handler_data_dir(pack, handler).join(filename);
+        assert!(
+            self.fs.exists(&path),
+            "expected rendered file at {}, but it does not exist",
+            path.display()
+        );
+        assert!(
+            !self.fs.is_symlink(&path),
+            "expected {} to be a regular file, but it is a symlink",
+            path.display()
+        );
+        let actual = self
+            .fs
+            .read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+        assert_eq!(
+            actual,
+            expected,
+            "rendered file {} has unexpected contents",
+            path.display()
+        );
+    }
+
+    /// Assert that a path is a regular file (not a symlink) with expected content.
+    pub fn assert_regular_file(&self, path: &Path, expected: &str) {
+        assert!(self.fs.exists(path), "expected {} to exist", path.display());
+        assert!(
+            !self.fs.is_symlink(path),
+            "expected {} to be a regular file, not a symlink",
+            path.display()
+        );
+        let actual = self
+            .fs
+            .read_to_string(path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+        assert_eq!(
+            actual,
+            expected,
+            "file {} has unexpected contents",
+            path.display()
+        );
+    }
+
     /// Returns the list of file names in a directory.
     pub fn list_dir_names(&self, path: &Path) -> Vec<String> {
         self.fs


### PR DESCRIPTION
## Context

dodot's core is symlink-based: the file in the dotfiles repo IS the deployed file. But many use cases require a transformation step — templates need variable expansion, plists need binary conversion, secrets need decryption. The **preprocessing pipeline** is the generic layer that handles all such cases.

This PR implements the pipeline infrastructure per the design in [`docs/proposals/preprocessing-pipeline.lex`](docs/proposals/preprocessing-pipeline.lex) (committed in 73e2e80). The pipeline runs as a new phase between directory walking and handler dispatch. Template expansion (the first real preprocessor) will build on this foundation in a follow-up PR per [`docs/proposals/template-expansion.lex`](docs/proposals/template-expansion.lex).

## Architecture

```
walk(pack_dir)
  → partition(preprocessor vs regular files)
  → expand(preprocessor files) → write to datastore
  → check collisions → merge entries
  → match rules → handlers → execute
```

Key design decision: **preprocessing is a pipeline phase, not a handler.** This means preprocessed files compose transparently with all existing handlers — a `.tmpl` file can be rendered AND symlinked, sourced, or executed depending on the stripped filename. No handler coupling.

## What's in this PR

### Core infrastructure
- **`Preprocessor` trait**: `name`, `transform_type` (Generative/Representational/Opaque), `matches_extension`, `stripped_name`, `expand`
- **`PreprocessorRegistry`**: dispatches files to preprocessors by extension
- **Pipeline function** (`preprocess_pack`): partitions entries, runs expansion, writes to datastore, detects collisions, produces virtual `PackEntry`s
- **Scanner refactoring**: extracted `PackEntry` struct, public `walk_pack` and `match_entries` methods (pure refactoring, all existing tests unchanged)
- **`DataStore.write_rendered_file`**: writes regular files (not symlinks) for preprocessor output
- **Orchestration integration**: `collect_pack_intents_with_preprocessors` wires the pipeline between walk and rule matching

### Two concrete preprocessors

Shipped with two preprocessors to validate the integration points:

1. **IdentityPreprocessor** (`.identity` extension) — passes content through unchanged. Exists purely for integration testing: validates the full pipeline (partitioning, expansion, datastore write, virtual match injection, handler composition) without depending on any transformation engine.

2. **UnarchivePreprocessor** (`.tar.gz` extension) — extracts archives into multiple files. Actually usable (e.g., pre-built CLI binaries in dotfiles). Validates the multi-file expansion path and all pipeline integration points except git merge strategies (which are template-specific).

### Config & error handling
- `[preprocessor] enabled = true` global kill switch in `.dodot.toml`
- `PreprocessorError` and `PreprocessorCollision` error variants with actionable messages

## Test coverage

**280 tests total** (51 new), organized by layer:

| Area | Tests | What's covered |
|------|-------|----------------|
| **Trait & registry** | 8 | Object safety, dispatch, multi-preprocessor, partial extension matching |
| **Identity preprocessor** | 10 | Extension matching, stripping, expansion, empty files, binary content, missing files, idempotency, double extension |
| **Unarchive preprocessor** | 8 | tar.gz extraction, directories, empty archives, single file, corrupted archives, missing files |
| **Pipeline** | 14 | Partitioning, virtual entries, collision detection, merging, source map completeness, subdirectory preservation, idempotency, error propagation, multiple files, empty registry |
| **DataStore** | 5 | write_rendered_file: create, overwrite, empty, binary, parent dir creation |
| **Integration** | 8 | End-to-end deploy with content verification, mixed packs, collision errors, config disable, error propagation, multi-preprocessor registry, no-registry passthrough |

## Test plan

- [x] All 229 pre-existing tests pass (no regressions from scanner refactoring or RuleMatch changes)
- [x] Identity preprocessor deploys through symlink handler end-to-end
- [x] Mixed packs (preprocessor + regular files) both deploy correctly
- [x] Collision detected when pack has both `config.toml` and `config.toml.identity`
- [x] Preprocessing disabled via config treats `.identity` files as regular
- [x] Corrupted archive errors propagate cleanly
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)