### PR TITLE
feat(probe): probe command tree + deployment-map (profiling Phase 1)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -6,6 +6,33 @@ CHANGELOG.md under a new version heading and clear this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Use sections: Added, Changed, Deprecated, Removed, Fixed, Security.
 
+## Added
+
+- **`dodot probe`** — a new diagnostics command tree for introspecting
+  deployed state. Three subcommands:
+  - `dodot probe` — summary listing the available probe subcommands.
+  - `dodot probe deployment-map` — rendered `pack / handler / kind /
+    source / datastore` table derived live from the datastore. Paths are
+    shortened to `~/…` where possible.
+  - `dodot probe show-data-dir [--depth N]` — bounded-depth tree view of
+    `<data_dir>` with per-node sizes and symlink targets. Truncated
+    subtrees report `(… N more)` so nothing disappears silently. Default
+    depth is 4; symlinks are never followed. Directories sort before
+    files.
+
+  All three honour `--output json` and emit a `{"kind": "…"}`-tagged
+  document for programmatic consumers.
+- **Deployment map file.** `dodot up` and `dodot down` now also write
+  `<data_dir>/deployment-map.tsv` alongside the regenerated shell init
+  script. The file is plain-text TSV with a `# dodot deployment map v1`
+  header, one row per datastore entry (`pack\thandler\tkind\tsource\tdatastore`),
+  overwritten on every run. Skipped during `--dry-run`. The TSV is what
+  `dodot probe deployment-map` reads, and is also the file that the
+  forthcoming `dodot refresh` (see `docs/proposals/magic.lex`) will
+  consume for source-template mtime touches.
+- `Pather::deployment_map_path()` trait method, returning
+  `<data_dir>/deployment-map.tsv`.
+
 ## Changed
 
 - Shell-related handlers now recognize `.bash` and `.zsh` extensions in

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -26,10 +26,12 @@ Use sections: Added, Changed, Deprecated, Removed, Fixed, Security.
   `<data_dir>/deployment-map.tsv` alongside the regenerated shell init
   script. The file is plain-text TSV with a `# dodot deployment map v1`
   header, one row per datastore entry (`pack\thandler\tkind\tsource\tdatastore`),
-  overwritten on every run. Skipped during `--dry-run`. The TSV is what
-  `dodot probe deployment-map` reads, and is also the file that the
-  forthcoming `dodot refresh` (see `docs/proposals/magic.lex`) will
-  consume for source-template mtime touches.
+  overwritten on every run. Skipped during `--dry-run`. `dodot probe
+  deployment-map` renders its table live from the datastore, not from
+  this file; the TSV is a written snapshot for machine-to-machine
+  consumers, including the forthcoming `dodot refresh` (see
+  `docs/proposals/magic.lex`), which will use it for source-template
+  mtime touches.
 - `Pather::deployment_map_path()` trait method, returning
   `<data_dir>/deployment-map.tsv`.
 

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -210,6 +210,37 @@ pub fn addignore_handler(
     Ok(Output::Render(result))
 }
 
