### PR TITLE
fix(commands): unify post-execution rendering through status (#42)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,3 +8,6 @@ Use sections: Added, Changed, Deprecated, Removed, Fixed, Security.
 
 ### Added
 - Provisioning script execution now prints `==== <pack> → <handler> → <script>  running…` before the spawn and `OK` (green) or `FAILED` (red) after, on stderr. Sentinel-skipped runs stay silent. Long-running scripts (e.g. brew installs) are no longer opaque from the user's side.
+
+### Changed
+- **`up` and `down` now render through `status::status()`** instead of using their own per-operation vocabulary. `dodot up video` and `dodot status video` produce identical right-column labels (`in PATH`, `sourced`, `deployed`) for the same observed state — previously `up` reported `staged bin` while `status` reported `in PATH`, which was confusing. Operation failures from `up` are overlaid as additional error rows on top of the status view. Dry-run output is unchanged (still shows planned operations). (#42)

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -1,8 +1,17 @@
 //! `down` command — remove all deployed state for packs.
+//!
+//! Output rendering: same principle as `up` — for real removals, render
+//! through `status::status()` so the per-file labels match what `dodot
+//! status` would show. After `down`, files appear in their `Pending`
+//! handler-specific form (`not in PATH`, `not sourced`, `pending`,
+//! `never run`). The action itself is communicated via the message
+//! line.
+//!
+//! Dry-run keeps the per-handler "would remove" rendering.
 
 use tracing::{debug, info};
 
-use crate::commands::{handler_symbol, DisplayFile, DisplayPack, PackStatusResult};
+use crate::commands::{handler_symbol, status, DisplayFile, DisplayPack, PackStatusResult};
 use crate::handlers::HANDLER_SYMLINK;
 use crate::packs;
 use crate::packs::orchestration::{self, ExecutionContext};
@@ -31,7 +40,8 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         all_packs.retain(|p| names.iter().any(|n| n == &p.name));
     }
 
-    let mut display_packs = Vec::new();
+    let mut affected_packs = Vec::new();
+    let mut dry_run_display: Vec<DisplayPack> = Vec::new();
     let mut any_removed = false;
 
     for pack in &all_packs {
@@ -44,61 +54,15 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
 
         info!(pack = %pack.name, handlers = ?handlers, "removing pack state");
         any_removed = true;
-        let mut files = Vec::new();
+        affected_packs.push(pack.name.clone());
 
-        for handler in &handlers {
-            // For symlink handler, list individual files (#14)
-            if handler == HANDLER_SYMLINK {
-                let handler_dir = ctx.paths.handler_data_dir(&pack.name, handler);
-                let entries = ctx.fs.read_dir(&handler_dir)?;
-                for entry in entries {
-                    let label = if ctx.dry_run {
-                        "[dry-run] would remove"
-                    } else {
-                        "removed"
-                    };
-                    let status = if ctx.dry_run { "pending" } else { "deployed" };
-                    files.push(DisplayFile {
-                        name: entry.name.clone(),
-                        symbol: handler_symbol(handler).into(),
-                        description: "state removed".into(),
-                        status: status.into(),
-                        status_label: label.into(),
-                        handler: handler.clone(),
-                    });
-                }
-            } else {
-                // Non-symlink handlers: show handler name
-                if ctx.dry_run {
-                    files.push(DisplayFile {
-                        name: handler.clone(),
-                        symbol: handler_symbol(handler).into(),
-                        description: "state will be removed".into(),
-                        status: "pending".into(),
-                        status_label: "[dry-run] would remove".into(),
-                        handler: handler.clone(),
-                    });
-                } else {
-                    files.push(DisplayFile {
-                        name: handler.clone(),
-                        symbol: handler_symbol(handler).into(),
-                        description: "state removed".into(),
-                        status: "deployed".into(),
-                        status_label: "removed".into(),
-                        handler: handler.clone(),
-                    });
-                }
-            }
-
-            if !ctx.dry_run {
+        if ctx.dry_run {
+            dry_run_display.push(build_dry_run_display(pack, &handlers, ctx)?);
+        } else {
+            for handler in &handlers {
                 ctx.datastore.remove_state(&pack.name, handler)?;
             }
         }
-
-        display_packs.push(DisplayPack {
-            name: pack.name.clone(),
-            files,
-        });
     }
 
     // Regenerate shell init script (now empty for removed packs)
@@ -106,6 +70,14 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         info!("regenerating shell init script");
         shell::write_init_script(ctx.fs.as_ref(), ctx.paths.as_ref())?;
     }
+
+    let display_packs = if ctx.dry_run {
+        dry_run_display
+    } else {
+        // Render through status — files for removed packs will now show as
+        // pending in their handler-specific vocabulary.
+        status::status(Some(&affected_packs), ctx)?.packs
+    };
 
     let message = if any_removed {
         "Packs deactivated."
@@ -120,5 +92,45 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         warnings,
         conflicts: Vec::new(),
         ignored_packs: Vec::new(),
+    })
+}
+
+/// Build the per-pack dry-run display: lists what would be removed,
+/// per-handler. For symlink handlers we list individual data-link entries
+/// since the user usually wants to know which files would be affected.
+fn build_dry_run_display(
+    pack: &packs::Pack,
+    handlers: &[String],
+    ctx: &ExecutionContext,
+) -> Result<DisplayPack> {
+    let mut files = Vec::new();
+    for handler in handlers {
+        if handler == HANDLER_SYMLINK {
+            let handler_dir = ctx.paths.handler_data_dir(&pack.name, handler);
+            let entries = ctx.fs.read_dir(&handler_dir)?;
+            for entry in entries {
+                files.push(DisplayFile {
+                    name: entry.name.clone(),
+                    symbol: handler_symbol(handler).into(),
+                    description: "state would be removed".into(),
+                    status: "pending".into(),
+                    status_label: "[dry-run] would remove".into(),
+                    handler: handler.clone(),
+                });
+            }
+        } else {
+            files.push(DisplayFile {
+                name: handler.clone(),
+                symbol: handler_symbol(handler).into(),
+                description: "state would be removed".into(),
+                status: "pending".into(),
+                status_label: "[dry-run] would remove".into(),
+                handler: handler.clone(),
+            });
+        }
+    }
+    Ok(DisplayPack {
+        name: pack.name.clone(),
+        files,
     })
 }

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -422,6 +422,17 @@ fn up_reports_conflict_when_file_exists() {
         "should mention conflict: {}",
         error_files[0].status_label
     );
