### PR TITLE
feat(adopt): two-phase atomic adoption with conflict sim + dry-run

### DIFF
--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -174,7 +174,7 @@ pub fn fill_handler(
 pub fn adopt_handler(
     matches: &clap::ArgMatches,
     _ctx: &CommandContext,
-) -> HandlerResult<commands::adopt::AdoptResult> {
+) -> HandlerResult<commands::PackStatusResult> {
     let ctx = build_readonly_ctx()?;
     let pack_name = matches.get_one::<String>("pack").expect("pack is required");
     let files: Vec<PathBuf> = matches
@@ -183,13 +183,17 @@ pub fn adopt_handler(
         .map(PathBuf::from)
         .collect();
     let force = matches.get_flag("force");
-    let result = commands::adopt::adopt(pack_name, &files, force, &ctx).map_err(|e| {
-        if matches!(e, dodot_lib::DodotError::PackNotFound { .. }) {
-            anyhow::anyhow!("{e}\n  Hint: run 'dodot init {pack_name}' first to create it")
-        } else {
-            e.into()
-        }
-    })?;
+    let no_follow = matches.get_flag("no-follow");
+    let dry_run = matches.get_flag("dry-run");
+    let result = commands::adopt::adopt(pack_name, &files, force, no_follow, dry_run, &ctx)
+        .map_err(|e| {
+            if matches!(e, dodot_lib::DodotError::PackNotFound { .. }) {
+                anyhow::anyhow!("{e}\n  Hint: run 'dodot init {pack_name}' first to create it")
+            } else {
+                e.into()
+            }
+        })?;
+    print_warnings(&result.warnings);
     Ok(Output::Render(result))
 }
 

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -93,7 +93,7 @@ fn build_app() -> App {
         .expect("register init")
         .command("fill", handlers::fill_handler, "message")
         .expect("register fill")
-        .command("adopt", handlers::adopt_handler, "message")
+        .command("adopt", handlers::adopt_handler, "pack-status")
         .expect("register adopt")
         .command("addignore", handlers::addignore_handler, "message")
         .expect("register addignore")
@@ -238,7 +238,19 @@ fn build_clap_command() -> ClapCommand {
                 .arg(
                     Arg::new("force")
                         .long("force")
-                        .help("Overwrite existing files in pack")
+                        .help("Overwrite existing destination files in the pack")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("dry-run")
+                        .long("dry-run")
+                        .help("Show what would be adopted without making changes")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("no-follow")
+                        .long("no-follow")
+                        .help("When the source is a symlink, move the link itself instead of its target")
                         .action(ArgAction::SetTrue),
                 ),
         )

--- a/crates/dodot-lib/src/commands/adopt.rs
+++ b/crates/dodot-lib/src/commands/adopt.rs
@@ -148,7 +148,10 @@ fn preflight(
     let mut skipped: Vec<String> = Vec::new();
 
     for raw_source in sources {
-        // Resolve to absolute. Relative paths are resolved against CWD.
+        // Resolve to absolute, then normalize. Relative paths are resolved
+        // against CWD. We normalize logically (strip `.`, collapse `..`)
+        // rather than calling `canonicalize()` because canonicalize follows
+        // symlinks, which would break `--no-follow`.
         let abs = if raw_source.is_absolute() {
             raw_source.clone()
         } else {
@@ -159,6 +162,7 @@ fn preflight(
                 })?
                 .join(raw_source)
         };
+        let abs = normalize_path(&abs);
 
         if !fs.exists(&abs) && !fs.is_symlink(&abs) {
             return Err(DodotError::Fs {
@@ -197,10 +201,15 @@ fn preflight(
 
         // Nested-source refusal: parent must be HOME (dodot's flat-at-top-level
         // rule applied to source paths too). Allow adopting from HOME directly.
+        // Canonicalize the parent (not the source itself — that would follow
+        // a symlink source and break `--no-follow`) so OS-level path
+        // equivalences like `/var` ↔ `/private/var` on macOS compare equal.
         let parent = abs
             .parent()
             .ok_or_else(|| DodotError::Other(format!("no parent directory: {}", abs.display())))?;
-        if parent != home {
+        let canon_parent = std::fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf());
+        let canon_home = std::fs::canonicalize(&home).unwrap_or_else(|_| home.clone());
+        if canon_parent != canon_home {
             return Err(DodotError::Other(format!(
                 "nested source not allowed: {}\n  hint: adopt the top-level directory instead (parent must be {})",
                 abs.display(),
@@ -439,6 +448,29 @@ fn swap_dir(source: &Path, pack_dest: &Path, fs: &dyn Fs) -> Result<()> {
 }
 
 // ── helpers ──────────────────────────────────────────────────────
+
+/// Normalize a path by collapsing `.` and `..` components without touching
+/// the filesystem.
+///
+/// Unlike `std::fs::canonicalize`, this does not follow symlinks — important
+/// for `--no-follow`, where we want to preserve the source as a link rather
+/// than resolve through it. Parent refs (`..`) are collapsed purely
+/// lexically, which is correct for the nested-parent check here since the
+/// caller has already joined against `current_dir()` for relative inputs.
+fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                result.pop();
+            }
+            other => result.push(other),
+        }
+    }
+    result
+}
 
 fn temp_sibling(path: &Path, tag: &str) -> PathBuf {
     let parent = path.parent().unwrap_or(Path::new("."));

--- a/crates/dodot-lib/src/commands/adopt.rs
+++ b/crates/dodot-lib/src/commands/adopt.rs
@@ -1,73 +1,464 @@
 //! `adopt` command — move existing files into a pack, creating symlinks back.
+//!
+//! Two-phase model:
+//!
+//! 1. **Copy phase** — recursively copy each source into the pack, preserving
+//!    inner symlinks and Unix permissions. Originals are never touched in this
+//!    phase. If anything fails, the partial copies are removed and the error
+//!    surfaces; home is pristine throughout.
+//!
+//! 2. **Swap phase** — per source, atomically replace the original with a
+//!    symlink to the pack copy. Files use a symlink-at-temp + rename-over-original
+//!    trick (POSIX atomic). Directories use a rename-to-backup + symlink + rm-backup
+//!    dance (one-step recoverable). A per-file failure cleans up that source's pack
+//!    copy only; previously-adopted sources remain adopted.
+//!
+//! Cross-pack deployment conflicts are detected after the copy phase and before
+//! the swap phase — adoption is refused if deploying the adopted files would
+//! collide with another pack. This check is not bypassed by `--force`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use serde::Serialize;
-
-use crate::packs::orchestration::ExecutionContext;
+use crate::commands::status;
+use crate::commands::PackStatusResult;
+use crate::conflicts;
+use crate::fs::Fs;
+use crate::packs;
+use crate::packs::orchestration::{self, ExecutionContext};
+use crate::rules;
 use crate::{DodotError, Result};
 
-#[derive(Debug, Clone, Serialize)]
-pub struct AdoptResult {
-    pub message: String,
-    pub details: Vec<String>,
+/// Plan for a single source: the resolved source path, what to call it in the
+/// pack, and the destination path.
+struct AdoptPlan {
+    /// The resolved source (post --no-follow handling).
+    source: PathBuf,
+    /// Destination inside the pack.
+    pack_dest: PathBuf,
+    /// `true` if the source is a directory (after --no-follow resolution).
+    is_dir: bool,
 }
 
-/// Move files from their current location into a pack, creating
-/// symlinks from the original location back to the pack.
+/// Move sources into a pack, creating symlinks from their original locations.
+///
+/// See the module-level docs for the two-phase model and failure semantics.
 pub fn adopt(
     pack_name: &str,
-    files: &[PathBuf],
+    sources: &[PathBuf],
     force: bool,
+    no_follow: bool,
+    dry_run: bool,
     ctx: &ExecutionContext,
-) -> Result<AdoptResult> {
-    let pack_path = ctx.paths.pack_path(pack_name);
+) -> Result<PackStatusResult> {
+    if sources.is_empty() {
+        return Err(DodotError::Other("no files specified".into()));
+    }
 
+    let pack_path = ctx.paths.pack_path(pack_name);
     if !ctx.fs.exists(&pack_path) {
         return Err(DodotError::PackNotFound {
             name: pack_name.into(),
         });
     }
+    if ctx.fs.exists(&pack_path.join(".dodotignore")) {
+        return Err(DodotError::PackInvalid {
+            name: pack_name.into(),
+            reason: "pack is marked ignored via .dodotignore".into(),
+        });
+    }
 
-    let mut details = Vec::new();
+    let (plans, skipped_already_adopted) =
+        preflight(pack_name, &pack_path, sources, force, no_follow, ctx)?;
 
-    for file in files {
-        if !ctx.fs.exists(file) {
+    // If every input was already adopted, there's nothing to do.
+    if plans.is_empty() {
+        let mut result = status::status(Some(&[pack_name.to_string()]), ctx)?;
+        result.dry_run = dry_run;
+        for msg in skipped_already_adopted {
+            result.warnings.push(msg);
+        }
+        return Ok(result);
+    }
+
+    // Phase 1 — copy every source into the pack. On failure, cleanup and bail.
+    if let Err(e) = copy_all(&plans, ctx.fs.as_ref()) {
+        cleanup_pack_copies(&plans, ctx.fs.as_ref());
+        return Err(e);
+    }
+
+    // Cross-pack deploy conflict simulation happens with the copies in place.
+    if let Err(e) = check_deploy_conflicts(ctx) {
+        cleanup_pack_copies(&plans, ctx.fs.as_ref());
+        return Err(e);
+    }
+
+    // Dry-run stops here: we've verified the plan is viable, now unwind.
+    if dry_run {
+        cleanup_pack_copies(&plans, ctx.fs.as_ref());
+        let mut result = status::status(Some(&[pack_name.to_string()]), ctx)?;
+        result.dry_run = true;
+        for msg in skipped_already_adopted {
+            result.warnings.push(msg);
+        }
+        return Ok(result);
+    }
+
+    // Phase 2 — per-source atomic swap. Failures are recorded, not fatal.
+    let failures = swap_all(&plans, ctx.fs.as_ref());
+
+    let mut result = status::status(Some(&[pack_name.to_string()]), ctx)?;
+    result.dry_run = false;
+    for msg in skipped_already_adopted {
+        result.warnings.push(msg);
+    }
+    for f in &failures {
+        result.warnings.push(format!(
+            "adopt failed: {}: {}",
+            f.source.display(),
+            f.reason
+        ));
+    }
+    Ok(result)
+}
+
+// ── Pre-flight ───────────────────────────────────────────────────
+
+fn preflight(
+    pack_name: &str,
+    pack_path: &Path,
+    sources: &[PathBuf],
+    force: bool,
+    no_follow: bool,
+    ctx: &ExecutionContext,
+) -> Result<(Vec<AdoptPlan>, Vec<String>)> {
+    let fs = ctx.fs.as_ref();
+    let home = ctx.paths.home_dir().to_path_buf();
+    let dotfiles_root = ctx.paths.dotfiles_root().to_path_buf();
+    let data_dir = ctx.paths.data_dir().to_path_buf();
+
+    let root_config = ctx.config_manager.root_config()?;
+    let pack_config = ctx.config_manager.config_for_pack(pack_path)?;
+    let ignore_patterns = {
+        let mut combined = root_config.pack.ignore.clone();
+        combined.extend(pack_config.pack.ignore.iter().cloned());
+        combined
+    };
+
+    let mut plans: Vec<AdoptPlan> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
+
+    for raw_source in sources {
+        // Resolve to absolute. Relative paths are resolved against CWD.
+        let abs = if raw_source.is_absolute() {
+            raw_source.clone()
+        } else {
+            std::env::current_dir()
+                .map_err(|e| DodotError::Fs {
+                    path: raw_source.clone(),
+                    source: e,
+                })?
+                .join(raw_source)
+        };
+
+        if !fs.exists(&abs) && !fs.is_symlink(&abs) {
             return Err(DodotError::Fs {
-                path: file.clone(),
-                source: std::io::Error::new(std::io::ErrorKind::NotFound, "file not found"),
+                path: abs,
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "source does not exist"),
             });
         }
 
-        let filename = file
-            .file_name()
-            .ok_or_else(|| DodotError::Other(format!("no filename: {}", file.display())))?;
-
-        // Strip leading dot for pack organization
-        let pack_filename = filename.to_string_lossy();
-        let pack_filename = pack_filename.strip_prefix('.').unwrap_or(&pack_filename);
-        let dest = pack_path.join(pack_filename);
-
-        if ctx.fs.exists(&dest) && !force {
-            return Err(DodotError::SymlinkConflict { path: dest });
+        // Already-adopted detection: source is a symlink whose target lives
+        // inside the dotfiles root or the data dir.
+        if fs.is_symlink(&abs) {
+            if let Ok(target) = fs.readlink(&abs) {
+                if target.starts_with(&dotfiles_root) || target.starts_with(&data_dir) {
+                    skipped.push(format!(
+                        "skipped: {} is already managed by dodot (-> {})",
+                        abs.display(),
+                        target.display()
+                    ));
+                    continue;
+                }
+            }
         }
 
-        // Move file into pack
-        ctx.fs.rename(file, &dest)?;
+        // Decide whether to follow a symlink source or treat it as the link itself.
+        let lmeta = fs.lstat(&abs)?;
+        let is_source_symlink = lmeta.is_symlink;
+        let treat_as_link = is_source_symlink && no_follow;
 
-        // Create symlink from original location to pack
-        ctx.fs.symlink(&dest, file)?;
+        // Effective metadata for is_dir and for the copy operation.
+        let is_dir = if treat_as_link {
+            false
+        } else {
+            let smeta = fs.stat(&abs)?;
+            smeta.is_dir
+        };
 
-        details.push(format!(
-            "{} → {}/{}",
-            file.display(),
-            pack_name,
-            pack_filename
-        ));
+        // Nested-source refusal: parent must be HOME (dodot's flat-at-top-level
+        // rule applied to source paths too). Allow adopting from HOME directly.
+        let parent = abs
+            .parent()
+            .ok_or_else(|| DodotError::Other(format!("no parent directory: {}", abs.display())))?;
+        if parent != home {
+            return Err(DodotError::Other(format!(
+                "nested source not allowed: {}\n  hint: adopt the top-level directory instead (parent must be {})",
+                abs.display(),
+                home.display()
+            )));
+        }
+
+        let file_name = abs
+            .file_name()
+            .ok_or_else(|| DodotError::Other(format!("no filename: {}", abs.display())))?
+            .to_string_lossy()
+            .into_owned();
+
+        // Strip a leading dot so `.vimrc` becomes `vimrc` in the pack.
+        let pack_filename = file_name
+            .strip_prefix('.')
+            .unwrap_or(&file_name)
+            .to_string();
+
+        // Filename-ignore check against pack + root ignore patterns.
+        if rules::should_skip_entry(&pack_filename, &ignore_patterns) {
+            return Err(DodotError::Other(format!(
+                "refusing to adopt {}: name '{}' matches an ignore pattern or is reserved",
+                abs.display(),
+                pack_filename
+            )));
+        }
+
+        let pack_dest = pack_path.join(&pack_filename);
+
+        // Destination conflict check. With --force, we'll remove the existing
+        // destination before copy; without, this is a hard refusal.
+        let dest_exists = fs.exists(&pack_dest) || fs.is_symlink(&pack_dest);
+        if dest_exists && !force {
+            return Err(DodotError::SymlinkConflict { path: pack_dest });
+        }
+
+        // Cross-plan filename collision: can't adopt two things with the same
+        // stripped name in a single invocation.
+        if plans.iter().any(|p| p.pack_dest == pack_dest) {
+            return Err(DodotError::Other(format!(
+                "two sources produce the same pack filename '{}'; adopt them separately",
+                pack_filename
+            )));
+        }
+
+        plans.push(AdoptPlan {
+            source: abs,
+            pack_dest,
+            is_dir,
+        });
     }
 
-    Ok(AdoptResult {
-        message: format!("Adopted {} file(s) into '{pack_name}'.", files.len()),
-        details,
-    })
+    // Permission pre-flight. We do this after planning so every error up to
+    // this point gives precise guidance; perms check catches late issues.
+    let _ = pack_name; // reserved for future per-pack perm messages
+    check_writable(fs, pack_path)?;
+    for plan in &plans {
+        check_readable(fs, &plan.source)?;
+        if let Some(src_parent) = plan.source.parent() {
+            check_writable(fs, src_parent)?;
+        }
+    }
+
+    Ok((plans, skipped))
+}
+
+fn check_writable(fs: &dyn Fs, dir: &Path) -> Result<()> {
+    // Probe write by creating and removing a unique marker file.
+    let probe = dir.join(format!(".dodot-adopt-probe-{}", nonce()));
+    fs.write_file(&probe, b"").map_err(|e| {
+        DodotError::Other(format!("not writable: {}: {}", dir.display(), err_msg(&e)))
+    })?;
+    let _ = fs.remove_file(&probe);
+    Ok(())
+}
+
+fn check_readable(fs: &dyn Fs, path: &Path) -> Result<()> {
+    // For directories, read_dir; for files, a stat is enough.
+    if fs.is_dir(path) {
+        fs.read_dir(path).map(|_| ())
+    } else {
+        fs.stat(path).map(|_| ())
+    }
+}
+
+// ── Phase 1: copy ─────────────────────────────────────────────────
+
+fn copy_all(plans: &[AdoptPlan], fs: &dyn Fs) -> Result<()> {
+    for plan in plans {
+        // --force case: wipe any existing destination before copying.
+        if fs.exists(&plan.pack_dest) || fs.is_symlink(&plan.pack_dest) {
+            if fs.is_dir(&plan.pack_dest) && !fs.is_symlink(&plan.pack_dest) {
+                fs.remove_dir_all(&plan.pack_dest)?;
+            } else {
+                fs.remove_file(&plan.pack_dest)?;
+            }
+        }
+        copy_tree(&plan.source, &plan.pack_dest, fs)?;
+    }
+    Ok(())
+}
+
+/// Recursively copy `src` into `dst`. Preserves inner symlinks as symlinks
+/// (does not follow them) and Unix permissions on files and directories.
+fn copy_tree(src: &Path, dst: &Path, fs: &dyn Fs) -> Result<()> {
+    let meta = fs.lstat(src)?;
+    if meta.is_symlink {
+        let target = fs.readlink(src)?;
+        fs.symlink(&target, dst)?;
+        return Ok(());
+    }
+    if meta.is_dir {
+        fs.mkdir_all(dst)?;
+        // Best-effort mode preserve on the directory itself; ignore failures
+        // (tempdirs on some platforms reject chmod on freshly-created dirs).
+        let _ = fs.set_permissions(dst, meta.mode);
+        for entry in fs.read_dir(src)? {
+            copy_tree(&entry.path, &dst.join(&entry.name), fs)?;
+        }
+        return Ok(());
+    }
+    if meta.is_file {
+        fs.copy_file(src, dst)?;
+        let _ = fs.set_permissions(dst, meta.mode);
+        return Ok(());
+    }
+    Err(DodotError::Other(format!(
+        "unsupported file type: {}",
+        src.display()
+    )))
+}
+
+fn cleanup_pack_copies(plans: &[AdoptPlan], fs: &dyn Fs) {
+    for plan in plans {
+        remove_best_effort(fs, &plan.pack_dest);
+    }
+}
+
+fn remove_best_effort(fs: &dyn Fs, path: &Path) {
+    if fs.is_symlink(path) {
+        let _ = fs.remove_file(path);
+    } else if fs.is_dir(path) {
+        let _ = fs.remove_dir_all(path);
+    } else if fs.exists(path) {
+        let _ = fs.remove_file(path);
+    }
+}
+
+// ── Deploy conflict check ─────────────────────────────────────────
+
+fn check_deploy_conflicts(ctx: &ExecutionContext) -> Result<()> {
+    let root_config = ctx.config_manager.root_config()?;
+    let packs::DiscoveredPacks { packs: all, .. } = packs::scan_packs(
+        ctx.fs.as_ref(),
+        ctx.paths.dotfiles_root(),
+        &root_config.pack.ignore,
+    )?;
+
+    let mut pack_intents = Vec::new();
+    for mut pack in all {
+        let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
+        pack.config = pack_config.to_handler_config();
+        match orchestration::collect_pack_intents(&pack, ctx) {
+            Ok(intents) => pack_intents.push((pack.name.clone(), intents)),
+            Err(_) => {
+                // Skip packs that fail to collect — they won't contribute
+                // conflicts, and their own errors surface via status/up.
+            }
+        }
+    }
+
+    let conflicts = conflicts::detect_cross_pack_conflicts(&pack_intents, ctx.fs.as_ref());
+    if !conflicts.is_empty() {
+        return Err(DodotError::CrossPackConflict { conflicts });
+    }
+    Ok(())
+}
+
+// ── Phase 2: atomic swap ──────────────────────────────────────────
+
+struct AdoptFailure {
+    source: PathBuf,
+    reason: String,
+}
+
+fn swap_all(plans: &[AdoptPlan], fs: &dyn Fs) -> Vec<AdoptFailure> {
+    let mut failures = Vec::new();
+    for plan in plans {
+        let result = if plan.is_dir {
+            swap_dir(&plan.source, &plan.pack_dest, fs)
+        } else {
+            swap_file_atomic(&plan.source, &plan.pack_dest, fs)
+        };
+        if let Err(e) = result {
+            // Roll back just this source: its pack copy is now orphaned.
+            remove_best_effort(fs, &plan.pack_dest);
+            failures.push(AdoptFailure {
+                source: plan.source.clone(),
+                reason: format!("{}", e),
+            });
+        }
+    }
+    failures
+}
+
+/// Atomic file swap: create symlink at a temp sibling, then rename over the
+/// original. `rename` is atomic on POSIX and replaces the existing file.
+fn swap_file_atomic(source: &Path, pack_dest: &Path, fs: &dyn Fs) -> Result<()> {
+    let tmp = temp_sibling(source, "tmp");
+    fs.symlink(pack_dest, &tmp)?;
+    if let Err(e) = fs.rename(&tmp, source) {
+        // Clean up temp link before returning.
+        let _ = fs.remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Directory swap: rename original aside, create symlink, remove backup. On
+/// symlink failure, restore the backup.
+fn swap_dir(source: &Path, pack_dest: &Path, fs: &dyn Fs) -> Result<()> {
+    let backup = temp_sibling(source, "old");
+    fs.rename(source, &backup)?;
+    match fs.symlink(pack_dest, source) {
+        Ok(()) => {
+            // Best-effort cleanup of the backup directory.
+            let _ = fs.remove_dir_all(&backup);
+            Ok(())
+        }
+        Err(e) => {
+            // Restore original on failure.
+            let _ = fs.rename(&backup, source);
+            Err(e)
+        }
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────
+
+fn temp_sibling(path: &Path, tag: &str) -> PathBuf {
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    parent.join(format!(".dodot-adopt-{}-{}-{}", tag, name, nonce()))
+}
+
+fn nonce() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let n = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{:x}", n)
+}
+
+fn err_msg(e: &DodotError) -> String {
+    format!("{e}")
 }

--- a/crates/dodot-lib/src/commands/adopt.rs
+++ b/crates/dodot-lib/src/commands/adopt.rs
@@ -37,6 +37,13 @@ struct AdoptPlan {
     pack_dest: PathBuf,
     /// `true` if the source is a directory (after --no-follow resolution).
     is_dir: bool,
+    /// `true` when `pack_dest` already had content before adoption (only
+    /// possible with `--force`). Rollback paths must NOT remove this plan's
+    /// `pack_dest`: on copy failure we've preserved the old content in
+    /// place; on later failure the new content is committed-destructively
+    /// per the user's --force opt-in, and we can't restore the old content
+    /// anyway.
+    destructive_overwrite: bool,
 }
 
 /// Move sources into a pack, creating symlinks from their original locations.
@@ -260,6 +267,7 @@ fn preflight(
             source: abs,
             pack_dest,
             is_dir,
+            destructive_overwrite: dest_exists, // only true under --force
         });
     }
 
@@ -305,17 +313,38 @@ fn check_readable(fs: &dyn Fs, path: &Path, is_dir: bool) -> Result<()> {
 
 fn copy_all(plans: &[AdoptPlan], fs: &dyn Fs) -> Result<()> {
     for plan in plans {
-        // --force case: wipe any existing destination before copying.
-        if fs.exists(&plan.pack_dest) || fs.is_symlink(&plan.pack_dest) {
-            if fs.is_dir(&plan.pack_dest) && !fs.is_symlink(&plan.pack_dest) {
-                fs.remove_dir_all(&plan.pack_dest)?;
-            } else {
-                fs.remove_file(&plan.pack_dest)?;
+        let had_existing_dest = fs.exists(&plan.pack_dest) || fs.is_symlink(&plan.pack_dest);
+        if had_existing_dest {
+            // --force path: stage the new content into a sibling temp path
+            // first so a failed copy leaves the old destination intact.
+            // Only after the copy succeeds do we remove the old content and
+            // move the stage into place.
+            let stage = temp_sibling(&plan.pack_dest, "stage");
+            if let Err(e) = copy_tree(&plan.source, &stage, fs) {
+                remove_best_effort(fs, &stage);
+                return Err(e);
             }
+            remove_path(&plan.pack_dest, fs)?;
+            if let Err(e) = fs.rename(&stage, &plan.pack_dest) {
+                remove_best_effort(fs, &stage);
+                return Err(e);
+            }
+        } else {
+            // No existing destination: copy directly.
+            copy_tree(&plan.source, &plan.pack_dest, fs)?;
         }
-        copy_tree(&plan.source, &plan.pack_dest, fs)?;
     }
     Ok(())
+}
+
+fn remove_path(path: &Path, fs: &dyn Fs) -> Result<()> {
+    if fs.is_symlink(path) {
+        fs.remove_file(path)
+    } else if fs.is_dir(path) {
+        fs.remove_dir_all(path)
+    } else {
+        fs.remove_file(path)
+    }
 }
 
 /// Recursively copy `src` into `dst`. Preserves inner symlinks as symlinks
@@ -350,6 +379,13 @@ fn copy_tree(src: &Path, dst: &Path, fs: &dyn Fs) -> Result<()> {
 
 fn cleanup_pack_copies(plans: &[AdoptPlan], fs: &dyn Fs) {
     for plan in plans {
+        // Destructive-overwrite plans: on copy failure, `pack_dest` still
+        // holds the preserved old content; on later failure the new
+        // content is committed-destructively per --force. Either way,
+        // don't remove.
+        if plan.destructive_overwrite {
+            continue;
+        }
         remove_best_effort(fs, &plan.pack_dest);
     }
 }

--- a/crates/dodot-lib/src/commands/adopt.rs
+++ b/crates/dodot-lib/src/commands/adopt.rs
@@ -268,7 +268,10 @@ fn preflight(
     let _ = pack_name; // reserved for future per-pack perm messages
     check_writable(fs, pack_path)?;
     for plan in &plans {
-        check_readable(fs, &plan.source)?;
+        // Pass the plan's `is_dir` (already resolved with `--no-follow`
+        // semantics) so a symlink-to-dir under `--no-follow` isn't probed
+        // via `read_dir` on the target.
+        check_readable(fs, &plan.source, plan.is_dir)?;
         if let Some(src_parent) = plan.source.parent() {
             check_writable(fs, src_parent)?;
         }
@@ -287,12 +290,14 @@ fn check_writable(fs: &dyn Fs, dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn check_readable(fs: &dyn Fs, path: &Path) -> Result<()> {
-    // For directories, read_dir; for files, a stat is enough.
-    if fs.is_dir(path) {
+fn check_readable(fs: &dyn Fs, path: &Path, is_dir: bool) -> Result<()> {
+    // For directories, read_dir; for files or symlinks, lstat (which does
+    // not follow) is enough — we don't need to reach through a symlink
+    // target, especially under `--no-follow`.
+    if is_dir {
         fs.read_dir(path).map(|_| ())
     } else {
-        fs.stat(path).map(|_| ())
+        fs.lstat(path).map(|_| ())
     }
 }
 

--- a/crates/dodot-lib/src/commands/adopt.rs
+++ b/crates/dodot-lib/src/commands/adopt.rs
@@ -364,13 +364,12 @@ fn check_deploy_conflicts(ctx: &ExecutionContext) -> Result<()> {
     for mut pack in all {
         let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
         pack.config = pack_config.to_handler_config();
-        match orchestration::collect_pack_intents(&pack, ctx) {
-            Ok(intents) => pack_intents.push((pack.name.clone(), intents)),
-            Err(_) => {
-                // Skip packs that fail to collect — they won't contribute
-                // conflicts, and their own errors surface via status/up.
-            }
-        }
+        // Propagate per-pack errors: if any pack can't be scanned we can't
+        // truthfully say "no conflict with that pack," so refuse outright
+        // rather than risk a false negative that lets us mutate into a
+        // state `dodot up` will later reject.
+        let intents = orchestration::collect_pack_intents(&pack, ctx)?;
+        pack_intents.push((pack.name.clone(), intents));
     }
 
     let conflicts = conflicts::detect_cross_pack_conflicts(&pack_intents, ctx.fs.as_ref());

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -713,6 +713,36 @@ fn adopt_already_adopted_source_is_skipped() {
 }
 
 #[test]
+fn adopt_relative_path_with_curdir_normalizes() {
+    // `dodot adopt mypack ./.vimrc` run from HOME must not be rejected as
+    // "nested" — the `.` component should normalize away so parent == HOME.
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("placeholder", "")
+        .done()
+        .home_file(".vimrc", "content")
+        .build();
+
+    // Run with CWD = HOME so the relative path resolves naturally.
+    let prev_cwd = std::env::current_dir().unwrap();
+    std::env::set_current_dir(&env.home).unwrap();
+    let ctx = make_ctx(&env);
+    let result = commands::adopt::adopt(
+        "vim",
+        &[std::path::PathBuf::from("./.vimrc")],
+        false,
+        false,
+        false,
+        &ctx,
+    );
+    std::env::set_current_dir(prev_cwd).unwrap();
+
+    result.expect("adopt should accept ./.vimrc when CWD is HOME");
+    env.assert_regular_file(&env.dotfiles_root.join("vim/vimrc"), "content");
+    assert!(env.fs.is_symlink(&env.home.join(".vimrc")));
+}
+
+#[test]
 fn adopt_ignored_pack_refused() {
     let env = TempEnvironment::builder()
         .pack("disabled")

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -966,6 +966,42 @@ fn adopt_no_follow_keeps_source_symlink_as_symlink() {
 }
 
 #[test]
+fn adopt_no_follow_on_dangling_symlink_succeeds() {
+    // A dangling symlink under --no-follow: readability check must inspect
+    // the link itself (lstat), not try to follow it into a non-existent
+    // target. Regression test: check_readable previously used fs.is_dir +
+    // fs.stat, both of which follow symlinks and would fail here.
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("placeholder", "")
+        .done()
+        .build();
+
+    // Create ~/.dangling -> /does/not/exist (target intentionally missing).
+    let source = env.home.join(".dangling");
+    env.fs
+        .symlink(std::path::Path::new("/does/not/exist"), &source)
+        .unwrap();
+
+    let ctx = make_ctx(&env);
+    commands::adopt::adopt(
+        "vim",
+        std::slice::from_ref(&source),
+        false,
+        true, // --no-follow
+        false,
+        &ctx,
+    )
+    .expect("adopt with --no-follow on a dangling symlink should succeed");
+
+    // The pack copy should itself be a symlink (preserving the dangling link).
+    let pack_copy = env.dotfiles_root.join("vim/dangling");
+    assert!(env.fs.is_symlink(&pack_copy));
+    let target = env.fs.readlink(&pack_copy).unwrap();
+    assert_eq!(target, std::path::PathBuf::from("/does/not/exist"));
+}
+
+#[test]
 fn adopt_nonexistent_source_errors() {
     let env = TempEnvironment::builder()
         .pack("vim")

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -460,13 +460,475 @@ fn adopt_moves_file_and_creates_symlink() {
     let ctx = make_ctx(&env);
     let source = env.home.join(".vimrc");
 
-    let result = commands::adopt::adopt("vim", std::slice::from_ref(&source), false, &ctx).unwrap();
-    assert!(result.message.contains("1 file"));
+    let result = commands::adopt::adopt(
+        "vim",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
 
-    // File should have moved into pack (without dot prefix)
-    env.assert_exists(&env.dotfiles_root.join("vim/vimrc"));
+    // File should have moved into pack (without dot prefix), content preserved
+    env.assert_regular_file(&env.dotfiles_root.join("vim/vimrc"), "set nocompatible");
     // Symlink should exist at original location
     assert!(env.fs.is_symlink(&source));
+
+    // Status output should include the vim pack with the adopted file
+    assert!(result.packs.iter().any(|p| p.name == "vim"));
+    let vim = result.packs.iter().find(|p| p.name == "vim").unwrap();
+    assert!(vim.files.iter().any(|f| f.name == "vimrc"));
+}
+
+#[test]
+fn adopt_preserves_executable_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let env = TempEnvironment::builder()
+        .pack("tools")
+        .file("placeholder", "")
+        .done()
+        .home_file("script.sh", "#!/bin/sh\necho hi")
+        .build();
+
+    let source = env.home.join("script.sh");
+    // Mark source as executable
+    let perms = std::fs::Permissions::from_mode(0o755);
+    std::fs::set_permissions(&source, perms).unwrap();
+
+    let ctx = make_ctx(&env);
+    commands::adopt::adopt(
+        "tools",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    let dest = env.dotfiles_root.join("tools/script.sh");
+    let meta = std::fs::metadata(&dest).unwrap();
+    assert_eq!(
+        meta.permissions().mode() & 0o777,
+        0o755,
+        "executable bit should be preserved on adopted file"
+    );
+}
+
+#[test]
+fn adopt_destination_conflict_refused_without_force() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "existing content")
+        .done()
+        .home_file(".vimrc", "new content")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".vimrc");
+
+    let err = commands::adopt::adopt(
+        "vim",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, crate::DodotError::SymlinkConflict { .. }),
+        "expected SymlinkConflict, got: {err}"
+    );
+
+    // Original file untouched; existing pack file untouched.
+    env.assert_regular_file(&source, "new content");
+    env.assert_regular_file(&env.dotfiles_root.join("vim/vimrc"), "existing content");
+}
+
+#[test]
+fn adopt_destination_conflict_resolved_with_force() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "OLD")
+        .done()
+        .home_file(".vimrc", "NEW")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".vimrc");
+
+    commands::adopt::adopt(
+        "vim",
+        std::slice::from_ref(&source),
+        true, // --force
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    env.assert_regular_file(&env.dotfiles_root.join("vim/vimrc"), "NEW");
+    assert!(env.fs.is_symlink(&source));
+}
+
+#[test]
+fn adopt_directory_creates_symlink_and_preserves_contents() {
+    let env = TempEnvironment::builder()
+        .pack("nvim")
+        .file("placeholder", "")
+        .done()
+        .home_file(".config/nvim/init.lua", "-- config")
+        .home_file(".config/nvim/lua/mod.lua", "-- module")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".config");
+
+    commands::adopt::adopt(
+        "nvim",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    // The directory is moved to pack/config (dot stripped) with contents.
+    let pack_dir = env.dotfiles_root.join("nvim/config");
+    env.assert_dir_exists(&pack_dir);
+    env.assert_regular_file(&pack_dir.join("nvim/init.lua"), "-- config");
+    env.assert_regular_file(&pack_dir.join("nvim/lua/mod.lua"), "-- module");
+
+    // Original path is now a symlink to the pack copy.
+    assert!(env.fs.is_symlink(&source));
+    let target = env.fs.readlink(&source).unwrap();
+    assert_eq!(target, pack_dir);
+}
+
+#[test]
+fn adopt_preserves_inner_symlinks_as_symlinks() {
+    let env = TempEnvironment::builder()
+        .pack("shell")
+        .file("placeholder", "")
+        .done()
+        .home_file("mydir/real.txt", "hello")
+        .build();
+
+    // Create an inner symlink: mydir/alias -> mydir/real.txt
+    let inner_target = env.home.join("mydir/real.txt");
+    let inner_link = env.home.join("mydir/alias");
+    env.fs.symlink(&inner_target, &inner_link).unwrap();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join("mydir");
+    commands::adopt::adopt(
+        "shell",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    // The inner link should still be a symlink inside the pack copy.
+    let copied_link = env.dotfiles_root.join("shell/mydir/alias");
+    assert!(
+        env.fs.is_symlink(&copied_link),
+        "inner symlink should be preserved as a symlink, not followed"
+    );
+}
+
+#[test]
+fn adopt_nested_source_refused() {
+    let env = TempEnvironment::builder()
+        .pack("nvim")
+        .file("placeholder", "")
+        .done()
+        .home_file(".config/nvim/init.lua", "-- config")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".config/nvim/init.lua");
+
+    let err = commands::adopt::adopt(
+        "nvim",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("nested"),
+        "expected 'nested' in error message, got: {msg}"
+    );
+
+    // Nothing mutated.
+    env.assert_regular_file(&source, "-- config");
+    env.assert_not_exists(&env.dotfiles_root.join("nvim/init.lua"));
+}
+
+#[test]
+fn adopt_already_adopted_source_is_skipped() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "content")
+        .done()
+        .build();
+
+    // Pre-link home file to the pack.
+    let source = env.home.join(".vimrc");
+    let pack_file = env.dotfiles_root.join("vim/vimrc");
+    env.fs.symlink(&pack_file, &source).unwrap();
+
+    let ctx = make_ctx(&env);
+    let result = commands::adopt::adopt(
+        "vim",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.contains("already managed")),
+        "expected already-managed warning, got: {:?}",
+        result.warnings
+    );
+    // Source still a symlink, pack file untouched.
+    assert!(env.fs.is_symlink(&source));
+    env.assert_regular_file(&pack_file, "content");
+}
+
+#[test]
+fn adopt_ignored_pack_refused() {
+    let env = TempEnvironment::builder()
+        .pack("disabled")
+        .file("placeholder", "")
+        .ignored()
+        .done()
+        .home_file(".vimrc", "x")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".vimrc");
+    let err = commands::adopt::adopt(
+        "disabled",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, crate::DodotError::PackInvalid { .. }),
+        "expected PackInvalid, got: {err}"
+    );
+}
+
+#[test]
+fn adopt_filename_matching_pack_ignore_refused() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("placeholder", "")
+        .config("[pack]\nignore = [\"*.bak\"]")
+        .done()
+        .home_file(".vimrc.bak", "old")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".vimrc.bak");
+    let err = commands::adopt::adopt(
+        "vim",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("ignore"),
+        "expected ignore-pattern message, got: {msg}"
+    );
+}
+
+#[test]
+fn adopt_deploy_conflict_refused() {
+    // Two packs, both would end up claiming ~/.vimrc after adoption.
+    let env = TempEnvironment::builder()
+        .pack("unix")
+        .file("vimrc", "existing")
+        .done()
+        .pack("work")
+        .file("placeholder", "")
+        .done()
+        .home_file(".vimrc", "new")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".vimrc");
+    let err = commands::adopt::adopt(
+        "work",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, crate::DodotError::CrossPackConflict { .. }),
+        "expected CrossPackConflict, got: {err}"
+    );
+
+    // Home untouched.
+    env.assert_regular_file(&source, "new");
+    // Pack copy rolled back.
+    env.assert_not_exists(&env.dotfiles_root.join("work/vimrc"));
+}
+
+#[test]
+fn adopt_deploy_conflict_not_bypassed_by_force() {
+    let env = TempEnvironment::builder()
+        .pack("unix")
+        .file("vimrc", "existing")
+        .done()
+        .pack("work")
+        .file("placeholder", "")
+        .done()
+        .home_file(".vimrc", "new")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".vimrc");
+    let err = commands::adopt::adopt(
+        "work",
+        std::slice::from_ref(&source),
+        true, // --force should NOT bypass deploy conflicts
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, crate::DodotError::CrossPackConflict { .. }),
+        "--force must not bypass deploy conflicts, got: {err}"
+    );
+}
+
+#[test]
+fn adopt_dry_run_makes_no_changes() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("placeholder", "")
+        .done()
+        .home_file(".vimrc", "content")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".vimrc");
+
+    let result = commands::adopt::adopt(
+        "vim",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        true, // dry-run
+        &ctx,
+    )
+    .unwrap();
+    assert!(result.dry_run);
+
+    // Nothing changed at home.
+    env.assert_regular_file(&source, "content");
+    assert!(!env.fs.is_symlink(&source));
+    // No copy in pack.
+    env.assert_not_exists(&env.dotfiles_root.join("vim/vimrc"));
+}
+
+#[test]
+fn adopt_no_follow_keeps_source_symlink_as_symlink() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("placeholder", "")
+        .done()
+        .home_file("real_vimrc", "real content")
+        .build();
+
+    // ~/.vimrc is a symlink to ~/real_vimrc
+    let real = env.home.join("real_vimrc");
+    let source = env.home.join(".vimrc");
+    env.fs.symlink(&real, &source).unwrap();
+
+    let ctx = make_ctx(&env);
+    commands::adopt::adopt(
+        "vim",
+        std::slice::from_ref(&source),
+        false,
+        true, // --no-follow
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    // The pack copy should be a symlink (not a regular file with copied content).
+    let pack_copy = env.dotfiles_root.join("vim/vimrc");
+    assert!(
+        env.fs.is_symlink(&pack_copy),
+        "--no-follow should preserve source symlink as a symlink in the pack"
+    );
+    // Home path replaced with a symlink into the pack.
+    assert!(env.fs.is_symlink(&source));
+}
+
+#[test]
+fn adopt_nonexistent_source_errors() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("placeholder", "")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".does-not-exist");
+    let err = commands::adopt::adopt(
+        "vim",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap_err();
+    assert!(matches!(err, crate::DodotError::Fs { .. }), "got: {err}");
+}
+
+#[test]
+fn adopt_empty_sources_errors() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("placeholder", "")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+    let err = commands::adopt::adopt("vim", &[], false, false, false, &ctx).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("no files"), "got: {msg}");
 }
 
 // ── addignore ───────────────────────────────────────────────
@@ -594,8 +1056,15 @@ fn adopt_nonexistent_pack_returns_pack_not_found() {
 
     let ctx = make_ctx(&env);
     let source = env.home.join(".vimrc");
-    let err =
-        commands::adopt::adopt("newpack", std::slice::from_ref(&source), false, &ctx).unwrap_err();
+    let err = commands::adopt::adopt(
+        "newpack",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap_err();
     assert!(
         matches!(err, crate::DodotError::PackNotFound { .. }),
         "expected PackNotFound, got: {err}"

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -768,6 +768,45 @@ fn adopt_filename_matching_pack_ignore_refused() {
 }
 
 #[test]
+fn adopt_broken_pack_blocks_conflict_check() {
+    // If another pack fails intent collection, adoption must refuse rather
+    // than silently proceed — otherwise the conflict check produces a false
+    // negative and we'd mutate into a state `dodot up` would later reject.
+    let env = TempEnvironment::builder()
+        .pack("broken")
+        .file("config.toml.tmpl", "{{ missing_var }}")
+        .done()
+        .pack("target")
+        .file("placeholder", "")
+        .done()
+        .home_file(".vimrc", "content")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".vimrc");
+    let err = commands::adopt::adopt(
+        "target",
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap_err();
+
+    // The error surfaces from the broken pack's intent collection
+    // (template render failure), not a silent success.
+    assert!(
+        matches!(err, crate::DodotError::TemplateRender { .. }),
+        "expected the broken pack's error to surface, got: {err}"
+    );
+
+    // Home untouched; no pack copy left behind.
+    env.assert_regular_file(&source, "content");
+    env.assert_not_exists(&env.dotfiles_root.join("target/vimrc"));
+}
+
+#[test]
 fn adopt_deploy_conflict_refused() {
     // Two packs, both would end up claiming ~/.vimrc after adoption.
     let env = TempEnvironment::builder()

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -965,6 +965,58 @@ fn adopt_no_follow_keeps_source_symlink_as_symlink() {
     assert!(env.fs.is_symlink(&source));
 }
 
+#[cfg(unix)]
+#[test]
+fn adopt_force_preserves_old_content_when_copy_fails() {
+    // With --force, the old destination must remain intact if the copy of
+    // the new source fails. Previously copy_all removed the dest before
+    // copying, so a copy failure silently lost the old content.
+    use std::os::unix::fs::PermissionsExt;
+
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "OLD")
+        .done()
+        .home_file(".vimrc", "NEW")
+        .build();
+
+    let source = env.home.join(".vimrc");
+    // chmod 000 makes the file unreadable, so the copy phase fails at
+    // read-time without tripping preflight (which uses lstat only).
+    std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let ctx = make_ctx(&env);
+    let result = commands::adopt::adopt(
+        "vim",
+        std::slice::from_ref(&source),
+        true, // --force
+        false,
+        false,
+        &ctx,
+    );
+
+    // Restore perms so drop-cleanup works regardless of assertion outcome.
+    let _ = std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o644));
+
+    assert!(
+        result.is_err(),
+        "adopt should fail when the source is unreadable"
+    );
+    // The old pack content must survive the failed --force adoption.
+    env.assert_regular_file(&env.dotfiles_root.join("vim/vimrc"), "OLD");
+    // Home file also untouched.
+    env.assert_regular_file(&source, "NEW");
+    // No lingering stage file in the pack.
+    let leftover = env.fs.read_dir(&env.dotfiles_root.join("vim")).unwrap();
+    for entry in leftover {
+        assert!(
+            !entry.name.contains("dodot-adopt-stage"),
+            "stage file leaked into pack: {}",
+            entry.name
+        );
+    }
+}
+
 #[test]
 fn adopt_no_follow_on_dangling_symlink_succeeds() {
     // A dangling symlink under --no-follow: readability check must inspect

--- a/tests/e2e/bats/test_adopt.bats
+++ b/tests/e2e/bats/test_adopt.bats
@@ -16,7 +16,10 @@ teardown() {
 
     run dodot adopt vim "$HOME/.vimrc"
     [ "$status" -eq 0 ]
-    assert_output_contains "1 file"
+    # Adopt output is now the destination pack's status (matches `dodot status vim`).
+    assert_output_contains "vim"
+    assert_output_contains "vimrc"
+    assert_output_contains "pending"
 
     # File should be in the pack (dot prefix stripped)
     assert_exists "$DOTFILES_ROOT/vim/vimrc"
@@ -54,7 +57,10 @@ teardown() {
 
     run dodot adopt shell "$HOME/.bashrc" "$HOME/.zshrc"
     [ "$status" -eq 0 ]
-    assert_output_contains "2 file"
+    # Status output lists both adopted files under the destination pack.
+    assert_output_contains "shell"
+    assert_output_contains "bashrc"
+    assert_output_contains "zshrc"
 
     assert_exists "$DOTFILES_ROOT/shell/bashrc"
     assert_exists "$DOTFILES_ROOT/shell/zshrc"
@@ -64,5 +70,5 @@ teardown() {
     create_pack "vim"
 
     run dodot adopt vim "$HOME/.nonexistent"
-    assert_output_contains "file not found"
+    assert_output_contains "source does not exist"
 }


### PR DESCRIPTION
## Summary

Rewrites `dodot adopt` around a two-phase model so partial failures leave the filesystem in a grokable state, and cross-pack deploy conflicts are caught before any mutation.

### Two-phase model

**Phase 1 — copy all sources into the pack (originals untouched).**
Recursive copy via the existing `Fs` trait. Preserves inner symlinks as symlinks (lstat/readlink/symlink), and Unix permissions on files + dirs. On any failure, partial pack copies are removed and the error surfaces; home is pristine throughout.

**Phase 2 — per-source atomic swap at the original location.**
- Files: create symlink at `<source>.dodot-adopt-tmp-*` and `rename` over the original. Single POSIX atomic syscall — no "file briefly missing" window even on Ctrl-C.
- Dirs: rename original to `.dodot-adopt-old-*`, create symlink, remove backup. One-step recoverable: symlink failure renames the backup back; a crashed process leaves an obvious sibling for manual recovery.
- Per-source phase-2 failures clean up that source's pack copy and are surfaced in `warnings`; successfully-adopted sources stay adopted.

### Cross-pack deploy conflicts

Simulation runs between phase 1 and phase 2: collect intents from every pack (with the new copies in place), run `detect_cross_pack_conflicts`, and refuse with `CrossPackConflict` on any collision. **Not bypassed by `--force`**.

### Pre-flight

Refuses: nested sources (parent ≠ HOME), already-adopted symlinks (target in dotfiles root or data dir), `.dodotignore`d packs, filenames matching pack/root ignore patterns, and non-writable pack/source-parent directories.

### Flags

| Flag | Effect |
|---|---|
| `--force` | overwrite existing destination file in the pack (does NOT bypass deploy conflicts or ignore rules) |
| `--dry-run` | validate the full plan (phase 1 + conflict sim) then roll back — no mutation at home, no pack copies left behind |
| `--no-follow` | source symlinks are moved as symlinks rather than their targets |

### Output

Returns `PackStatusResult` (via `status::status(pack)` after the swap) — success output matches `dodot status <pack>`, and phase-2 failures surface as warnings alongside it. Drops the `AdoptResult` struct.

## Test plan

- [x] 362 library tests pass (16 new adopt cases + all pre-existing)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Eyeball `dodot adopt ~/.somefile mypack` against a real dotfiles repo
- [ ] Eyeball `dodot adopt ~/.config mypack --dry-run`
- [ ] Verify `--no-follow` on a real iCloud-symlinked dotfile

### New test cases

`adopt_moves_file_and_creates_symlink`, `adopt_preserves_executable_permissions`, `adopt_destination_conflict_refused_without_force`, `adopt_destination_conflict_resolved_with_force`, `adopt_directory_creates_symlink_and_preserves_contents`, `adopt_preserves_inner_symlinks_as_symlinks`, `adopt_nested_source_refused`, `adopt_already_adopted_source_is_skipped`, `adopt_ignored_pack_refused`, `adopt_filename_matching_pack_ignore_refused`, `adopt_deploy_conflict_refused`, `adopt_deploy_conflict_not_bypassed_by_force`, `adopt_dry_run_makes_no_changes`, `adopt_no_follow_keeps_source_symlink_as_symlink`, `adopt_nonexistent_source_errors`, `adopt_empty_sources_errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)