+/// `dodot probe` — bare summary of probe subcommands.
+pub fn probe_summary_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::probe::ProbeResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    Ok(Output::Render(commands::probe::summary(&ctx)?))
+}
+
+/// `dodot probe deployment-map` — source↔deployed map view.
+pub fn probe_deployment_map_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::probe::ProbeResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    Ok(Output::Render(commands::probe::deployment_map(&ctx)?))
+}
+
+/// `dodot probe show-data-dir [--depth N]` — data-dir tree view.
+pub fn probe_show_data_dir_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::probe::ProbeResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    let depth = matches
+        .get_one::<usize>("depth")
+        .copied()
+        .unwrap_or(commands::probe::DEFAULT_SHOW_DATA_DIR_DEPTH);
+    Ok(Output::Render(commands::probe::show_data_dir(&ctx, depth)?))
+}
+
 // ── Passthrough handlers (bypass standout rendering) ────────────
 
 /// `dodot config` — delegates to clapfig's config subcommands.

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -88,6 +88,7 @@ static TEMPLATE_ENTRIES: &[(&str, &str)] = &[
     ("pack-status.jinja", render::TEMPLATE_PACK_STATUS),
     ("list.jinja", render::TEMPLATE_LIST),
     ("message.jinja", render::TEMPLATE_MESSAGE),
+    ("probe.jinja", render::TEMPLATE_PROBE),
 ];
 
 fn build_app() -> App {
@@ -112,6 +113,20 @@ fn build_app() -> App {
         .expect("register adopt")
         .command("addignore", handlers::addignore_handler, "message")
         .expect("register addignore")
+        .command("probe", handlers::probe_summary_handler, "probe")
+        .expect("register probe")
+        .command(
+            "probe.deployment-map",
+            handlers::probe_deployment_map_handler,
+            "probe",
+        )
+        .expect("register probe.deployment-map")
+        .command(
+            "probe.show-data-dir",
+            handlers::probe_show_data_dir_handler,
+            "probe",
+        )
+        .expect("register probe.show-data-dir")
         .command_groups(vec![
             CommandGroup {
                 title: "Core".into(),
@@ -132,6 +147,11 @@ fn build_app() -> App {
                     Some("fill".into()),
                     Some("addignore".into()),
                 ],
+            },
+            CommandGroup {
+                title: "Diagnostics".into(),
+                help: None,
+                commands: vec![Some("probe".into())],
             },
             CommandGroup {
                 title: "Misc".into(),
@@ -313,5 +333,26 @@ fn build_clap_command() -> ClapCommand {
         )
         .subcommand(
             ClapCommand::new("init-sh").about("Print shell init script for eval in .zshrc/.bashrc"),
+        )
+        .subcommand(
+            ClapCommand::new("probe")
+                .about("Introspect deployed state (deployment map, data directory)")
+                .subcommand_required(false)
+                .arg_required_else_help(false)
+                .subcommand(
+                    ClapCommand::new("deployment-map")
+                        .about("Show the source↔deployed map"),
+                )
+                .subcommand(
+                    ClapCommand::new("show-data-dir")
+                        .about("Tree view of dodot's data directory")
+                        .arg(
+                            Arg::new("depth")
+                                .long("depth")
+                                .help("Maximum tree depth (default 4)")
+                                .value_parser(clap::value_parser!(usize))
+                                .num_args(1),
+                        ),
+                ),
         )
 }

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -15,6 +15,7 @@ use crate::commands::{handler_symbol, status, DisplayFile, DisplayPack, PackStat
 use crate::handlers::HANDLER_SYMLINK;
 use crate::packs;
 use crate::packs::orchestration::{self, ExecutionContext};
+use crate::probe;
 use crate::shell;
 use crate::Result;
 
@@ -65,10 +66,13 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         }
     }
 
-    // Regenerate shell init script (now empty for removed packs)
+    // Regenerate shell init script and deployment map (now reflecting
+    // the removed state).
     if !ctx.dry_run {
         info!("regenerating shell init script");
         shell::write_init_script(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+        info!("writing deployment map");
+        probe::write_deployment_map(ctx.fs.as_ref(), ctx.paths.as_ref())?;
     }
 
     let display_packs = if ctx.dry_run {

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod down;
 pub mod fill;
 pub mod init;
 pub mod list;
+pub mod probe;
 pub mod status;
 pub mod up;
 

--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -1,0 +1,443 @@
+//! `probe` command family — introspection subcommands.
+//!
+//! Today there are three: `deployment-map`, `show-data-dir`, and the
+//! bare `probe` (which renders a summary pointing at the others). A
+//! later phase adds `shell-init` (timing reports). See
+//! `docs/proposals/profiling.lex`.
+//!
+//! All variants serialize through a single `ProbeResult` enum that is
+//! `#[serde(tag = "kind")]`-tagged; the matching Jinja template
+//! branches on `kind` to pick the right section.
+
+use serde::Serialize;
+
+use crate::packs::orchestration::ExecutionContext;
+use crate::probe::{collect_data_dir_tree, collect_deployment_map, DeploymentMapEntry, TreeNode};
+use crate::Result;
+
+/// Default max depth for `probe show-data-dir`. Enough to show
+/// `packs / <pack> / <handler> / <entry>` without scrolling off
+/// screen for reasonable installs; deeper subtrees are summarised.
+pub const DEFAULT_SHOW_DATA_DIR_DEPTH: usize = 4;
+
+/// Display-shaped deployment-map row. Paths are pre-shortened to
+/// `~/…` where they live under HOME so the rendered table stays
+/// narrow; the machine-readable TSV on disk keeps absolute paths.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeploymentDisplayEntry {
+    pub pack: String,
+    pub handler: String,
+    pub kind: String,
+    /// Pre-shortened (`~/…`) absolute source path; empty for
+    /// non-symlink entries (sentinels, rendered files).
+    pub source: String,
+    /// Pre-shortened absolute datastore path.
+    pub datastore: String,
+}
+
+/// One line of tree output, pre-flattened for the template.
+///
+/// The template for a tree is annoying to write directly in Jinja
+/// (indentation, prefix characters, etc.), so we flatten the tree to
+/// a list of `(indent, name, annotation)` triples here.
+#[derive(Debug, Clone, Serialize)]
+pub struct TreeLine {
+    /// Indent prefix (e.g. `"  │  ├─ "`).
+    pub prefix: String,
+    /// The node's display name (basename for non-root nodes).
+    pub name: String,
+    /// A dim-styled annotation shown after the name (size, link target,
+    /// truncation count). Empty when the node has nothing extra to say.
+    pub annotation: String,
+}
+
+/// Result of any `probe` invocation. Serialises with a `kind` tag so
+/// the Jinja template can dispatch on it.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum ProbeResult {
+    /// `dodot probe` with no subcommand — a summary pointing the user
+    /// at the real subcommands.
+    Summary {
+        data_dir: String,
+        available: Vec<ProbeSubcommandInfo>,
+    },
+    /// `dodot probe deployment-map` — the source↔deployed map.
+    DeploymentMap {
+        data_dir: String,
+        map_path: String,
+        entries: Vec<DeploymentDisplayEntry>,
+    },
+    /// `dodot probe show-data-dir` — a bounded tree view of
+    /// `<data_dir>`.
+    ShowDataDir {
+        data_dir: String,
+        /// Flattened, template-ready lines.
+        lines: Vec<TreeLine>,
+        total_nodes: usize,
+        /// Size in bytes of the whole tree (symlinks counted by their
+        /// link-entry size).
+        total_size: u64,
+    },
+}
+
+/// One entry in the `probe` summary listing.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProbeSubcommandInfo {
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
+/// The full list of probe subcommands, used by the summary view.
+/// Keeping them in one array keeps the CLI registration, clap
+/// registration, and summary output trivially in sync.
+pub const PROBE_SUBCOMMANDS: &[ProbeSubcommandInfo] = &[
+    ProbeSubcommandInfo {
+        name: "deployment-map",
+        description: "Source↔deployed map — what dodot linked where.",
+    },
+    ProbeSubcommandInfo {
+        name: "show-data-dir",
+        description: "Tree of dodot's data directory, with sizes.",
+    },
+];
+
+// ── Entry points ────────────────────────────────────────────────────
+
+/// Render the bare `dodot probe` summary.
+pub fn summary(ctx: &ExecutionContext) -> Result<ProbeResult> {
+    Ok(ProbeResult::Summary {
+        data_dir: ctx.paths.data_dir().display().to_string(),
+        available: PROBE_SUBCOMMANDS.to_vec(),
+    })
+}
+
+/// Render the deployment map for display.
+///
+/// Reads the current datastore state (not the on-disk TSV) so the
+/// output is always fresh even if the user never ran `dodot up`.
+pub fn deployment_map(ctx: &ExecutionContext) -> Result<ProbeResult> {
+    let raw = collect_deployment_map(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+    let home = ctx.paths.home_dir();
+    let entries = raw
+        .into_iter()
+        .map(|e| into_display_entry(e, home))
+        .collect();
+
+    Ok(ProbeResult::DeploymentMap {
+        data_dir: ctx.paths.data_dir().display().to_string(),
+        map_path: ctx.paths.deployment_map_path().display().to_string(),
+        entries,
+    })
+}
+
+/// Render the data-dir tree.
+pub fn show_data_dir(ctx: &ExecutionContext, max_depth: usize) -> Result<ProbeResult> {
+    let tree = collect_data_dir_tree(ctx.fs.as_ref(), ctx.paths.as_ref(), max_depth)?;
+    let total_nodes = tree.count_nodes();
+    let total_size = tree.total_size();
+    let mut lines = Vec::new();
+    flatten_tree(&tree, "", true, &mut lines, true);
+    Ok(ProbeResult::ShowDataDir {
+        data_dir: ctx.paths.data_dir().display().to_string(),
+        lines,
+        total_nodes,
+        total_size,
+    })
+}
+
+// ── Display helpers ─────────────────────────────────────────────────
+
+fn into_display_entry(e: DeploymentMapEntry, home: &std::path::Path) -> DeploymentDisplayEntry {
+    DeploymentDisplayEntry {
+        pack: e.pack,
+        handler: e.handler,
+        kind: e.kind.as_str().into(),
+        source: if e.source.as_os_str().is_empty() {
+            // Sentinel / rendered file — no source file backs this entry.
+            // Show an em dash so the column stays populated.
+            "—".into()
+        } else {
+            display_path(&e.source, home)
+        },
+        datastore: display_path(&e.datastore, home),
+    }
+}
+
+fn display_path(p: &std::path::Path, home: &std::path::Path) -> String {
+    if let Ok(rel) = p.strip_prefix(home) {
+        format!("~/{}", rel.display())
+    } else {
+        p.display().to_string()
+    }
+}
+
+/// Flatten a `TreeNode` into [`TreeLine`]s with box-drawing prefixes.
+///
+/// `prefix` is the continuation prefix applied to this node's
+/// descendants (e.g. `"│  "` if this node has more siblings below,
+/// `"   "` if it's the last). `is_last` controls the branch glyph for
+/// this node itself (`"└─ "` vs `"├─ "`). `is_root` skips the branch
+/// glyph on the topmost call so the root displays flush-left.
+fn flatten_tree(
+    node: &TreeNode,
+    prefix: &str,
+    is_last: bool,
+    out: &mut Vec<TreeLine>,
+    is_root: bool,
+) {
+    let branch = if is_root {
+        String::new()
+    } else if is_last {
+        "└─ ".to_string()
+    } else {
+        "├─ ".to_string()
+    };
+    let line_prefix = format!("{prefix}{branch}");
+    out.push(TreeLine {
+        prefix: line_prefix,
+        name: node.name.clone(),
+        annotation: annotate(node),
+    });
+
+    if node.children.is_empty() {
+        return;
+    }
+
+    // Extend the prefix for children. The root contributes no prefix
+    // characters; a last-child contributes "   "; an inner child
+    // contributes "│  ".
+    let child_prefix = if is_root {
+        String::new()
+    } else if is_last {
+        format!("{prefix}   ")
+    } else {
+        format!("{prefix}│  ")
+    };
+
+    let last_idx = node.children.len() - 1;
+    for (i, child) in node.children.iter().enumerate() {
+        flatten_tree(child, &child_prefix, i == last_idx, out, false);
+    }
+}
+
+fn annotate(node: &TreeNode) -> String {
+    match node.kind {
+        "dir" => match node.truncated_count {
+            Some(n) if n > 0 => format!("(… {n} more)"),
+            _ => String::new(),
+        },
+        "file" => match node.size {
+            Some(n) => humanize_bytes(n),
+            None => String::new(),
+        },
+        "symlink" => match &node.link_target {
+            Some(t) => format!("→ {t}"),
+            None => "→ (broken)".into(),
+        },
+        _ => String::new(),
+    }
+}
+
+/// Compact byte sizing: "512 B", "1.2 KB", "3.4 MB".
+///
+/// KB = 1024 bytes. No fractional KB below 1024.
+pub fn humanize_bytes(n: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    if n < KB {
+        format!("{n} B")
+    } else if n < MB {
+        format!("{:.1} KB", n as f64 / KB as f64)
+    } else if n < GB {
+        format!("{:.1} MB", n as f64 / MB as f64)
+    } else {
+        format!("{:.1} GB", n as f64 / GB as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::probe::{DeploymentKind, DeploymentMapEntry};
+    use std::path::PathBuf;
+
+    fn home() -> PathBuf {
+        PathBuf::from("/home/alice")
+    }
+
+    #[test]
+    fn display_path_shortens_home() {
+        assert_eq!(
+            display_path(&PathBuf::from("/home/alice/dotfiles/vim/rc"), &home()),
+            "~/dotfiles/vim/rc"
+        );
+    }
+
+    #[test]
+    fn display_path_keeps_paths_outside_home() {
+        assert_eq!(
+            display_path(&PathBuf::from("/opt/data"), &home()),
+            "/opt/data"
+        );
+    }
+
+    #[test]
+    fn humanize_bytes_boundaries() {
+        assert_eq!(humanize_bytes(0), "0 B");
+        assert_eq!(humanize_bytes(1023), "1023 B");
+        assert_eq!(humanize_bytes(1024), "1.0 KB");
+        assert_eq!(humanize_bytes(1024 * 1024), "1.0 MB");
+        assert_eq!(humanize_bytes(1024 * 1024 * 1024), "1.0 GB");
+    }
+
+    #[test]
+    fn into_display_entry_handles_sentinel_source() {
+        let entry = DeploymentMapEntry {
+            pack: "nvim".into(),
+            handler: "install".into(),
+            kind: DeploymentKind::File,
+            source: PathBuf::new(),
+            datastore: PathBuf::from("/home/alice/.local/share/dodot/packs/nvim/install/sent"),
+        };
+        let display = into_display_entry(entry, &home());
+        assert_eq!(display.source, "—");
+        assert!(display.datastore.starts_with("~/"));
+    }
+
+    #[test]
+    fn tree_flattening_produces_branch_glyphs() {
+        // Fabricate a small tree:
+        //   root
+        //   ├─ a
+        //   │  └─ aa
+        //   └─ b
+        let tree = TreeNode {
+            name: "root".into(),
+            path: PathBuf::from("/root"),
+            kind: "dir",
+            size: None,
+            link_target: None,
+            truncated_count: None,
+            children: vec![
+                TreeNode {
+                    name: "a".into(),
+                    path: PathBuf::from("/root/a"),
+                    kind: "dir",
+                    size: None,
+                    link_target: None,
+                    truncated_count: None,
+                    children: vec![TreeNode {
+                        name: "aa".into(),
+                        path: PathBuf::from("/root/a/aa"),
+                        kind: "file",
+                        size: Some(10),
+                        link_target: None,
+                        truncated_count: None,
+                        children: Vec::new(),
+                    }],
+                },
+                TreeNode {
+                    name: "b".into(),
+                    path: PathBuf::from("/root/b"),
+                    kind: "file",
+                    size: Some(42),
+                    link_target: None,
+                    truncated_count: None,
+                    children: Vec::new(),
+                },
+            ],
+        };
+        let mut lines = Vec::new();
+        flatten_tree(&tree, "", true, &mut lines, true);
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[0].name, "root");
+        assert_eq!(lines[0].prefix, ""); // root is flush-left
+        assert_eq!(lines[1].name, "a");
+        assert!(lines[1].prefix.ends_with("├─ "));
+        assert_eq!(lines[2].name, "aa");
+        assert!(lines[2].prefix.ends_with("└─ "));
+        assert!(lines[2].prefix.starts_with("│")); // parent is not last
+        assert_eq!(lines[3].name, "b");
+        assert!(lines[3].prefix.ends_with("└─ "));
+        assert_eq!(lines[3].annotation, "42 B");
+    }
+
+    #[test]
+    fn annotate_symlink_with_target() {
+        let node = TreeNode {
+            name: "link".into(),
+            path: PathBuf::from("/x"),
+            kind: "symlink",
+            size: Some(20),
+            link_target: Some("/target".into()),
+            truncated_count: None,
+            children: Vec::new(),
+        };
+        assert_eq!(annotate(&node), "→ /target");
+    }
+
+    #[test]
+    fn annotate_broken_symlink() {
+        let node = TreeNode {
+            name: "link".into(),
+            path: PathBuf::from("/x"),
+            kind: "symlink",
+            size: Some(20),
+            link_target: None,
+            truncated_count: None,
+            children: Vec::new(),
+        };
+        assert_eq!(annotate(&node), "→ (broken)");
+    }
+
+    #[test]
+    fn annotate_truncated_dir() {
+        let node = TreeNode {
+            name: "deep".into(),
+            path: PathBuf::from("/x"),
+            kind: "dir",
+            size: None,
+            link_target: None,
+            truncated_count: Some(7),
+            children: Vec::new(),
+        };
+        assert_eq!(annotate(&node), "(… 7 more)");
+    }
+
+    #[test]
+    fn probe_result_deployment_map_serialises_with_kind_tag() {
+        let result = ProbeResult::DeploymentMap {
+            data_dir: "/d".into(),
+            map_path: "/d/deployment-map.tsv".into(),
+            entries: Vec::new(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["kind"], "deployment-map");
+        assert!(json["entries"].is_array());
+    }
+
+    #[test]
+    fn probe_result_show_data_dir_serialises_with_kind_tag() {
+        let result = ProbeResult::ShowDataDir {
+            data_dir: "/d".into(),
+            lines: Vec::new(),
+            total_nodes: 1,
+            total_size: 0,
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["kind"], "show-data-dir");
+        assert_eq!(json["total_nodes"], 1);
+    }
+
+    #[test]
+    fn probe_subcommands_list_matches_variants() {
+        // Failsafe: if we add a probe subcommand to the enum we should
+        // add it to the summary list too. This assertion catches the
+        // former getting ahead of the latter.
+        let names: Vec<&str> = PROBE_SUBCOMMANDS.iter().map(|s| s.name).collect();
+        assert!(names.contains(&"deployment-map"));
+        assert!(names.contains(&"show-data-dir"));
+    }
+}

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -3140,6 +3140,157 @@ fn by_status_groups_packs_under_banners() {
     assert!(output.contains("nvim"), "output: {output}");
 }
 
+// ── probe ──────────────────────────────────────────────────────
+
+#[test]
+fn probe_summary_lists_available_subcommands() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    let result = commands::probe::summary(&ctx).unwrap();
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(output.contains("deployment-map"), "output:\n{output}");
+    assert!(output.contains("show-data-dir"), "output:\n{output}");
+}
+
+#[test]
+fn probe_deployment_map_renders_rows_after_up() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("aliases.sh", "alias vi=vim")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    let result = commands::probe::deployment_map(&ctx).unwrap();
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(output.contains("vim"), "output:\n{output}");
+    assert!(output.contains("shell"), "output:\n{output}");
+    assert!(output.contains("aliases.sh"), "output:\n{output}");
+}
+
+#[test]
+fn probe_deployment_map_empty_state_shows_hint() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    let result = commands::probe::deployment_map(&ctx).unwrap();
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        output.contains("nothing deployed"),
+        "empty probe should point the user at `dodot up`; got:\n{output}"
+    );
+}
+
+#[test]
+fn probe_show_data_dir_renders_tree_with_sizes() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("aliases.sh", "alias vi=vim")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    let result = commands::probe::show_data_dir(&ctx, 4).unwrap();
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(output.contains("packs"), "output:\n{output}");
+    assert!(output.contains("vim"), "output:\n{output}");
+    assert!(output.contains("shell"), "output:\n{output}");
+    // Tree should use box-drawing glyphs somewhere.
+    assert!(
+        output.contains("├") || output.contains("└"),
+        "expected branch glyphs in tree; got:\n{output}"
+    );
+}
+
+#[test]
+fn probe_deployment_map_json_mode_is_kind_tagged() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    let result = commands::probe::deployment_map(&ctx).unwrap();
+    let output = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["kind"], "deployment-map");
+    assert!(parsed["entries"].is_array());
+}
+
+// ── deployment map (written on up/down alongside the init script) ──
+
+#[test]
+fn up_writes_deployment_map() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("aliases.sh", "alias vi=vim")
+        .file("bin/tool", "#!/bin/sh")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    env.assert_exists(&env.paths.deployment_map_path());
+    let content = env
+        .fs
+        .read_to_string(&env.paths.deployment_map_path())
+        .unwrap();
+    assert!(content.starts_with("# dodot deployment map v1"));
+    assert!(
+        content.contains("vim\tshell\tsymlink\t"),
+        "expected a vim/shell row; content:\n{content}"
+    );
+    assert!(
+        content.contains("vim\tpath\tsymlink\t"),
+        "expected a vim/path row; content:\n{content}"
+    );
+}
+
+#[test]
+fn down_refreshes_deployment_map_to_empty() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("aliases.sh", "alias vi=vim")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+    // Precondition: map has a row.
+    let content_before = env
+        .fs
+        .read_to_string(&env.paths.deployment_map_path())
+        .unwrap();
+    assert!(content_before.contains("aliases.sh"));
+
+    commands::down::down(None, &ctx).unwrap();
+
+    let content_after = env
+        .fs
+        .read_to_string(&env.paths.deployment_map_path())
+        .unwrap();
+    // Header stays; data rows are gone.
+    assert!(content_after.starts_with("# dodot deployment map v1"));
+    assert!(
+        !content_after.contains("aliases.sh"),
+        "map should be empty after down; got:\n{content_after}"
+    );
+}
+
+#[test]
+fn up_dry_run_does_not_touch_deployment_map() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("aliases.sh", "alias vi=vim")
+        .done()
+        .build();
+
+    let mut ctx = make_ctx(&env);
+    ctx.dry_run = true;
+    commands::up::up(None, &ctx).unwrap();
+
+    // Map file should not have been written for a dry-run.
+    env.assert_not_exists(&env.paths.deployment_map_path());
+}
+
 #[test]
 fn by_status_folds_ignored_packs_into_ignored_group() {
     let env = TempEnvironment::builder()

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -29,6 +29,7 @@ use crate::conflicts;
 use crate::datastore::format_command_for_display;
 use crate::operations::HandlerIntent;
 use crate::packs::orchestration::{self, ExecutionContext, PackResult};
+use crate::probe;
 use crate::shell;
 use crate::Result;
 
@@ -109,10 +110,12 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         }
     }
 
