### PR TITLE
feat: template preprocessor (Phase T1, core rendering)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,7 @@ dependencies = [
  "confique",
  "flate2",
  "glob",
+ "minijinja",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -11,6 +11,7 @@ clapfig = "0.16"
 confique = "0.4"
 flate2 = "1"
 glob = "0.3"
+minijinja = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -247,7 +247,46 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         let rules = mappings_to_rules(&pack_config.mappings);
 
         let scanner = Scanner::new(ctx.fs.as_ref());
-        let matches = scanner.scan_pack(&pack, &rules, &pack_config.pack.ignore)?;
+
+        // Walk and preprocess so the status display sees *post-preprocessing*
+        // filenames (e.g. `config.toml` rather than `config.toml.tmpl`).
+        // Without this step, status reports templates under their source
+        // name and wrongly marks them "pending" because the verification
+        // path (`~/.config.toml.tmpl`) doesn't exist.
+        let entries = scanner.walk_pack(&pack.path, &pack_config.pack.ignore)?;
+        let preprocess_result = if pack_config.preprocessor.enabled {
+            let registry = crate::preprocessing::default_registry(
+                &pack_config.preprocessor.template,
+                ctx.paths.as_ref(),
+            )?;
+            if !registry.is_empty() {
+                match crate::preprocessing::pipeline::preprocess_pack(
+                    entries,
+                    &registry,
+                    &pack,
+                    ctx.fs.as_ref(),
+                    ctx.datastore.as_ref(),
+                ) {
+                    Ok(r) => r,
+                    Err(err) => {
+                        // Preprocessing failure surfaces as a warning; we
+                        // still want to show whatever we can from the
+                        // intent-collection attempt below.
+                        warnings.push(format!(
+                            "preprocessing failed for pack '{}': {}",
+                            pack.name, err
+                        ));
+                        crate::preprocessing::pipeline::PreprocessResult::passthrough(Vec::new())
+                    }
+                }
+            } else {
+                crate::preprocessing::pipeline::PreprocessResult::passthrough(entries)
+            }
+        } else {
+            crate::preprocessing::pipeline::PreprocessResult::passthrough(entries)
+        };
+        let all_entries = preprocess_result.merged_entries();
+        let matches = scanner.match_entries(&all_entries, &rules, &pack.name);
 
         // Collect intents for conflict detection
         match orchestration::collect_pack_intents(&pack, ctx) {

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -1501,3 +1501,56 @@ fn up_auto_chmod_disabled_via_config() {
         "auto_chmod_exec=false should leave file non-executable"
     );
 }
+
+// ── status: preprocessed file display ──────────────────────────
+
+#[test]
+fn status_reports_template_under_stripped_name() {
+    // Regression guard: before the fix, status used the raw scanner
+    // output (pre-preprocessing) for its file list, so a `greet.tmpl`
+    // template would be listed as `greet.tmpl` and wrongly reported as
+    // "pending" even after `dodot up` deployed the rendered `greet`.
+    let env = TempEnvironment::builder()
+        .pack("app")
+        .file("greet.tmpl", "hello {{ name }}")
+        .config("[preprocessor.template.vars]\nname = \"Alice\"\n")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+
+    // Run up first so the deployment state is "deployed".
+    commands::up::up(None, &ctx).unwrap();
+
+    let result = commands::status::status(None, &ctx).unwrap();
+
+    assert_eq!(result.packs.len(), 1);
+    let files = &result.packs[0].files;
+    assert_eq!(files.len(), 1, "files: {files:?}");
+
+    // The display name must be the stripped name, not the .tmpl source.
+    assert_eq!(files[0].name, "greet", "file name: {}", files[0].name);
+    assert_eq!(
+        files[0].status, "deployed",
+        "template should report as deployed after up, not pending"
+    );
+}
+
+#[test]
+fn status_reports_template_pending_before_up() {
+    // Even without running up, status should use the stripped name.
+    let env = TempEnvironment::builder()
+        .pack("app")
+        .file("greet.tmpl", "hello {{ name }}")
+        .config("[preprocessor.template.vars]\nname = \"Alice\"\n")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    let result = commands::status::status(None, &ctx).unwrap();
+
+    let files = &result.packs[0].files;
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].name, "greet");
+    assert_eq!(files[0].status, "pending");
+}

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -119,6 +119,26 @@ pub struct PreprocessorSection {
     /// Global kill switch for all preprocessing.
     #[config(default = true)]
     pub enabled: bool,
+
+    #[config(nested)]
+    pub template: PreprocessorTemplateSection,
+}
+
+/// Template preprocessor settings.
+#[derive(Config, Debug, Clone, Serialize, Deserialize)]
+pub struct PreprocessorTemplateSection {
+    /// File extensions that trigger template rendering. Each extension
+    /// is matched as a suffix (e.g. `"tmpl"` matches `config.toml.tmpl`).
+    #[config(default = ["tmpl", "template"])]
+    pub extensions: Vec<String>,
+
+    /// User-defined variables, accessible as bare names in templates
+    /// (e.g. `name = "Alice"` makes `{{ name }}` render as `Alice`).
+    ///
+    /// Reserved: `dodot` and `env` are built-in namespaces; using them
+    /// as var names raises an error at load time.
+    #[config(default = {})]
+    pub vars: std::collections::HashMap<String, String>,
 }
 
 /// File-to-handler mapping patterns.

--- a/crates/dodot-lib/src/error.rs
+++ b/crates/dodot-lib/src/error.rs
@@ -61,6 +61,15 @@ pub enum DodotError {
         expanded_name: String,
     },
 
+    #[error("template render failed for {}:\n  {message}", source_file.display())]
+    TemplateRender {
+        source_file: PathBuf,
+        message: String,
+    },
+
+    #[error("template variable name \"{name}\" is reserved (dodot and env are built-in namespaces); choose a different name in [preprocessor.template.vars]")]
+    TemplateReservedVar { name: String },
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -270,12 +270,12 @@ pub fn collect_pack_intents(
     pack: &Pack,
     ctx: &ExecutionContext,
 ) -> Result<Vec<crate::operations::HandlerIntent>> {
-    let root_config = ctx.config_manager.config_for_pack(&pack.path)?;
+    let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
     let registry = crate::preprocessing::default_registry(
-        &root_config.preprocessor.template,
+        &pack_config.preprocessor.template,
         ctx.paths.as_ref(),
     )?;
-    collect_pack_intents_with_preprocessors(pack, ctx, Some(&registry))
+    collect_pack_intents_inner(pack, ctx, &pack_config, Some(&registry))
 }
 
 /// Like [`collect_pack_intents`], but accepts an explicit preprocessor