+    // Overlay error rows must identify the failing file in the left column,
+    // not render with an empty name (regression: PR #45 review).
+    assert!(
+        !error_files[0].name.is_empty(),
+        "error row should name the failing file, got empty name"
+    );
+    assert!(
+        error_files[0].name.contains("gitconfig"),
+        "error row name should reference gitconfig, got: {}",
+        error_files[0].name
+    );
 
     // Original file should be untouched
     env.assert_file_contents(&env.home.join(".gitconfig"), "[user]\n  name = old");

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -230,6 +230,117 @@ fn up_deploys_packs() {
     assert!(deployed_count > 0, "some files should be deployed after up");
 }
 
+/// Regression for #42 (unify status rendering): `up` and `status` must
+/// produce identical per-file status_label strings for the same handler
+/// state. Before #42, `up` reported "staged bin" while `status` reported
+/// "in PATH" for the same path-handler state — confusing duplicate
+/// vocabulary.
+#[test]
+fn up_and_status_produce_matching_labels() {
+    let env = TempEnvironment::builder()
+        .pack("multi")
+        .file("vimrc", "set nocompat") // symlink handler
+        .file("aliases.sh", "alias x=y") // shell handler
+        .done()
+        .pack("withbin")
+        .file("bin/tool", "#!/bin/sh\necho hi")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+
+    let up_result = commands::up::up(None, &ctx).unwrap();
+    let status_result = commands::status::status(None, &ctx).unwrap();
+
+    // Build (pack, file_name) -> status_label maps for both.
+    let to_map = |packs: &[commands::DisplayPack]| {
+        let mut map = std::collections::HashMap::new();
+        for p in packs {
+            for f in &p.files {
+                if f.status == "error" || f.name.is_empty() {
+                    continue; // skip overlay error rows that have no status counterpart
+                }
+                map.insert((p.name.clone(), f.name.clone()), f.status_label.clone());
+            }
+        }
+        map
+    };
+
+    let up_labels = to_map(&up_result.packs);
+    let status_labels = to_map(&status_result.packs);
+
+    assert_eq!(
+        up_labels, status_labels,
+        "up and status should report identical status_labels for the same files"
+    );
+
+    // Spot-check the actual labels: should be the steady-state vocabulary
+    // ("deployed", "sourced", "in PATH"), not the executor vocabulary
+    // ("staged X", "executed: X").
+    let labels: Vec<&str> = up_labels.values().map(String::as_str).collect();
+    assert!(
+        labels.contains(&"in PATH"),
+        "expected path handler to render as 'in PATH', got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"sourced"),
+        "expected shell handler to render as 'sourced', got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"deployed"),
+        "expected symlink handler to render as 'deployed', got: {labels:?}"
+    );
+    assert!(
+        labels.iter().all(|l| !l.starts_with("staged ")),
+        "no label should use the executor's 'staged X' vocabulary, got: {labels:?}"
+    );
+}
+
+/// Regression for #42: `down` should likewise render through status, not
+/// hand-rolled "removed" / "state removed" labels.
+#[test]
+fn down_and_status_produce_matching_labels() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "x")
+        .file("aliases.sh", "alias v=vim")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    let down_result = commands::down::down(None, &ctx).unwrap();
+    let status_result = commands::status::status(None, &ctx).unwrap();
+
+    let to_map = |packs: &[commands::DisplayPack]| {
+        let mut map = std::collections::HashMap::new();
+        for p in packs {
+            for f in &p.files {
+                if f.status == "error" || f.name.is_empty() {
+                    continue;
+                }
+                map.insert((p.name.clone(), f.name.clone()), f.status_label.clone());
+            }
+        }
+        map
+    };
+
+    let down_labels = to_map(&down_result.packs);
+    let status_labels = to_map(&status_result.packs);
+    assert_eq!(
+        down_labels, status_labels,
+        "down and status should report identical status_labels for the same files"
+    );
+
+    // After down, files should be in handler-specific pending vocabulary.
+    let labels: Vec<&str> = down_labels.values().map(String::as_str).collect();
+    assert!(
+        labels.iter().all(|l| !l.contains("removed")),
+        "down output should use status vocabulary, not 'removed', got: {labels:?}"
+    );
+}
+
 #[test]
 fn up_generates_shell_init() {
     let env = TempEnvironment::builder()

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -7,11 +7,23 @@
 //!
 //! This prevents partial deployments where one pack silently overwrites
 //! another pack's symlinks.
+//!
+//! ## Output rendering
+//!
+//! For non-dry-run executions, `up` renders by calling `status::status()`
+//! on the affected packs after execution and overlaying any operation
+//! errors. This guarantees that the per-file labels you see after `up`
+//! match exactly what you'd see if you ran `status` immediately
+//! afterward — there's a single rendering path, not two.
+//!
+//! Dry-run keeps the per-intent rendering since there's no
+//! post-execution state to verify.
 
 use tracing::{debug, info};
 
 use crate::commands::{
-    handler_description, handler_symbol, status_style, DisplayFile, DisplayPack, PackStatusResult,
+    handler_description, handler_symbol, status, status_style, DisplayFile, DisplayPack,
+    PackStatusResult,
 };
 use crate::conflicts;
 use crate::datastore::format_command_for_display;
@@ -103,9 +115,48 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         shell::write_init_script(ctx.fs.as_ref(), ctx.paths.as_ref())?;
     }
 