-    // Regenerate shell init script
+    // Regenerate shell init script and deployment map
     if !ctx.dry_run {
         info!("regenerating shell init script");
         shell::write_init_script(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+        info!("writing deployment map");
+        probe::write_deployment_map(ctx.fs.as_ref(), ctx.paths.as_ref())?;
     }
 
     let has_failures = pack_results

--- a/crates/dodot-lib/src/lib.rs
+++ b/crates/dodot-lib/src/lib.rs
@@ -11,6 +11,7 @@ pub mod operations;
 pub mod packs;
 pub mod paths;
 pub mod preprocessing;
+pub mod probe;
 pub mod render;
 pub mod rules;
 pub mod shell;

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -58,6 +58,12 @@ pub trait Pather: Send + Sync {
     fn init_script_path(&self) -> PathBuf {
         self.shell_dir().join("dodot-init.sh")
     }
+
+    /// Path to the deployment map TSV, overwritten on every `up` / `down`.
+    /// See `docs/proposals/profiling.lex` §3.2.
+    fn deployment_map_path(&self) -> PathBuf {
+        self.data_dir().join("deployment-map.tsv")
+    }
 }
 
 /// XDG-compliant path resolver.

--- a/crates/dodot-lib/src/probe/data_dir_tree.rs
+++ b/crates/dodot-lib/src/probe/data_dir_tree.rs
@@ -1,0 +1,302 @@
+//! Tree walk of `<data_dir>` for `dodot probe show-data-dir`.
+//!
+//! The walk is bounded: directories beyond `max_depth` are summarised
+//! as a single child with the entry count, so the output stays readable
+//! on installs with large pack sets. Symlinks are never followed — we
+//! report the link target as a string instead, which is what the user
+//! debugging "where did dodot put X?" wants to see.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::fs::{DirEntry, Fs};
+use crate::paths::Pather;
+use crate::Result;
+
+/// One node in the data-dir tree. Directories have children; files have
+/// a size; symlinks carry the resolved target path so the renderer can
+/// show `→ /…`.
+#[derive(Debug, Clone, Serialize)]
+pub struct TreeNode {
+    /// Display name — the file/dir basename for everything except the
+    /// root, which uses the full data_dir path.
+    pub name: String,
+    /// Absolute path to this node.
+    pub path: PathBuf,
+    /// `"dir"`, `"file"`, `"symlink"`, or `"truncated"`. The renderer
+    /// picks an icon based on this.
+    pub kind: &'static str,
+    /// Size in bytes for files (via `lstat`, so symlinks report the
+    /// link-entry size, not the target's).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    /// Symlink target as a plain string (not resolved). None for
+    /// non-symlinks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_target: Option<String>,
+    /// For `kind == "truncated"`, the number of children not expanded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncated_count: Option<usize>,
+    /// Children of a directory. Empty for files/symlinks.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub children: Vec<TreeNode>,
+}
+
+/// Walk `<data_dir>` to `max_depth` levels deep and return a tree of
+/// [`TreeNode`]s rooted at the data directory.
+///
+/// `max_depth = 0` returns just the root with no children. `max_depth = 1`
+/// shows immediate children of data_dir but doesn't recurse into them,
+/// and so on. A reasonable default for display is 4 (enough to show
+/// `packs / <pack> / <handler> / <entry>`).
+pub fn collect_data_dir_tree(
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+    max_depth: usize,
+) -> Result<TreeNode> {
+    let root = paths.data_dir().to_path_buf();
+    walk(fs, &root, &root_name(&root), max_depth)
+}
+
+fn root_name(root: &Path) -> String {
+    root.display().to_string()
+}
+
+fn walk(fs: &dyn Fs, path: &Path, display_name: &str, remaining_depth: usize) -> Result<TreeNode> {
+    // The root may not exist on a fresh install. Represent it as an
+    // empty directory rather than erroring — `probe show-data-dir` on a
+    // brand-new system should print "empty", not fail.
+    if !fs.exists(path) {
+        return Ok(TreeNode {
+            name: display_name.to_string(),
+            path: path.to_path_buf(),
+            kind: "dir",
+            size: None,
+            link_target: None,
+            truncated_count: None,
+            children: Vec::new(),
+        });
+    }
+
+    // Classify via lstat so symlinks are never followed.
+    let meta = fs.lstat(path)?;
+
+    if meta.is_symlink {
+        let target = fs.readlink(path).ok().map(|p| p.display().to_string());
+        return Ok(TreeNode {
+            name: display_name.to_string(),
+            path: path.to_path_buf(),
+            kind: "symlink",
+            size: Some(meta.len),
+            link_target: target,
+            truncated_count: None,
+            children: Vec::new(),
+        });
+    }
+
+    if !meta.is_dir {
+        return Ok(TreeNode {
+            name: display_name.to_string(),
+            path: path.to_path_buf(),
+            kind: "file",
+            size: Some(meta.len),
+            link_target: None,
+            truncated_count: None,
+            children: Vec::new(),
+        });
+    }
+
+    // Directory.
+    if remaining_depth == 0 {
+        // Report how many entries are hidden so the user knows the
+        // subtree wasn't empty.
+        let count = fs.read_dir(path).map(|v| v.len()).unwrap_or(0);
+        return Ok(TreeNode {
+            name: display_name.to_string(),
+            path: path.to_path_buf(),
+            kind: "dir",
+            size: None,
+            link_target: None,
+            truncated_count: if count > 0 { Some(count) } else { None },
+            children: Vec::new(),
+        });
+    }
+
+    let mut entries = fs.read_dir(path)?;
+    entries.sort_by(|a, b| {
+        directory_order(a)
+            .cmp(&directory_order(b))
+            .then(a.name.cmp(&b.name))
+    });
+
+    let mut children = Vec::with_capacity(entries.len());
+    for entry in entries {
+        children.push(walk(fs, &entry.path, &entry.name, remaining_depth - 1)?);
+    }
+
+    Ok(TreeNode {
+        name: display_name.to_string(),
+        path: path.to_path_buf(),
+        kind: "dir",
+        size: None,
+        link_target: None,
+        truncated_count: None,
+        children,
+    })
+}
+
+/// Sort key: directories before files, both sorted by name afterwards.
+/// Keeps the tree output visually grouped (all subdirs on top).
+fn directory_order(entry: &DirEntry) -> u8 {
+    if entry.is_dir {
+        0
+    } else {
+        1
+    }
+}
+
+impl TreeNode {
+    /// Count nodes in the subtree rooted here (including self).
+    pub fn count_nodes(&self) -> usize {
+        1 + self.children.iter().map(Self::count_nodes).sum::<usize>()
+    }
+
+    /// Total file size (symlinks counted by their link-entry size).
+    pub fn total_size(&self) -> u64 {
+        self.size.unwrap_or(0) + self.children.iter().map(Self::total_size).sum::<u64>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TempEnvironment;
+
+    #[test]
+    fn missing_data_dir_returns_empty_root() {
+        let env = TempEnvironment::builder().build();
+        // Remove the data dir to simulate a fresh install.
+        env.fs.remove_dir_all(&env.data_dir).unwrap();
+
+        let root = collect_data_dir_tree(env.fs.as_ref(), env.paths.as_ref(), 4).unwrap();
+        assert_eq!(root.kind, "dir");
+        assert!(root.children.is_empty());
+    }
+
+    #[test]
+    fn depth_zero_returns_root_only_with_truncated_count() {
+        let env = TempEnvironment::builder().build();
+        // Create a couple of files under data_dir so there's something to truncate.
+        env.fs
+            .write_file(&env.data_dir.join("a.txt"), b"hi")
+            .unwrap();
+        env.fs
+            .write_file(&env.data_dir.join("b.txt"), b"hi")
+            .unwrap();
+
+        let root = collect_data_dir_tree(env.fs.as_ref(), env.paths.as_ref(), 0).unwrap();
+        assert_eq!(root.kind, "dir");
+        assert!(root.children.is_empty());
+        assert!(root.truncated_count.unwrap() >= 2);
+    }
+
+    #[test]
+    fn files_report_size() {
+        let env = TempEnvironment::builder().build();
+        env.fs
+            .write_file(&env.data_dir.join("hello.txt"), b"hello world")
+            .unwrap();
+
+        let root = collect_data_dir_tree(env.fs.as_ref(), env.paths.as_ref(), 1).unwrap();
+        let hello = root
+            .children
+            .iter()
+            .find(|c| c.name == "hello.txt")
+            .expect("hello.txt node");
+        assert_eq!(hello.kind, "file");
+        assert_eq!(hello.size, Some(11));
+    }
+
+    #[test]
+    fn symlinks_carry_target_and_are_not_followed() {
+        let env = TempEnvironment::builder().build();
+        let target = env.home.join("real.txt");
+        env.fs.write_file(&target, b"xx").unwrap();
+        env.fs
+            .symlink(&target, &env.data_dir.join("link.txt"))
+            .unwrap();
+
+        let root = collect_data_dir_tree(env.fs.as_ref(), env.paths.as_ref(), 1).unwrap();
+        let link = root
+            .children
+            .iter()
+            .find(|c| c.name == "link.txt")
+            .expect("link.txt node");
+        assert_eq!(link.kind, "symlink");
+        assert_eq!(link.link_target.as_deref(), Some(target.to_str().unwrap()));
+    }
+
+    #[test]
+    fn directories_before_files_then_alphabetical() {
+        let env = TempEnvironment::builder().build();
+        env.fs.mkdir_all(&env.data_dir.join("packs")).unwrap();
+        env.fs.mkdir_all(&env.data_dir.join("shell")).unwrap();
+        env.fs
+            .write_file(&env.data_dir.join("deployment-map.tsv"), b"x")
+            .unwrap();
+        env.fs
+            .write_file(&env.data_dir.join("zzz.txt"), b"x")
+            .unwrap();
+
+        let root = collect_data_dir_tree(env.fs.as_ref(), env.paths.as_ref(), 1).unwrap();
+        let names: Vec<&str> = root.children.iter().map(|c| c.name.as_str()).collect();
+        // packs, shell (dirs, alphabetical), then deployment-map.tsv, zzz.txt (files).
+        assert_eq!(
+            names,
+            vec!["packs", "shell", "deployment-map.tsv", "zzz.txt"]
+        );
+    }
+
+    #[test]
+    fn deep_tree_truncates_at_max_depth() {
+        let env = TempEnvironment::builder().build();
+        let deep = env.data_dir.join("packs").join("vim").join("shell");
+        env.fs.mkdir_all(&deep).unwrap();
+        env.fs.write_file(&deep.join("aliases.sh"), b"x").unwrap();
+
+        // Depth 2: root -> packs -> vim (truncated, not expanded).
+        let root = collect_data_dir_tree(env.fs.as_ref(), env.paths.as_ref(), 2).unwrap();
+        let packs = root
+            .children
+            .iter()
+            .find(|c| c.name == "packs")
+            .expect("packs node");
+        let vim = packs
+            .children
+            .iter()
+            .find(|c| c.name == "vim")
+            .expect("vim node");
+        assert!(vim.children.is_empty(), "vim should be a truncation leaf");
+        assert_eq!(vim.truncated_count, Some(1));
+    }
+
+    #[test]
+    fn count_and_total_size_helpers_agree() {
+        let env = TempEnvironment::builder().build();
+        // Start from a clean data_dir so we control the exact shape.
+        // (TempEnvironment pre-creates `shell/` and `packs/` — fine for
+        // realism, but confuses exact-count assertions.)
+        env.fs.remove_dir_all(&env.data_dir).unwrap();
+        env.fs.mkdir_all(&env.data_dir).unwrap();
+
+        env.fs.write_file(&env.data_dir.join("a"), b"hi").unwrap(); // 2 bytes
+        env.fs
+            .write_file(&env.data_dir.join("b"), b"hello")
+            .unwrap(); // 5 bytes
+
+        let root = collect_data_dir_tree(env.fs.as_ref(), env.paths.as_ref(), 1).unwrap();
+        assert_eq!(root.count_nodes(), 3); // root + 2 children
+        assert_eq!(root.total_size(), 7);
+    }
+}

--- a/crates/dodot-lib/src/probe/deployment_map.rs
+++ b/crates/dodot-lib/src/probe/deployment_map.rs
@@ -1,12 +1,14 @@
 //! The deployment map.
 //!
 //! The deployment map is a plain-text TSV under `<data_dir>/deployment-map.tsv`
-//! with one row per datastore entry:
+//! with a two-line `#`-comment preamble followed by one TSV row per
+//! datastore entry. An example file:
 //!
 //! ```text
 //! # dodot deployment map v1
-//! # columns: pack, handler, kind, source, datastore
-//! pack\thandler\tkind\tsource\tdatastore
+//! # columns: pack\thandler\tkind\tsource\tdatastore
+//! vim\tshell\tsymlink\t/home/alice/dotfiles/vim/aliases.sh\t/home/alice/.local/share/dodot/packs/vim/shell/aliases.sh
+//! git\tsymlink\tsymlink\t/home/alice/dotfiles/git/gitconfig\t/home/alice/.local/share/dodot/packs/git/symlink/gitconfig
 //! ```
 //!
 //! The file is overwritten on every `dodot up` / `dodot down` so it

--- a/crates/dodot-lib/src/probe/deployment_map.rs
+++ b/crates/dodot-lib/src/probe/deployment_map.rs
@@ -1,0 +1,502 @@
+//! The deployment map.
+//!
+//! The deployment map is a plain-text TSV under `<data_dir>/deployment-map.tsv`
+//! with one row per datastore entry:
+//!
+//! ```text
+//! # dodot deployment map v1
+//! # columns: pack, handler, kind, source, datastore
+//! pack\thandler\tkind\tsource\tdatastore
+//! ```
+//!
+//! The file is overwritten on every `dodot up` / `dodot down` so it
+//! always matches the current datastore state. Its primary consumers
+//! are:
+//!
+//! - `dodot refresh` (see `docs/proposals/magic.lex`), which needs the
+//!   source→deployed mapping to decide which source templates to
+//!   mtime-touch when a deployed file diverges.
+//! - `dodot probe deployment-map`, the human-facing reader.
+//!
+//! # Sources of truth
+//!
+//! The map is derived *from the datastore alone* — we never re-run the
+//! handlers to regenerate it. This keeps the writer trivial and keeps
+//! the map honest: if the datastore has drifted from what the handlers
+//! would produce today, the map reflects the datastore (which is what
+//! the init script reads), not a hypothetical re-derivation.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::fs::Fs;
+use crate::paths::Pather;
+use crate::Result;
+
+/// How a single datastore entry is materialised on disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeploymentKind {
+    /// The entry is a symlink in the datastore pointing at a source file
+    /// inside the dotfiles repo. This covers `symlink`, `shell`, and
+    /// `path` handlers.
+    Symlink,
+    /// The entry is a regular file written by dodot (a sentinel for
+    /// `install` / `homebrew`, or a preprocessor's rendered output).
+    File,
+    /// The entry is a directory written by a preprocessor
+    /// (e.g. expanded archive contents).
+    Directory,
+}
+
+impl DeploymentKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Symlink => "symlink",
+            Self::File => "file",
+            Self::Directory => "directory",
+        }
+    }
+}
+
+/// One row in the deployment map.
+///
+/// `source` is the absolute path in the dotfiles repo (for symlink
+/// entries — empty for file / directory entries, which are not backed by
+/// a source file). `datastore` is the absolute path inside `<data_dir>`
+/// where the entry lives.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeploymentMapEntry {
+    pub pack: String,
+    pub handler: String,
+    pub kind: DeploymentKind,
+    #[serde(default)]
+    pub source: PathBuf,
+    pub datastore: PathBuf,
+}
+
+/// Walk the datastore and collect one [`DeploymentMapEntry`] per
+/// visible entry under `<data_dir>/packs/<pack>/<handler>/`.
+///
+/// The walk is non-recursive within a handler directory: dodot's
+/// data layout is `packs/<pack>/<handler>/<entry>`, and any deeper
+/// structure (preprocessor-expanded subtrees under `rendered` handler
+/// directories, for instance) is represented as a single [`Directory`]
+/// row. Consumers that care about subtree contents can walk from the
+/// `datastore` path themselves.
+///
+/// [`Directory`]: DeploymentKind::Directory
+pub fn collect_deployment_map(fs: &dyn Fs, paths: &dyn Pather) -> Result<Vec<DeploymentMapEntry>> {
+    let packs_dir = paths.data_dir().join("packs");
+    if !fs.is_dir(&packs_dir) {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = Vec::new();
+
+    let mut pack_entries = fs.read_dir(&packs_dir)?;
+    pack_entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    for pack_dir in pack_entries {
+        if !pack_dir.is_dir {
+            continue;
+        }
+        let pack_name = pack_dir.name.clone();
+
+        let mut handler_dirs = fs.read_dir(&pack_dir.path)?;
+        handler_dirs.sort_by(|a, b| a.name.cmp(&b.name));
+
+        for handler_dir in handler_dirs {
+            if !handler_dir.is_dir {
+                continue;
+            }
+            let handler_name = handler_dir.name.clone();
+
+            let mut items = fs.read_dir(&handler_dir.path)?;
+            items.sort_by(|a, b| a.name.cmp(&b.name));
+
+            for item in items {
+                let kind = classify_entry(fs, &item);
+                let source = if kind == DeploymentKind::Symlink {
+                    // readlink may fail on a broken symlink — we still
+                    // want to record the entry so the user can see it.
+                    fs.readlink(&item.path).unwrap_or_default()
+                } else {
+                    PathBuf::new()
+                };
+
+                entries.push(DeploymentMapEntry {
+                    pack: pack_name.clone(),
+                    handler: handler_name.clone(),
+                    kind,
+                    source,
+                    datastore: item.path.clone(),
+                });
+            }
+        }
+    }
+
+    Ok(entries)
+}
+
+fn classify_entry(fs: &dyn Fs, entry: &crate::fs::DirEntry) -> DeploymentKind {
+    if entry.is_symlink {
+        DeploymentKind::Symlink
+    } else if entry.is_dir {
+        DeploymentKind::Directory
+    } else if entry.is_file {
+        DeploymentKind::File
+    } else {
+        // Fallback: query the fs directly. Shouldn't be reachable in
+        // practice since read_dir populates all three flags.
+        match fs.lstat(&entry.path) {
+            Ok(m) if m.is_symlink => DeploymentKind::Symlink,
+            Ok(m) if m.is_dir => DeploymentKind::Directory,
+            _ => DeploymentKind::File,
+        }
+    }
+}
+
+/// Format the deployment map as TSV.
+///
+/// The output is deterministic (entries are emitted in the order
+/// returned by [`collect_deployment_map`], which sorts by pack, then
+/// handler, then entry name).
+pub fn format_deployment_map(entries: &[DeploymentMapEntry]) -> String {
+    let mut out = String::new();
+    out.push_str("# dodot deployment map v1\n");
+    out.push_str("# columns: pack\thandler\tkind\tsource\tdatastore\n");
+    for e in entries {
+        out.push_str(&format_row(e));
+        out.push('\n');
+    }
+    out
+}
+
+fn format_row(e: &DeploymentMapEntry) -> String {
+    format!(
+        "{}\t{}\t{}\t{}\t{}",
+        e.pack,
+        e.handler,
+        e.kind.as_str(),
+        e.source.display(),
+        e.datastore.display(),
+    )
+}
+
+/// Collect, format, and write the deployment map to
+/// `<data_dir>/deployment-map.tsv`. Returns the written path.
+pub fn write_deployment_map(fs: &dyn Fs, paths: &dyn Pather) -> Result<PathBuf> {
+    let entries = collect_deployment_map(fs, paths)?;
+    let content = format_deployment_map(&entries);
+    let map_path = paths.deployment_map_path();
+    fs.mkdir_all(paths.data_dir())?;
+    fs.write_file(&map_path, content.as_bytes())?;
+    Ok(map_path)
+}
+
+/// Read and parse a deployment-map TSV file.
+///
+/// Blank lines and `#`-prefixed comments are ignored. Rows with the
+/// wrong column count are skipped silently — the map is best-effort
+/// and a truncated file should not crash the reader.
+pub fn read_deployment_map(fs: &dyn Fs, path: &Path) -> Result<Vec<DeploymentMapEntry>> {
+    if !fs.exists(path) {
+        return Ok(Vec::new());
+    }
+    let content = fs.read_to_string(path)?;
+    Ok(parse_deployment_map(&content))
+}
+
+fn parse_deployment_map(content: &str) -> Vec<DeploymentMapEntry> {
+    content.lines().filter_map(parse_row).collect()
+}
+
+fn parse_row(line: &str) -> Option<DeploymentMapEntry> {
+    let trimmed = line.trim_end_matches('\r');
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let mut parts = trimmed.splitn(5, '\t');
+    let pack = parts.next()?;
+    let handler = parts.next()?;
+    let kind_str = parts.next()?;
+    let source = parts.next()?;
+    let datastore = parts.next()?;
+    let kind = match kind_str {
+        "symlink" => DeploymentKind::Symlink,
+        "file" => DeploymentKind::File,
+        "directory" => DeploymentKind::Directory,
+        _ => return None,
+    };
+    Some(DeploymentMapEntry {
+        pack: pack.to_string(),
+        handler: handler.to_string(),
+        kind,
+        source: PathBuf::from(source),
+        datastore: PathBuf::from(datastore),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datastore::{CommandOutput, CommandRunner, DataStore, FilesystemDataStore};
+    use crate::testing::TempEnvironment;
+    use std::sync::Arc;
+
+    struct NoopRunner;
+    impl CommandRunner for NoopRunner {
+        fn run(&self, _: &str, _: &[String]) -> Result<CommandOutput> {
+            Ok(CommandOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    fn make_datastore(env: &TempEnvironment) -> FilesystemDataStore {
+        FilesystemDataStore::new(env.fs.clone(), env.paths.clone(), Arc::new(NoopRunner))
+    }
+
+    #[test]
+    fn empty_datastore_yields_empty_map() {
+        let env = TempEnvironment::builder().build();
+        let entries = collect_deployment_map(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn symlink_entries_capture_source_and_datastore() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "alias vi=vim")
+            .done()
+            .build();
+
+        let ds = make_datastore(&env);
+        let source = env.dotfiles_root.join("vim/aliases.sh");
+        ds.create_data_link("vim", "shell", &source).unwrap();
+
+        let entries = collect_deployment_map(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].pack, "vim");
+        assert_eq!(entries[0].handler, "shell");
+        assert_eq!(entries[0].kind, DeploymentKind::Symlink);
+        assert_eq!(entries[0].source, source);
+        assert_eq!(
+            entries[0].datastore,
+            env.paths
+                .handler_data_dir("vim", "shell")
+                .join("aliases.sh")
+        );
+    }
+
+    #[test]
+    fn entries_sort_by_pack_then_handler_then_name() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "")
+            .file("bin/tool", "#!/bin/sh")
+            .done()
+            .pack("git")
+            .file("gitconfig", "")
+            .done()
+            .build();
+
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+        ds.create_data_link("vim", "path", &env.dotfiles_root.join("vim/bin"))
+            .unwrap();
+        ds.create_data_link("git", "symlink", &env.dotfiles_root.join("git/gitconfig"))
+            .unwrap();
+
+        let entries = collect_deployment_map(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+
+        let keys: Vec<(String, String)> = entries
+            .iter()
+            .map(|e| (e.pack.clone(), e.handler.clone()))
+            .collect();
+        // git/symlink comes before vim/{path,shell} (sorted by pack),
+        // and vim/path comes before vim/shell (sorted by handler).
+        assert_eq!(
+            keys,
+            vec![
+                ("git".into(), "symlink".into()),
+                ("vim".into(), "path".into()),
+                ("vim".into(), "shell".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn sentinel_file_classified_as_file_with_no_source() {
+        let env = TempEnvironment::builder().build();
+
+        // Simulate an install handler sentinel: a plain file in the
+        // handler dir, not a symlink.
+        let handler_dir = env.paths.handler_data_dir("nvim", "install");
+        env.fs.mkdir_all(&handler_dir).unwrap();
+        env.fs
+            .write_file(
+                &handler_dir.join("install.sh-abc123"),
+                b"completed|2026-01-01",
+            )
+            .unwrap();
+
+        let entries = collect_deployment_map(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, DeploymentKind::File);
+        assert!(
+            entries[0].source.as_os_str().is_empty(),
+            "sentinels have no source file; got {:?}",
+            entries[0].source
+        );
+    }
+
+    #[test]
+    fn broken_symlink_still_recorded_with_empty_source() {
+        let env = TempEnvironment::builder().build();
+
+        let handler_dir = env.paths.handler_data_dir("nvim", "shell");
+        env.fs.mkdir_all(&handler_dir).unwrap();
+        // Point at a path that doesn't exist. readlink still works on
+        // broken symlinks, so in this case source is captured. To test
+        // the *unreadable* branch we'd need to simulate a failure;
+        // broken-but-readable is the realistic case.
+        let broken_target = env.dotfiles_root.join("nvim/gone.sh");
+        env.fs
+            .symlink(&broken_target, &handler_dir.join("gone.sh"))
+            .unwrap();
+
+        let entries = collect_deployment_map(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, DeploymentKind::Symlink);
+        assert_eq!(entries[0].source, broken_target);
+    }
+
+    #[test]
+    fn write_and_reread_roundtrip() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "")
+            .done()
+            .build();
+
+        let ds = make_datastore(&env);
+        let source = env.dotfiles_root.join("vim/aliases.sh");
+        ds.create_data_link("vim", "shell", &source).unwrap();
+
+        let path = write_deployment_map(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        assert_eq!(path, env.paths.deployment_map_path());
+        env.assert_exists(&path);
+
+        let content = env.fs.read_to_string(&path).unwrap();
+        assert!(content.starts_with("# dodot deployment map v1"));
+        assert!(content.contains("vim\tshell\tsymlink\t"));
+
+        let parsed = read_deployment_map(env.fs.as_ref(), &path).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].pack, "vim");
+        assert_eq!(parsed[0].source, source);
+    }
+
+    #[test]
+    fn read_returns_empty_when_file_missing() {
+        let env = TempEnvironment::builder().build();
+        let parsed =
+            read_deployment_map(env.fs.as_ref(), &env.paths.deployment_map_path()).unwrap();
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn parser_ignores_comments_and_blank_lines() {
+        let content = "\
+# a comment
+\n\
+vim\tshell\tsymlink\t/src/a\t/ds/a
+# another
+
+git\tsymlink\tsymlink\t/src/b\t/ds/b
+";
+        let parsed = parse_deployment_map(content);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].pack, "vim");
+        assert_eq!(parsed[1].pack, "git");
+    }
+
+    #[test]
+    fn parser_skips_malformed_rows() {
+        // Too few columns and an unknown kind should both be dropped,
+        // not crash.
+        let content = "\
+only-two-cols\tvalue
+vim\tshell\tweird-kind\t/a\t/b
+vim\tshell\tsymlink\t/a\t/b
+";
+        let parsed = parse_deployment_map(content);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].kind, DeploymentKind::Symlink);
+    }
+
+    #[test]
+    fn format_has_header_and_one_row_per_entry() {
+        let entries = vec![
+            DeploymentMapEntry {
+                pack: "vim".into(),
+                handler: "shell".into(),
+                kind: DeploymentKind::Symlink,
+                source: PathBuf::from("/src/a"),
+                datastore: PathBuf::from("/ds/a"),
+            },
+            DeploymentMapEntry {
+                pack: "vim".into(),
+                handler: "install".into(),
+                kind: DeploymentKind::File,
+                source: PathBuf::new(),
+                datastore: PathBuf::from("/ds/sentinel"),
+            },
+        ];
+        let s = format_deployment_map(&entries);
+        let lines: Vec<&str> = s.lines().collect();
+        assert_eq!(lines.len(), 4); // 2 comments + 2 data rows
+        assert!(lines[0].starts_with('#'));
+        assert!(lines[1].starts_with('#'));
+        assert_eq!(lines[2], "vim\tshell\tsymlink\t/src/a\t/ds/a");
+        assert_eq!(lines[3], "vim\tinstall\tfile\t\t/ds/sentinel");
+    }
+
+    #[test]
+    fn empty_input_produces_header_only() {
+        let s = format_deployment_map(&[]);
+        let lines: Vec<&str> = s.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].starts_with("# dodot"));
+        assert!(lines[1].starts_with("# columns"));
+    }
+
+    #[test]
+    fn paths_with_tabs_would_break_tsv_but_are_not_produced_by_dodot() {
+        // Documenting an invariant rather than testing a path: dodot
+        // never creates paths containing literal tab characters, so we
+        // don't escape them in the TSV. A pack dir named "foo\tbar"
+        // would produce a malformed row — but dodot's pack discovery
+        // rejects such names upstream (ignore list + XDG conventions).
+        //
+        // This test just locks in the current format so a future change
+        // that wants tab-containing paths has to explicitly revisit
+        // escaping.
+        let entry = DeploymentMapEntry {
+            pack: "p".into(),
+            handler: "h".into(),
+            kind: DeploymentKind::Symlink,
+            source: PathBuf::from("/a"),
+            datastore: PathBuf::from("/b"),
+        };
+        let row = format_row(&entry);
+        assert_eq!(row.matches('\t').count(), 4);
+    }
+}