@@ -288,17 +288,30 @@ pub fn collect_pack_intents_with_preprocessors(
     ctx: &ExecutionContext,
     preprocessors: Option<&crate::preprocessing::PreprocessorRegistry>,
 ) -> Result<Vec<crate::operations::HandlerIntent>> {
-    let root_config = ctx.config_manager.config_for_pack(&pack.path)?;
-    let rules = crate::config::mappings_to_rules(&root_config.mappings);
+    let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
+    collect_pack_intents_inner(pack, ctx, &pack_config, preprocessors)
+}
+
+/// Shared implementation that takes a pre-loaded pack config. Both
+/// entrypoints load the config once and pass it through so we don't
+/// re-merge config for every pack (the ConfigManager caches by path,
+/// but passing the config explicitly makes the data flow obvious).
+fn collect_pack_intents_inner(
+    pack: &Pack,
+    ctx: &ExecutionContext,
+    pack_config: &crate::config::DodotConfig,
+    preprocessors: Option<&crate::preprocessing::PreprocessorRegistry>,
+) -> Result<Vec<crate::operations::HandlerIntent>> {
+    let rules = crate::config::mappings_to_rules(&pack_config.mappings);
 
     // Phase 1: Walk pack directory
     let scanner = Scanner::new(ctx.fs.as_ref());
-    let entries = scanner.walk_pack(&pack.path, &root_config.pack.ignore)?;
+    let entries = scanner.walk_pack(&pack.path, &pack_config.pack.ignore)?;
     debug!(pack = %pack.name, entries = entries.len(), "walked pack directory");
 
     // Phase 2: Preprocessing
     let preprocess_result = if let Some(registry) = preprocessors {
-        if !registry.is_empty() && root_config.preprocessor.enabled {
+        if !registry.is_empty() && pack_config.preprocessor.enabled {
             crate::preprocessing::pipeline::preprocess_pack(
                 entries,
                 registry,

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -270,7 +270,11 @@ pub fn collect_pack_intents(
     pack: &Pack,
     ctx: &ExecutionContext,
 ) -> Result<Vec<crate::operations::HandlerIntent>> {
-    let registry = crate::preprocessing::default_registry();
+    let root_config = ctx.config_manager.config_for_pack(&pack.path)?;
+    let registry = crate::preprocessing::default_registry(
+        &root_config.preprocessor.template,
+        ctx.paths.as_ref(),
+    )?;
     collect_pack_intents_with_preprocessors(pack, ctx, Some(&registry))
 }
 
@@ -1091,6 +1095,292 @@ mod tests {
         assert!(
             has_expanded_source,
             "production collect_pack_intents should expand .tar.gz via the default registry. Intents: {intents:?}"
+        );
+    }
+
+    // ── Template preprocessor integration tests ─────────────────
+
+    #[test]
+    fn template_deploys_rendered_content_via_symlink_handler() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file(
+                "config.toml.tmpl",
+                "name = \"{{ name }}\"\nos = \"{{ dodot.os }}\"",
+            )
+            .config("[preprocessor.template.vars]\nname = \"Alice\"\n")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let intents = collect_pack_intents(&pack, &ctx).unwrap();
+        let user_path = match &intents[0] {
+            crate::operations::HandlerIntent::Link { user_path, .. } => user_path.clone(),
+            other => panic!("expected Link intent, got: {other:?}"),
+        };
+
+        let results = execute_intents(intents, &ctx).unwrap();
+        assert!(
+            results.iter().all(|r| r.success),
+            "expected success: {results:?}"
+        );
+
+        let content = ctx.fs.read_to_string(&user_path).unwrap();
+        let expected_os = std::env::consts::OS;
+        assert_eq!(content, format!("name = \"Alice\"\nos = \"{expected_os}\""));
+    }
+
+    #[test]
+    fn template_with_shell_handler_sources_rendered_content() {
+        // aliases.sh.tmpl should match the shell handler after stripping.
+        let env = TempEnvironment::builder()
+            .pack("tools")
+            .file("aliases.sh.tmpl", "alias hello='echo {{ greeting }}'")
+            .config("[preprocessor.template.vars]\ngreeting = \"world\"\n")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "tools".into(),
+            path: env.dotfiles_root.join("tools"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("tools"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let intents = collect_pack_intents(&pack, &ctx).unwrap();
+        assert_eq!(intents.len(), 1);
+
+        match &intents[0] {
+            crate::operations::HandlerIntent::Stage {
+                handler, source, ..
+            } => {
+                assert_eq!(handler, "shell", "shell handler should own this");
+                let content = ctx.fs.read_to_string(source).unwrap();
+                assert_eq!(content, "alias hello='echo world'");
+            }
+            other => panic!("expected Stage intent, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn template_respects_per_pack_var_overrides() {
+        // Root config defines name=Alice; pack overrides to name=Bob.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("greeting.tmpl", "hello {{ name }}")
+            .config("[preprocessor.template.vars]\nname = \"Bob\"\n")
+            .done()
+            .build();
+
+        // Root config: name = Alice
+        env.fs
+            .write_file(
+                &env.dotfiles_root.join(".dodot.toml"),
+                b"[preprocessor.template.vars]\nname = \"Alice\"\n",
+            )
+            .unwrap();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let intents = collect_pack_intents(&pack, &ctx).unwrap();
+        match &intents[0] {
+            crate::operations::HandlerIntent::Link { source, .. } => {
+                let content = ctx.fs.read_to_string(source).unwrap();
+                assert_eq!(content, "hello Bob", "pack-level override should win");
+            }
+            other => panic!("expected Link intent, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn template_disabled_via_config_treats_files_as_regular() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.tmpl", "name = \"{{ name }}\"")
+            .done()
+            .build();
+
+        env.fs
+            .write_file(
+                &env.dotfiles_root.join(".dodot.toml"),
+                b"[preprocessor]\nenabled = false\n",
+            )
+            .unwrap();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let intents = collect_pack_intents(&pack, &ctx).unwrap();
+        // With preprocessing disabled, the .tmpl file is treated as a
+        // regular file and deployed verbatim (retaining the .tmpl extension).
+        assert_eq!(intents.len(), 1);
+        match &intents[0] {
+            crate::operations::HandlerIntent::Link {
+                source, user_path, ..
+            } => {
+                assert!(
+                    source.to_string_lossy().ends_with("config.toml.tmpl"),
+                    "source: {}",
+                    source.display()
+                );
+                assert!(
+                    user_path.to_string_lossy().contains(".tmpl"),
+                    "user_path should keep .tmpl extension: {}",
+                    user_path.display()
+                );
+            }
+            other => panic!("expected Link intent, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn template_render_error_surfaces_with_source_path() {
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("bad.tmpl", "value = \"{{ undefined_var }}\"")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let err = collect_pack_intents(&pack, &ctx).unwrap_err();
+        match err {
+            crate::DodotError::TemplateRender { source_file, .. } => {
+                assert!(
+                    source_file.ends_with("bad.tmpl"),
+                    "source_file: {}",
+                    source_file.display()
+                );
+            }
+            other => panic!("expected TemplateRender, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn template_reserved_var_fails_fast() {
+        // A user tries to define `dodot` as a variable — construction
+        // of the preprocessor should fail before any rendering happens.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("file.txt", "x")
+            .done()
+            .build();
+
+        env.fs
+            .write_file(
+                &env.dotfiles_root.join(".dodot.toml"),
+                b"[preprocessor.template.vars]\ndodot = \"pwn\"\n",
+            )
+            .unwrap();
+
+        let ctx = make_context(&env);
+        let pack = Pack {
+            name: "app".into(),
+            path: env.dotfiles_root.join("app"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let err = collect_pack_intents(&pack, &ctx).unwrap_err();
+        assert!(
+            matches!(err, crate::DodotError::TemplateReservedVar { ref name } if name == "dodot"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn template_with_install_handler_sentinel_reflects_rendered_content() {
+        // install.sh.tmpl should render, and the sentinel should be
+        // based on the rendered content (so vars changes re-run the
+        // script). Verify by checking the sentinel name includes the
+        // hash of the rendered content, not the template source.
+        let env = TempEnvironment::builder()
+            .pack("setup")
+            .file(
+                "install.sh.tmpl",
+                "#!/bin/sh\necho \"installing on {{ dodot.os }}\"",
+            )
+            .done()
+            .build();
+
+        let mut ctx = make_context(&env);
+        ctx.no_provision = false; // actually run install this time
+
+        let pack = Pack {
+            name: "setup".into(),
+            path: env.dotfiles_root.join("setup"),
+            config: ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("setup"))
+                .unwrap()
+                .to_handler_config(),
+        };
+
+        let intents = collect_pack_intents(&pack, &ctx).unwrap();
+        let (sentinel, rendered_path) = match &intents[0] {
+            crate::operations::HandlerIntent::Run {
+                sentinel,
+                arguments,
+                ..
+            } => (
+                sentinel.clone(),
+                std::path::PathBuf::from(arguments.last().unwrap()),
+            ),
+            other => panic!("expected Run intent, got: {other:?}"),
+        };
+
+        // Sentinel is "install.sh-{checksum}" where checksum is the
+        // SHA-256 of the *rendered* script in the datastore.
+        assert!(sentinel.starts_with("install.sh-"));
+
+        // Verify the rendered file contains the OS substitution
+        let content = ctx.fs.read_to_string(&rendered_path).unwrap();
+        assert!(
+            content.contains(std::env::consts::OS),
+            "rendered content should have OS substituted: {content}"
         );
     }
 }

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod identity;
 pub mod pipeline;
+pub mod template;
 pub mod unarchive;
 
 use std::path::{Path, PathBuf};
@@ -135,13 +136,25 @@ impl Default for PreprocessorRegistry {
 
 /// The default registry used on the normal execution path.
 ///
-/// Contains all user-facing preprocessors. The [`identity`] preprocessor
-/// is test-only and is intentionally *not* registered here (it would
-/// match innocuous-looking `.identity` files in user dotfiles).
-pub fn default_registry() -> PreprocessorRegistry {
+/// Contains all user-facing preprocessors:
+/// - [`unarchive::UnarchivePreprocessor`] for `.tar.gz` extraction
+/// - [`template::TemplatePreprocessor`] for Jinja2-style templates
+///
+/// The [`identity`] preprocessor is test-only and is intentionally *not*
+/// registered here (it would match innocuous-looking `.identity` files in
+/// user dotfiles).
+pub fn default_registry(
+    template_config: &crate::config::PreprocessorTemplateSection,
+    pather: &dyn crate::paths::Pather,
+) -> Result<PreprocessorRegistry> {
     let mut registry = PreprocessorRegistry::new();
     registry.register(Box::new(unarchive::UnarchivePreprocessor::new()));
-    registry
+    registry.register(Box::new(template::TemplatePreprocessor::new(
+        template_config.extensions.clone(),
+        template_config.vars.clone(),
+        pather,
+    )?));
+    Ok(registry)
 }
 
 #[cfg(test)]

--- a/crates/dodot-lib/src/preprocessing/pipeline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline.rs
@@ -18,15 +18,21 @@ use crate::rules::PackEntry;
 use crate::{DodotError, Result};
 
 /// Validate that a preprocessor-produced path is safe to materialise in
-/// the datastore: relative, no root/prefix/parent-dir components.
+/// the datastore: relative, no root/prefix/parent-dir components, and
+/// not effectively empty.
 ///
 /// Malicious or malformed preprocessor output (tar-slip, absolute paths,
 /// `..` segments) can escape the pack namespace and overwrite arbitrary
-/// files. We reject such paths before any disk write.
+/// files. Empty paths (or paths made up only of `.` components) are
+/// rejected because they would silently fail at the datastore layer with
+/// an opaque error — here we produce a clean diagnostic naming the
+/// preprocessor and source file.
 fn validate_safe_relative_path(path: &Path, preprocessor: &str, source_file: &Path) -> Result<()> {
+    let mut has_normal = false;
     for component in path.components() {
         match component {
-            Component::Normal(_) | Component::CurDir => {}
+            Component::Normal(_) => has_normal = true,
+            Component::CurDir => {}
             Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
                 return Err(DodotError::PreprocessorError {
                     preprocessor: preprocessor.into(),
@@ -39,7 +45,32 @@ fn validate_safe_relative_path(path: &Path, preprocessor: &str, source_file: &Pa
             }
         }
     }
+    if !has_normal {
+        return Err(DodotError::PreprocessorError {
+            preprocessor: preprocessor.into(),
+            source_file: source_file.to_path_buf(),
+            message: format!(
+                "preprocessor produced an empty output path (\"{}\"). This usually means a file like \
+                 `.tmpl` or `.identity` has no stem after stripping the preprocessor extension — \
+                 rename the source file so that it has a non-empty name after stripping.",
+                path.display()
+            ),
+        });
+    }
     Ok(())
+}
+
+/// Normalise a validated relative path by dropping `CurDir` components,
+/// so that `./foo` and `foo` are treated as the same virtual path for
+/// collision detection. Only call after [`validate_safe_relative_path`].
+fn normalize_relative(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        if let Component::Normal(n) = component {
+            out.push(n);
+        }
+    }
+    out
 }
 
 /// The result of preprocessing a pack's file entries.
@@ -187,6 +218,11 @@ pub fn preprocess_pack(
                 preprocessor.name(),
                 &entry.absolute_path,
             )?;
+
+            // Normalise `./foo` and `foo` to the same canonical form, so
+            // that collision detection and downstream comparisons don't
+            // silently diverge from the datastore's own normalisation.
+            let virtual_relative = normalize_relative(&virtual_relative);
 
             // Phase 4: Collision check (against both regular entries and
             // previously-expanded virtual entries)
@@ -1044,6 +1080,174 @@ mod tests {
         assert_eq!(
             env.fs.read_to_string(&file_entry.absolute_path).unwrap(),
             "hello"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_path_from_preprocessor() {
+        // A preprocessor that produces an empty relative_path (e.g. a
+        // template file named literally `.tmpl` whose stripped name is
+        // empty) must be rejected with a clean PreprocessorError, not
+        // cascaded to the datastore's opaque "empty datastore path"
+        // message.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("bad.zz", "x")
+            .done()
+            .build();
+
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(ScriptedPreprocessor {
+            name: "scripted",
+            extension: ".zz",
+            outputs: vec![crate::preprocessing::ExpandedFile {
+                relative_path: PathBuf::from(""),
+                content: b"nope".to_vec(),
+                is_dir: false,
+            }],
+        }));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "bad.zz".into(),
+            absolute_path: env.dotfiles_root.join("app/bad.zz"),
+            is_dir: false,
+        }];
+
+        let err =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        assert!(
+            matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("empty output path")),
+            "expected empty-path error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_curdir_only_path_from_preprocessor() {
+        // `./` or `.` alone normalises to empty — same rejection.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("bad.zz", "x")
+            .done()
+            .build();
+
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(ScriptedPreprocessor {
+            name: "scripted",
+            extension: ".zz",
+            outputs: vec![crate::preprocessing::ExpandedFile {
+                relative_path: PathBuf::from("."),
+                content: b"nope".to_vec(),
+                is_dir: false,
+            }],
+        }));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "bad.zz".into(),
+            absolute_path: env.dotfiles_root.join("app/bad.zz"),
+            is_dir: false,
+        }];
+
+        let err =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        assert!(
+            matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("empty output path")),
+            "expected empty-path error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn curdir_prefixed_paths_collide_with_plain_paths() {
+        // Two preprocessor outputs — one `./foo` and one `foo` — must
+        // be treated as a collision. Before normalisation these lived
+        // at distinct HashSet keys but the same datastore path, so the
+        // second write silently clobbered the first.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("bundle.zz", "x")
+            .done()
+            .build();
+
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(ScriptedPreprocessor {
+            name: "scripted",
+            extension: ".zz",
+            outputs: vec![
+                crate::preprocessing::ExpandedFile {
+                    relative_path: PathBuf::from("foo"),
+                    content: b"first".to_vec(),
+                    is_dir: false,
+                },
+                crate::preprocessing::ExpandedFile {
+                    relative_path: PathBuf::from("./foo"),
+                    content: b"second".to_vec(),
+                    is_dir: false,
+                },
+            ],
+        }));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "bundle.zz".into(),
+            absolute_path: env.dotfiles_root.join("app/bundle.zz"),
+            is_dir: false,
+        }];
+
+        let err =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        assert!(
+            matches!(err, DodotError::PreprocessorCollision { .. }),
+            "expected PreprocessorCollision for ./foo vs foo, got: {err}"
+        );
+    }
+
+    #[test]
+    fn virtual_entry_relative_path_is_normalized() {
+        // When a preprocessor emits `./foo`, the resulting virtual entry
+        // must carry a normalised relative path. Otherwise downstream
+        // code (e.g. rule matching or status display) sees both shapes
+        // and treats them as different files.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("bundle.zz", "x")
+            .done()
+            .build();
+
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(ScriptedPreprocessor {
+            name: "scripted",
+            extension: ".zz",
+            outputs: vec![crate::preprocessing::ExpandedFile {
+                relative_path: PathBuf::from("./nested/file.txt"),
+                content: b"hi".to_vec(),
+                is_dir: false,
+            }],
+        }));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "bundle.zz".into(),
+            absolute_path: env.dotfiles_root.join("app/bundle.zz"),
+            is_dir: false,
+        }];
+
+        let result =
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+
+        assert_eq!(result.virtual_entries.len(), 1);
+        assert_eq!(
+            result.virtual_entries[0].relative_path,
+            PathBuf::from("nested/file.txt"),
+            "CurDir components must be stripped from virtual entry"
         );
     }
 }

--- a/crates/dodot-lib/src/preprocessing/template.rs
+++ b/crates/dodot-lib/src/preprocessing/template.rs
@@ -1,0 +1,493 @@
+//! Template preprocessor — renders Jinja2-style templates via MiniJinja.
+//!
+//! Matches files with configurable extensions (default: `.tmpl`,
+//! `.template`), renders them against a variable context with three
+//! namespaces:
+//!
+//! - `dodot.*` — built-in values (os, arch, hostname, username, home,
+//!   dotfiles_root), computed once at preprocessor construction.
+//! - `env.*` — dynamic lookup of process environment variables.
+//! - bare names — user-defined variables from
+//!   `[preprocessor.template.vars]` in `.dodot.toml`.
+//!
+//! Uses MiniJinja strict undefined-behaviour: references to missing vars
+//! raise a render error rather than silently producing empty strings.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use minijinja::value::{Enumerator, Object, ObjectRepr, Value};
+use minijinja::{Environment, UndefinedBehavior};
+
+use crate::fs::Fs;
+use crate::paths::Pather;
+use crate::preprocessing::{ExpandedFile, Preprocessor, TransformType};
+use crate::{DodotError, Result};
+
+/// Reserved top-level variable names.
+const RESERVED_VARS: &[&str] = &["dodot", "env"];
+
+/// MiniJinja object that looks up process environment variables on
+/// attribute access. `{{ env.SHELL }}` becomes `std::env::var("SHELL")`.
+/// Missing env vars become `None`, which MiniJinja in strict mode
+/// reports as an undefined-value error at render time.
+#[derive(Debug)]
+struct EnvLookup;
+
+impl Object for EnvLookup {
+    fn repr(self: &Arc<Self>) -> ObjectRepr {
+        ObjectRepr::Map
+    }
+
+    fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
+        let name = key.as_str()?;
+        std::env::var(name).ok().map(Value::from)
+    }
+
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        // Don't enumerate environment variables — printing `{{ env }}`
+        // as a whole shouldn't dump the whole process environment.
+        Enumerator::NonEnumerable
+    }
+}
+
+/// Template rendering preprocessor. Generative (one-way) transform.
+pub struct TemplatePreprocessor {
+    extensions: Vec<String>,
+    env: Environment<'static>,
+}
+
+impl std::fmt::Debug for TemplatePreprocessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TemplatePreprocessor")
+            .field("extensions", &self.extensions)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TemplatePreprocessor {
+    /// Construct a new template preprocessor.
+    ///
+    /// Validates that no user-defined variable uses a reserved name
+    /// (`dodot` or `env`). Populates the MiniJinja environment with
+    /// the `dodot.*` builtins from `pather` + system info, an `env.*`
+    /// dynamic lookup, and each user variable as a bare global.
+    pub fn new(
+        extensions: Vec<String>,
+        user_vars: HashMap<String, String>,
+        pather: &dyn Pather,
+    ) -> Result<Self> {
+        for name in user_vars.keys() {
+            if RESERVED_VARS.contains(&name.as_str()) {
+                return Err(DodotError::TemplateReservedVar { name: name.clone() });
+            }
+        }
+
+        let mut env = Environment::new();
+        env.set_undefined_behavior(UndefinedBehavior::Strict);
+
+        env.add_global("dodot", Value::from(build_dodot_context(pather)));
+        env.add_global("env", Value::from_object(EnvLookup));
+
+        for (name, val) in user_vars {
+            env.add_global(name, Value::from(val));
+        }
+
+        Ok(Self { extensions, env })
+    }
+}
+
+impl Preprocessor for TemplatePreprocessor {
+    fn name(&self) -> &str {
+        "template"
+    }
+
+    fn transform_type(&self) -> TransformType {
+        TransformType::Generative
+    }
+
+    fn matches_extension(&self, filename: &str) -> bool {
+        self.extensions
+            .iter()
+            .any(|ext| filename.ends_with(&format!(".{ext}")))
+    }
+
+    fn stripped_name(&self, filename: &str) -> String {
+        for ext in &self.extensions {
+            let suffix = format!(".{ext}");
+            if let Some(stripped) = filename.strip_suffix(&suffix) {
+                return stripped.to_string();
+            }
+        }
+        filename.to_string()
+    }
+
+    fn expand(&self, source: &Path, fs: &dyn Fs) -> Result<Vec<ExpandedFile>> {
+        let template_str = fs.read_to_string(source)?;
+
+        let rendered =
+            self.env
+                .render_str(&template_str, ())
+                .map_err(|e| DodotError::TemplateRender {
+                    source_file: source.to_path_buf(),
+                    message: format_minijinja_error(&e),
+                })?;
+
+        let filename = source
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+        let stripped = self.stripped_name(&filename);
+
+        Ok(vec![ExpandedFile {
+            relative_path: PathBuf::from(stripped),
+            content: rendered.into_bytes(),
+            is_dir: false,
+        }])
+    }
+}
+
+/// Build the `dodot.*` namespace map.
+///
+/// Values are resolved best-effort from the environment; if hostname or
+/// username cannot be determined, an empty string is returned so
+/// templates don't fail outright (users will notice the empty value
+/// and fix their environment).
+fn build_dodot_context(pather: &dyn Pather) -> BTreeMap<String, String> {
+    let mut ctx = BTreeMap::new();
+    ctx.insert("os".into(), std::env::consts::OS.into());
+    ctx.insert("arch".into(), std::env::consts::ARCH.into());
+    ctx.insert("hostname".into(), detect_hostname());
+    ctx.insert("username".into(), detect_username());
+    ctx.insert("home".into(), pather.home_dir().display().to_string());
+    ctx.insert(
+        "dotfiles_root".into(),
+        pather.dotfiles_root().display().to_string(),
+    );
+    ctx
+}
+
+fn detect_hostname() -> String {
+    if let Ok(h) = std::env::var("HOSTNAME") {
+        if !h.is_empty() {
+            return h;
+        }
+    }
+    // Fallback: shell out. Ignore errors and return empty string.
+    std::process::Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
+}
+
+fn detect_username() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_default()
+}
+
+/// Compact a MiniJinja error into a single human-readable string with
+/// a suggestion for the common "undefined variable" case.
+fn format_minijinja_error(err: &minijinja::Error) -> String {
+    use minijinja::ErrorKind;
+
+    let base = match err.kind() {
+        ErrorKind::UndefinedError => {
+            // Best-effort: MiniJinja's error message already says
+            // "undefined value" but doesn't always name the variable.
+            // The Display impl includes line info.
+            let mut msg = err.to_string();
+            msg.push_str(
+                "\n  hint: define the variable in [preprocessor.template.vars] in .dodot.toml,\n  or reference an environment variable with {{ env.NAME }} (with a default filter if optional)",
+            );
+            msg
+        }
+        ErrorKind::SyntaxError => err.to_string(),
+        _ => err.to_string(),
+    };
+
+    // MiniJinja sometimes appends "referenced from" traces; strip them
+    // to keep the error message compact.
+    base.lines().take(10).collect::<Vec<_>>().join("\n  ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::XdgPather;
+
+    fn make_pather() -> XdgPather {
+        XdgPather::builder()
+            .home("/home/alice")
+            .dotfiles_root("/home/alice/dotfiles")
+            .xdg_config_home("/home/alice/.config")
+            .data_dir("/home/alice/.local/share/dodot")
+            .build()
+            .unwrap()
+    }
+
+    fn new_pp(vars: HashMap<String, String>) -> TemplatePreprocessor {
+        TemplatePreprocessor::new(vec!["tmpl".into(), "template".into()], vars, &make_pather())
+            .unwrap()
+    }
+
+    // ── Trait basics ────────────────────────────────────────────
+
+    #[test]
+    fn trait_properties() {
+        let pp = new_pp(HashMap::new());
+        assert_eq!(pp.name(), "template");
+        assert_eq!(pp.transform_type(), TransformType::Generative);
+    }
+
+    #[test]
+    fn matches_default_extensions() {
+        let pp = new_pp(HashMap::new());
+        assert!(pp.matches_extension("config.toml.tmpl"));
+        assert!(pp.matches_extension("config.toml.template"));
+        assert!(!pp.matches_extension("config.toml"));
+        assert!(!pp.matches_extension("config.tmpl.bak"));
+    }
+
+    #[test]
+    fn matches_custom_extension() {
+        let pp =
+            TemplatePreprocessor::new(vec!["j2".into()], HashMap::new(), &make_pather()).unwrap();
+        assert!(pp.matches_extension("nginx.conf.j2"));
+        assert!(!pp.matches_extension("nginx.conf.tmpl"));
+    }
+
+    #[test]
+    fn stripped_name_removes_either_extension() {
+        let pp = new_pp(HashMap::new());
+        assert_eq!(pp.stripped_name("config.toml.tmpl"), "config.toml");
+        assert_eq!(pp.stripped_name("config.toml.template"), "config.toml");
+        assert_eq!(pp.stripped_name("already-stripped"), "already-stripped");
+    }
+
+    // ── Reserved variable names ─────────────────────────────────
+
+    #[test]
+    fn reserved_dodot_var_rejected() {
+        let mut vars = HashMap::new();
+        vars.insert("dodot".into(), "x".into());
+        let err = TemplatePreprocessor::new(vec!["tmpl".into()], vars, &make_pather()).unwrap_err();
+        assert!(
+            matches!(err, DodotError::TemplateReservedVar { ref name } if name == "dodot"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn reserved_env_var_rejected() {
+        let mut vars = HashMap::new();
+        vars.insert("env".into(), "x".into());
+        let err = TemplatePreprocessor::new(vec!["tmpl".into()], vars, &make_pather()).unwrap_err();
+        assert!(matches!(err, DodotError::TemplateReservedVar { .. }));
+    }
+
+    // ── Rendering ───────────────────────────────────────────────
+
+    #[test]
+    fn renders_user_var() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("greeting.tmpl", "hello {{ name }}")
+            .done()
+            .build();
+
+        let mut vars = HashMap::new();
+        vars.insert("name".into(), "Alice".into());
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], vars, env.paths.as_ref()).unwrap();
+
+        let source = env.dotfiles_root.join("app/greeting.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].relative_path, PathBuf::from("greeting"));
+        assert_eq!(String::from_utf8_lossy(&result[0].content), "hello Alice");
+    }
+
+    #[test]
+    fn renders_dodot_builtins() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file(
+                "info.tmpl",
+                "home={{ dodot.home }} root={{ dodot.dotfiles_root }} os={{ dodot.os }}",
+            )
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/info.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+
+        let rendered = String::from_utf8_lossy(&result[0].content);
+        let home = env.paths.home_dir().display().to_string();
+        let root = env.paths.dotfiles_root().display().to_string();
+        assert!(
+            rendered.contains(&format!("home={home}")),
+            "rendered: {rendered}"
+        );
+        assert!(
+            rendered.contains(&format!("root={root}")),
+            "rendered: {rendered}"
+        );
+        assert!(rendered.contains(&format!("os={}", std::env::consts::OS)));
+    }
+
+    #[test]
+    fn renders_env_var() {
+        // Use a likely-present env var with a fallback for determinism.
+        // PATH should always be set during tests.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("has_path.tmpl", "path={{ env.PATH }}")
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/has_path.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let rendered = String::from_utf8_lossy(&result[0].content).into_owned();
+
+        assert!(rendered.starts_with("path="));
+        assert!(
+            rendered.len() > "path=".len(),
+            "env.PATH should have some value"
+        );
+    }
+
+    #[test]
+    fn missing_env_var_errors() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("bad.tmpl", "value={{ env.DEFINITELY_UNSET_VAR_ZZZ_12345 }}")
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/bad.tmpl");
+        // Ensure the env var is genuinely unset
+        std::env::remove_var("DEFINITELY_UNSET_VAR_ZZZ_12345");
+        let err = pp.expand(&source, env.fs.as_ref()).unwrap_err();
+        assert!(
+            matches!(err, DodotError::TemplateRender { ref source_file, .. } if source_file == &source),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn undefined_user_var_errors() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("bad.tmpl", "value={{ not_defined }}")
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/bad.tmpl");
+        let err = pp.expand(&source, env.fs.as_ref()).unwrap_err();
+        assert!(
+            matches!(err, DodotError::TemplateRender { ref message, .. } if message.contains("not_defined") || message.contains("undefined")),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn syntax_error_reports_source_file() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("broken.tmpl", "{% if %}unterminated")
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/broken.tmpl");
+        let err = pp.expand(&source, env.fs.as_ref()).unwrap_err();
+        assert!(
+            matches!(err, DodotError::TemplateRender { ref source_file, .. } if source_file == &source),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn renders_filters_and_conditionals() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file(
+                "multi.tmpl",
+                "NAME={{ name | upper }}\n{% if show %}shown{% else %}hidden{% endif %}",
+            )
+            .done()
+            .build();
+
+        let mut vars = HashMap::new();
+        vars.insert("name".into(), "alice".into());
+        vars.insert("show".into(), "true".into());
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], vars, env.paths.as_ref()).unwrap();
+
+        let source = env.dotfiles_root.join("app/multi.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let rendered = String::from_utf8_lossy(&result[0].content);
+        assert!(rendered.contains("NAME=ALICE"), "rendered: {rendered}");
+        assert!(rendered.contains("shown"), "rendered: {rendered}");
+    }
+
+    #[test]
+    fn renders_empty_template() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("empty.tmpl", "")
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/empty.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].content.is_empty());
+    }
+
+    #[test]
+    fn renders_template_without_substitutions() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("plain.tmpl", "just plain text\nno vars here")
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/plain.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&result[0].content),
+            "just plain text\nno vars here"
+        );
+    }
+}

--- a/crates/dodot-lib/src/preprocessing/template.rs
+++ b/crates/dodot-lib/src/preprocessing/template.rs
@@ -108,14 +108,18 @@ impl Preprocessor for TemplatePreprocessor {
     }
 
     fn matches_extension(&self, filename: &str) -> bool {
-        self.extensions
-            .iter()
-            .any(|ext| filename.ends_with(&format!(".{ext}")))
+        self.extensions.iter().any(|ext| {
+            // Tolerate user config that writes extensions with or without
+            // a leading dot (".tmpl" vs "tmpl"); without this, ".tmpl"
+            // would produce "..tmpl" and silently fail to match.
+            let suffix = format!(".{}", ext.trim_start_matches('.'));
+            filename.ends_with(&suffix)
+        })
     }
 
     fn stripped_name(&self, filename: &str) -> String {
         for ext in &self.extensions {
-            let suffix = format!(".{ext}");
+            let suffix = format!(".{}", ext.trim_start_matches('.'));
             if let Some(stripped) = filename.strip_suffix(&suffix) {
                 return stripped.to_string();
             }
@@ -151,16 +155,23 @@ impl Preprocessor for TemplatePreprocessor {
 
 /// Build the `dodot.*` namespace map.
 ///
-/// Values are resolved best-effort from the environment; if hostname or
-/// username cannot be determined, an empty string is returned so
-/// templates don't fail outright (users will notice the empty value
-/// and fix their environment).
+/// Keys we can always resolve (os, arch, home, dotfiles_root) are
+/// always inserted. Keys that depend on environment detection
+/// (hostname, username) are inserted only when a non-empty value is
+/// found — otherwise they are omitted so that template access via
+/// `{{ dodot.hostname }}` triggers a strict-undefined render error,
+/// rather than silently injecting an empty string. Users who want a
+/// fallback can write `{{ dodot.hostname | default("unknown") }}`.
 fn build_dodot_context(pather: &dyn Pather) -> BTreeMap<String, String> {
     let mut ctx = BTreeMap::new();
     ctx.insert("os".into(), std::env::consts::OS.into());
     ctx.insert("arch".into(), std::env::consts::ARCH.into());
-    ctx.insert("hostname".into(), detect_hostname());
-    ctx.insert("username".into(), detect_username());
+    if let Some(h) = detect_hostname() {
+        ctx.insert("hostname".into(), h);
+    }
+    if let Some(u) = detect_username() {
+        ctx.insert("username".into(), u);
+    }
     ctx.insert("home".into(), pather.home_dir().display().to_string());
     ctx.insert(
         "dotfiles_root".into(),
@@ -169,31 +180,34 @@ fn build_dodot_context(pather: &dyn Pather) -> BTreeMap<String, String> {
     ctx
 }
 
-fn detect_hostname() -> String {
+fn detect_hostname() -> Option<String> {
     if let Ok(h) = std::env::var("HOSTNAME") {
         if !h.is_empty() {
-            return h;
+            return Some(h);
         }
     }
-    // Fallback: shell out. Ignore errors and return empty string.
-    std::process::Command::new("hostname")
-        .output()
-        .ok()
-        .and_then(|out| {
-            if out.status.success() {
-                Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
-            } else {
-                None
-            }
-        })
-        .unwrap_or_default()
+    // Fallback: shell out. Ignore errors.
+    let output = std::process::Command::new("hostname").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
 }
 
-fn detect_username() -> String {
-    std::env::var("USER")
-        .or_else(|_| std::env::var("USERNAME"))
-        .or_else(|_| std::env::var("LOGNAME"))
-        .unwrap_or_default()
+fn detect_username() -> Option<String> {
+    for var in ["USER", "USERNAME", "LOGNAME"] {
+        if let Ok(v) = std::env::var(var) {
+            if !v.is_empty() {
+                return Some(v);
+            }
+        }
+    }
+    None
 }
 
 /// Compact a MiniJinja error into a single human-readable string with
@@ -489,5 +503,92 @@ mod tests {
             String::from_utf8_lossy(&result[0].content),
             "just plain text\nno vars here"
         );
+    }
+
+    #[test]
+    fn extension_with_leading_dot_still_matches() {
+        // Tolerate config that writes extensions as `.tmpl` instead of
+        // `tmpl`. Without the leading-dot trim, `.ends_with("..tmpl")`
+        // would silently never match and templates would not be processed.
+        let pp = TemplatePreprocessor::new(
+            vec![".tmpl".into(), ".template".into()],
+            HashMap::new(),
+            &make_pather(),
+        )
+        .unwrap();
+        assert!(pp.matches_extension("config.toml.tmpl"));
+        assert!(pp.matches_extension("app.template"));
+        assert_eq!(pp.stripped_name("config.toml.tmpl"), "config.toml");
+    }
+
+    #[test]
+    fn missing_dodot_key_raises_strict_error() {
+        // The `build_dodot_context` fix omits `hostname`/`username` from
+        // the map when they cannot be detected (rather than injecting
+        // empty strings, which would silently deploy broken configs).
+        //
+        // We avoid manipulating `std::env` here (not thread-safe; other
+        // tests read USER) and instead verify the underlying invariant:
+        // any missing key on the `dodot` object triggers the
+        // strict-undefined error. Under this invariant, an undetected
+        // username/hostname behaves the same as any other missing key.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("uses_missing.tmpl", "value={{ dodot.nonexistent_key_zzz }}")
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/uses_missing.tmpl");
+        let err = pp.expand(&source, env.fs.as_ref()).unwrap_err();
+        assert!(
+            matches!(err, DodotError::TemplateRender { .. }),
+            "accessing a missing dodot.* key must error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_dodot_key_can_be_defaulted() {
+        // Ergonomic escape hatch: Jinja's `default` filter lets users
+        // tolerate potentially-missing fields without raising.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file(
+                "defaulted.tmpl",
+                "value={{ dodot.nonexistent_key_zzz | default(\"unknown\") }}",
+            )
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/defaulted.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        assert_eq!(String::from_utf8_lossy(&result[0].content), "value=unknown");
+    }
+
+    #[test]
+    fn build_dodot_context_omits_undetected_optional_keys() {
+        // Directly exercise the map-building helper: given a Pather but
+        // the detection helpers return None (simulated via testing the
+        // helper return invariants), verify the map structure.
+        //
+        // Since `detect_username`/`detect_hostname` read real env/system
+        // state, we can only assert: if they return Some, the key is
+        // present; if they return None, the key is absent.
+        let ctx = build_dodot_context(&make_pather());
+
+        // These are always present:
+        assert!(ctx.contains_key("os"));
+        assert!(ctx.contains_key("arch"));
+        assert!(ctx.contains_key("home"));
+        assert!(ctx.contains_key("dotfiles_root"));
+
+        // Optional keys: present iff the detection helper returned Some.
+        assert_eq!(ctx.contains_key("username"), detect_username().is_some());
+        assert_eq!(ctx.contains_key("hostname"), detect_hostname().is_some());
     }
 }

--- a/crates/dodot-lib/src/preprocessing/template.rs
+++ b/crates/dodot-lib/src/preprocessing/template.rs
@@ -648,6 +648,121 @@ mod tests {
     }
 
     #[test]
+    fn env_var_default_filter_bridges_missing_vars() {
+        // The documented escape hatch for optional env vars is
+        // `{{ env.NAME | default("...") }}`. If `default` doesn't work,
+        // users have no way to reference env vars that might not be set —
+        // so this specific pattern must stay functional.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file(
+                "cfg.tmpl",
+                "editor={{ env.DODOT_MISSING_VAR_ZZZ | default(\"vim\") }}",
+            )
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/cfg.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        assert_eq!(String::from_utf8_lossy(&result[0].content), "editor=vim");
+    }
+
+    #[test]
+    fn renders_for_loop_over_user_var() {
+        // Regression guard: MiniJinja supports loops, but we want to
+        // confirm that user-defined vars (which are plain strings) still
+        // work inside a minimal control-flow structure. Strings are
+        // iterable as sequences of characters — confirm our value-layer
+        // doesn't silently block that.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file(
+                "loop.tmpl",
+                "{% for c in word %}{{ c | upper }}{% endfor %}",
+            )
+            .done()
+            .build();
+
+        let mut vars = HashMap::new();
+        vars.insert("word".into(), "hi".into());
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], vars, env.paths.as_ref()).unwrap();
+
+        let source = env.dotfiles_root.join("app/loop.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        assert_eq!(String::from_utf8_lossy(&result[0].content), "HI");
+    }
+
+    #[test]
+    fn renders_unicode_content_and_vars() {
+        // Template content and user vars may contain non-ASCII. Confirm
+        // both pass through without mangling.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("greet.tmpl", "こんにちは {{ name }}! 🎉")
+            .done()
+            .build();
+
+        let mut vars = HashMap::new();
+        vars.insert("name".into(), "世界".into());
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], vars, env.paths.as_ref()).unwrap();
+
+        let source = env.dotfiles_root.join("app/greet.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&result[0].content),
+            "こんにちは 世界! 🎉"
+        );
+    }
+
+    #[test]
+    fn rendering_is_deterministic_across_calls() {
+        // Calling `expand` multiple times with the same inputs must
+        // produce byte-identical output. This guards against any
+        // hidden state leaking between renders (e.g. a stale globals
+        // cache, a reseeded RNG, or a leaked side-effect into the
+        // Environment).
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file(
+                "cfg.tmpl",
+                "name={{ name }} os={{ dodot.os }} home={{ dodot.home }}",
+            )
+            .done()
+            .build();
+
+        let mut vars = HashMap::new();
+        vars.insert("name".into(), "Alice".into());
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], vars, env.paths.as_ref()).unwrap();
+
+        let source = env.dotfiles_root.join("app/cfg.tmpl");
+        let first = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let second = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let third = pp.expand(&source, env.fs.as_ref()).unwrap();
+
+        assert_eq!(first[0].content, second[0].content);
+        assert_eq!(second[0].content, third[0].content);
+    }
+
+    #[test]
+    fn stripped_name_of_literal_extension_returns_empty() {
+        // Edge case recording the current (defensive) behavior: a file
+        // named exactly `.tmpl` (extension and nothing else) strips to
+        // the empty string. In normal packs the scanner filters dotfiles
+        // out before they reach the preprocessor, so this won't happen
+        // via user flows. But a misconfigured preprocessor extension or
+        // an archive entry with no stem could still produce an empty
+        // path downstream, and the pipeline is expected to reject that
+        // with a useful error — see
+        // `pipeline::rejects_empty_path_from_preprocessor`.
+        let pp = new_pp(HashMap::new());
+        assert_eq!(pp.stripped_name(".tmpl"), "");
+        assert!(pp.matches_extension(".tmpl"));
+    }
+
+    #[test]
     fn build_dodot_context_omits_undetected_optional_keys() {
         // Directly exercise the map-building helper: given a Pather but
         // the detection helpers return None (simulated via testing the

--- a/crates/dodot-lib/src/preprocessing/template.rs
+++ b/crates/dodot-lib/src/preprocessing/template.rs
@@ -15,7 +15,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use minijinja::value::{Enumerator, Object, ObjectRepr, Value};
 use minijinja::{Environment, UndefinedBehavior};
@@ -30,8 +30,9 @@ const RESERVED_VARS: &[&str] = &["dodot", "env"];
 
 /// MiniJinja object that looks up process environment variables on
 /// attribute access. `{{ env.SHELL }}` becomes `std::env::var("SHELL")`.
-/// Missing env vars become `None`, which MiniJinja in strict mode
-/// reports as an undefined-value error at render time.
+/// Missing env vars return `None` from `get_value`, which MiniJinja
+/// treats as an undefined attribute (a render error under strict mode).
+/// For optional variables, use `{{ env.NAME | default("...") }}`.
 #[derive(Debug)]
 struct EnvLookup;
 
@@ -73,6 +74,9 @@ impl TemplatePreprocessor {
     /// (`dodot` or `env`). Populates the MiniJinja environment with
     /// the `dodot.*` builtins from `pather` + system info, an `env.*`
     /// dynamic lookup, and each user variable as a bare global.
+    ///
+    /// Extensions are normalized at construction: a leading dot (e.g.
+    /// `".tmpl"`) is stripped so both `"tmpl"` and `".tmpl"` work.
     pub fn new(
         extensions: Vec<String>,
         user_vars: HashMap<String, String>,
@@ -83,6 +87,11 @@ impl TemplatePreprocessor {
                 return Err(DodotError::TemplateReservedVar { name: name.clone() });
             }
         }
+
+        let extensions: Vec<String> = extensions
+            .into_iter()
+            .map(|e| e.trim_start_matches('.').to_string())
+            .collect();
 
         let mut env = Environment::new();
         env.set_undefined_behavior(UndefinedBehavior::Strict);
@@ -108,23 +117,32 @@ impl Preprocessor for TemplatePreprocessor {
     }
 
     fn matches_extension(&self, filename: &str) -> bool {
+        // Extensions are normalized (no leading dot) at construction.
+        // We require a literal "." before the extension to avoid e.g.
+        // "mpl" matching "foo.tmpl". No per-call allocation.
         self.extensions.iter().any(|ext| {
-            // Tolerate user config that writes extensions with or without
-            // a leading dot (".tmpl" vs "tmpl"); without this, ".tmpl"
-            // would produce "..tmpl" and silently fail to match.
-            let suffix = format!(".{}", ext.trim_start_matches('.'));
-            filename.ends_with(&suffix)
+            filename
+                .strip_suffix(ext.as_str())
+                .is_some_and(|prefix| prefix.ends_with('.'))
         })
     }
 
     fn stripped_name(&self, filename: &str) -> String {
-        for ext in &self.extensions {
-            let suffix = format!(".{}", ext.trim_start_matches('.'));
-            if let Some(stripped) = filename.strip_suffix(&suffix) {
-                return stripped.to_string();
-            }
-        }
-        filename.to_string()
+        // If multiple configured extensions match (e.g. "tmpl" and
+        // "j2.tmpl" both suffixes of the same filename), prefer the
+        // longest so behaviour is deterministic and independent of
+        // config ordering.
+        self.extensions
+            .iter()
+            .filter_map(|ext| {
+                filename
+                    .strip_suffix(ext.as_str())
+                    .and_then(|prefix| prefix.strip_suffix('.'))
+                    .map(|stripped| (ext.len(), stripped))
+            })
+            .max_by_key(|(len, _)| *len)
+            .map(|(_, stripped)| stripped.to_string())
+            .unwrap_or_else(|| filename.to_string())
     }
 
     fn expand(&self, source: &Path, fs: &dyn Fs) -> Result<Vec<ExpandedFile>> {
@@ -162,15 +180,19 @@ impl Preprocessor for TemplatePreprocessor {
 /// `{{ dodot.hostname }}` triggers a strict-undefined render error,
 /// rather than silently injecting an empty string. Users who want a
 /// fallback can write `{{ dodot.hostname | default("unknown") }}`.
+///
+/// Hostname and username detection is cached process-wide via
+/// [`OnceLock`] so that building a template preprocessor for each pack
+/// does not respawn `hostname(1)` every time.
 fn build_dodot_context(pather: &dyn Pather) -> BTreeMap<String, String> {
     let mut ctx = BTreeMap::new();
     ctx.insert("os".into(), std::env::consts::OS.into());
     ctx.insert("arch".into(), std::env::consts::ARCH.into());
-    if let Some(h) = detect_hostname() {
-        ctx.insert("hostname".into(), h);
+    if let Some(h) = cached_hostname() {
+        ctx.insert("hostname".into(), h.clone());
     }
-    if let Some(u) = detect_username() {
-        ctx.insert("username".into(), u);
+    if let Some(u) = cached_username() {
+        ctx.insert("username".into(), u.clone());
     }
     ctx.insert("home".into(), pather.home_dir().display().to_string());
     ctx.insert(
@@ -178,6 +200,20 @@ fn build_dodot_context(pather: &dyn Pather) -> BTreeMap<String, String> {
         pather.dotfiles_root().display().to_string(),
     );
     ctx
+}
+
+/// Process-wide cached hostname. First call resolves and pins the
+/// result for the lifetime of the process.
+fn cached_hostname() -> Option<&'static String> {
+    static CACHE: OnceLock<Option<String>> = OnceLock::new();
+    CACHE.get_or_init(detect_hostname).as_ref()
+}
+
+/// Process-wide cached username. Same caching semantics as
+/// [`cached_hostname`].
+fn cached_username() -> Option<&'static String> {
+    static CACHE: OnceLock<Option<String>> = OnceLock::new();
+    CACHE.get_or_init(detect_username).as_ref()
 }
 
 fn detect_hostname() -> Option<String> {
@@ -519,6 +555,47 @@ mod tests {
         assert!(pp.matches_extension("config.toml.tmpl"));
         assert!(pp.matches_extension("app.template"));
         assert_eq!(pp.stripped_name("config.toml.tmpl"), "config.toml");
+    }
+
+    #[test]
+    fn overlapping_suffix_does_not_false_match() {
+        // If a user configures an extension that is a suffix of another
+        // legitimate filename part (e.g. "mpl" as a suffix of "tmpl"),
+        // the matcher must require the literal "." boundary before the
+        // extension — otherwise "foo.tmpl" would be wrongly recognised
+        // as a "mpl" template and stripped to "foo.t".
+        let pp =
+            TemplatePreprocessor::new(vec!["mpl".into()], HashMap::new(), &make_pather()).unwrap();
+        assert!(!pp.matches_extension("foo.tmpl"));
+        assert_eq!(pp.stripped_name("foo.tmpl"), "foo.tmpl");
+
+        // Files that legitimately end with `.mpl` still match.
+        assert!(pp.matches_extension("song.mpl"));
+        assert_eq!(pp.stripped_name("song.mpl"), "song");
+    }
+
+    #[test]
+    fn overlapping_extensions_prefer_longest_match() {
+        // If a filename ends with both configured extensions (e.g.
+        // "foo.j2.tmpl" matches both "tmpl" and "j2.tmpl"), prefer the
+        // longest match so behaviour is deterministic regardless of
+        // config ordering.
+        let pp = TemplatePreprocessor::new(
+            vec!["tmpl".into(), "j2.tmpl".into()],
+            HashMap::new(),
+            &make_pather(),
+        )
+        .unwrap();
+        assert_eq!(pp.stripped_name("config.j2.tmpl"), "config");
+
+        // Opposite config order yields the same result.
+        let pp_reversed = TemplatePreprocessor::new(
+            vec!["j2.tmpl".into(), "tmpl".into()],
+            HashMap::new(),
+            &make_pather(),
+        )
+        .unwrap();
+        assert_eq!(pp_reversed.stripped_name("config.j2.tmpl"), "config");
     }
 
     #[test]

--- a/docs/reference/templates.lex
+++ b/docs/reference/templates.lex
@@ -1,0 +1,200 @@
+Template Expansion
+
+    Some dotfiles need to vary between machines: a different git user per host, an OS-specific Homebrew prefix, a laptop-vs-workstation shell prompt. Rather than forking configs or hand-editing after every clone, dodot renders Jinja2-style templates at deploy time. One versioned source file can produce different outputs on different hosts.
+
+    Any pack file whose name ends in `.tmpl` or `.template` is a template. dodot strips that extension, renders the content, and hands the result to the normal handler pipeline. `git/gitconfig.tmpl` is rendered and then symlinked as `~/.gitconfig`, exactly as if `gitconfig` had been there all along.
+
+    Rendering is transparent: there is no `dodot render` step, no staging area, no "please remember to regenerate". Every `dodot up` re-renders, so editing the template or changing a variable picks up on the next deploy.
+
+1. A First Example
+
+    A git config you want on every machine, with a different user per host:
+
+    Rendering a variable:
+
+        $ cat ~/dotfiles/git/gitconfig.tmpl
+        [user]
+            name = {{ name }}
+            email = {{ name | lower }}@example.com
+
+        $ cat ~/dotfiles/git/.dodot.toml
+        [preprocessor.template.vars]
+        name = "Alice"
+
+        $ dodot up git
+        ... symlink:  git/gitconfig -> ~/.gitconfig: deployed
+
+        $ cat ~/.gitconfig
+        [user]
+            name = Alice
+            email = alice@example.com
+
+    :: shell ::
+
+    The `.tmpl` extension is the only trigger — no flags, no opt-in. `dodot status` shows the file under its stripped name (`gitconfig`, not `gitconfig.tmpl`), because that's what actually gets deployed.
+
+2. What You Can Reference in a Template
+
+    Three namespaces are always available inside a template:
+
+    - `dodot.*` — built-in values describing the machine and your dotfiles setup.
+    - `env.*` — lookup of the current process's environment variables.
+    - Bare names — variables you define under `[preprocessor.template.vars]`.
+
+    Dodot built-ins:
+
+        {{ dodot.os }}              host os    (e.g. "linux", "macos")
+        {{ dodot.arch }}            cpu arch   (e.g. "aarch64", "x86_64")
+        {{ dodot.hostname }}        machine hostname
+        {{ dodot.username }}        current user
+        {{ dodot.home }}            absolute $HOME
+        {{ dodot.dotfiles_root }}   absolute dotfiles root
+
+    :: jinja ::
+
+    `os`, `arch`, `home`, and `dotfiles_root` are always populated. `hostname` and `username` are best-effort: if dodot can't detect them, the key is omitted rather than silently set to an empty string. See section 5 for how to tolerate that.
+
+    The `env` namespace is looked up on demand. `{{ env.EDITOR }}` calls the equivalent of `std::env::var("EDITOR")` at render time — so whatever the user has in their shell when `dodot up` runs is what gets baked in.
+
+3. Defining Your Own Variables
+
+    User variables live under `[preprocessor.template.vars]` in any `.dodot.toml` — root or pack. Values are strings; you reference them by bare name.
+
+    Declaring vars in a root config:
+
+        # ~/dotfiles/.dodot.toml
+        [preprocessor.template.vars]
+        editor = "nvim"
+        host_tier = "workstation"
+
+    :: toml ::
+
+    Using them in a template:
+
+        # ~/dotfiles/tools/aliases.sh.tmpl
+        alias e='{{ editor }}'
+        # tier: {{ host_tier }}
+
+    :: shell ::
+
+    Pack-level vars override root-level vars of the same name. The natural workflow: set defaults in the root `.dodot.toml`, then override per pack when a specific pack needs something different. No merging inside a single value — override replaces.
+
+    Reserved names: `dodot` and `env` are the built-in namespaces, and cannot be used as variable names. dodot refuses to start up with a clear error if it finds `dodot = "..."` or `env = "..."` in `[preprocessor.template.vars]`.
+
+4. Branching on Host or OS
+
+    The common case for templates is conditional content. Jinja's `{% if %}` / `{% else %}` block handles it:
+
+    OS-specific content:
+
+        # ~/dotfiles/shell/profile.sh.tmpl
+        {% if dodot.os == "macos" %}
+        export HOMEBREW_PREFIX=/opt/homebrew
+        {% else %}
+        export HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
+        {% endif %}
+
+    :: shell ::
+
+    Hostname-based branching works the same way:
+
+    Per-host branching:
+
+        {% if dodot.hostname == "laptop" %}
+        export PROMPT_SYMBOL="💻 "
+        {% else %}
+        export PROMPT_SYMBOL="🖥  "
+        {% endif %}
+
+    :: shell ::
+
+    For anything more complex than OS or hostname, define your own classifier variable (e.g. `host_role = "work"` in the per-machine pack config) and branch on that.
+
+5. Undefined Variables Are Errors; Defaults Are Explicit
+
+    dodot runs templates in strict mode: referencing a variable that doesn't exist is a render error, and `dodot up` refuses to deploy that pack. This is deliberate — silently substituting an empty string on a typo is exactly how you end up with a `.gitconfig` that has `email = @example.com` and don't notice for six months.
+
+    Undefined variable surfaces clearly:
+
+        $ cat ~/dotfiles/vim/gvimrc.tmpl
+        set background={{ theme }}
+
+        $ dodot up vim
+        ... template render failed for ~/dotfiles/vim/gvimrc.tmpl:
+              undefined value (in <string>:1)
+              hint: define the variable in [preprocessor.template.vars] in .dodot.toml,
+              or reference an environment variable with {{ env.NAME }} (with a default filter if optional)
+
+    :: shell ::
+
+    When a value is genuinely optional, say so explicitly with Jinja's `default` filter:
+
+    Tolerating optional values:
+
+        editor = {{ env.EDITOR | default("nvim") }}
+        host   = {{ dodot.hostname | default("unknown") }}
+        tier   = {{ host_tier | default("unspecified") }}
+
+    :: jinja ::
+
+    `default` works for all three namespaces: env lookups, `dodot.*` keys that may not be detected, and user-defined vars. The rule of thumb: if a template can render without a value, make that explicit.
+
+6. Disabling Preprocessing
+
+    Two kill switches, both in `.dodot.toml`.
+
+    Global kill switch:
+
+        [preprocessor]
+        enabled = false
+
+    :: toml ::
+
+    With `enabled = false`, `.tmpl` files are not rendered — they're deployed verbatim, extension intact. Useful when a pack ships a `.tmpl` file as-is (say, an example template that the user will customize later), or as a temporary circuit-breaker during debugging.
+
+    Pack-level override: the same key under a pack's `.dodot.toml` overrides the root setting, so you can enable preprocessing globally and disable it for one specific pack.
+
+7. Custom Extensions
+
+    The default trigger extensions are `tmpl` and `template`. Override them in config:
+
+    Custom extensions:
+
+        [preprocessor.template]
+        extensions = ["j2", "jinja"]
+
+    :: toml ::
+
+    A leading dot is tolerated: `".j2"` and `"j2"` are treated the same. When a filename matches more than one configured extension — e.g. `config.j2.tmpl` with both `"tmpl"` and `"j2.tmpl"` registered — dodot strips the longest match, independently of the order in which extensions are listed.
+
+8. Collisions with Regular Files
+
+    A pack cannot contain both `config.toml` and `config.toml.tmpl`: they would map to the same deployed name. Rather than picking one silently, dodot refuses to deploy the pack and reports the conflict:
+
+    Collision diagnostic:
+
+        $ dodot up app
+        ... intent collection error: preprocessing collision in pack "app":
+              config.toml.tmpl expands to config.toml, which conflicts with
+              an existing pack file or another preprocessor's output
+
+    :: shell ::
+
+    The rule applies symmetrically to multiple preprocessors: if two preprocessors produce the same output name, the second one raises the same collision error.
+
+9. For Developers: Where Rendered Output Lives
+
+    Each rendered template is written to:
+
+    Rendered file path:
+
+        $XDG_DATA_HOME/dodot/packs/<pack>/preprocessed/<stripped-name>
+
+    :: text ::
+
+    That file is what the handlers see. The symlink handler creates `~/.gitconfig` pointing at the rendered file; the install handler executes the rendered `install.sh`; the path handler stages the rendered script into the PATH directory. Directory structure is preserved — `pack/sub/file.tmpl` renders to `.../preprocessed/sub/file`.
+
+    Two consequences worth knowing:
+
+    - _Diagnostics_ — if you want to see exactly what dodot produced for a given template, that directory is the source of truth.
+    - _Hashing_ — the install handler derives its completion sentinel from the hash of the *rendered* script, not the `.tmpl` source. Changing a variable (or the value of `dodot.hostname` after moving machines) re-triggers the install step even if the template itself didn't change.

--- a/tests/e2e/bats/test_preprocessing.bats
+++ b/tests/e2e/bats/test_preprocessing.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# E2E tests for the preprocessing pipeline (template + unarchive).
+#
+# Intentionally narrow: the Rust suite already covers the matrix of
+# preprocessor behaviours. These tests verify the *integration* — that
+# `dodot up` wires preprocessing into the real binary, renders
+# `.tmpl` files end-to-end, and exposes clean errors to the CLI.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "template file is rendered and deployed via symlink" {
+    create_pack "app"
+    create_pack_file "app" "vimrc.tmpl" 'set user={{ name }}
+set os={{ dodot.os }}'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    # The user-visible file has the `.tmpl` extension stripped and gets
+    # the dotfile prefix from the symlink handler: vimrc → ~/.vimrc.
+    [ -L "$HOME/.vimrc" ]
+
+    # Rendered content: the variable is substituted and dodot.os is a
+    # non-empty string (whatever the host OS is).
+    assert_file_contains "$HOME/.vimrc" "set user=Alice"
+    assert_file_contains "$HOME/.vimrc" "set os="
+
+    # The rendered file lives in the datastore under packs/<pack>/preprocessed/.
+    assert_exists "$XDG_DATA_HOME/dodot/packs/app/preprocessed/vimrc"
+}
+
+@test "template can be disabled globally via root config" {
+    create_root_config '[preprocessor]
+enabled = false'
+    create_pack "app"
+    create_pack_file "app" "vimrc.tmpl" 'set user={{ name }}'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    # With preprocessing disabled the `.tmpl` file is deployed verbatim,
+    # extension preserved, no rendering.
+    [ -L "$HOME/.vimrc.tmpl" ]
+    assert_file_contains "$HOME/.vimrc.tmpl" '{{ name }}'
+}
+
+@test "undefined template variable surfaces with source path" {
+    create_pack "app"
+    create_pack_file "app" "bad.tmpl" 'value = "{{ nope }}"'
+
+    # `dodot up` reports per-pack errors in its output but still exits 0
+    # when at least the run itself completed. The important thing is the
+    # error naming the template so the user can find it, plus no stray
+    # file getting deployed.
+    run dodot up
+    assert_output_contains "bad.tmpl"
+    assert_output_contains "template render failed"
+    [ ! -e "$HOME/.bad" ]
+}
+
+@test "pack config overrides root config for template vars" {
+    create_root_config '[preprocessor.template.vars]
+name = "Root"'
+    create_pack "app"
+    create_pack_file "app" "greeting.tmpl" 'hello {{ name }}'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Pack"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+    # File is top-level, so it deploys as ~/.greeting (dotfile prefix).
+    assert_file_contains "$HOME/.greeting" "hello Pack"
+}
+
+@test "template collision with regular file is rejected" {
+    create_pack "app"
+    create_pack_file "app" "config.toml" "regular"
+    create_pack_file "app" "config.toml.tmpl" 'templated {{ 1 + 1 }}'
+
+    run dodot up
+    assert_output_contains "preprocessing collision"
+    assert_output_contains "config.toml"
+    # Neither file should have been deployed — the pack short-circuits
+    # on the collision.
+    [ ! -e "$HOME/.config.toml" ]
+}
+
+@test "template with env var and default filter renders fallback" {
+    create_pack "app"
+    create_pack_file "app" "settings.tmpl" 'editor={{ env.DODOT_MISSING_VAR | default("nano") }}'
+
+    # Make sure the probe variable is truly unset for this process.
+    unset DODOT_MISSING_VAR
+
+    run dodot up
+    [ "$status" -eq 0 ]
+    assert_file_contains "$HOME/.settings" "editor=nano"
+}


### PR DESCRIPTION
## Context

The preprocessing pipeline landed in #35. This PR ships the first real preprocessor: **template expansion**, per [`docs/proposals/template-expansion.lex`](docs/proposals/template-expansion.lex).

Scope is **Phase T1 only** — core Jinja2-style rendering with the three-namespace variable system. Divergence detection, reverse merge heuristics, and the `dodot transform check/status/install-hook` commands (Phase T2) are deferred to a follow-up PR. This split keeps review focused on rendering, which is most of the user value and has the cleanest scope.

## What works after this PR

A user can drop `.tmpl` / `.template` files anywhere in their dotfiles and they'll be rendered with variables at `dodot up` time:

```toml
# ~/dotfiles/.dodot.toml
[preprocessor.template.vars]
name = "Alice"
email = "alice@example.com"
```

```
# ~/dotfiles/app/config.toml.tmpl
[user]
name = "{{ name }}"
email = "{{ email }}"
host = "{{ dodot.hostname }}"
shell = "{{ env.SHELL }}"
```

After `dodot up`, `~/.config/app/config.toml` (or wherever the downstream handler deploys) contains the rendered output.

Composition works with every existing handler:
- `config.toml.tmpl` → symlink handler
- `aliases.sh.tmpl` → shell handler (sourced via init script)
- `install.sh.tmpl` → install handler (sentinel tracks rendered content hash, so var changes re-run the script)
- `Brewfile.tmpl` → homebrew handler
- `bin/mytool.tmpl` → path handler

## Variable namespaces

| Namespace | Source | Example |
|---|---|---|
| `dodot.*` | built-ins (os, arch, hostname, username, home, dotfiles_root) | `{{ dodot.os }}` |
| `env.*` | process environment (dynamic lookup via `minijinja::value::Object`) | `{{ env.SHELL }}` |
| bare names | `[preprocessor.template.vars]` in `.dodot.toml` | `{{ name }}` |

- **Strict undefined** — missing vars raise render errors rather than silently emitting empty strings.
- **Reserved names** — using `dodot` or `env` as a user var name fails at preprocessor construction.
- **Per-pack overrides** — user vars follow the normal 3-layer config hierarchy (defaults < root < pack).

## Engine

MiniJinja 2.x (Jinja2-compatible, Rust-native, by the creator of Jinja2). Supports `{{ var }}`, `{% if %}`, `{% for %}`, filters (`| upper`), comments (`{# #}`).

## Test coverage

**318 tests** (+22 over the 296 preprocessing baseline):

| Layer | Tests | What's covered |
|---|---|---|
| Template unit | 15 | Trait basics, extension matching (default + custom), reserved vars, user vars, `dodot.*` builtins, `env.*` lookup, missing env var, undefined user var, syntax error, filters + conditionals, empty template, plain text |
| Integration | 7 | Symlink deploy with content verification, shell handler composition, per-pack var overrides, `enabled = false` disables preprocessing, render errors surface with source path, reserved var fails fast, install handler sentinel reflects rendered content |

Manual smoke test with `hello {{ dodot.os }} {{ name }}` produced `hello macos world` as expected.

## Files

New: `crates/dodot-lib/src/preprocessing/template.rs`

Modified:
- `crates/dodot-lib/Cargo.toml` — minijinja dep
- `crates/dodot-lib/src/config/mod.rs` — `PreprocessorTemplateSection`
- `crates/dodot-lib/src/error.rs` — `TemplateRender`, `TemplateReservedVar` variants
- `crates/dodot-lib/src/preprocessing/mod.rs` — `template` submodule, updated `default_registry` signature
- `crates/dodot-lib/src/packs/orchestration.rs` — pass template config + pather to `default_registry`

## Not in this PR (follow-ups)

Phase T2 (separate PR):
- Baseline caching on deploy
- Divergence detection (4-state matrix: output/input changed)
- Re-deploy warn-and-skip when deployed file has been modified
- `dodot transform check` command with reverse-merge heuristics
- `dodot-conflict` marker insertion for ambiguous lines
- `dodot transform install-hook` for pre-commit integration

Phase T3 (separate PR):
- `no_reverse` per-file opt-out
- First-deployment onboarding hint
- `dodot transform status` command

## Test plan

- [x] 296 pre-existing tests pass (no regressions from scanner/registry wiring changes)
- [x] Template renders user vars, builtins, env vars
- [x] Strict undefined behaviour raises errors with source file path
- [x] Composition: `.tmpl` through symlink, shell, install handlers
- [x] Per-pack var overrides; `enabled = false` disables preprocessing
- [x] Reserved var names rejected at construction
- [x] Install sentinel hashes rendered content (vars change → re-run)
- [x] `cargo clippy` clean, `cargo fmt` clean
- [x] Manual smoke test from outside the test harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)