### PR TITLE
feat(scanner): top-level-only matching, wholesale dir linking (#37)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -18,3 +18,15 @@ Use sections: Added, Changed, Deprecated, Removed, Fixed, Security.
 - `dodot up` now uses a two-phase execution model: collect all intents first, then execute — replacing the previous sequential per-pack execution
 - `--force` does not override cross-pack conflicts (it only applies to pre-existing non-dodot files); cross-pack conflicts require a configuration fix
 - Orchestration pipeline split into `collect_pack_intents()` and `execute_intents()` for composability
+- **Scanner is top-level only** (#37): rules match pack depth-1 entries only; nested files are the responsibility of the handler that owns the containing top-level entry. Fixes two long-standing issues:
+  - A pack's `bin/tool` was being **both** staged via the path handler *and* symlinked individually via the catchall — now only the `bin/` directory is claimed (by path). One shell command, one status line.
+  - A nested `foo/install.sh` used to trigger the install handler because matching was on basename-only; now only a top-level `install.sh` does.
+- **Symlink handler links top-level directories wholesale**: `warp/themes/` now becomes a single symlink `~/.config/themes → <pack>/warp/themes`, not a per-file listing. Falls back to per-file mode (current behavior) when `[symlink] protected_paths` or `[symlink.targets]` reach inside the directory, preserving every existing security guarantee.
+- **Top-level dirs default to `$XDG_CONFIG_HOME/<name>`** (aligning code with the longstanding docs). Top-level *files* still default to `$HOME/.<name>`. `force_home`, `_home/`, `_xdg/`, `dot.`, and `targets` overrides all still apply.
+- Handler trait gains `match_mode()` (`Precise` / `Catchall`) and `scope()` (`Exclusive` / `Shared`), with a registry invariant that at most one handler may be simultaneously `Catchall` + `Exclusive`. No behavior change for existing handlers; the formalization future-proofs adding non-claiming observers.
+- `Handler::to_intents` now receives an `&dyn Fs` so handlers can inspect directory contents when deciding wholesale-vs-per-file treatment.
+
+### Migration notes
+- If you previously relied on nested files being individually symlinked (e.g. `warp/themes/nord.yaml → ~/.config/themes/nord.yaml`), the whole `themes/` directory is now one symlink. The observed path `~/.config/themes/nord.yaml` still resolves identically via the directory link.
+- If you need nested per-file behavior (different targets per file, or selective inclusion), add `[symlink.targets]` entries or list individual files in `[symlink] protected_paths` — either triggers per-file mode for the containing directory.
+- If you had nested `install.sh` / `aliases.sh` / `Brewfile` that were (perhaps unintentionally) being picked up by their handlers, move them to the pack's top level or use `[mappings]` overrides.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "standout"
-version = "7.3.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c3d5c63594a2662f23617de22a84a227e21c8e9c26f57566afaf7e2aaa4e6"
+checksum = "1d553ef61879a613f7ea87895e064ab969f50fff4470832778c0376249981f64"
 dependencies = [
  "anyhow",
  "clap",
@@ -1733,18 +1733,18 @@ dependencies = [
 
 [[package]]
 name = "standout-bbparser"
-version = "7.3.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb7d47ea77fb63af7d239988f6ac8e9511b1552e77dbbaf48b34b58f5e57926"
+checksum = "d61dc503cd072f812ba97f04b93f0a0ac00109c7207a88652101edd0c1c89900"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "standout-dispatch"
-version = "7.3.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50cd846432fdaf7e3b06da221b6679e1c0d62e851555a7e323185082d85266b"
+checksum = "5b5f87bf4f1240a1cd1d357b045aa91fbd21ed636500fa66a8839e96b8ddc5e8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "standout-macros"
-version = "7.3.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2225e85cf7022aa6bce8cfd2c49fabe5297f2f71dce15838929b4d72495d25cf"
+checksum = "aa8ed8ed9b98b5f93e55f3649f3830c5e6caa5717b087c3e86ccb7da10d89891"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1766,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "standout-pipe"
-version = "7.3.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af8e1989b6fcf84126bfa0bf2066e6f7c3bba01322dd3ac8b0c8a61c710988f"
+checksum = "d70d62ce4542cb5ac1c540752804748ab61e75211abdd1c3b4eb2f7113c7fbe7"
 dependencies = [
  "thiserror 2.0.18",
  "wait-timeout",
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "standout-render"
-version = "7.3.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199ead9789ff6d467a6f22f9637b7d875ae1d890598cad7c3aaa9f01c691ad8c"
+checksum = "d7494cb3875e7f0d227f380f5c8bba8e47fdbbd2a1e03ace7bae5acf78de45fd"
 dependencies = [
  "console",
  "cssparser",
@@ -1797,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "standout-seeker"
-version = "7.3.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058c963d4580bfd5276d863a763fd6b4d8b43576adee262eefbfd4e0b7c3dc62"
+checksum = "c3fbd4004f2e48b7c99658eff80588271d3d8f164f3ab07c3d1d7cf8b7962266"
 dependencies = [
  "regex",
  "thiserror 2.0.18",

--- a/crates/dodot-cli/Cargo.toml
+++ b/crates/dodot-cli/Cargo.toml
@@ -16,7 +16,7 @@ clapfig = "0.16"
 clap = { version = "4", features = ["derive"] }
 dodot-lib = { version = "0.10.0", path = "../dodot-lib" }
 serde = { version = "1", features = ["derive"] }
-standout = "7.3"
+standout = "7.5"
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -99,9 +99,29 @@ pub fn up_handler(
 ) -> HandlerResult<commands::PackStatusResult> {
     let ctx = build_ctx(matches)?;
     let filter = pack_filter(matches);
-    let result = commands::up::up(filter.as_deref(), &ctx)?;
-    print_warnings(&result.warnings);
-    Ok(Output::Render(result))
+    match commands::up::up(filter.as_deref(), &ctx) {
+        Ok(result) => {
+            print_warnings(&result.warnings);
+            Ok(Output::Render(result))
+        }
+        Err(dodot_lib::DodotError::CrossPackConflict { conflicts }) => {
+            // Render conflicts through the same template as status, so the
+            // user sees the rich, styled output instead of a raw error dump.
+            let home = ctx.paths.home_dir();
+            let display_conflicts = conflicts
+                .iter()
+                .map(|c| commands::DisplayConflict::from_conflict(c, home))
+                .collect();
+            Ok(Output::Render(commands::PackStatusResult {
+                message: None,
+                dry_run: ctx.dry_run,
+                packs: Vec::new(),
+                warnings: Vec::new(),
+                conflicts: display_conflicts,
+            }))
+        }
+        Err(e) => Err(e.into()),
+    }
 }
 
 pub fn down_handler(

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -80,6 +80,7 @@ fn build_app() -> App {
         .help_handling(true)
         .templates(standout::embed_templates!("src/templates"))
         .styles(standout::embed_styles!("src/styles"))
+        .default_theme("dodot")
         .command("status", handlers::status_handler, "pack-status")
         .expect("register status")
         .command("up", handlers::up_handler, "pack-status")

--- a/crates/dodot-cli/src/styles/dodot.css
+++ b/crates/dodot-cli/src/styles/dodot.css
@@ -1,17 +1,17 @@
 /* dodot CLI theme — semantic styles for all output */
 
 .pack-name {
-    color: #005F87;
+    color: #000;
     font-weight: bold;
 }
 
 .handler-symbol {
-    color: #875F00;
+    color: #999;
     font-weight: bold;
 }
 
 .description {
-    opacity: 0.6;
+    dim: true;
 }
 
 .deployed {
@@ -19,7 +19,8 @@
 }
 
 .pending {
-    color: #5F5F87;
+    background: #f8f8f8;
+    color: #000;
 }
 
 .error {
@@ -41,9 +42,34 @@
 }
 
 .dim {
-    opacity: 0.6;
+    dim: true;
 }
 
 .header {
     font-weight: bold;
+}
+
+.conflict-banner {
+    color: #FFFFFF;
+    background: #D70000;
+    font-weight: bold;
+}
+
+.conflict-header {
+    color: #FFFFFF;
+    background: #D70000;
+    font-weight: bold;
+}
+
+.conflict-target {
+    color: #D70000;
+    font-weight: bold;
+}
+
+.conflict-pack {
+    color: #D70000;
+}
+
+.conflict-hint {
+    dim: true;
 }

--- a/crates/dodot-cli/src/templates/pack-status.jinja
+++ b/crates/dodot-cli/src/templates/pack-status.jinja
@@ -1,6 +1,17 @@
-{% if message %}[message]{{ message }}[/message]
+{% if conflicts %}[conflict-banner] ✗ Cross-pack conflicts detected — see details below [/conflict-banner]
+{% endif %}{% if message %}[message]{{ message }}[/message]
 {% endif %}{% if dry_run %}[dry-run]  (dry run — no changes made)[/dry-run]
 {% endif %}{% for pack in packs %}[pack-name]{{ pack.name }}[/pack-name]
 {% for file in pack.files %}  {{ file.name | col(24) }} [handler-symbol]{{ file.symbol }}[/handler-symbol] [description]{{ file.description | col(30) }}[/description]  [{{ file.status }}]{{ file.status_label }}[/{{ file.status }}]
 {% endfor %}
-{% endfor %}
+{% endfor %}{% if conflicts %}
+[conflict-header] Cross-pack conflicts [/conflict-header]
+{% for c in conflicts %}
+{% if c.kind == "symlink" %}The target path [conflict-target]{{ c.target }}[/conflict-target] would be used by multiple packs:
+{% else %}The executable [conflict-target]{{ c.target }}[/conflict-target] would be shadowed across multiple packs in $PATH:
+{% endif %}{% for cl in c.claimants %}  - [conflict-pack]{{ cl.source }}[/conflict-pack]
+{% endfor %}{% endfor %}
+[conflict-hint]Common fixes: give them unique names, override the destination in the pack's config,[/conflict-hint]
+[conflict-hint]or ignore the pack entirely. See `dodot config --help` for the last option.[/conflict-hint]
+[conflict-hint]`dodot up` won't run while conflicts exist.[/conflict-hint]
+{% endif %}

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -118,5 +118,6 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         dry_run: ctx.dry_run,
         packs: display_packs,
         warnings,
+        conflicts: Vec::new(),
     })
 }

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -84,6 +84,83 @@ pub struct DisplayPack {
     pub files: Vec<DisplayFile>,
 }
 
+/// One claimant of a cross-pack conflict, formatted for display.
+#[derive(Debug, Clone, Serialize)]
+pub struct DisplayClaimant {
+    /// Pack name.
+    pub pack: String,
+    /// Short, pack-relative source description (e.g. `git/env.sh`).
+    pub source: String,
+}
+
+/// A single cross-pack conflict, flattened for template rendering.
+#[derive(Debug, Clone, Serialize)]
+pub struct DisplayConflict {
+    /// Conflict kind. Serializes as `"symlink"` or `"path"` so the
+    /// template can branch on it.
+    pub kind: String,
+    /// Human-readable target (path for symlink, executable name for path).
+    pub target: String,
+    pub claimants: Vec<DisplayClaimant>,
+}
+
+impl DisplayConflict {
+    /// Convert a detection-layer conflict into its display form,
+    /// shortening paths relative to `home` when possible.
+    pub fn from_conflict(c: &crate::conflicts::Conflict, home: &std::path::Path) -> Self {
+        let kind = match c.kind {
+            crate::conflicts::ConflictKind::SymlinkTarget => "symlink",
+            crate::conflicts::ConflictKind::PathExecutable => "path",
+        };
+        let target = match c.kind {
+            crate::conflicts::ConflictKind::SymlinkTarget => shorten_path(&c.target, home),
+            crate::conflicts::ConflictKind::PathExecutable => c
+                .target
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| c.target.display().to_string()),
+        };
+        let claimants = c
+            .claimants
+            .iter()
+            .map(|cl| DisplayClaimant {
+                pack: cl.pack.clone(),
+                source: pack_relative_source(&cl.source, &cl.pack),
+            })
+            .collect();
+        DisplayConflict {
+            kind: kind.into(),
+            target,
+            claimants,
+        }
+    }
+}
+
+fn shorten_path(p: &std::path::Path, home: &std::path::Path) -> String {
+    if let Ok(rel) = p.strip_prefix(home) {
+        format!("~/{}", rel.display())
+    } else {
+        p.display().to_string()
+    }
+}
+
+/// Render a claimant source as `<pack>/<relative-path>` when possible,
+/// falling back to just the filename.
+fn pack_relative_source(source: &std::path::Path, pack: &str) -> String {
+    let s = source.to_string_lossy();
+    let marker = format!("/{pack}/");
+    if let Some(idx) = s.rfind(&marker) {
+        let rel = &s[idx + 1..];
+        return rel.to_string();
+    }
+    // Fallback: pack/filename
+    let fname = source
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    format!("{pack}/{fname}")
+}
+
 /// Result type for commands that display pack status
 /// (status, up, down).
 #[derive(Debug, Clone, Serialize)]
@@ -94,4 +171,7 @@ pub struct PackStatusResult {
     pub packs: Vec<DisplayPack>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
+    /// Cross-pack conflicts to display at the end of the output.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub conflicts: Vec<DisplayConflict>,
 }

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -80,6 +80,7 @@ fn verify_symlink(
     source: &std::path::Path,
     pack: &str,
     rel_path: &str,
+    is_dir: bool,
     config: &crate::handlers::HandlerConfig,
     ctx: &ExecutionContext,
 ) -> Health {
@@ -116,7 +117,7 @@ fn verify_symlink(
     }
 
     // Step 4: Check user link at the currently-resolved target
-    let user_target = resolve_target(rel_path, config, ctx.paths.as_ref());
+    let user_target = resolve_target(rel_path, is_dir, config, ctx.paths.as_ref());
 
     if ctx.fs.is_symlink(&user_target) {
         match ctx.fs.readlink(&user_target) {
@@ -272,19 +273,18 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
 
         let mut files = Vec::new();
         for m in &matches {
-            // Skip directory entries for symlink handler — only show leaf files (#11)
-            // Keep directory entries for other handlers (e.g. path handler uses bin/ dirs)
-            if m.is_dir && m.handler == HANDLER_SYMLINK {
-                continue;
-            }
-
             let rel_str = m.relative_path.to_string_lossy().into_owned();
 
             // Per-file chain verification based on handler type
             let health = match m.handler.as_str() {
-                "symlink" => {
-                    verify_symlink(&m.absolute_path, &pack.name, &rel_str, &pack.config, ctx)
-                }
+                "symlink" => verify_symlink(
+                    &m.absolute_path,
+                    &pack.name,
+                    &rel_str,
+                    m.is_dir,
+                    &pack.config,
+                    ctx,
+                ),
                 "shell" | "path" => verify_staged(&m.absolute_path, &pack.name, &m.handler, ctx),
                 _ => {
                     // install, homebrew — use existing handler check_status
@@ -306,7 +306,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
 
             // Compute actual target path for symlink handler display
             let user_target = if m.handler == HANDLER_SYMLINK {
-                let target = resolve_target(&rel_str, &pack.config, ctx.paths.as_ref());
+                let target = resolve_target(&rel_str, m.is_dir, &pack.config, ctx.paths.as_ref());
                 let home = ctx.paths.home_dir();
                 let display = if let Ok(rel) = target.strip_prefix(home) {
                     format!("~/{}", rel.display())

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -11,7 +11,8 @@
 use tracing::{debug, info};
 
 use crate::commands::{
-    handler_description, handler_symbol, DisplayFile, DisplayPack, PackStatusResult,
+    handler_description, handler_symbol, DisplayConflict, DisplayFile, DisplayPack,
+    PackStatusResult,
 };
 use crate::config::mappings_to_rules;
 use crate::conflicts;
@@ -177,38 +178,6 @@ fn verify_staged(
     Health::Deployed
 }
 
-/// Format cross-pack conflict warnings for status output.
-fn conflict_warnings(conflicts: &[conflicts::Conflict], home: &std::path::Path) -> Vec<String> {
-    let mut warnings = Vec::new();
-    if conflicts.is_empty() {
-        return warnings;
-    }
-
-    warnings.push("cross-pack conflicts detected:".into());
-    for c in conflicts {
-        let target_display = if let Ok(rel) = c.target.strip_prefix(home) {
-            format!("~/{}", rel.display())
-        } else {
-            c.target.display().to_string()
-        };
-        warnings.push(format!("  target: {target_display}"));
-        for claimant in &c.claimants {
-            warnings.push(format!(
-                "    - pack '{}' ({} handler): {}",
-                claimant.pack,
-                claimant.handler,
-                claimant.source.display()
-            ));
-        }
-    }
-    warnings.push(
-        "fix your configuration — `dodot up` will refuse to deploy until conflicts are resolved."
-            .into(),
-    );
-
-    warnings
-}
-
 /// Run the `status` command: scan packs and verify deployment chain per file.
 ///
 /// Also performs cross-pack conflict detection and surfaces potential
@@ -365,15 +334,18 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         });
     }
 
-    // Detect and surface cross-pack conflicts as warnings
+    // Detect and surface cross-pack conflicts as structured display data
     let detected_conflicts = conflicts::detect_cross_pack_conflicts(&pack_intents, ctx.fs.as_ref());
-    if !detected_conflicts.is_empty() {
+    let home = ctx.paths.home_dir();
+    let display_conflicts: Vec<DisplayConflict> = detected_conflicts
+        .iter()
+        .map(|c| DisplayConflict::from_conflict(c, home))
+        .collect();
+    if !display_conflicts.is_empty() {
         info!(
-            count = detected_conflicts.len(),
+            count = display_conflicts.len(),
             "cross-pack conflicts detected"
         );
-        let home = ctx.paths.home_dir();
-        warnings.extend(conflict_warnings(&detected_conflicts, home));
     } else {
         debug!("no cross-pack conflicts");
     }
@@ -383,5 +355,6 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         dry_run: false,
         packs: display_packs,
         warnings,
+        conflicts: display_conflicts,
     })
 }

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -97,7 +97,10 @@ fn status_renders_with_standout() {
 // ── status: correct target paths ────────────────────────────
 
 #[test]
-fn status_shows_xdg_target_for_subdirectory_files() {
+fn status_shows_xdg_target_for_subdirectory() {
+    // Top-level directories (e.g. `nvim`) are linked wholesale to
+    // `$XDG_CONFIG_HOME/<name>` — a single entry in status, not
+    // one per nested file.
     let env = TempEnvironment::builder()
         .pack("nvim")
         .file("nvim/init.lua", "-- nvim config")
@@ -108,22 +111,23 @@ fn status_shows_xdg_target_for_subdirectory_files() {
     let result = commands::status::status(None, &ctx).unwrap();
 
     let nvim_pack = &result.packs[0];
-    let init_file = nvim_pack
+    let nvim_entry = nvim_pack
         .files
         .iter()
-        .find(|f| f.name.contains("init.lua"))
-        .expect("should have init.lua");
+        .find(|f| f.name == "nvim")
+        .expect("should have nvim dir entry");
 
-    // Should show ~/.config/nvim/init.lua, not ~/.nvim/init.lua
     assert!(
-        init_file.description.contains(".config/nvim"),
-        "expected XDG path, got: {}",
-        init_file.description
+        nvim_entry.description.contains(".config/nvim"),
+        "expected XDG path for wholesale dir, got: {}",
+        nvim_entry.description
     );
 }
 
 #[test]
-fn status_does_not_list_directories() {
+fn status_lists_top_level_dirs_wholesale() {
+    // Top-level dirs now appear as single entries (linked wholesale),
+    // not expanded into one entry per nested file.
     let env = TempEnvironment::builder()
         .pack("nvim")
         .file("nvim/init.lua", "-- nvim config")
@@ -135,14 +139,12 @@ fn status_does_not_list_directories() {
     let result = commands::status::status(None, &ctx).unwrap();
 
     let nvim_pack = &result.packs[0];
-    // Should not have directory entries like "nvim" or "nvim/lua"
-    for file in &nvim_pack.files {
-        assert!(
-            file.name.contains('.'),
-            "expected only files (with extensions), got directory entry: {}",
-            file.name
-        );
-    }
+    let names: Vec<&str> = nvim_pack.files.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["nvim"],
+        "expected single wholesale dir entry, got {names:?}"
+    );
 }
 
 // ── up ──────────────────────────────────────────────────────

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -1181,26 +1181,14 @@ fn status_warns_on_potential_cross_pack_conflict() {
     let ctx = make_ctx(&env);
     let result = commands::status::status(None, &ctx).unwrap();
 
-    // Status should still succeed (it's informational)
-    assert!(!result.warnings.is_empty(), "should have conflict warnings");
-
-    let warnings_text = result.warnings.join("\n");
-    assert!(
-        warnings_text.contains("cross-pack conflicts"),
-        "warnings: {warnings_text}"
-    );
-    assert!(
-        warnings_text.contains("pack-a"),
-        "warnings: {warnings_text}"
-    );
-    assert!(
-        warnings_text.contains("pack-b"),
-        "warnings: {warnings_text}"
-    );
-    assert!(
-        warnings_text.contains("dodot up"),
-        "should hint that up will refuse: {warnings_text}"
-    );
+    // Status should still succeed (it's informational) and surface the
+    // conflict as structured data on the result.
+    assert_eq!(result.conflicts.len(), 1, "should detect one conflict");
+    let c = &result.conflicts[0];
+    assert_eq!(c.kind, "symlink");
+    let packs: Vec<&str> = c.claimants.iter().map(|cl| cl.pack.as_str()).collect();
+    assert!(packs.contains(&"pack-a"), "claimants: {:?}", c.claimants);
+    assert!(packs.contains(&"pack-b"), "claimants: {:?}", c.claimants);
 }
 
 #[test]
@@ -1219,8 +1207,13 @@ fn status_no_warnings_without_conflicts() {
 
     assert!(
         result.warnings.is_empty(),
-        "no conflict warnings expected, got: {:?}",
+        "no warnings expected, got: {:?}",
         result.warnings
+    );
+    assert!(
+        result.conflicts.is_empty(),
+        "no conflicts expected, got: {:?}",
+        result.conflicts
     );
 }
 
@@ -1247,10 +1240,10 @@ fn status_shows_conflict_even_when_not_deployed() {
         }
     }
 
-    // But warnings should flag the conflict
+    // Conflict data should still be emitted.
     assert!(
-        !result.warnings.is_empty(),
-        "should warn about potential conflict even when undeployed"
+        !result.conflicts.is_empty(),
+        "should flag potential conflict even when undeployed"
     );
 }
 
@@ -1271,8 +1264,8 @@ fn status_filtered_to_one_pack_no_conflict_warning() {
     let result = commands::status::status(Some(&filter), &ctx).unwrap();
 
     assert!(
-        result.warnings.is_empty(),
-        "single-pack filter should not produce cross-pack warnings"
+        result.conflicts.is_empty(),
+        "single-pack filter should not produce cross-pack conflicts"
     );
 }
 
@@ -1292,14 +1285,15 @@ fn status_conflict_with_config_mapping() {
     let ctx = make_ctx(&env);
     let result = commands::status::status(None, &ctx).unwrap();
 
-    let warnings_text = result.warnings.join("\n");
-    assert!(
-        warnings_text.contains("cross-pack conflicts"),
-        "config mapping collision should produce a warning: {warnings_text}"
+    assert_eq!(
+        result.conflicts.len(),
+        1,
+        "config mapping collision should surface one conflict"
     );
     assert!(
-        warnings_text.contains("myapp/settings.toml") || warnings_text.contains("settings.toml"),
-        "should mention the conflicting target: {warnings_text}"
+        result.conflicts[0].target.contains("settings.toml"),
+        "should mention the conflicting target: {:?}",
+        result.conflicts[0]
     );
 }
 

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -163,6 +163,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         dry_run: ctx.dry_run,
         packs: display_packs,
         warnings: Vec::new(),
+        conflicts: Vec::new(),
     })
 }
 

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -176,6 +176,7 @@ impl DodotConfig {
             protected_paths: self.symlink.protected_paths.clone(),
             targets: self.symlink.targets.clone(),
             auto_chmod_exec: self.path.auto_chmod_exec,
+            pack_ignore: self.pack.ignore.clone(),
         }
     }
 }

--- a/crates/dodot-lib/src/conflicts.rs
+++ b/crates/dodot-lib/src/conflicts.rs
@@ -33,11 +33,28 @@ pub struct Claimant {
     pub source: PathBuf,
 }
 
+/// What kind of collision this conflict represents.
+///
+/// The two kinds have different display semantics: symlink conflicts
+/// have a filesystem target path, while path-executable conflicts have
+/// a bare executable name whose location is "somewhere in $PATH".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictKind {
+    /// Multiple packs resolve to the same user symlink target.
+    SymlinkTarget,
+    /// Multiple packs stage a `$PATH` directory that contains files
+    /// with the same name — only the first in PATH order would be used.
+    PathExecutable,
+}
+
 /// A cross-pack conflict: multiple packs claim the same effective target.
 #[derive(Debug, Clone)]
 pub struct Conflict {
-    /// The resolved target path (filesystem path for Link intents,
-    /// descriptive label for path executable collisions).
+    /// The kind of collision.
+    pub kind: ConflictKind,
+    /// For [`ConflictKind::SymlinkTarget`]: the resolved filesystem path.
+    /// For [`ConflictKind::PathExecutable`]: a sentinel path
+    /// `<path-executable>/<name>` — read `.file_name()` for the bare name.
     pub target: PathBuf,
     /// Every pack that claims this target.
     pub claimants: Vec<Claimant>,
@@ -82,10 +99,13 @@ pub fn detect_cross_pack_conflicts(
 ) -> Vec<Conflict> {
     let mut targets: HashMap<PathBuf, Vec<Claimant>> = HashMap::new();
 
+    let mut kinds: HashMap<PathBuf, ConflictKind> = HashMap::new();
+
     for (pack_name, intents) in pack_intents {
         for intent in intents {
             // Symlink target conflicts
             if let HandlerIntent::Link { user_path, .. } = intent {
+                kinds.insert(user_path.clone(), ConflictKind::SymlinkTarget);
                 targets
                     .entry(user_path.clone())
                     .or_default()
@@ -106,6 +126,7 @@ pub fn detect_cross_pack_conflicts(
                         for entry in entries {
                             if entry.is_file || entry.is_symlink {
                                 let key = Path::new("<path-executable>").join(&entry.name);
+                                kinds.insert(key.clone(), ConflictKind::PathExecutable);
                                 targets.entry(key).or_default().push(Claimant {
                                     pack: pack_name.clone(),
                                     handler: handler.clone(),
@@ -126,7 +147,17 @@ pub fn detect_cross_pack_conflicts(
             let first = &claimants[0].pack;
             claimants.len() > 1 && claimants.iter().any(|c| c.pack != *first)
         })
-        .map(|(target, claimants)| Conflict { target, claimants })
+        .map(|(target, claimants)| {
+            let kind = kinds
+                .get(&target)
+                .copied()
+                .unwrap_or(ConflictKind::SymlinkTarget);
+            Conflict {
+                kind,
+                target,
+                claimants,
+            }
+        })
         .collect();
 
     // Sort for deterministic output
@@ -551,6 +582,7 @@ mod tests {
     #[test]
     fn conflict_display_includes_all_info() {
         let conflict = Conflict {
+            kind: ConflictKind::SymlinkTarget,
             target: PathBuf::from("/home/.aliases"),
             claimants: vec![
                 Claimant {
@@ -576,6 +608,7 @@ mod tests {
     fn format_conflicts_combines_multiple() {
         let conflicts = vec![
             Conflict {
+                kind: ConflictKind::SymlinkTarget,
                 target: PathBuf::from("/home/.a"),
                 claimants: vec![
                     Claimant {
@@ -591,6 +624,7 @@ mod tests {
                 ],
             },
             Conflict {
+                kind: ConflictKind::SymlinkTarget,
                 target: PathBuf::from("/home/.b"),
                 claimants: vec![
                     Claimant {

--- a/crates/dodot-lib/src/handlers/homebrew.rs
+++ b/crates/dodot-lib/src/handlers/homebrew.rs
@@ -37,6 +37,7 @@ impl Handler for HomebrewHandler<'_> {
         matches: &[RuleMatch],
         _config: &HandlerConfig,
         _paths: &dyn Pather,
+        _fs: &dyn Fs,
     ) -> Result<Vec<HandlerIntent>> {
         let mut intents = Vec::new();
 

--- a/crates/dodot-lib/src/handlers/install.rs
+++ b/crates/dodot-lib/src/handlers/install.rs
@@ -37,6 +37,7 @@ impl Handler for InstallHandler<'_> {
         matches: &[RuleMatch],
         _config: &HandlerConfig,
         _paths: &dyn Pather,
+        _fs: &dyn Fs,
     ) -> Result<Vec<HandlerIntent>> {
         let mut intents = Vec::new();
 
@@ -176,7 +177,12 @@ mod tests {
             .unwrap();
 
         let intents = handler
-            .to_intents(&matches, &HandlerConfig::default(), &pather)
+            .to_intents(
+                &matches,
+                &HandlerConfig::default(),
+                &pather,
+                env.fs.as_ref(),
+            )
             .unwrap();
 
         assert_eq!(intents.len(), 1);

--- a/crates/dodot-lib/src/handlers/mod.rs
+++ b/crates/dodot-lib/src/handlers/mod.rs
@@ -36,6 +36,31 @@ pub enum HandlerCategory {
     CodeExecution,
 }
 
+/// Whether a handler matches specific names or acts as a catchall.
+///
+/// [`MatchMode::Precise`] handlers only match whitelisted patterns
+/// (e.g. `bin/`, `install.sh`). [`MatchMode::Catchall`] handlers
+/// match anything not already claimed and must run after all precise
+/// handlers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchMode {
+    Precise,
+    Catchall,
+}
+
+/// Whether a handler's match is consumed or leaves the entry available.
+///
+/// [`HandlerScope::Exclusive`] handlers consume their matches — once
+/// claimed, no other handler sees the entry. [`HandlerScope::Shared`]
+/// handlers let other handlers also process the same entry (future
+/// use-cases like audit/indexing). At most one `Exclusive` + `Catchall`
+/// handler may exist in a registry; this is validated at build time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandlerScope {
+    Exclusive,
+    Shared,
+}
+
 /// The status of a handler's operations for a single file.
 #[derive(Debug, Clone, Serialize)]
 pub struct HandlerStatus {
@@ -66,15 +91,35 @@ pub trait Handler: Send + Sync {
     /// Whether this is a configuration or code-execution handler.
     fn category(&self) -> HandlerCategory;
 
+    /// How this handler decides what to claim.
+    ///
+    /// Defaults to [`MatchMode::Precise`]. Override to `Catchall` for
+    /// a fallback handler (like symlink) that takes anything not
+    /// already claimed.
+    fn match_mode(&self) -> MatchMode {
+        MatchMode::Precise
+    }
+
+    /// Whether a match removes the entry from further consideration.
+    ///
+    /// Defaults to [`HandlerScope::Exclusive`] — a matched entry is
+    /// consumed and no other handler will see it.
+    fn scope(&self) -> HandlerScope {
+        HandlerScope::Exclusive
+    }
+
     /// Transform matched files into intents.
     ///
     /// This is the heart of each handler — it declares what operations
-    /// are needed without performing any I/O.
+    /// are needed without performing any I/O. `fs` is provided so a
+    /// handler that owns a directory entry can inspect its contents
+    /// to decide wholesale vs per-file treatment.
     fn to_intents(
         &self,
         matches: &[RuleMatch],
         config: &HandlerConfig,
         paths: &dyn Pather,
+        fs: &dyn Fs,
     ) -> Result<Vec<HandlerIntent>>;
 
     /// Check whether a file has been deployed by this handler.
@@ -141,7 +186,25 @@ pub fn create_registry(fs: &dyn Fs) -> HashMap<String, Box<dyn Handler + '_>> {
         HANDLER_HOMEBREW.into(),
         Box::new(homebrew::HomebrewHandler::new(fs)),
     );
+    validate_registry(&registry);
     registry
+}
+
+/// Enforce registry invariants.
+///
+/// At most one handler may be simultaneously [`MatchMode::Catchall`]
+/// and [`HandlerScope::Exclusive`]. Two such handlers would fight over
+/// the same "leftover" entries with no principled way to pick a winner.
+fn validate_registry(registry: &HashMap<String, Box<dyn Handler + '_>>) {
+    let exclusive_catchalls: Vec<&str> = registry
+        .values()
+        .filter(|h| h.match_mode() == MatchMode::Catchall && h.scope() == HandlerScope::Exclusive)
+        .map(|h| h.name())
+        .collect();
+    assert!(
+        exclusive_catchalls.len() <= 1,
+        "at most one exclusive catchall handler allowed, found: {exclusive_catchalls:?}"
+    );
 }
 
 #[cfg(test)]
@@ -185,5 +248,60 @@ mod tests {
         let config = HandlerConfig::default();
         assert!(config.force_home.is_empty());
         assert!(config.protected_paths.is_empty());
+    }
+
+    #[test]
+    fn default_registry_has_exactly_one_exclusive_catchall() {
+        let fs = crate::fs::OsFs::new();
+        let registry = create_registry(&fs);
+        let exclusive_catchalls: Vec<&str> = registry
+            .values()
+            .filter(|h| {
+                h.match_mode() == MatchMode::Catchall && h.scope() == HandlerScope::Exclusive
+            })
+            .map(|h| h.name())
+            .collect();
+        assert_eq!(exclusive_catchalls, vec!["symlink"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "at most one exclusive catchall handler")]
+    fn two_exclusive_catchalls_panic() {
+        struct FakeCatchall;
+        impl Handler for FakeCatchall {
+            fn name(&self) -> &str {
+                "fake"
+            }
+            fn category(&self) -> HandlerCategory {
+                HandlerCategory::Configuration
+            }
+            fn match_mode(&self) -> MatchMode {
+                MatchMode::Catchall
+            }
+            fn scope(&self) -> HandlerScope {
+                HandlerScope::Exclusive
+            }
+            fn to_intents(
+                &self,
+                _matches: &[RuleMatch],
+                _config: &HandlerConfig,
+                _paths: &dyn Pather,
+                _fs: &dyn Fs,
+            ) -> Result<Vec<HandlerIntent>> {
+                Ok(Vec::new())
+            }
+            fn check_status(
+                &self,
+                _file: &Path,
+                _pack: &str,
+                _datastore: &dyn DataStore,
+            ) -> Result<HandlerStatus> {
+                unreachable!()
+            }
+        }
+        let fs = crate::fs::OsFs::new();
+        let mut registry = create_registry(&fs);
+        registry.insert("fake".into(), Box::new(FakeCatchall));
+        validate_registry(&registry);
     }
 }

--- a/crates/dodot-lib/src/handlers/mod.rs
+++ b/crates/dodot-lib/src/handlers/mod.rs
@@ -4,8 +4,11 @@
 //! (operations). Each handler knows how to transform a set of matched
 //! files into [`HandlerIntent`]s that the executor will carry out.
 //!
-//! Handlers are pure data transformers — they declare what operations
-//! they need without performing any I/O themselves.
+//! Handlers are intent planners. They may perform **read-only**
+//! filesystem inspection (e.g. the symlink handler reads a matched
+//! directory's contents to decide between wholesale and per-file
+//! linking) but must not mutate anything — mutations are the executor's
+//! job. This keeps planning idempotent and safe to re-run.
 
 pub mod homebrew;
 pub mod install;
@@ -110,10 +113,11 @@ pub trait Handler: Send + Sync {
 
     /// Transform matched files into intents.
     ///
-    /// This is the heart of each handler — it declares what operations
-    /// are needed without performing any I/O. `fs` is provided so a
-    /// handler that owns a directory entry can inspect its contents
-    /// to decide wholesale vs per-file treatment.
+    /// This is the heart of each handler: it declares what operations
+    /// are needed. `fs` is available for **read-only** inspection
+    /// (e.g. enumerating a matched directory to decide wholesale vs
+    /// per-file linking). Handlers must not write, delete, or rename
+    /// anything here — mutations happen in the executor.
     fn to_intents(
         &self,
         matches: &[RuleMatch],
@@ -148,6 +152,11 @@ pub struct HandlerConfig {
     /// Whether to auto-`chmod +x` files in path-handler directories.
     /// See [`PathSection::auto_chmod_exec`](crate::config::PathSection::auto_chmod_exec).
     pub auto_chmod_exec: bool,
+    /// Pack-level ignore patterns (from `[pack] ignore`). Handlers that
+    /// recurse into a matched directory should apply these so the
+    /// per-file fallback doesn't pick up `.DS_Store`, `.git`, etc.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pack_ignore: Vec<String>,
 }
 
 impl Default for HandlerConfig {
@@ -157,6 +166,7 @@ impl Default for HandlerConfig {
             protected_paths: Vec::new(),
             targets: std::collections::HashMap::new(),
             auto_chmod_exec: true,
+            pack_ignore: Vec::new(),
         }
     }
 }
@@ -195,13 +205,19 @@ pub fn create_registry(fs: &dyn Fs) -> HashMap<String, Box<dyn Handler + '_>> {
 /// At most one handler may be simultaneously [`MatchMode::Catchall`]
 /// and [`HandlerScope::Exclusive`]. Two such handlers would fight over
 /// the same "leftover" entries with no principled way to pick a winner.
+///
+/// This is a developer-only invariant: the built-in registry is
+/// hard-coded and third-party handlers would be added via code, not
+/// user input. We use `debug_assert!` so release builds never panic
+/// from a misconfiguration here; if the invariant is violated in a
+/// dev build the panic surfaces immediately.
 fn validate_registry(registry: &HashMap<String, Box<dyn Handler + '_>>) {
     let exclusive_catchalls: Vec<&str> = registry
         .values()
         .filter(|h| h.match_mode() == MatchMode::Catchall && h.scope() == HandlerScope::Exclusive)
         .map(|h| h.name())
         .collect();
-    assert!(
+    debug_assert!(
         exclusive_catchalls.len() <= 1,
         "at most one exclusive catchall handler allowed, found: {exclusive_catchalls:?}"
     );

--- a/crates/dodot-lib/src/handlers/path.rs
+++ b/crates/dodot-lib/src/handlers/path.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 
 use crate::datastore::DataStore;
+use crate::fs::Fs;
 use crate::handlers::{Handler, HandlerCategory, HandlerConfig, HandlerStatus, HANDLER_PATH};
 use crate::operations::HandlerIntent;
 use crate::paths::Pather;
@@ -25,6 +26,7 @@ impl Handler for PathHandler {
         matches: &[RuleMatch],
         _config: &HandlerConfig,
         _paths: &dyn Pather,
+        _fs: &dyn Fs,
     ) -> Result<Vec<HandlerIntent>> {
         Ok(matches
             .iter()

--- a/crates/dodot-lib/src/handlers/shell.rs
+++ b/crates/dodot-lib/src/handlers/shell.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 
 use crate::datastore::DataStore;
+use crate::fs::Fs;
 use crate::handlers::{Handler, HandlerCategory, HandlerConfig, HandlerStatus, HANDLER_SHELL};
 use crate::operations::HandlerIntent;
 use crate::paths::Pather;
@@ -25,6 +26,7 @@ impl Handler for ShellHandler {
         matches: &[RuleMatch],
         _config: &HandlerConfig,
         _paths: &dyn Pather,
+        _fs: &dyn Fs,
     ) -> Result<Vec<HandlerIntent>> {
         Ok(matches
             .iter()

--- a/crates/dodot-lib/src/handlers/symlink.rs
+++ b/crates/dodot-lib/src/handlers/symlink.rs
@@ -148,6 +148,13 @@ fn collect_per_file_intents(
 ) -> Result<()> {
     let entries = fs.read_dir(dir)?;
     for entry in entries {
+        // Skip dodot's own files and anything matching the pack's
+        // ignore patterns — same filter the scanner applies at walk
+        // time, so per-file fallback doesn't pick up `.DS_Store`,
+        // `.dodot.toml`, `*.swp`, etc.
+        if crate::rules::should_skip_entry(&entry.name, &config.pack_ignore) {
+            continue;
+        }
         if entry.is_dir {
             collect_per_file_intents(m, &entry.path, config, paths, fs, out)?;
             continue;
@@ -662,6 +669,44 @@ mod tests {
             assert!(user_path.ends_with(".ssh/config"));
         } else {
             panic!("expected Link intent");
+        }
+    }
+
+    #[test]
+    fn per_file_fallback_skips_special_and_pack_ignored_files() {
+        // When per-file mode kicks in (because of a protected_path),
+        // the recursion must apply the same filters the scanner uses:
+        // dodot's own files and pack-ignore globs like `.DS_Store`.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("cfg")
+            .file("ssh/config", "Host *")
+            .file("ssh/id_rsa", "secret")
+            .file("ssh/.DS_Store", "garbage")
+            .file("ssh/.dodot.toml", "# pack config")
+            .done()
+            .build();
+        let m = build_dir_match(&env, "cfg", "ssh");
+        let handler = SymlinkHandler;
+        let config = HandlerConfig {
+            protected_paths: vec!["ssh/id_rsa".into()],
+            pack_ignore: vec![".DS_Store".into()],
+            ..HandlerConfig::default()
+        };
+        let paths = crate::paths::XdgPather::builder()
+            .home(&env.home)
+            .dotfiles_root(&env.dotfiles_root)
+            .build()
+            .unwrap();
+        let intents = handler
+            .to_intents(&[m], &config, &paths, env.fs.as_ref())
+            .unwrap();
+        assert_eq!(
+            intents.len(),
+            1,
+            "only ssh/config should be linked. Got: {intents:?}"
+        );
+        if let HandlerIntent::Link { source, .. } = &intents[0] {
+            assert!(source.ends_with("ssh/config"));
         }
     }
 

--- a/crates/dodot-lib/src/handlers/symlink.rs
+++ b/crates/dodot-lib/src/handlers/symlink.rs
@@ -11,7 +11,11 @@
 use std::path::{Path, PathBuf};
 
 use crate::datastore::DataStore;
-use crate::handlers::{Handler, HandlerCategory, HandlerConfig, HandlerStatus, HANDLER_SYMLINK};
+use crate::fs::Fs;
+use crate::handlers::{
+    Handler, HandlerCategory, HandlerConfig, HandlerScope, HandlerStatus, MatchMode,
+    HANDLER_SYMLINK,
+};
 use crate::operations::HandlerIntent;
 use crate::paths::Pather;
 use crate::rules::RuleMatch;
@@ -28,19 +32,24 @@ impl Handler for SymlinkHandler {
         HandlerCategory::Configuration
     }
 
+    fn match_mode(&self) -> MatchMode {
+        MatchMode::Catchall
+    }
+
+    fn scope(&self) -> HandlerScope {
+        HandlerScope::Exclusive
+    }
+
     fn to_intents(
         &self,
         matches: &[RuleMatch],
         config: &HandlerConfig,
         paths: &dyn Pather,
+        fs: &dyn Fs,
     ) -> Result<Vec<HandlerIntent>> {
         let mut intents = Vec::new();
 
         for m in matches {
-            if m.is_dir {
-                continue; // symlink handler doesn't process directories
-            }
-
             let rel_str = m.relative_path.to_string_lossy();
 
             // Check protected paths
@@ -48,14 +57,17 @@ impl Handler for SymlinkHandler {
                 continue;
             }
 
-            let user_path = resolve_target(&rel_str, config, paths);
-
-            intents.push(HandlerIntent::Link {
-                pack: m.pack.clone(),
-                handler: HANDLER_SYMLINK.into(),
-                source: m.absolute_path.clone(),
-                user_path,
-            });
+            if m.is_dir {
+                intents.extend(dir_intents(m, config, paths, fs)?);
+            } else {
+                let user_path = resolve_target(&rel_str, false, config, paths);
+                intents.push(HandlerIntent::Link {
+                    pack: m.pack.clone(),
+                    handler: HANDLER_SYMLINK.into(),
+                    source: m.absolute_path.clone(),
+                    user_path,
+                });
+            }
         }
 
         Ok(intents)
@@ -83,6 +95,84 @@ impl Handler for SymlinkHandler {
     }
 }
 
+/// Produce symlink intents for a directory match.
+///
+/// Wholesale mode (one symlink for the whole directory) is the default.
+/// Per-file mode is triggered when the directory contains any file whose
+/// relative path matches a `protected_paths` entry or appears as a key
+/// in `symlink.targets`. In per-file mode we recurse and emit one Link
+/// intent per non-protected file, each resolved independently.
+fn dir_intents(
+    m: &RuleMatch,
+    config: &HandlerConfig,
+    paths: &dyn Pather,
+    fs: &dyn Fs,
+) -> Result<Vec<HandlerIntent>> {
+    let rel_str = m.relative_path.to_string_lossy();
+    let dir_prefix = format!("{rel_str}/");
+
+    let has_override = config.protected_paths.iter().any(|p| {
+        let normalized = p.strip_prefix('.').unwrap_or(p);
+        normalized.starts_with(&dir_prefix)
+            || p.starts_with(&dir_prefix)
+            || normalized == rel_str
+            || p == rel_str.as_ref()
+    }) || config
+        .targets
+        .keys()
+        .any(|k| k.starts_with(&dir_prefix) || k == rel_str.as_ref());
+
+    if !has_override {
+        let user_path = resolve_target(&rel_str, true, config, paths);
+        return Ok(vec![HandlerIntent::Link {
+            pack: m.pack.clone(),
+            handler: HANDLER_SYMLINK.into(),
+            source: m.absolute_path.clone(),
+            user_path,
+        }]);
+    }
+
+    // Per-file mode: recurse the directory and emit one intent per file.
+    let mut intents = Vec::new();
+    collect_per_file_intents(m, &m.absolute_path, config, paths, fs, &mut intents)?;
+    Ok(intents)
+}
+
+fn collect_per_file_intents(
+    m: &RuleMatch,
+    dir: &Path,
+    config: &HandlerConfig,
+    paths: &dyn Pather,
+    fs: &dyn Fs,
+    out: &mut Vec<HandlerIntent>,
+) -> Result<()> {
+    let entries = fs.read_dir(dir)?;
+    for entry in entries {
+        if entry.is_dir {
+            collect_per_file_intents(m, &entry.path, config, paths, fs, out)?;
+            continue;
+        }
+        let rel = entry
+            .path
+            .strip_prefix(&m.absolute_path)
+            .ok()
+            .map(|r| m.relative_path.join(r))
+            .unwrap_or_else(|| PathBuf::from(&entry.name));
+        let rel_str = rel.to_string_lossy();
+        if is_protected(&rel_str, &config.protected_paths) {
+            continue;
+        }
+        let user_path = resolve_target(&rel_str, false, config, paths);
+        out.push(HandlerIntent::Link {
+            pack: m.pack.clone(),
+            handler: HANDLER_SYMLINK.into(),
+            source: entry.path.clone(),
+            user_path,
+        });
+    }
+    Ok(())
+}
+
 /// Strip the `dot.` prefix from a filename, returning the dotted version.
 /// `dot.bashrc` → `.bashrc`, `dot.vimrc` → `.vimrc`.
 /// Only applies to top-level files (no `/` in path).
@@ -97,14 +187,20 @@ fn strip_dot_prefix(rel_path: &str) -> Option<String> {
 
 /// Resolve the target path for a symlink using the layered system.
 ///
+/// `is_dir` is true when the match is a top-level directory that will
+/// be linked wholesale — in that case the default target is
+/// `$XDG_CONFIG_HOME/<name>` (dirs are not dot-prefixed).
+///
 /// Priority (highest first):
 /// 0. Custom target override from config (`[symlink.targets]`)
 /// 1. `dot.` prefix convention (top-level only)
 /// 2. Layer 3: Explicit `_home/` or `_xdg/` directory prefix
 /// 3. Layer 2: `force_home` config list
-/// 4. Layer 1: Smart defaults (top-level → `$HOME`, subdirs → `$XDG_CONFIG_HOME`)
+/// 4. Layer 1: Smart defaults (top-level file → `$HOME/.{name}`,
+///    top-level dir → `$XDG_CONFIG_HOME/{name}`, subdirs → `$XDG_CONFIG_HOME/{path}`)
 pub(crate) fn resolve_target(
     rel_path: &str,
+    is_dir: bool,
     config: &HandlerConfig,
     paths: &dyn Pather,
 ) -> PathBuf {
@@ -184,6 +280,10 @@ pub(crate) fn resolve_target(
 
     // Layer 1: Smart defaults
     if !rel_path.contains('/') {
+        if is_dir {
+            // Top-level dir → $XDG_CONFIG_HOME/{name} (dirs are not dot-prefixed).
+            return xdg_config.join(rel_path);
+        }
         // Top-level file → $HOME/.{name}
         let filename = Path::new(rel_path)
             .file_name()
@@ -284,34 +384,34 @@ mod tests {
 
     #[test]
     fn top_level_file_goes_to_home_with_dot() {
-        let target = resolve_target("vimrc", &default_config(), &test_pather());
+        let target = resolve_target("vimrc", false, &default_config(), &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.vimrc"));
     }
 
     #[test]
     fn top_level_dotfile_keeps_dot() {
-        let target = resolve_target(".bashrc", &default_config(), &test_pather());
+        let target = resolve_target(".bashrc", false, &default_config(), &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.bashrc"));
     }
 
     #[test]
     fn subdirectory_goes_to_xdg() {
         let config = HandlerConfig::default(); // no force_home
-        let target = resolve_target("nvim/init.lua", &config, &test_pather());
+        let target = resolve_target("nvim/init.lua", false, &config, &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.config/nvim/init.lua"));
     }
 
     #[test]
     fn dotted_subdirectory_goes_to_home() {
         let config = HandlerConfig::default();
-        let target = resolve_target(".vim/colors/theme.vim", &config, &test_pather());
+        let target = resolve_target(".vim/colors/theme.vim", false, &config, &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.vim/colors/theme.vim"));
     }
 
     #[test]
     fn config_prefix_stripped() {
         let config = HandlerConfig::default();
-        let target = resolve_target("config/nvim/init.lua", &config, &test_pather());
+        let target = resolve_target("config/nvim/init.lua", false, &config, &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.config/nvim/init.lua"));
     }
 
@@ -319,13 +419,13 @@ mod tests {
 
     #[test]
     fn force_home_top_level() {
-        let target = resolve_target("bashrc", &default_config(), &test_pather());
+        let target = resolve_target("bashrc", false, &default_config(), &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.bashrc"));
     }
 
     #[test]
     fn force_home_subdirectory() {
-        let target = resolve_target("ssh/config", &default_config(), &test_pather());
+        let target = resolve_target("ssh/config", false, &default_config(), &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.ssh/config"));
     }
 
@@ -334,14 +434,14 @@ mod tests {
     #[test]
     fn home_prefix_override() {
         let config = HandlerConfig::default();
-        let target = resolve_target("_home/vim/vimrc", &config, &test_pather());
+        let target = resolve_target("_home/vim/vimrc", false, &config, &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.vim/vimrc"));
     }
 
     #[test]
     fn xdg_prefix_override() {
         let config = HandlerConfig::default();
-        let target = resolve_target("_xdg/nvim/init.lua", &config, &test_pather());
+        let target = resolve_target("_xdg/nvim/init.lua", false, &config, &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.config/nvim/init.lua"));
     }
 
@@ -383,20 +483,20 @@ mod tests {
 
     #[test]
     fn dot_prefix_stripped_for_top_level() {
-        let target = resolve_target("dot.bashrc", &default_config(), &test_pather());
+        let target = resolve_target("dot.bashrc", false, &default_config(), &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.bashrc"));
     }
 
     #[test]
     fn dot_prefix_with_force_home() {
-        let target = resolve_target("dot.zshrc", &default_config(), &test_pather());
+        let target = resolve_target("dot.zshrc", false, &default_config(), &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.zshrc"));
     }
 
     #[test]
     fn dot_prefix_non_forced_file() {
         let config = HandlerConfig::default(); // no force_home
-        let target = resolve_target("dot.vimrc", &config, &test_pather());
+        let target = resolve_target("dot.vimrc", false, &config, &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.vimrc"));
     }
 
@@ -404,7 +504,7 @@ mod tests {
     fn dot_prefix_not_applied_to_subdirs() {
         // dot. prefix only works for top-level files
         let config = HandlerConfig::default();
-        let target = resolve_target("subdir/dot.conf", &config, &test_pather());
+        let target = resolve_target("subdir/dot.conf", false, &config, &test_pather());
         // Should NOT strip dot. — it's not top-level
         assert_eq!(target, PathBuf::from("/home/alice/.config/subdir/dot.conf"));
     }
@@ -427,7 +527,7 @@ mod tests {
             .targets
             .insert("misterious.conf".into(), "/var/etc/misterious.conf".into());
 
-        let target = resolve_target("misterious.conf", &config, &test_pather());
+        let target = resolve_target("misterious.conf", false, &config, &test_pather());
         assert_eq!(target, PathBuf::from("/var/etc/misterious.conf"));
     }
 
@@ -439,7 +539,7 @@ mod tests {
             "my-documents/home-bound.conf".into(),
         );
 
-        let target = resolve_target("home-bound.conf", &config, &test_pather());
+        let target = resolve_target("home-bound.conf", false, &config, &test_pather());
         assert_eq!(
             target,
             PathBuf::from("/home/alice/.config/my-documents/home-bound.conf")
@@ -454,7 +554,7 @@ mod tests {
             .targets
             .insert("bashrc".into(), "/custom/bashrc".into());
 
-        let target = resolve_target("bashrc", &config, &test_pather());
+        let target = resolve_target("bashrc", false, &config, &test_pather());
         assert_eq!(target, PathBuf::from("/custom/bashrc"));
     }
 
@@ -462,7 +562,142 @@ mod tests {
     fn no_custom_target_falls_through() {
         let config = HandlerConfig::default();
         // No targets configured — should use default behavior
-        let target = resolve_target("vimrc", &config, &test_pather());
+        let target = resolve_target("vimrc", false, &config, &test_pather());
         assert_eq!(target, PathBuf::from("/home/alice/.vimrc"));
+    }
+
+    // ── Top-level dir resolution ────────────────────────────────
+
+    #[test]
+    fn top_level_dir_goes_to_xdg() {
+        let config = HandlerConfig::default();
+        let target = resolve_target("nvim", true, &config, &test_pather());
+        assert_eq!(target, PathBuf::from("/home/alice/.config/nvim"));
+    }
+
+    #[test]
+    fn top_level_dir_still_respects_force_home() {
+        let target = resolve_target("ssh", true, &default_config(), &test_pather());
+        assert_eq!(target, PathBuf::from("/home/alice/.ssh"));
+    }
+
+    // ── Wholesale vs per-file dir behavior ──────────────────────
+
+    fn build_dir_match(env: &crate::testing::TempEnvironment, pack: &str, dir: &str) -> RuleMatch {
+        RuleMatch {
+            relative_path: PathBuf::from(dir),
+            absolute_path: env.dotfiles_root.join(pack).join(dir),
+            pack: pack.into(),
+            handler: HANDLER_SYMLINK.into(),
+            is_dir: true,
+            options: std::collections::HashMap::new(),
+            preprocessor_source: None,
+        }
+    }
+
+    #[test]
+    fn plain_top_level_dir_produces_single_wholesale_intent() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("warp")
+            .file("themes/nord.yaml", "a")
+            .file("themes/vs_code.yaml", "b")
+            .done()
+            .build();
+        let m = build_dir_match(&env, "warp", "themes");
+        let handler = SymlinkHandler;
+        let paths = crate::paths::XdgPather::builder()
+            .home(&env.home)
+            .dotfiles_root(&env.dotfiles_root)
+            .build()
+            .unwrap();
+        let intents = handler
+            .to_intents(&[m], &HandlerConfig::default(), &paths, env.fs.as_ref())
+            .unwrap();
+        assert_eq!(intents.len(), 1, "plain dir -> single wholesale intent");
+        if let HandlerIntent::Link {
+            source, user_path, ..
+        } = &intents[0]
+        {
+            assert!(source.ends_with("warp/themes"));
+            assert!(user_path.ends_with(".config/themes"));
+        } else {
+            panic!("expected Link intent");
+        }
+    }
+
+    #[test]
+    fn dir_with_protected_path_falls_back_to_per_file_and_skips_protected() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("secret")
+            .file("ssh/config", "Host *")
+            .file("ssh/id_rsa", "DO NOT LINK")
+            .done()
+            .build();
+        let m = build_dir_match(&env, "secret", "ssh");
+        let handler = SymlinkHandler;
+        let config = HandlerConfig {
+            protected_paths: vec!["ssh/id_rsa".into()],
+            force_home: vec!["ssh".into()],
+            ..HandlerConfig::default()
+        };
+        let paths = crate::paths::XdgPather::builder()
+            .home(&env.home)
+            .dotfiles_root(&env.dotfiles_root)
+            .build()
+            .unwrap();
+        let intents = handler
+            .to_intents(&[m], &config, &paths, env.fs.as_ref())
+            .unwrap();
+        assert_eq!(
+            intents.len(),
+            1,
+            "only ssh/config should be linked; id_rsa skipped. Got: {intents:?}"
+        );
+        if let HandlerIntent::Link {
+            source, user_path, ..
+        } = &intents[0]
+        {
+            assert!(source.ends_with("ssh/config"));
+            // force_home=["ssh"] routes subdir config to $HOME/.ssh/config
+            assert!(user_path.ends_with(".ssh/config"));
+        } else {
+            panic!("expected Link intent");
+        }
+    }
+
+    #[test]
+    fn dir_with_targets_override_falls_back_to_per_file() {
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("config/main.toml", "x")
+            .file("config/aux.toml", "y")
+            .done()
+            .build();
+        let m = build_dir_match(&env, "app", "config");
+        let handler = SymlinkHandler;
+        let mut targets = std::collections::HashMap::new();
+        targets.insert("config/main.toml".into(), "/etc/main.toml".into());
+        let config = HandlerConfig {
+            targets,
+            ..HandlerConfig::default()
+        };
+        let paths = crate::paths::XdgPather::builder()
+            .home(&env.home)
+            .dotfiles_root(&env.dotfiles_root)
+            .build()
+            .unwrap();
+        let intents = handler
+            .to_intents(&[m], &config, &paths, env.fs.as_ref())
+            .unwrap();
+        // Both files should get per-file intents — targets override forces
+        // per-file mode so main.toml gets the explicit path.
+        assert_eq!(intents.len(), 2, "intents: {intents:?}");
+        let main = intents
+            .iter()
+            .find(|i| matches!(i, HandlerIntent::Link { source, .. } if source.ends_with("config/main.toml")))
+            .expect("main.toml intent");
+        if let HandlerIntent::Link { user_path, .. } = main {
+            assert_eq!(user_path, &PathBuf::from("/etc/main.toml"));
+        }
     }
 }

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -364,7 +364,12 @@ fn collect_pack_intents_inner(
         }
 
         if let Some(handler_matches) = groups.get(handler_name) {
-            let intents = handler.to_intents(handler_matches, &pack.config, ctx.paths.as_ref())?;
+            let intents = handler.to_intents(
+                handler_matches,
+                &pack.config,
+                ctx.paths.as_ref(),
+                ctx.fs.as_ref(),
+            )?;
             debug!(
                 pack = %pack.name,
                 handler = %handler_name,

--- a/crates/dodot-lib/src/render/mod.rs
+++ b/crates/dodot-lib/src/render/mod.rs
@@ -58,17 +58,48 @@ header:
 dry-run:
   fg: yellow
   italic: true
+
+conflict-banner:
+  fg: white
+  bg: red
+  bold: true
+
+conflict-header:
+  fg: white
+  bg: red
+  bold: true
+
+conflict-target:
+  fg: red
+  bold: true
+
+conflict-pack:
+  fg: red
+
+conflict-hint:
+  dim: true
 "#;
 
 // ── Templates ───────────────────────────────────────────────────
 
 /// Status / up / down — pack-level output with file listings.
-pub const TEMPLATE_PACK_STATUS: &str = r#"{% if message %}[message]{{ message }}[/message]
+pub const TEMPLATE_PACK_STATUS: &str = r#"{% if conflicts %}[conflict-banner] ✗ Cross-pack conflicts detected — see details below [/conflict-banner]
+{% endif %}{% if message %}[message]{{ message }}[/message]
 {% endif %}{% if dry_run %}[dry-run]  (dry run — no changes made)[/dry-run]
 {% endif %}{% for pack in packs %}[pack-name]{{ pack.name }}[/pack-name]
 {% for file in pack.files %}  {{ file.name | col(24) }} [handler-symbol]{{ file.symbol }}[/handler-symbol] [description]{{ file.description | col(30) }}[/description]  [{{ file.status }}]{{ file.status_label }}[/{{ file.status }}]
 {% endfor %}
-{% endfor %}"#;
+{% endfor %}{% if conflicts %}
+[conflict-header] Cross-pack conflicts [/conflict-header]
+{% for c in conflicts %}
+{% if c.kind == "symlink" %}The target path [conflict-target]{{ c.target }}[/conflict-target] would be used by multiple packs:
+{% else %}The executable [conflict-target]{{ c.target }}[/conflict-target] would be shadowed across multiple packs in $PATH:
+{% endif %}{% for cl in c.claimants %}  - [conflict-pack]{{ cl.source }}[/conflict-pack]
+{% endfor %}{% endfor %}
+[conflict-hint]Common fixes: give them unique names, override the destination in the pack's config,[/conflict-hint]
+[conflict-hint]or ignore the pack entirely. See `dodot config --help` for the last option.[/conflict-hint]
+[conflict-hint]`dodot up` won't run while conflicts exist.[/conflict-hint]
+{% endif %}"#;
 
 /// List — just pack names.
 pub const TEMPLATE_LIST: &str = r#"{% for pack in packs %}{{ pack.name }}{% if pack.ignored %} [dim](ignored)[/dim]{% endif %}

--- a/crates/dodot-lib/src/rules/mod.rs
+++ b/crates/dodot-lib/src/rules/mod.rs
@@ -229,7 +229,29 @@ impl<'a> Scanner<'a> {
     /// Skips hidden files (except `.config`), special files
     /// (`.dodot.toml`, `.dodotignore`), and files matching
     /// pack-level ignore patterns.
+    /// Walk the pack's top-level children only.
+    ///
+    /// Returns depth-1 entries (files and directories directly under
+    /// the pack root). Nested files/dirs are **not** returned — handlers
+    /// that receive a directory entry decide internally whether and how
+    /// to recurse (e.g. symlink falls back to per-file mode when
+    /// `protected_paths` or `targets` reach inside the dir).
+    ///
+    /// Preprocessing is the one exception: it still needs to see nested
+    /// files to discover templates (`*.tmpl`) and the like. Use
+    /// [`Scanner::walk_pack_recursive`] for that use case.
     pub fn walk_pack(
+        &self,
+        pack_path: &Path,
+        ignore_patterns: &[String],
+    ) -> Result<Vec<PackEntry>> {
+        let mut results = Vec::new();
+        self.list_top_level(pack_path, ignore_patterns, &mut results)?;
+        Ok(results)
+    }
+
+    /// Walk the pack recursively. Only used by the preprocessing pipeline.
+    pub fn walk_pack_recursive(
         &self,
         pack_path: &Path,
         ignore_patterns: &[String],
@@ -274,6 +296,45 @@ impl<'a> Scanner<'a> {
 
         matches.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
         matches
+    }
+
+    /// Enumerate the direct children of `pack_path`, skipping hidden,
+    /// special, and ignored entries. No recursion.
+    fn list_top_level(
+        &self,
+        pack_path: &Path,
+        ignore_patterns: &[String],
+        results: &mut Vec<PackEntry>,
+    ) -> Result<()> {
+        let entries = self.fs.read_dir(pack_path)?;
+
+        for entry in entries {
+            let name = &entry.name;
+
+            if name.starts_with('.') && name != ".config" {
+                continue;
+            }
+            if SPECIAL_FILES.contains(&name.as_str()) {
+                continue;
+            }
+            if is_ignored(name, ignore_patterns) {
+                continue;
+            }
+
+            let rel_path = entry
+                .path
+                .strip_prefix(pack_path)
+                .unwrap_or(&entry.path)
+                .to_path_buf();
+
+            results.push(PackEntry {
+                relative_path: rel_path,
+                absolute_path: entry.path.clone(),
+                is_dir: entry.is_dir,
+            });
+        }
+
+        Ok(())
     }
 
     fn walk_dir(
@@ -721,7 +782,33 @@ mod tests {
     }
 
     #[test]
-    fn scan_pack_nested_files() {
+    fn nested_install_sh_is_not_matched_by_install_rule() {
+        // A file named install.sh that lives deep inside a directory
+        // must NOT activate the install handler. Only a top-level
+        // install.sh triggers it.
+        let env = TempEnvironment::builder()
+            .pack("sneaky")
+            .file("config/install.sh", "echo boom")
+            .done()
+            .build();
+
+        let scanner = Scanner::new(env.fs.as_ref());
+        let pack = make_pack("sneaky", env.dotfiles_root.join("sneaky"));
+        let rules = default_rules();
+
+        let matches = scanner.scan_pack(&pack, &rules, &[]).unwrap();
+
+        assert!(
+            !matches.iter().any(|m| m.handler == "install"),
+            "nested install.sh should not route to install handler: {matches:?}"
+        );
+    }
+
+    #[test]
+    fn scan_pack_returns_only_top_level_entries() {
+        // Under the top-level-only scanner, nested files are not surfaced
+        // as individual matches. The containing dir is the matched entry;
+        // handlers (symlink wholesale, path, …) decide how to recurse.
         let env = TempEnvironment::builder()
             .pack("nvim")
             .file("nvim/init.lua", "require('config')")
@@ -735,14 +822,19 @@ mod tests {
 
         let matches = scanner.scan_pack(&pack, &rules, &[]).unwrap();
 
-        let file_matches: Vec<String> = matches
+        let relpaths: Vec<String> = matches
             .iter()
-            .filter(|m| !m.is_dir)
             .map(|m| m.relative_path.to_string_lossy().to_string())
             .collect();
 
-        assert!(file_matches.contains(&"nvim/init.lua".to_string()));
-        assert!(file_matches.contains(&"nvim/lua/plugins.lua".to_string()));
+        assert!(
+            relpaths.iter().any(|p| p == "nvim"),
+            "top-level nvim dir should match: {relpaths:?}"
+        );
+        assert!(
+            !relpaths.iter().any(|p| p.contains('/')),
+            "no nested paths expected: {relpaths:?}"
+        );
     }
 
     // ── Grouping tests (from PR 5, kept) ────────────────────────

--- a/crates/dodot-lib/src/rules/mod.rs
+++ b/crates/dodot-lib/src/rules/mod.rs
@@ -193,7 +193,18 @@ fn matches_entry(pattern: &CompiledPattern, filename: &str, is_dir: bool) -> boo
 // ── Scanner ─────────────────────────────────────────────────────
 
 /// Files that are always skipped during scanning.
-const SPECIAL_FILES: &[&str] = &[".dodot.toml", ".dodotignore"];
+pub const SPECIAL_FILES: &[&str] = &[".dodot.toml", ".dodotignore"];
+
+/// Should this entry name be skipped at scan or handler-recursion time?
+///
+/// Combines the three always-on filters: dodot's own files
+/// (`SPECIAL_FILES`) and the pack's `ignore` glob patterns. Hidden
+/// files are NOT filtered here — the caller decides whether to skip
+/// dotfiles (the scanner does, for the top-level walk; the symlink
+/// handler's per-file fallback does not, since the user opted in).
+pub fn should_skip_entry(name: &str, ignore_patterns: &[String]) -> bool {
+    SPECIAL_FILES.contains(&name) || is_ignored(name, ignore_patterns)
+}
 
 /// Scans pack directories and matches files against rules.
 pub struct Scanner<'a> {

--- a/docs/reference/handlers.lex
+++ b/docs/reference/handlers.lex
@@ -36,11 +36,26 @@ Handlers Guide
 
         See `dodot_lib::handlers::path`.
 
-2. Handler Categories
+2. Matching Model
+
+    Handlers are classified along two axes:
+
+    - *Match mode* — *Precise* (whitelisted names like `bin/`, `install.sh`, `Brewfile`) or *Catchall* (anything the precise handlers didn't claim).
+    - *Scope* — *Exclusive* (a match is consumed — no other handler sees that entry) or *Shared* (the entry remains available; reserved for future observer-style handlers).
+
+    Invariants:
+    - At most one handler may be simultaneously *Catchall* + *Exclusive*. `symlink` is that handler today.
+    - Catchall handlers run after all precise handlers.
+
+    Scanning is top-level only: the scanner enumerates depth-1 entries of the pack (files and directories directly under the pack root). It does *not* recurse. A handler that receives a directory entry decides how to treat its contents — the path handler stages the whole directory into `$PATH`, the symlink handler creates one wholesale symlink for it (falling back to per-file mode when `protected_paths` or `symlink.targets` reach inside).
+
+    If you want a nested path handled individually (different target, excluded from a wholesale link, etc.), declare it explicitly via `[symlink.targets]` or list it in `[symlink] protected_paths`. These triggers promote the nested path out of its parent's wholesale treatment.
+
+3. Handler Categories
 
     Handlers are divided into two categories based on their operation types.
 
-    2.1. Code Execution Handlers (provisioning)
+    3.1. Code Execution Handlers (provisioning)
 
         - Generate *RunCommand* operations with sentinels
         - Install Handler: runs setup scripts once
@@ -48,7 +63,7 @@ Handlers Guide
         - Operations are tracked to prevent re-execution
         - Run by default with `dodot up`, skip with `--no-provision`
 
-    2.2. Configuration Handlers (always run)
+    3.2. Configuration Handlers (always run)
 
         - Generate *CreateDataLink* and *CreateUserLink* operations
         - Symlink Handler: creates configuration symlinks
@@ -57,7 +72,7 @@ Handlers Guide
         - Operations are idempotent (safe to run multiple times)
         - Always run with `dodot up`
 
-3. Quick Reference
+4. Quick Reference
 
     Handler summary:
         | Handler  | Category       | Operations                    | Purpose                  |
@@ -68,7 +83,7 @@ Handlers Guide
         | path     | Configuration  | CreateDataLink                | Manage PATH entries      |
     :: table ::
 
-4. Handler Documentation Structure
+5. Handler Documentation Structure
 
     Each handler's module documentation contains:
 
@@ -85,7 +100,7 @@ Handlers Guide
     - Best Practices: usage recommendations
     - Comparison: when to use vs other handlers
 
-5. Creating Custom Handlers
+6. Creating Custom Handlers
 
     While dodot includes comprehensive built-in handlers, you can create custom ones:
 
@@ -96,7 +111,7 @@ Handlers Guide
 
     Handlers are simple data transformers: they just declare what intents they need, not how to perform them. See `dodot_lib::handlers::Handler` trait and `dodot_lib::operations::HandlerIntent`.
 
-6. Best Practices
+7. Best Practices
 
     - Read the handler module docs: each handler has extensive documentation
     - Use the right tool: each handler has a specific purpose
@@ -105,7 +120,7 @@ Handlers Guide
     - Organize by pack: group related configurations
     - Use standard patterns: follow naming conventions
 
-7. Troubleshooting
+8. Troubleshooting
 
     - Not running? Check rule patterns and priorities.
     - Errors? Each handler module lists common error codes.

--- a/docs/reference/symlink-paths.lex
+++ b/docs/reference/symlink-paths.lex
@@ -6,9 +6,9 @@ Symlink Deployment Paths
 
     Dodot respects the `XDG_CONFIG_HOME` specification. In essence, it means that if the user has set the `XDG_CONFIG_HOME` environment variable, dodot will honor it, otherwise it will default to `~/.config`. Therefore your config home is either `$XDG_CONFIG_HOME` or `$HOME`. For brevity's sake, we will refer to it as `$XDG_CONFIG_HOME` in the rest of this document.
 
-    Hence in the simplest cases `<pack>/<file-or-dir>` will be symlinked to `$XDG_CONFIG_HOME/<file-or-dir>`.
+    Hence in the simplest cases `<pack>/<file-or-dir>` will be symlinked to `$XDG_CONFIG_HOME/<file-or-dir>`. Top-level *files* default to `$HOME/.<name>` (so `vim/vimrc` → `~/.vimrc`); top-level *directories* default to `$XDG_CONFIG_HOME/<name>` (so `warp/themes/` → `~/.config/themes`).
 
-    Note that symlinks are flat: dodot will create symlinks for files and directories, but it will not create symlinks for files inside directories.
+    Note that symlinks are flat: dodot creates one symlink per top-level entry of the pack. For a top-level directory, that means the directory itself is linked, not each nested file individually. Per-file behavior can be re-enabled for a specific directory by adding an `[symlink.targets]` entry that reaches inside it or by listing a file inside it in `[symlink] protected_paths` — either triggers per-file mode for that directory (and only that directory).
 
 2. The `dot.<file>` Convention
 

--- a/docs/reference/symlink-paths.lex
+++ b/docs/reference/symlink-paths.lex
@@ -14,7 +14,7 @@ Symlink Deployment Paths
 
     Most dotfiles are, predictably, prefixed with a dot. While that's very useful for keeping your home dir tidy, it does mean that these files inside your dotfiles root repo are hidden by default (i.e. for `ls`). This can be confusing, requiring you to ensure you are seeing hidden files on whatever tool or editor you are using.
 
-    To make this easier, if a symlink path starts with "dot.", dodot will strip the "dot" prefix. For example `<pack>/dot.bashrc` will be symlinked to `$XDG_CONFIG_HOME/.bashrc`.
+    To make this easier, if a top-level file name starts with "dot.", dodot strips the "dot" prefix and routes the result to `$HOME` (the `dot.` convention is only meaningful for files that the user would expect at `$HOME/.<name>`). For example `<pack>/dot.bashrc` will be symlinked to `$HOME/.bashrc`.
 
     If you have a file that actually starts with "dot.", you can use a `.dodot.toml` config to override the symlink path.
 

--- a/tests/e2e/bats/test_dot_prefix.bats
+++ b/tests/e2e/bats/test_dot_prefix.bats
@@ -67,12 +67,23 @@ teardown() {
 # ── Subdirectory files are NOT stripped ──────────────────────────
 
 @test "dot. prefix not stripped for subdirectory files" {
+    # Under the top-level-only scanner, the subdir is linked wholesale;
+    # nested files are visible through the link. The dot. prefix is a
+    # top-level-only convention and must NOT be stripped for files
+    # living inside a linked directory.
     create_pack_file "app" "subdir/dot.conf" "config"
 
     run dodot status
     [ "$status" -eq 0 ]
-    # Subdirectory files keep the dot. prefix
-    assert_output_contains "dot.conf"
+    # Status shows the wholesale subdir entry, not the nested file.
+    assert_output_contains "subdir"
+    assert_output_contains "~/.config/subdir"
+
+    # After deploy, the nested file is reachable through the dir symlink,
+    # and its name retains the literal `dot.` prefix (no stripping).
+    dodot up
+    assert_exists "$HOME/.config/subdir/dot.conf"
+    assert_not_exists "$HOME/.config/subdir/.conf"
 }
 
 # ── Full lifecycle ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Formalizes the handler model and fixes the scanner so it matches the mental model you described in #37.

### Handler trait
- `MatchMode` (`Precise` / `Catchall`) and `HandlerScope` (`Exclusive` / `Shared`) declared on the trait with defaults.
- `symlink` is the only `Catchall` + `Exclusive` handler; everything else is `Precise` + `Exclusive`.
- Registry validates at build time: at most one `Catchall` + `Exclusive`. Future shared/observer handlers can slot in cleanly.
- `to_intents` gets `&dyn Fs` so a handler receiving a directory entry can inspect its contents before deciding.

### Scanner
- `walk_pack` → **depth-1 only**. Nested files no longer flow into matching.
- `walk_pack_recursive` preserved for the preprocessing pipeline's discovery use case.
- Two long-standing bugs fixed as a side effect:
  - A pack's `bin/tool` was being **both** staged into `$PATH` (via path) **and** symlinked individually to `~/.config/bin/tool` (via the catchall). Now path claims `bin/` exclusively; no stray symlinks.
  - A nested `foo/bar/install.sh` used to trigger the install handler because matching was on basename-only. Now only a top-level `install.sh` does. Locked in with a regression test.

### Symlink handler
- Top-level directories are linked **wholesale** by default — one `~/.config/themes → <pack>/warp/themes` instead of per-file listings.
- Falls back to **per-file mode** when `[symlink] protected_paths` or `[symlink.targets]` reach inside the directory — preserving every existing security guarantee. `.ssh/id_rsa` still blocked, per-file target overrides still honored.
- `resolve_target` gains `is_dir`: top-level dirs default to `\$XDG_CONFIG_HOME/<name>` (aligning with the docs that have always said so); top-level files keep `\$HOME/.<name>`. `force_home`, `_home/`, `_xdg/`, `dot.`, and `targets` overrides continue to work for both.

### Security
Per your direction on #37, no new blacklist mechanism. The three existing knobs (`[pack] ignore`, `[symlink] force_home`, `[symlink] protected_paths`) cover the surface; wholesale-dir linking hooks into `protected_paths` to stay safe.

### Before / After

A pack with `bin/tool`:
```
# Before
mypack
  bin                      + \$PATH/bin             not in PATH
  bin/tool                 ➞ ~/.config/bin/tool    pending    ← phantom

# After
mypack
  bin                      + \$PATH/bin             not in PATH
```

A pack with `warp/themes/*.yaml`:
```
# Before
warp
  themes/nord-light.yaml   ➞ ~/.config/themes/nord-light.yaml
  themes/nord.yaml         ➞ ~/.config/themes/nord.yaml
  themes/polar.yaml        ➞ ~/.config/themes/polar.yaml
  themes/vs_code.yaml      ➞ ~/.config/themes/vs_code.yaml

# After
warp
  themes                   ➞ ~/.config/themes
```

## Test plan

- [x] `cargo test` — 343 pass, 0 fail. 8 new tests for the new behaviors (wholesale-dir, protected-path fallback, targets fallback, top-level-dir XDG resolution, top-level-dir force_home, registry invariant, nested-install.sh-not-matched, scan-returns-top-level).
- [x] `cargo clippy --all-targets` clean.
- [x] `cargo fmt --check` clean.
- [x] Manual: tested with contrived \`bin/tool\` pack — one + \$PATH/bin line, no stray symlink on deploy.
- [x] Manual: tested against user's own dotfiles repo — 6-pack \`env.sh\` conflict still detected; \`bin/\` packs collapse to single line; path-executable shadowing still detected when two packs both have \`bin/deploy\`.
- [ ] Real-world smoke: deploy to a fresh \$HOME with a real dotfiles tree before merging.

## Migration notes

Called out in CHANGELOG_UNRELEASED.md. Short version:
- Nested files inside a top-level dir are now part of that dir's single symlink. The on-disk paths users see (\`~/.config/themes/nord.yaml\`) still resolve, because the whole \`themes/\` dir is linked.
- If a specific nested file needs its own target, add it to \`[symlink.targets]\` (triggers per-file mode for the containing dir).
- Any accidentally-matched nested \`install.sh\` / \`aliases.sh\` / \`Brewfile\` no longer run; move to pack top level.

Closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)