--- a/crates/dodot-lib/src/probe/mod.rs
+++ b/crates/dodot-lib/src/probe/mod.rs
@@ -1,0 +1,24 @@
+//! Probe — introspection for the deployed state.
+//!
+//! Today this module provides two read-only views over `<data_dir>`:
+//!
+//! - [`deployment_map`] — the `pack / handler / source / deployed` map
+//!   that `dodot refresh` (see `docs/proposals/magic.lex`) also
+//!   consumes. Written alongside the shell init script on every `up`
+//!   and `down`.
+//! - [`data_dir_tree`] — a bounded-depth tree walk for `dodot probe
+//!   show-data-dir`.
+//!
+//! See `docs/proposals/profiling.lex` for the full feature spec. A
+//! later phase will add shell-init timing reports under
+//! `<data_dir>/probes/shell-init/`; that state lives in a sibling
+//! submodule when it lands.
+
+pub mod data_dir_tree;
+pub mod deployment_map;
+
+pub use data_dir_tree::{collect_data_dir_tree, TreeNode};
+pub use deployment_map::{
+    collect_deployment_map, read_deployment_map, write_deployment_map, DeploymentKind,
+    DeploymentMapEntry,
+};

--- a/crates/dodot-lib/src/render/mod.rs
+++ b/crates/dodot-lib/src/render/mod.rs
@@ -116,6 +116,10 @@ pub const TEMPLATE_LIST: &str = include_str!("../templates/list.jinja");
 /// Simple message output (init, fill, adopt, addignore).
 pub const TEMPLATE_MESSAGE: &str = include_str!("../templates/message.jinja");
 