-    // Convert to display format
-    let home = ctx.paths.home_dir();
-    let display_packs: Vec<DisplayPack> = pack_results
+    let has_failures = pack_results
+        .iter()
+        .any(|pr| !pr.success || pr.operations.iter().any(|op| !op.success));
+
+    // Build display packs.
+    //
+    // For real executions, render through status::status() so the user sees
+    // the same labels they'd see by running `dodot status` immediately
+    // afterward. Operation failures are overlaid as additional rows.
+    //
+    // For dry-run, render the simulated operations directly — there's no
+    // post-execution state to verify, and the user wants to see the planned
+    // changes, not the unchanged current state.
+    let display_packs = if ctx.dry_run {
+        render_intents(&pack_results, ctx.paths.home_dir())
+    } else {
+        let pack_names: Vec<String> = packs.iter().map(|p| p.name.clone()).collect();
+        let status_result = status::status(Some(&pack_names), ctx)?;
+        overlay_errors(status_result.packs, &pack_results)
+    };
+
+    let message = if has_failures {
+        "Packs deployed with errors.".into()
+    } else {
+        "Packs deployed.".into()
+    };
+
+    Ok(PackStatusResult {
+        message: Some(message),
+        dry_run: ctx.dry_run,
+        packs: display_packs,
+        warnings: Vec::new(),
+        conflicts: Vec::new(),
+        ignored_packs: Vec::new(),
+    })
+}
+
+/// Render operations directly from pack_results — used for dry-run, where
+/// there's no executed state to verify and the user wants to see the
+/// planned changes rather than the unchanged status quo.
+fn render_intents(pack_results: &[PackResult], home: &std::path::Path) -> Vec<DisplayPack> {
+    pack_results
         .iter()
         .map(|pr| {
             let mut files: Vec<DisplayFile> = pr
@@ -129,7 +180,6 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
                 })
                 .collect();
 
-            // Include error from orchestration (e.g. pack-level config error)
             if let Some(err) = &pr.error {
                 files.push(DisplayFile {
                     name: String::new(),
@@ -146,26 +196,50 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
                 files,
             }
         })
-        .collect();
+        .collect()
+}
 
