### PR TITLE
refactor: explicit ExecutionPhase for intra-pack handler order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Intra-pack handler execution order is now explicit.** Previously ordering was `category → alphabetical by handler name`, which happened to produce the right sequence (homebrew, install, path, shell, symlink) but was fragile — adding a handler with a name sorted earlier alphabetically would have silently reordered the pipeline. Handlers now declare an `ExecutionPhase` (`Provision` → `Setup` → `PathExport` → `ShellInit` → `Link`), and `rules::handler_execution_order` sorts on the enum's declared order. The observable order is unchanged; the contract is now encoded in the type system, and adding a handler requires a deliberate choice of phase. `HandlerCategory` (used by `--no-provision`) is derived from phase. Catchall-last is now enforced by `Link` being the final variant rather than by convention.
+
 ## [0.18.4] - 2026-04-24
 
 ### Added

--- a/crates/dodot-lib/src/handlers/homebrew.rs
+++ b/crates/dodot-lib/src/handlers/homebrew.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 
 use crate::datastore::DataStore;
 use crate::fs::Fs;
-use crate::handlers::{Handler, HandlerCategory, HandlerConfig, HandlerStatus, HANDLER_HOMEBREW};
+use crate::handlers::{ExecutionPhase, Handler, HandlerConfig, HandlerStatus, HANDLER_HOMEBREW};
 use crate::operations::HandlerIntent;
 use crate::paths::Pather;
 use crate::rules::RuleMatch;
@@ -28,8 +28,8 @@ impl Handler for HomebrewHandler<'_> {
         HANDLER_HOMEBREW
     }
 