+/// Probe — deployment map, data-dir tree, summary. Branches on the
+/// `kind` field of the serialized result.
+pub const TEMPLATE_PROBE: &str = include_str!("../templates/probe.jinja");
+
 // ── Renderer ────────────────────────────────────────────────────
 
 /// Create the dodot theme from the embedded YAML definition.
@@ -132,6 +136,7 @@ pub fn create_renderer() -> Renderer {
         .unwrap();
     renderer.add_template("list", TEMPLATE_LIST).unwrap();
     renderer.add_template("message", TEMPLATE_MESSAGE).unwrap();
+    renderer.add_template("probe", TEMPLATE_PROBE).unwrap();
     renderer
 }
 
@@ -154,6 +159,7 @@ pub fn render<T: serde::Serialize>(
         "pack-status" => TEMPLATE_PACK_STATUS,
         "list" => TEMPLATE_LIST,
         "message" => TEMPLATE_MESSAGE,
+        "probe" => TEMPLATE_PROBE,
         other => {
             return Err(crate::DodotError::Other(format!(
                 "unknown template: {other}"

--- a/crates/dodot-lib/src/templates/probe.jinja
+++ b/crates/dodot-lib/src/templates/probe.jinja
@@ -1,0 +1,23 @@
+{%- if kind == "summary" -%}
+[header]dodot probe[/header]
+  [dim]data_dir:[/dim] {{ data_dir }}
+
+[header]Subcommands:[/header]
+{% for sub in available %}  [pack-name]{{ sub.name | col(20) }}[/pack-name] [description]{{ sub.description }}[/description]
+{% endfor %}
+{%- elif kind == "deployment-map" -%}
+[header]Deployment map[/header]
+  [dim]file:[/dim] {{ map_path }}
+
+{% if entries %}  [dim]{{ "pack" | col(16) }} {{ "handler" | col(10) }} {{ "kind" | col(10) }} {{ "source" | col(40) }} datastore[/dim]
+{% for e in entries %}  [pack-name]{{ e.pack | col(16) }}[/pack-name] [handler-symbol]{{ e.handler | col(10) }}[/handler-symbol] [description]{{ e.kind | col(10) }}[/description] {{ e.source | col(40) }} [dim]{{ e.datastore }}[/dim]
+{% endfor %}{% else %}  [dim](nothing deployed — run `dodot up` first)[/dim]
+{% endif %}
+{%- elif kind == "show-data-dir" -%}
+[header]Data directory[/header]
+  [dim]root:[/dim] {{ data_dir }}
+  [dim]nodes:[/dim] {{ total_nodes }}   [dim]size:[/dim] {{ total_size }} B
+
+{% for line in lines %}{{ line.prefix }}{{ line.name }}{% if line.annotation %} [dim]{{ line.annotation }}[/dim]{% endif %}
+{% endfor %}
+{%- endif -%}

--- a/docs/proposals/profiling.lex
+++ b/docs/proposals/profiling.lex
@@ -35,7 +35,7 @@ Design Specification: Profiling and the Probe Command
 
     2.2. Plain Text, No Ceremony
 
-        Every file dodot writes in service of this feature is plain text (TSV). No JSON, no TOML, no schema versioning header. The reader is dodot itself and, when the user cares, `awk`. This matters because the shell writer has to be simple enough to be obviously correct by inspection, and because the user should never feel they need dodot to read dodot's own records.
+        Every file dodot writes in service of this feature is plain text (TSV). No JSON, no TOML, no heavyweight schema envelope. A file may begin with one or more `#`-prefixed comment lines — a short `# dodot <name> v1` marker plus a column legend — and that is the extent of any "header" we allow ourselves. Comments must be ignorable by line-oriented readers, so `awk '$1 !~ /^#/'` is a complete parser. The reader is dodot itself and, when the user cares, `awk`. This matters because the shell writer has to be simple enough to be obviously correct by inspection, and because the user should never feel they need dodot to read dodot's own records.
 
     2.3. Opt-Out, Not Opt-In
 
@@ -139,7 +139,7 @@ Design Specification: Profiling and the Probe Command
 
     5.4. `probe deployment-map`
 
-        Reads `deployment-map.tsv` and renders it as a table grouped by pack. This is the human-facing view of the file that `refresh` consumes machine-to-machine.
+        Renders the source→deployed mapping as a table grouped by pack. The view is derived live from the datastore — not from the on-disk `deployment-map.tsv` — so `dodot probe deployment-map` tells the truth even if the user has never run `dodot up` since the feature shipped, and even if `up`/`down` last ran with `--dry-run`. The TSV on disk (§3.2) is a separate artifact produced by `up`/`down` for machine-to-machine consumers such as `refresh`; both views are derived from the same datastore, and under normal operation they agree.
 
 
 6. Prior Art

--- a/docs/proposals/profiling.lex
+++ b/docs/proposals/profiling.lex
@@ -1,0 +1,194 @@
+Design Specification: Profiling and the Probe Command
+
+    This document specifies `dodot probe` — a small introspection surface that lets users see what dodot is doing, where it lives on disk, and how much time it costs their shell to start. It also specifies the shell-side instrumentation that collects the timing data, and the plain-text records dodot persists on its behalf.
+
+    Profiling sits alongside the other introspection-leaning features (status, list) but answers a different question: not "what is deployed?" but "what does the deployment look like at runtime, and what is it costing me?" It is explicitly *not* a performance-tuning framework — it is a small, honest lens.
+
+    The design also produces a deliverable that the sync/refresh work in @./magic.lex needs for its own reasons: a plain-text source-to-deployed map. Packaging that map here keeps the profiling and refresh stories from each growing their own bespoke mini-stores.
+
+
+1. Motivation
+
+    1.1. The Init Script Is a Small Critical Path
+
+        A dotfile manager runs exactly once per shell — at init — but that one run is inside every subsequent terminal the user will ever open. The current `dodot-init.sh` [../crates/dodot-lib/src/shell/mod.rs] is trivially small: a few `export PATH=...` lines and one `. "<path>"` per sourced file. On its own it costs almost nothing. But the files the user writes inside those sourced scripts can and do become slow. When a new shell starts feeling heavy, the question "which file is to blame?" is answerable today only by reaching for `zprof` or `zsh/xtrace`, neither of which is particularly friendly, and both of which the user has to rig up themselves.
+
+        dodot already owns the script that sources these files. It is the obvious place to carry a lightweight, always-on timer that never bothers the user — until the user asks.
+
+    1.2. Other Things Worth Knowing
+
+        While we are instrumenting the init script, two other questions are cheap to answer once we have the plumbing:
+
+            - Did any sourced file exit non-zero? The shell uses `[ -f ... ] && . "..."` today, which silently swallows failures. Recording the exit status turns hidden breakage into visible data.
+            - What deployed file corresponds to which source file? The datastore knows this, but only through symlink chains that are inconvenient to walk by hand. A plain-text map is useful to both the user (for audit) and to dodot itself (for `refresh`, per @./magic.lex §2).
+
+        Neither of these is performance-related, but both share the `probe` framing: they let the user see inside an otherwise opaque deployment.
+
+
+2. Principles
+
+    2.1. Thou Shalt Not Slow Down the Shell
+
+        This is the binding constraint. Profiling that costs the user more than it gives them is worse than no profiling. We hold ourselves to a budget: the per-file instrumentation must add less than a few microseconds per sourced file, using only shell builtins, with no forks, and writing at most one line per file to a single append-only TSV.
+
+        Where the shell does not support cheap high-resolution timing (classic `/bin/sh`, bash before 5.0), the instrumentation silently degrades to a zero-cost no-op and the probe output plainly says "timings unavailable in this shell". We do not emulate precision we don't have, and we do not slow a user down to collect data we can't collect well.
+
+    2.2. Plain Text, No Ceremony
+
+        Every file dodot writes in service of this feature is plain text (TSV). No JSON, no TOML, no schema versioning header. The reader is dodot itself and, when the user cares, `awk`. This matters because the shell writer has to be simple enough to be obviously correct by inspection, and because the user should never feel they need dodot to read dodot's own records.
+
+    2.3. Opt-Out, Not Opt-In
+
+        Profiling is on by default. The cost is paid; paying it and discarding the data is silly. Users who object can set `profiling.enabled = false` in the root `.dodot.toml` and the init script is regenerated without the timing wrapper on the next `dodot up`. There is no middle ground and no runtime flag — the instrumentation lives in the generated script or it doesn't.
+
+
+3. What We Record
+
+    3.1. Per-Run Report
+
+        Each shell-init run writes one file to `<data_dir>/probes/shell-init/`, named:
+
+            profile-<unix-ts>-<pid>-<rand>.tsv
+
+        :: text ::
+
+        The `<unix-ts>` is seconds since epoch (builtin, no fork). The `<pid>` and a small `$RANDOM`-derived suffix give uniqueness across concurrent shells — relying on timestamp alone is not safe, since tmux or a `foot --server` session may fire several inits within the same second.
+
+        The file begins with a short `#`-prefixed preamble (shell, version, init-script path, start timestamp, total elapsed) and then one TSV row per instrumented step:
+
+            phase  pack  handler  target  duration_us  exit_status
+
+        :: text ::
+
+        `phase` distinguishes `path` (a PATH export — near-instant, but recorded for completeness and ordering) from `source` (a sourced shell file). `target` is the absolute path being sourced or added to PATH. `duration_us` is measured with `EPOCHREALTIME` on bash 5+ / zsh, which gives microsecond resolution from a pair of variable reads. `exit_status` is the return code of the sourced script; for PATH entries it is always 0.
+
+        A realistic file on a well-groomed dotfiles install runs 20–40 rows and lands under 4 KB.
+
+    3.2. Deployment Map
+
+        At the end of every `dodot up` and `dodot down`, dodot also writes `<data_dir>/deployment-map.tsv` with one row per deployed artifact:
+
+            pack  handler  source_path  deployed_path
+
+        :: text ::
+
+        Unlike the per-run profile, this file is overwritten, not rotated: there is only ever one current map. It is the operational complement to the init script — the init script is "what shell commands run"; the map is "what files are in play".
+
+        This file's primary consumer is `dodot refresh` from @./magic.lex, which needs to know which source templates back which deployed files so it can mtime-touch the right subset. `dodot probe deployment-map` is simply a friendly reader for the same file.
+
+    3.3. What We Do Not Record
+
+        We do not try to stand in for `zprof`. Deep intra-file profiling — which function inside `aliases.sh` was slow — is outside our scope, and suggesting we solve it would be dishonest. When a user's probe report shows a single 200 ms `source`, the correct next step is pointing them at `zprof` or `zsh-trace` with a one-line note in the probe output.
+
+        We also do not record environment-size growth, function counts, or any other "inside the shell" state. Collecting those cheaply would require running functions inside the user's shell, which violates principle 2.1.
+
+
+4. Retention
+
+    4.1. Rotation Policy
+
+        The default is `profiling.keep_last_runs = 100`. This is a root-only config key; per-pack scoping is meaningless. At 4 KB per file, 100 runs is ~400 KB — small enough that the number can safely default high, and historical data is genuinely useful for spotting "this got slower last Tuesday" regressions.
+
+        Rotation runs at `dodot up` time, not inside the init script. Pruning inside the init script would require an `ls` or equivalent, which costs a fork; keeping pruning on the write side (dodot, which is already running its own process) is free. The rare user who never runs `dodot up` again will accumulate indefinitely, but that same user has no active profiling audience either — the accumulation is harmless.
+
+    4.2. Concurrent Writers
+
+        Two shells starting at the same instant write to distinct filenames by construction (`<pid>-<rand>`), so they do not collide. We do not use any locking. A partial write from a crashed shell leaves a truncated TSV, which the reader tolerates: rows are independent and a short file is just a short report.
+
+
+5. The `probe` Command Tree
+
+    5.1. Subcommand Shape
+
+        `probe` is registered as a standout command group following the pattern of the existing `status`/`up`/`down` commands [../crates/dodot-cli/src/main.rs]:
+
+            dodot probe                        # help + summary of last run
+            dodot probe shell-init             # detailed timings, last run
+            dodot probe shell-init --runs N    # aggregate over last N runs
+            dodot probe shell-init --history   # one-line trend across runs
+            dodot probe show-data-dir          # tree of <data_dir>
+            dodot probe deployment-map         # source -> deployed table
+
+        :: text ::
+
+        Each subcommand returns structured data to a Jinja template under `crates/dodot-lib/src/templates/` and is rendered through standout with the existing theme. Table output uses standout's built-in column rendering — the semantic classes in `dodot.css` handle the styling, so no new theme work is needed.
+
+    5.2. `probe shell-init`
+
+        The default output groups timings first by pack and then by handler, with a total per group and a grand total at the bottom:
+
+            PACK         HANDLER  TARGET              TIME     STATUS
+            [nvm]        shell    lazy-nvm.sh         2.4 ms   ok
+            [git]        shell    aliases.sh          0.3 ms   ok
+                         path     bin                 <1 μs    ok
+            [brew]       shell    shellenv.sh        18.7 ms   ok
+            ---
+            total (user)                              21.4 ms
+            dodot framing                              0.2 ms
+            grand total                               21.6 ms
+
+        :: text ::
+
+        The `--runs N` flag aggregates across the most recent N reports and shows p50 / p95 / max per target. This is the view for spotting regressions: the eye catches a `p95` that is much worse than `p50`. `--history` is the same data collapsed to one row per run, dated, for a trend glance.
+
+        A footer always prints "for intra-file profiling, see `zprof` (zsh) or `PS4` tracing (bash)" — this keeps us honest about our scope (§3.3).
+
+    5.3. `probe show-data-dir`
+
+        A tree view of `<data_dir>` with file sizes, limited to a reasonable depth so the output doesn't scroll off-screen. The intent is "I'm debugging; show me what dodot has on disk" — the same role that `brew doctor` serves for Homebrew, minus the diagnostic assertions.
+
+    5.4. `probe deployment-map`
+
+        Reads `deployment-map.tsv` and renders it as a table grouped by pack. This is the human-facing view of the file that `refresh` consumes machine-to-machine.
+
+
+6. Prior Art
+
+    We looked at what the shell-startup-tuning ecosystem already offers, because duplicating existing tools would be wasteful and because their limitations informed our scope:
+
+    zprof (zsh builtin):
+        Function-level profiler loaded via `zmodload zsh/zprof`. Accurate, zero-install, but only profiles function calls — plain inline code in sourced files is invisible. Users have to wrap suspect code in self-destructive functions to make it measurable.
+
+    zsh-trace (ddribin/zsh-trace):
+        Uses `xtrace` with a microsecond-formatted `PS4` to capture every executed line, then post-processes into summaries and flamegraphs. Powerful but heavyweight to set up and to read; the output is much richer than most users want.
+
+    chezmoi doctor, brew doctor:
+        Diagnostic surfaces shaped like "check for problems and report yes/no". Useful as a framing precedent for our `probe` subcommand (low ceremony, friendly output) but not timing-related.
+
+    yadm, stow:
+        No built-in profiling. Users fall back to generic shell profiling tools.
+
+    Our niche sits below zprof/zsh-trace and above "do nothing": we time only the top-level sources dodot itself controls, free of charge, always on. For anything deeper, we point at the specialists.
+
+
+7. Phased Implementation
+
+    Phase 1: deployment map and `probe show-data-dir`.
+        No init-script changes. Wire `deployment-map.tsv` writing into the tail of `commands::up` and `commands::down` alongside `shell::write_init_script`. Ship `probe`, `probe show-data-dir`, and `probe deployment-map`. This alone unblocks `dodot refresh` from @./magic.lex.
+
+    Phase 2: shell-init timing.
+        Extend `shell::generate_init_script` to emit the per-file timing wrapper and the preamble writer. Wire `probe shell-init` reader and the default (single-run) view. Add the `profiling` config section.
+
+    Phase 3: aggregation.
+        Add `--runs N` and `--history` flags to `probe shell-init`. Rotation runs at `dodot up` time (prune `<data_dir>/probes/shell-init/` to `keep_last_runs` entries by filename sort).
+
+    Phase 4: regression hints (optional).
+        If phase 3 reveals an appetite for it, teach `probe shell-init` to highlight targets whose current-run duration is above their historical p95. Pure presentation; same data. We do not plan this as table stakes.
+
+
+8. What This Costs the User
+
+    Being honest about the price tag:
+
+        - roughly 100 microseconds added to shell startup on bash 5+ / zsh, per the instrumentation math in §3.1 (twenty sources × two variable reads × one appended line)
+        - a TSV file per shell start under `<data_dir>/probes/`, bounded at the configured retention
+        - nothing on shells that do not support `EPOCHREALTIME` — instrumentation compiles out
+
+    Being honest about what this does not cost:
+
+        - no new setup the user has to remember
+        - no external dependencies
+        - no change to when `dodot up` / `dodot down` fire
+        - no network, no background daemon, no watcher
+
+    We think that is a good deal. The cost is bounded and, for most users, imperceptible. The data is there when they want it and invisible when they don't. That is the shape a probe should have.

--- a/tests/e2e/bats/test_probe.bats
+++ b/tests/e2e/bats/test_probe.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot probe` — deployment map and data-dir tree.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+# ── probe (summary) ─────────────────────────────────────────────
+
+@test "probe lists available subcommands" {
+    run dodot probe
+    [ "$status" -eq 0 ]
+    assert_output_contains "deployment-map"
+    assert_output_contains "show-data-dir"
+    assert_output_contains "data_dir"
+}
+
+@test "probe shows data_dir rooted under XDG_DATA_HOME" {
+    run dodot probe
+    [ "$status" -eq 0 ]
+    assert_output_contains "$XDG_DATA_HOME/dodot"
+}
+
+# ── probe deployment-map ────────────────────────────────────────
+
+@test "deployment-map on fresh install shows empty hint" {
+    run dodot probe deployment-map
+    [ "$status" -eq 0 ]
+    assert_output_contains "nothing deployed"
+}
+
+@test "deployment-map lists entries after up" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    create_pack_file "vim" "home.vimrc" "set nocompatible"
+    dodot up
+
+    run dodot probe deployment-map
+    [ "$status" -eq 0 ]
+    assert_output_contains "vim"
+    # shell handler (aliases.sh) and symlink handler (home.vimrc) should both show
+    assert_output_contains "shell"
+    assert_output_contains "symlink"
+    assert_output_contains "aliases.sh"
+}
+
+@test "deployment-map TSV file is written alongside init script" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+
+    assert_exists "$XDG_DATA_HOME/dodot/deployment-map.tsv"
+    assert_file_contains "$XDG_DATA_HOME/dodot/deployment-map.tsv" "# dodot deployment map v1"
+    assert_file_contains "$XDG_DATA_HOME/dodot/deployment-map.tsv" "vim.*shell.*symlink"
+}
+
+@test "deployment-map is refreshed on down" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+    assert_file_contains "$XDG_DATA_HOME/dodot/deployment-map.tsv" "aliases.sh"
+
+    dodot down
+
+    # File still exists (header preserved), but no data rows.
+    assert_exists "$XDG_DATA_HOME/dodot/deployment-map.tsv"
+    assert_file_contains "$XDG_DATA_HOME/dodot/deployment-map.tsv" "# dodot deployment map v1"
+    run grep -v '^#' "$XDG_DATA_HOME/dodot/deployment-map.tsv"
+    # Only blank lines (if any) should remain.
+    for line in $output; do
+        [ -z "$(echo "$line" | tr -d '[:space:]')" ]
+    done
+}
+
+@test "deployment-map points to the right TSV path" {
+    run dodot probe deployment-map
+    [ "$status" -eq 0 ]
+    assert_output_contains "deployment-map.tsv"
+}
+
+# ── probe show-data-dir ─────────────────────────────────────────
+
+@test "show-data-dir on fresh install renders the empty data_dir" {
+    run dodot probe show-data-dir
+    [ "$status" -eq 0 ]
+    # Header is always there.
+    assert_output_contains "Data directory"
+    assert_output_contains "$XDG_DATA_HOME/dodot"
+}
+
+@test "show-data-dir displays packs tree after up" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    create_pack_bin "tools" "mytool" '#!/bin/sh
+echo hi'
+    dodot up
+
+    run dodot probe show-data-dir
+    [ "$status" -eq 0 ]
+    assert_output_contains "packs"
+    assert_output_contains "vim"
+    assert_output_contains "shell"
+    assert_output_contains "tools"
+    assert_output_contains "path"
+    # Tree should use box-drawing glyphs somewhere.
+    [[ "$output" == *"├"* || "$output" == *"└"* ]]
+}
+
+@test "show-data-dir --depth 1 shows only immediate children" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+
+    run dodot probe show-data-dir --depth 1
+    [ "$status" -eq 0 ]
+    # At depth 1 we see "packs" but not the vim pack inside.
+    assert_output_contains "packs"
+    assert_output_not_contains "vim"
+}
+
+@test "show-data-dir includes deployment-map.tsv after up" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+
+    run dodot probe show-data-dir
+    [ "$status" -eq 0 ]
+    assert_output_contains "deployment-map.tsv"
+}
+
+# ── read-only safety ────────────────────────────────────────────
+
+@test "probe never modifies the dotfiles root" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    # Snapshot: list of files + their contents hashes.
+    local before
+    before="$(cd "$DOTFILES_ROOT" && find . -type f | sort | xargs -I{} sh -c 'printf "%s %s\n" "{}" "$(cat "{}")"')"
+
+    dodot probe
+    dodot probe deployment-map
+    dodot probe show-data-dir
+
+    local after
+    after="$(cd "$DOTFILES_ROOT" && find . -type f | sort | xargs -I{} sh -c 'printf "%s %s\n" "{}" "$(cat "{}")"')"
+
+    [ "$before" = "$after" ]
+}
+
+# ── JSON output ─────────────────────────────────────────────────
+
+@test "probe --output json emits kind-tagged JSON" {
+    run dodot --output json probe
+    [ "$status" -eq 0 ]
+    assert_output_contains '"kind"'
+    assert_output_contains '"summary"'
+    assert_output_contains '"available"'
+}
+
+@test "probe deployment-map --output json emits entries array" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+
+    run dodot --output json probe deployment-map
+    [ "$status" -eq 0 ]
+    assert_output_contains '"kind"'
+    assert_output_contains '"deployment-map"'
+    assert_output_contains '"entries"'
+    assert_output_contains '"pack": "vim"'
+}

--- a/tests/e2e/bats/test_probe.bats
+++ b/tests/e2e/bats/test_probe.bats
@@ -131,16 +131,27 @@ echo hi'
 
 @test "probe never modifies the dotfiles root" {
     create_pack_file "vim" "aliases.sh" "alias vi=vim"
-    # Snapshot: list of files + their contents hashes.
+
+    # Snapshot per-file cksum digests, excluding `.git/` (sandbox_setup
+    # runs `git init`, and git's internal state can tick over as a side
+    # effect of subprocesses finding themselves inside a repo — we only
+    # care that no *pack content* changed). cksum is POSIX, binary-safe,
+    # and fast enough for a small sandbox.
+    _snapshot_dotfiles() {
+        cd "$DOTFILES_ROOT" && find . -path './.git' -prune -o -type f -print0 \
+            | sort -z \
+            | xargs -0 cksum
+    }
+
     local before
-    before="$(cd "$DOTFILES_ROOT" && find . -type f | sort | xargs -I{} sh -c 'printf "%s %s\n" "{}" "$(cat "{}")"')"
+    before="$(_snapshot_dotfiles)"
 
     dodot probe
     dodot probe deployment-map
     dodot probe show-data-dir
 
     local after
-    after="$(cd "$DOTFILES_ROOT" && find . -type f | sort | xargs -I{} sh -c 'printf "%s %s\n" "{}" "$(cat "{}")"')"
+    after="$(_snapshot_dotfiles)"
 
     [ "$before" = "$after" ]
 }


### PR DESCRIPTION
## Summary

Phase 1 of the profiling feature spec (`docs/proposals/profiling.lex`): introduces the read-only `dodot probe` diagnostics surface and the `<data_dir>/deployment-map.tsv` artifact. No shell-init instrumentation yet — that is Phase 2.

### What's in

**New command tree — `dodot probe`:**
- `dodot probe` — summary listing available probe subcommands.
- `dodot probe deployment-map` — rendered \`pack / handler / kind / source / datastore\` table derived live from the datastore.
- \`dodot probe show-data-dir [--depth N]\` — bounded-depth tree view of \`<data_dir>\` with per-node sizes, symlink targets, and \`(… N more)\` truncation markers.

All three honour \`--output json\` and emit a \`{\"kind\": \"…\"}\`-tagged document.

**Deployment map file.** \`dodot up\` and \`dodot down\` now write \`<data_dir>/deployment-map.tsv\` alongside the regenerated shell init script. Skipped during \`--dry-run\`. Plain TSV, header-prefixed, one row per datastore entry. This is also the artifact \`dodot refresh\` (see \`docs/proposals/magic.lex\`) will consume — packaging it here avoids two bespoke mini-stores.

### Design notes

- **Derived from the datastore, not re-run.** The map reflects what's actually on disk. If the datastore has drifted from what the handlers would produce today, the map reflects reality, not a hypothetical re-derivation.
- **One \`ProbeResult\` enum, one template.** All three subcommands share a \`#[serde(tag = \"kind\")]\`-tagged enum and a single \`probe.jinja\` that branches on kind. Alternative (three separate commands/templates) was considered and rejected as more wiring for no UX gain.
- **Standout dispatch uses dotted paths.** \`probe.deployment-map\` and \`probe.show-data-dir\` are registered as distinct dispatch targets; \`probe\` (no dots) is the summary handler.

### Test plan
- [x] 38 new unit tests (probe module: 17, commands::probe: 11, integration: 7, rendering: 3)
- [x] 14 new bats e2e tests (\`tests/e2e/bats/test_probe.bats\`), including a read-only safety check that verifies probe never mutates the dotfiles root
- [x] \`cargo test\` — 440 pass
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`bats tests/e2e/bats/\` — 127 pass (113 pre-existing + 14 new)
- [x] Smoke-checked against real dotfiles on the author's system (read-only, non-destructive)

### Follow-ups (explicitly out of scope)
- Phase 2: shell-init timing instrumentation + \`probe shell-init\` reader
- Phase 3: aggregation (\`--runs N\`, p50/p95, \`--history\`)
- Phase 4: optional regression hints

See \`docs/proposals/profiling.lex\` §7 for the phased plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)