-    // Message reflects actual results
-    let has_failures = pack_results
-        .iter()
-        .any(|pr| !pr.success || pr.operations.iter().any(|op| !op.success));
-    let message = if has_failures {
-        "Packs deployed with errors.".into()
-    } else {
-        "Packs deployed.".into()
-    };
+/// Take the steady-state DisplayPacks produced by `status::status()` and
+/// append error rows for any failed operations or pack-level errors. The
+/// status rows still describe what *is* on disk; the appended rows
+/// describe what *failed* during the just-completed execution.
+pub(crate) fn overlay_errors(
+    mut packs: Vec<DisplayPack>,
+    pack_results: &[PackResult],
+) -> Vec<DisplayPack> {
+    for pr in pack_results {
+        let display_pack = match packs.iter_mut().find(|p| p.name == pr.pack_name) {
+            Some(p) => p,
+            None => continue,
+        };
 
-    Ok(PackStatusResult {
-        message: Some(message),
-        dry_run: ctx.dry_run,
-        packs: display_packs,
-        warnings: Vec::new(),
-        conflicts: Vec::new(),
-        ignored_packs: Vec::new(),
-    })
+        for op_result in &pr.operations {
+            if op_result.success {
+                continue;
+            }
+            let handler = op_result.operation.handler().to_string();
+            display_pack.files.push(DisplayFile {
+                name: String::new(),
+                symbol: handler_symbol(&handler).into(),
+                description: String::new(),
+                status: "error".into(),
+                status_label: op_result.message.clone(),
+                handler,
+            });
+        }
+
+        if let Some(err) = &pr.error {
+            display_pack.files.push(DisplayFile {
+                name: String::new(),
+                symbol: "×".into(),
+                description: String::new(),
+                status: "error".into(),
+                status_label: err.clone(),
+                handler: String::new(),
+            });
+        }
+    }
+    packs
 }
 
 /// Extract handler name, display name, and optional user target from an operation.

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -133,7 +133,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     } else {
         let pack_names: Vec<String> = packs.iter().map(|p| p.name.clone()).collect();
         let status_result = status::status(Some(&pack_names), ctx)?;
-        overlay_errors(status_result.packs, &pack_results)
+        overlay_errors(status_result.packs, &pack_results, ctx.paths.home_dir())
     };
 
     let message = if has_failures {
@@ -206,6 +206,7 @@ fn render_intents(pack_results: &[PackResult], home: &std::path::Path) -> Vec<Di
 pub(crate) fn overlay_errors(
     mut packs: Vec<DisplayPack>,
     pack_results: &[PackResult],
+    home: &std::path::Path,
 ) -> Vec<DisplayPack> {
     for pr in pack_results {
         let display_pack = match packs.iter_mut().find(|p| p.name == pr.pack_name) {
@@ -217,11 +218,11 @@ pub(crate) fn overlay_errors(
             if op_result.success {
                 continue;
             }
-            let handler = op_result.operation.handler().to_string();
+            let (handler, name, user_target) = extract_op_info(&op_result.operation, home);
             display_pack.files.push(DisplayFile {
-                name: String::new(),
+                name: name.clone(),
                 symbol: handler_symbol(&handler).into(),
-                description: String::new(),
+                description: handler_description(&handler, &name, user_target.as_deref()),
                 status: "error".into(),
                 status_label: op_result.message.clone(),
                 handler,


### PR DESCRIPTION
## Summary

- `dodot up` and `dodot down` now render their post-execution output by calling `status::status()` on the affected packs, so the per-file labels match exactly what `dodot status` shows immediately afterward.
- Operation failures from `up` are overlaid as additional error rows on top of the status view (you still see "this specific file failed" alongside "here's the resulting state").
- Two regression tests pin the unification: one for `up` vs `status`, one for `down` vs `status`.

Closes #42.

## Why

Before this PR, `dodot up video` reported `staged bin` and `dodot status video` reported `in PATH` for the same observed state — two different vocabularies for the same thing, surfaced during the 0.14.0 pilot. Same drift in `down` (`removed` vs. status's pending vocabulary).

Three parallel rendering paths existed:

1. `commands/status.rs` — handler-aware steady-state vocabulary (`in PATH`, `sourced`, `deployed`)
2. `commands/up.rs` — executor messages from `OperationResult.message` (`staged X`, `executed: X`)
3. `commands/down.rs` — hand-rolled (`removed`, `state removed`)

Now there's one: status. The principle (from the user's design note in #42): **rich status as the single source of truth that all commands leverage.**

## What changed

- `commands/up.rs`: after execute, calls `status::status(Some(&pack_names), ctx)` and uses its `DisplayPack` list. New helper `overlay_errors()` appends per-op-failure and pack-level-error rows. Dry-run path unchanged (kept under a new `render_intents()` helper since there's no executed state to verify in that mode).
- `commands/down.rs`: after removal, same pattern. Drops the hand-rolled "removed" / "state removed" labels. Dry-run still uses "[dry-run] would remove" since status can't represent a hypothetical.
- `commands/adopt.rs`: already used `status::status()` in both branches — no change.
- `commands/tests.rs`: two new regression tests asserting `up` vs `status` and `down` vs `status` produce identical `status_label` maps.

## Test plan

- [x] `cargo test -p dodot-lib --lib` (366 → 368 tests pass, including new `up_and_status_produce_matching_labels` and `down_and_status_produce_matching_labels`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Live verify: `dodot up <pack>` and `dodot status <pack>` show identical labels for symlink, shell, path, and install handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