-    fn category(&self) -> HandlerCategory {
-        HandlerCategory::CodeExecution
+    fn phase(&self) -> ExecutionPhase {
+        ExecutionPhase::Provision
     }
 
     fn to_intents(

--- a/crates/dodot-lib/src/handlers/install.rs
+++ b/crates/dodot-lib/src/handlers/install.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 
 use crate::datastore::DataStore;
 use crate::fs::Fs;
-use crate::handlers::{Handler, HandlerCategory, HandlerConfig, HandlerStatus, HANDLER_INSTALL};
+use crate::handlers::{ExecutionPhase, Handler, HandlerConfig, HandlerStatus, HANDLER_INSTALL};
 use crate::operations::HandlerIntent;
 use crate::paths::Pather;
 use crate::rules::RuleMatch;
@@ -28,8 +28,8 @@ impl Handler for InstallHandler<'_> {
         HANDLER_INSTALL
     }
 
-    fn category(&self) -> HandlerCategory {
-        HandlerCategory::CodeExecution
+    fn phase(&self) -> ExecutionPhase {
+        ExecutionPhase::Setup
     }
 
     fn to_intents(

--- a/crates/dodot-lib/src/handlers/mod.rs
+++ b/crates/dodot-lib/src/handlers/mod.rs
@@ -39,6 +39,55 @@ pub enum HandlerCategory {
     CodeExecution,
 }
 
+/// The ordered execution phase a handler belongs to.
+///
+/// Phases run in declaration order — the derived [`Ord`] drives
+/// [`crate::rules::handler_execution_order`]. Each handler belongs to
+/// exactly one phase, so adding a handler is a deliberate design
+/// choice: *where does this fit in the pipeline?* rather than a silent
+/// answer from alphabetical sort.
+///
+/// # Why this order
+///
+/// - [`Provision`](Self::Provision) installs packages. Anything later
+///   (including user `install.sh` scripts) may depend on the tools it
+///   put on PATH.
+/// - [`Setup`](Self::Setup) runs user-authored setup scripts that can
+///   lean on Provision having completed (`brew` and formulas available).
+/// - [`PathExport`](Self::PathExport) stages `bin/` directories onto
+///   `$PATH`. It runs before [`ShellInit`](Self::ShellInit) so shell
+///   init scripts can reference the executables it exposes.
+/// - [`ShellInit`](Self::ShellInit) registers shell startup files.
+/// - [`Link`](Self::Link) is the catchall symlink phase. It runs last
+///   because the symlink handler is catchall — precise handlers above
+///   must have already claimed their files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub enum ExecutionPhase {
+    /// Install packages (homebrew).
+    Provision,
+    /// Run user setup scripts (install).
+    Setup,
+    /// Stage directories onto `$PATH` (path).
+    PathExport,
+    /// Register shell init files (shell).
+    ShellInit,
+    /// Catchall: link remaining files (symlink). Always last.
+    Link,
+}
+
+impl ExecutionPhase {
+    /// The category this phase belongs to.
+    ///
+    /// Provision and Setup run user-authored code and are gated by
+    /// sentinels; the rest are idempotent filesystem work.
+    pub fn category(self) -> HandlerCategory {
+        match self {
+            Self::Provision | Self::Setup => HandlerCategory::CodeExecution,
+            Self::PathExport | Self::ShellInit | Self::Link => HandlerCategory::Configuration,
+        }
+    }
+}
+
 /// Whether a handler matches specific names or acts as a catchall.
 ///
 /// [`MatchMode::Precise`] handlers only match whitelisted patterns
@@ -91,8 +140,20 @@ pub trait Handler: Send + Sync {
     /// Unique name for this handler (e.g. `"symlink"`, `"install"`).
     fn name(&self) -> &str;
 
+    /// Execution phase for this handler.
+    ///
+    /// Determines where this handler runs in the per-pack pipeline.
+    /// See [`ExecutionPhase`] for the ordering and the rationale for
+    /// each slot.
+    fn phase(&self) -> ExecutionPhase;
+
     /// Whether this is a configuration or code-execution handler.
-    fn category(&self) -> HandlerCategory;
+    ///
+    /// Derived from [`Self::phase`]; override only if a handler's
+    /// phase doesn't imply its category (none today).
+    fn category(&self) -> HandlerCategory {
+        self.phase().category()
+    }
 
     /// How this handler decides what to claim.
     ///
@@ -247,6 +308,52 @@ mod tests {
     }
 
     #[test]
+    fn execution_phase_declaration_order_drives_ord() {
+        assert!(ExecutionPhase::Provision < ExecutionPhase::Setup);
+        assert!(ExecutionPhase::Setup < ExecutionPhase::PathExport);
+        assert!(ExecutionPhase::PathExport < ExecutionPhase::ShellInit);
+        assert!(ExecutionPhase::ShellInit < ExecutionPhase::Link);
+    }
+
+    #[test]
+    fn execution_phase_category_mapping() {
+        assert_eq!(
+            ExecutionPhase::Provision.category(),
+            HandlerCategory::CodeExecution
+        );
+        assert_eq!(
+            ExecutionPhase::Setup.category(),
+            HandlerCategory::CodeExecution
+        );
+        assert_eq!(
+            ExecutionPhase::PathExport.category(),
+            HandlerCategory::Configuration
+        );
+        assert_eq!(
+            ExecutionPhase::ShellInit.category(),
+            HandlerCategory::Configuration
+        );
+        assert_eq!(
+            ExecutionPhase::Link.category(),
+            HandlerCategory::Configuration
+        );
+    }
+
+    #[test]
+    fn builtin_handler_phases() {
+        let fs = crate::fs::OsFs::new();
+        let registry = create_registry(&fs);
+        assert_eq!(
+            registry[HANDLER_HOMEBREW].phase(),
+            ExecutionPhase::Provision
+        );
+        assert_eq!(registry[HANDLER_INSTALL].phase(), ExecutionPhase::Setup);
+        assert_eq!(registry[HANDLER_PATH].phase(), ExecutionPhase::PathExport);
+        assert_eq!(registry[HANDLER_SHELL].phase(), ExecutionPhase::ShellInit);
+        assert_eq!(registry[HANDLER_SYMLINK].phase(), ExecutionPhase::Link);
+    }
+
+    #[test]
     fn handler_status_serializes() {
         let status = HandlerStatus {
             file: "vimrc".into(),
@@ -288,8 +395,8 @@ mod tests {
             fn name(&self) -> &str {
                 "fake"
             }
-            fn category(&self) -> HandlerCategory {
-                HandlerCategory::Configuration
+            fn phase(&self) -> ExecutionPhase {
+                ExecutionPhase::Link
             }
             fn match_mode(&self) -> MatchMode {
                 MatchMode::Catchall

--- a/crates/dodot-lib/src/handlers/path.rs
+++ b/crates/dodot-lib/src/handlers/path.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use crate::datastore::DataStore;
 use crate::fs::Fs;
-use crate::handlers::{Handler, HandlerCategory, HandlerConfig, HandlerStatus, HANDLER_PATH};
+use crate::handlers::{ExecutionPhase, Handler, HandlerConfig, HandlerStatus, HANDLER_PATH};
 use crate::operations::HandlerIntent;
 use crate::paths::Pather;
 use crate::rules::RuleMatch;
@@ -17,8 +17,8 @@ impl Handler for PathHandler {
         HANDLER_PATH
     }
 
-    fn category(&self) -> HandlerCategory {
-        HandlerCategory::Configuration
+    fn phase(&self) -> ExecutionPhase {
+        ExecutionPhase::PathExport
     }
 
     fn to_intents(

--- a/crates/dodot-lib/src/handlers/shell.rs
+++ b/crates/dodot-lib/src/handlers/shell.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use crate::datastore::DataStore;
 use crate::fs::Fs;
-use crate::handlers::{Handler, HandlerCategory, HandlerConfig, HandlerStatus, HANDLER_SHELL};
+use crate::handlers::{ExecutionPhase, Handler, HandlerConfig, HandlerStatus, HANDLER_SHELL};
 use crate::operations::HandlerIntent;
 use crate::paths::Pather;
 use crate::rules::RuleMatch;
@@ -17,8 +17,8 @@ impl Handler for ShellHandler {
         HANDLER_SHELL
     }
 
-    fn category(&self) -> HandlerCategory {
-        HandlerCategory::Configuration
+    fn phase(&self) -> ExecutionPhase {
+        ExecutionPhase::ShellInit
     }
 
     fn to_intents(

--- a/crates/dodot-lib/src/handlers/symlink.rs
+++ b/crates/dodot-lib/src/handlers/symlink.rs
@@ -21,8 +21,7 @@ use std::path::{Path, PathBuf};
 use crate::datastore::DataStore;
 use crate::fs::Fs;
 use crate::handlers::{
-    Handler, HandlerCategory, HandlerConfig, HandlerScope, HandlerStatus, MatchMode,
-    HANDLER_SYMLINK,
+    ExecutionPhase, Handler, HandlerConfig, HandlerScope, HandlerStatus, MatchMode, HANDLER_SYMLINK,
 };
 use crate::operations::HandlerIntent;
 use crate::paths::Pather;
@@ -36,8 +35,8 @@ impl Handler for SymlinkHandler {
         HANDLER_SYMLINK
     }
 
-    fn category(&self) -> HandlerCategory {
-        HandlerCategory::Configuration
+    fn phase(&self) -> ExecutionPhase {
+        ExecutionPhase::Link
     }
 
     fn match_mode(&self) -> MatchMode {

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -354,11 +354,11 @@ fn collect_pack_intents_inner(
 
     // Phase 4: Group by handler
     let groups = rules::group_by_handler(&matches);
-    let order = rules::handler_execution_order(&groups);
-    debug!(pack = %pack.name, handlers = ?order, "handler execution order");
 
-    // Build handler registry
+    // Build handler registry (drives the phase-based execution order).
     let registry = handlers::create_registry(ctx.fs.as_ref());
+    let order = rules::handler_execution_order(&groups, &registry);
+    debug!(pack = %pack.name, handlers = ?order, "handler execution order");
 
     // Generate intents from each handler
     let mut all_intents = Vec::new();

--- a/crates/dodot-lib/src/rules/mod.rs
+++ b/crates/dodot-lib/src/rules/mod.rs
@@ -86,35 +86,29 @@ pub fn group_by_handler(matches: &[RuleMatch]) -> HashMap<String, Vec<RuleMatch>
 
 /// Returns handler names in execution order.
 ///
-/// Code execution handlers (install, homebrew) run **first** so that
-/// provisioning happens before config linking. Within each category,
-/// handlers are sorted alphabetically for determinism.
-pub fn handler_execution_order(groups: &HashMap<String, Vec<RuleMatch>>) -> Vec<String> {
-    use crate::handlers::{
-        HandlerCategory, HANDLER_HOMEBREW, HANDLER_INSTALL, HANDLER_PATH, HANDLER_SHELL,
-        HANDLER_SYMLINK,
-    };
-
-    fn category_of(name: &str) -> HandlerCategory {
-        match name {
-            HANDLER_INSTALL | HANDLER_HOMEBREW => HandlerCategory::CodeExecution,
-            HANDLER_SYMLINK | HANDLER_SHELL | HANDLER_PATH => HandlerCategory::Configuration,
-            _ => HandlerCategory::Configuration,
-        }
-    }
-
+/// Order is driven by each handler's [`ExecutionPhase`]
+/// (see [`crate::handlers::ExecutionPhase`] for the full phase list and
+/// why each slot is where it is). The phase enum's declaration order
+/// *is* the execution order — `Provision` → `Setup` → `PathExport` →
+/// `ShellInit` → `Link`.
+///
+/// Handler names not present in the registry are placed last in
+/// alphabetical order (they get ignored by the pipeline anyway).
+///
+/// [`ExecutionPhase`]: crate::handlers::ExecutionPhase
+pub fn handler_execution_order(
+    groups: &HashMap<String, Vec<RuleMatch>>,
+    registry: &HashMap<String, Box<dyn crate::handlers::Handler + '_>>,
+) -> Vec<String> {
     let mut names: Vec<String> = groups.keys().cloned().collect();
     names.sort_by(|a, b| {
-        let cat_a = category_of(a);
-        let cat_b = category_of(b);
-        match (cat_a, cat_b) {
-            (HandlerCategory::CodeExecution, HandlerCategory::Configuration) => {
-                std::cmp::Ordering::Less
-            }
-            (HandlerCategory::Configuration, HandlerCategory::CodeExecution) => {
-                std::cmp::Ordering::Greater
-            }
-            _ => a.cmp(b),
+        let pa = registry.get(a).map(|h| h.phase());
+        let pb = registry.get(b).map(|h| h.phase());
+        match (pa, pb) {
+            (Some(x), Some(y)) => x.cmp(&y),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => a.cmp(b),
         }
     });
     names
@@ -889,7 +883,7 @@ mod tests {
     }
 
     #[test]
-    fn handler_execution_order_code_first() {
+    fn handler_execution_order_follows_phase_declaration() {
         let mut groups = HashMap::new();
         groups.insert("symlink".into(), vec![]);
         groups.insert("install".into(), vec![]);
@@ -897,20 +891,32 @@ mod tests {
         groups.insert("homebrew".into(), vec![]);
         groups.insert("path".into(), vec![]);
 
-        let order = handler_execution_order(&groups);
+        let fs = crate::fs::OsFs::new();
+        let registry = crate::handlers::create_registry(&fs);
+        let order = handler_execution_order(&groups, &registry);
 
-        let install_pos = order.iter().position(|n| n == "install").unwrap();
-        let homebrew_pos = order.iter().position(|n| n == "homebrew").unwrap();
-        let symlink_pos = order.iter().position(|n| n == "symlink").unwrap();
-        let shell_pos = order.iter().position(|n| n == "shell").unwrap();
-        let path_pos = order.iter().position(|n| n == "path").unwrap();
+        // Exact order matches ExecutionPhase declaration:
+        // Provision(homebrew) -> Setup(install) -> PathExport(path)
+        //   -> ShellInit(shell) -> Link(symlink)
+        assert_eq!(
+            order,
+            vec!["homebrew", "install", "path", "shell", "symlink"]
+        );
+    }
 
-        assert!(install_pos < symlink_pos);
-        assert!(homebrew_pos < shell_pos);
-        assert!(homebrew_pos < path_pos);
-        assert!(homebrew_pos < install_pos);
-        assert!(path_pos < shell_pos);
-        assert!(shell_pos < symlink_pos);
+    #[test]
+    fn handler_execution_order_places_unknown_handlers_last() {
+        let mut groups = HashMap::new();
+        groups.insert("symlink".into(), vec![]);
+        groups.insert("zzz-unknown".into(), vec![]);
+        groups.insert("homebrew".into(), vec![]);
+
+        let fs = crate::fs::OsFs::new();
+        let registry = crate::handlers::create_registry(&fs);
+        let order = handler_execution_order(&groups, &registry);
+
+        // Known handlers keep phase order; unknown lands at the end.
+        assert_eq!(order, vec!["homebrew", "symlink", "zzz-unknown"]);
     }
 
     #[test]

--- a/docs/dev/types-and-structure.lex
+++ b/docs/dev/types-and-structure.lex
@@ -93,7 +93,8 @@ Types and Structure
 
             pub trait Handler: Send + Sync {
                 fn name(&self) -> &str;
-                fn category(&self) -> HandlerCategory;
+                fn phase(&self) -> ExecutionPhase;
+                fn category(&self) -> HandlerCategory { self.phase().category() }
                 fn match_mode(&self) -> MatchMode { MatchMode::Precise }
                 fn scope(&self) -> HandlerScope { HandlerScope::Exclusive }
                 fn to_intents(
@@ -113,7 +114,21 @@ Types and Structure
 
         :: rust ::
 
-        `category` splits handlers into Configuration and Code Execution (see [./../reference/handlers.lex]). `match_mode` and `scope` are the classification axes from the matching model. `to_intents` produces the handler's plan; `fs` is passed read-only for tasks like enumerating a matched directory to decide wholesale vs per-file linking. `check_status` reports whether a single file has been deployed by this handler.
+        `phase` places the handler in the intra-pack execution order (see [./../reference/handlers.lex] for the phase list and ordering rationale). `category` is derived from phase — Configuration vs Code Execution — and drives `--no-provision`. `match_mode` and `scope` are the classification axes from the matching model. `to_intents` produces the handler's plan; `fs` is passed read-only for tasks like enumerating a matched directory to decide wholesale vs per-file linking. `check_status` reports whether a single file has been deployed by this handler.
+
+        Execution phases:
+
+            pub enum ExecutionPhase {
+                Provision,   // homebrew
+                Setup,       // install
+                PathExport,  // path
+                ShellInit,   // shell
+                Link,        // symlink (catchall, always last)
+            }
+
+        :: rust ::
+
+        The enum's *declaration order* is the execution order — `derive(Ord)` does the rest. `rules::handler_execution_order` sorts handler-name groups by looking up each name's phase in the registry and ordering on that. Adding a handler is a deliberate design choice: which phase does it belong to? There is no alphabetical fallback between known handlers.
 
     4.4. `HandlerIntent`
 

--- a/docs/reference/architecture.lex
+++ b/docs/reference/architecture.lex
@@ -44,6 +44,8 @@ Architecture
 
         Matches are grouped by the handler that claimed them. Each group is handed to its handler as a batch. This lets handlers make decisions that span multiple files — the symlink handler, for example, can reason about whether a whole directory should be linked wholesale or per-file based on whether any nested path was independently claimed.
 
+        The groups are processed in a fixed order: `Provision` → `Setup` → `PathExport` → `ShellInit` → `Link`. The order is encoded as an `ExecutionPhase` enum declared in execution order, so it's explicit and type-checked rather than an accident of handler naming. See [./handlers.lex] §3 for the phase list and the rationale behind each slot.
+
     2.5. Intents
 
         Each handler inspects its group and produces a list of intents. An intent is a declaration: "I want this file linked to that target"; "I want this script executable and sourced at login"; "I want this command run once, keyed by this sentinel." Intents are shape-limited to three kinds — link, stage, run — so the executor has a small surface to handle.

--- a/docs/reference/handlers.lex
+++ b/docs/reference/handlers.lex
@@ -44,15 +44,40 @@ Handlers
 
     The scanner that produces matches works only at the pack's top level — it does not recurse. A handler that receives a directory entry decides how to treat its contents. The path handler stages the whole directory into `$PATH`; the symlink handler creates one symlink for the directory as a whole. If you want a nested path handled independently, you declare it explicitly in `.dodot.toml` (via `[symlink.targets]` or by naming a file inside it in `[symlink] protected_paths`).
 
-3. Configuration vs Code Execution
+3. Execution Order
 
-    Handlers fall into two categories that behave differently at deploy time.
+    Within a single pack, handlers run in a fixed, documented order. The order is driven by an `ExecutionPhase` enum whose variants are declared in execution order — adding or moving a phase is a visible, deliberate code change, not an accident of alphabetical sort.
 
-    3.1. Configuration handlers
+    Phases, in order:
+
+        | Phase         | Handler   | Why here                                                           |
+        | `Provision`   | homebrew  | Installs packages. Anything later may depend on tools it exposes.  |
+        | `Setup`       | install   | User-authored scripts that can lean on Provision completing first. |
+        | `PathExport`  | path      | Stages `bin/` onto PATH; runs before ShellInit.                    |
+        | `ShellInit`   | shell     | Shell startup files that may reference binaries from PathExport.   |
+        | `Link`        | symlink   | Catchall; must be last so precise handlers claim their files.      |
+
+    :: table align=llll ::
+
+    Two design invariants pin this order down.
+
+    The catchall phase is always last.
+        `symlink` is the only catchall handler (`MatchMode::Catchall`). Running it before any precise handler would let it claim files that belong elsewhere. `Link` sitting at the bottom of the enum is not a convention — it's the shape of "precise before catchall" written into the type.
+
+    Code-execution phases run before configuration phases.
+        `Provision` and `Setup` produce a filesystem a user's shell needs to see (installed binaries, `brew` formulae, generated files). `PathExport`, `ShellInit`, and `Link` deploy configuration that may reference those outputs. Reversing them would let a shell rc file try to source a program that hasn't been installed yet.
+
+    The preprocessing layer (`.tmpl`, `.plist.xml`, `.age`) sits *upstream* of this ordering — templates are rendered before rules match, so by the time the phase order kicks in every match is a concrete file. See [./pre-processors.lex] for how preprocessors fit into the pipeline.
+
+4. Configuration vs Code Execution
+
+    Handlers fall into two categories that behave differently at deploy time. Category is derived from phase (`Provision` and `Setup` are Code Execution; the rest are Configuration).
+
+    4.1. Configuration handlers
 
         symlink, shell, and path. Their operations are idempotent filesystem work: create a link, stage a file. Running them a second time produces the same result as running them once; no special tracking is required. `dodot up` always runs them in full.
 
-    3.2. Code execution handlers
+    4.2. Code execution handlers
 
         install and homebrew. Their operations run user-authored shell commands. These are assumed _not_ to be idempotent in general — `install.sh` might install packages, write files, mutate the system — and re-running them on every `dodot up` would be slow, surprising, or both. Even Brewfile processing, though nominally idempotent, can take many seconds per pack.
 
@@ -63,20 +88,20 @@ Handlers
 
         When the content of a code-execution input changes (you edited `install.sh`, or the rendered output of `install.sh.tmpl` changed), the sentinel's content hash no longer matches, and the handler re-runs automatically. You only need `--provision-rerun` when you want to re-run without an input change.
 
-4. Quick Reference
+5. Quick Reference
 
-    Handler summary:
+    Handler summary (rows in execution order):
 
-        | Handler  | Category       | Default claims                                  | Effect                              |
-        | symlink  | Configuration  | Anything else (catchall)                        | Link to `~` or `~/.config/`         |
-        | shell    | Configuration  | `aliases.sh`, `profile.sh`, `login.sh`          | Sourced at shell login              |
-        | path     | Configuration  | `bin/`                                          | Prepended to `$PATH`                |
-        | install  | Code Execution | `install.sh`                                    | Run once per content hash           |
-        | homebrew | Code Execution | `Brewfile`                                      | `brew bundle` once per content hash |
+        | Handler  | Phase       | Category       | Default claims                         | Effect                              |
+        | homebrew | Provision   | Code Execution | `Brewfile`                             | `brew bundle` once per content hash |
+        | install  | Setup       | Code Execution | `install.sh`                           | Run once per content hash           |
+        | path     | PathExport  | Configuration  | `bin/`                                 | Prepended to `$PATH`                |
+        | shell    | ShellInit   | Configuration  | `aliases.sh`, `profile.sh`, `login.sh` | Sourced at shell login              |
+        | symlink  | Link        | Configuration  | Anything else (catchall)               | Link to `~` or `~/.config/`         |
 
-    :: table align=llll ::
+    :: table align=lllll ::
 
-5. Why Handlers Look the Way They Do
+6. Why Handlers Look the Way They Do
 
     A few design decisions worth naming.
 

--- a/docs/reference/handlers.lex
+++ b/docs/reference/handlers.lex
@@ -57,7 +57,7 @@ Handlers
         | `ShellInit`   | shell     | Shell startup files that may reference binaries from PathExport.   |
         | `Link`        | symlink   | Catchall; must be last so precise handlers claim their files.      |
 
-    :: table align=llll ::
+    :: table align=lll ::
 
     Two design invariants pin this order down.
 


### PR DESCRIPTION
## Summary

- Replace implicit `category + alphabetical` sort with an ordered `ExecutionPhase` enum (`Provision` → `Setup` → `PathExport` → `ShellInit` → `Link`).
- Observable handler order is unchanged; the contract is now encoded in the type system.
- `Handler::phase()` is required; `Handler::category()` defaults to `phase().category()`, so `--no-provision` keeps working.
- Catchall-last is enforced by `Link` being the terminal variant (was a convention).

## Why

The previous order only worked because the alphabetical tiebreaker accidentally aligned with intent (`homebrew < install`, `path < shell < symlink`). A future handler with a name sorted earlier would have silently reordered the pipeline. Making the order a declared enum turns it into a visible, type-checked design choice — adding a handler forces a deliberate phase pick rather than inheriting one from `str::cmp`.

## What changed

- `crates/dodot-lib/src/handlers/mod.rs`: new `ExecutionPhase` enum (derive `Ord`), `phase()` on the `Handler` trait, `category()` derived.
- Five handler impls: each returns its phase, drops its `category()`.
- `rules::handler_execution_order` now takes the registry and sorts by `handler.phase()`.
- `packs/orchestration.rs` builds the registry before computing the order.
- Docs: `handlers.lex` §3 (new), `architecture.lex` §2.4, `dev/types-and-structure.lex` trait + enum.
- CHANGELOG entry under Unreleased.

## Test plan

- [x] `cargo test --workspace` — 400 passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] New unit tests: `execution_phase_declaration_order_drives_ord`, `execution_phase_category_mapping`, `builtin_handler_phases`, `handler_execution_order_follows_phase_declaration`, `handler_execution_order_places_unknown_handlers_last`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)