### PR TITLE
feat(probe): shell-init timing instrumentation (profiling Phase 2)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -34,6 +34,29 @@ Use sections: Added, Changed, Deprecated, Removed, Fixed, Security.
   mtime touches.
 - `Pather::deployment_map_path()` trait method, returning
   `<data_dir>/deployment-map.tsv`.
+- **Shell-init profiling** (Phase 2 of `docs/proposals/profiling.lex`).
+  When `[profiling] enabled = true` (the default) the generated
+  `dodot-init.sh` carries a runtime-detected timing wrapper around each
+  `source` and `PATH` line. On bash 5+ / zsh, every shell startup writes
+  one TSV under `<data_dir>/probes/shell-init/profile-<unix_ts>-<pid>-<rand>.tsv`
+  with microsecond `EPOCHREALTIME` start/end pairs and the source's exit
+  status — turning silent failures in user shell scripts into visible
+  data. Older shells (`/bin/sh`, bash <5) fall through to the
+  unmodified source/PATH path with one extra `[ "$_dodot_prof" = "1" ]`
+  comparison of overhead. Disable via `[profiling] enabled = false` in
+  the root `.dodot.toml`; the resulting init script is byte-identical to
+  Phase 1.
+- **`dodot probe shell-init`** — reads the most recent profile TSV and
+  renders it grouped by pack and handler, with per-row durations,
+  per-group subtotals, and a final user-sourced / dodot-framing / grand
+  total breakdown. Falls back to a hint when no profile has been written
+  yet, or when profiling is disabled in config.
+- New `[profiling]` config section (root-only): `enabled` (default
+  `true`) and `keep_last_runs` (default `100`, capped at the
+  configured number per `dodot up`'s rotation pass; `0` disables
+  rotation defensively rather than wiping history).
+- `Pather::probes_shell_init_dir()` trait method, returning
+  `<data_dir>/probes/shell-init`.
 
 ## Changed
 

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -241,6 +241,15 @@ pub fn probe_show_data_dir_handler(
     Ok(Output::Render(commands::probe::show_data_dir(&ctx, depth)?))
 }
 
+/// `dodot probe shell-init` — most recent shell-startup profile.
+pub fn probe_shell_init_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::probe::ProbeResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    Ok(Output::Render(commands::probe::shell_init(&ctx)?))
+}
+
 // ── Passthrough handlers (bypass standout rendering) ────────────
 
 /// `dodot config` — delegates to clapfig's config subcommands.
@@ -287,7 +296,12 @@ fn clean_debug_format(input: &str) -> String {
 pub fn init_sh_passthrough() -> Result<(), anyhow::Error> {
     let dotfiles_root = discover_dotfiles_root()?;
     let ctx = ExecutionContext::production(&dotfiles_root)?;
-    let script = dodot_lib::shell::generate_init_script(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+    let root_config = ctx.config_manager.root_config()?;
+    let script = dodot_lib::shell::generate_init_script(
+        ctx.fs.as_ref(),
+        ctx.paths.as_ref(),
+        root_config.profiling.enabled,
+    )?;
     print!("{script}");
     Ok(())
 }

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -127,6 +127,12 @@ fn build_app() -> App {
             "probe",
         )
         .expect("register probe.show-data-dir")
+        .command(
+            "probe.shell-init",
+            handlers::probe_shell_init_handler,
+            "probe",
+        )
+        .expect("register probe.shell-init")
         .command_groups(vec![
             CommandGroup {
                 title: "Core".into(),
@@ -353,6 +359,11 @@ fn build_clap_command() -> ClapCommand {
                                 .value_parser(clap::value_parser!(usize))
                                 .num_args(1),
                         ),
+                )
+                .subcommand(
+                    ClapCommand::new("shell-init").about(
+                        "Per-source timings for the most recent shell startup",
+                    ),
                 ),
         )
 }

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -70,7 +70,11 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
     // the removed state).
     if !ctx.dry_run {
         info!("regenerating shell init script");
-        shell::write_init_script(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+        shell::write_init_script(
+            ctx.fs.as_ref(),
+            ctx.paths.as_ref(),
+            root_config.profiling.enabled,
+        )?;
         info!("writing deployment map");
         probe::write_deployment_map(ctx.fs.as_ref(), ctx.paths.as_ref())?;
     }

--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -12,7 +12,10 @@
 use serde::Serialize;
 
 use crate::packs::orchestration::ExecutionContext;
-use crate::probe::{collect_data_dir_tree, collect_deployment_map, DeploymentMapEntry, TreeNode};
+use crate::probe::{
+    collect_data_dir_tree, collect_deployment_map, group_profile, read_latest_profile,
+    DeploymentMapEntry, GroupedProfile, TreeNode,
+};
 use crate::Result;
 
 /// Default max depth for `probe show-data-dir`. Enough to show
@@ -79,6 +82,54 @@ pub enum ProbeResult {
         /// link-entry size).
         total_size: u64,
     },
+    /// `dodot probe shell-init` — the most recent shell-startup profile,
+    /// grouped by pack and handler.
+    ShellInit(ShellInitView),
+}
+
+/// Display payload for `probe shell-init`. Pulled into its own struct
+/// so the JSON view stays clean and the variant constructor in
+/// `shell_init()` reads naturally.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitView {
+    /// Source filename of the report (for "which run is this?" UX).
+    /// Empty when no profile has been written yet.
+    pub filename: String,
+    /// Shell label as recorded in the preamble (e.g. `bash 5.3.9`).
+    pub shell: String,
+    /// True when the profiling wrapper is enabled in config.
+    pub profiling_enabled: bool,
+    /// True when the directory exists and contained a parseable file.
+    pub has_profile: bool,
+    /// Pre-grouped rows for the template; empty when `has_profile` is
+    /// false.
+    pub groups: Vec<ShellInitGroup>,
+    pub user_total_us: u64,
+    pub framing_us: u64,
+    pub total_us: u64,
+    /// Where the profiles live on disk (so the user can `ls` it).
+    pub profiles_dir: String,
+}
+
+/// Display row for one entry in a shell-init group.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitRow {
+    pub target: String,
+    pub duration_us: u64,
+    pub duration_label: String,
+    pub exit_status: i32,
+    /// `"ok"` or `"err"` — drives the styling tag in the template.
+    pub status_class: &'static str,
+}
+
+/// Display group: one (pack, handler) bucket of shell-init rows.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitGroup {
+    pub pack: String,
+    pub handler: String,
+    pub rows: Vec<ShellInitRow>,
+    pub group_total_us: u64,
+    pub group_total_label: String,
 }
 
 /// One entry in the `probe` summary listing.
@@ -95,6 +146,10 @@ pub const PROBE_SUBCOMMANDS: &[ProbeSubcommandInfo] = &[
     ProbeSubcommandInfo {
         name: "deployment-map",
         description: "Source↔deployed map — what dodot linked where.",
+    },
+    ProbeSubcommandInfo {
+        name: "shell-init",
+        description: "Per-source timings for the most recent shell startup.",
     },
     ProbeSubcommandInfo {
         name: "show-data-dir",
@@ -129,6 +184,95 @@ pub fn deployment_map(ctx: &ExecutionContext) -> Result<ProbeResult> {
         map_path: ctx.paths.deployment_map_path().display().to_string(),
         entries,
     })
+}
+
+/// Render the most recent shell-init profile.
+///
+/// When no profile has been written yet (fresh install, or profiling
+/// disabled, or the user hasn't started a shell since the last `up`),
+/// returns a "no data" view with `has_profile = false`. The template
+/// uses that flag to print a hint instead of an empty table.
+pub fn shell_init(ctx: &ExecutionContext) -> Result<ProbeResult> {
+    let root_config = ctx.config_manager.root_config()?;
+    let profiling_enabled = root_config.profiling.enabled;
+
+    let profile_opt = read_latest_profile(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+    let profiles_dir = ctx.paths.probes_shell_init_dir().display().to_string();
+
+    let view = match profile_opt {
+        Some(profile) => {
+            let grouped = group_profile(&profile);
+            ShellInitView {
+                filename: profile.filename.clone(),
+                shell: profile.shell.clone(),
+                profiling_enabled,
+                has_profile: true,
+                groups: shell_init_groups(&grouped),
+                user_total_us: grouped.user_total_us,
+                framing_us: grouped.framing_us,
+                total_us: grouped.total_us,
+                profiles_dir,
+            }
+        }
+        None => ShellInitView {
+            filename: String::new(),
+            shell: String::new(),
+            profiling_enabled,
+            has_profile: false,
+            groups: Vec::new(),
+            user_total_us: 0,
+            framing_us: 0,
+            total_us: 0,
+            profiles_dir,
+        },
+    };
+
+    Ok(ProbeResult::ShellInit(view))
+}
+
+fn shell_init_groups(grouped: &GroupedProfile) -> Vec<ShellInitGroup> {
+    grouped
+        .groups
+        .iter()
+        .map(|g| ShellInitGroup {
+            pack: g.pack.clone(),
+            handler: g.handler.clone(),
+            rows: g
+                .rows
+                .iter()
+                .map(|r| ShellInitRow {
+                    target: short_target(&r.target),
+                    duration_us: r.duration_us,
+                    duration_label: humanize_us(r.duration_us),
+                    exit_status: r.exit_status,
+                    status_class: if r.exit_status == 0 { "ok" } else { "error" },
+                })
+                .collect(),
+            group_total_us: g.group_total_us,
+            group_total_label: humanize_us(g.group_total_us),
+        })
+        .collect()
+}
+
+/// Display-friendly basename for a target path. The fully-qualified
+/// path is in the on-disk profile already; the rendered table is
+/// narrow.
+fn short_target(target: &str) -> String {
+    std::path::Path::new(target)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| target.to_string())
+}
+
+/// Compact human duration: "0 µs" / "1.2 ms" / "350 ms" / "1.4 s".
+pub fn humanize_us(us: u64) -> String {
+    if us < 1_000 {
+        format!("{us} µs")
+    } else if us < 1_000_000 {
+        format!("{:.1} ms", us as f64 / 1_000.0)
+    } else {
+        format!("{:.2} s", us as f64 / 1_000_000.0)
+    }
 }
 
 /// Render the data-dir tree.

--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -118,7 +118,10 @@ pub struct ShellInitRow {
     pub duration_us: u64,
     pub duration_label: String,
     pub exit_status: i32,
-    /// `"ok"` or `"err"` — drives the styling tag in the template.
+    /// `"deployed"` (success — rendered green) or `"error"` (non-zero
+    /// source exit). These map directly to existing styles in
+    /// `crate::render`'s theme; using fresh names here would require
+    /// theme additions for no UX gain.
     pub status_class: &'static str,
 }
 
@@ -245,7 +248,11 @@ fn shell_init_groups(grouped: &GroupedProfile) -> Vec<ShellInitGroup> {
                     duration_us: r.duration_us,
                     duration_label: humanize_us(r.duration_us),
                     exit_status: r.exit_status,
-                    status_class: if r.exit_status == 0 { "ok" } else { "error" },
+                    status_class: if r.exit_status == 0 {
+                        "deployed"
+                    } else {
+                        "error"
+                    },
                 })
                 .collect(),
             group_total_us: g.group_total_us,

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -113,9 +113,25 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     // Regenerate shell init script and deployment map
     if !ctx.dry_run {
         info!("regenerating shell init script");
-        shell::write_init_script(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+        let root_config = ctx.config_manager.root_config()?;
+        shell::write_init_script(
+            ctx.fs.as_ref(),
+            ctx.paths.as_ref(),
+            root_config.profiling.enabled,
+        )?;
         info!("writing deployment map");
         probe::write_deployment_map(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+        // Prune old shell-init profile reports. Cheap (one read_dir +
+        // a few unlinks at most) and runs in dodot's process, not the
+        // user's shell.
+        let removed = probe::rotate_profiles(
+            ctx.fs.as_ref(),
+            ctx.paths.as_ref(),
+            root_config.profiling.keep_last_runs,
+        )?;
+        if removed > 0 {
+            debug!(removed, "pruned old shell-init profiles");
+        }
     }
 
     let has_failures = pack_results

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -40,6 +40,9 @@ pub struct DodotConfig {
 
     #[config(nested)]
     pub preprocessor: PreprocessorSection,
+
+    #[config(nested)]
+    pub profiling: ProfilingSection,
 }
 
 /// Pack-level settings.
@@ -139,6 +142,29 @@ pub struct PreprocessorTemplateSection {
     /// as var names raises an error at load time.
     #[config(default = {})]
     pub vars: std::collections::HashMap<String, String>,
+}
+
+/// Shell-init profiling settings. Root-only — per-pack overrides are
+/// meaningless (the init script is one thing; you can't half-profile it).
+///
+/// See `docs/proposals/profiling.lex` for the full design.
+#[derive(Config, Debug, Clone, Serialize, Deserialize)]
+pub struct ProfilingSection {
+    /// Whether the generated `dodot-init.sh` carries the timing wrapper
+    /// around each `source` and PATH line. When false, the init script
+    /// is byte-identical to the pre-Phase-2 form. When true, bash 5+ /
+    /// zsh sessions emit one TSV per shell startup under
+    /// `<data_dir>/probes/shell-init/`; older shells fall through to
+    /// the no-op path even with the wrapper present.
+    #[config(default = true)]
+    pub enabled: bool,
+
+    /// Maximum number of `<data_dir>/probes/shell-init/profile-*.tsv`
+    /// files to retain. Older files are pruned at the end of every
+    /// `dodot up`. At ~4 KB per run, the default budget is roughly
+    /// 400 KB on disk.
+    #[config(default = 100)]
+    pub keep_last_runs: usize,
 }
 
 /// File-to-handler mapping patterns.
@@ -433,6 +459,26 @@ mod tests {
             ]
         );
         assert!(cfg.mappings.skip.is_empty());
+
+        // ── profiling defaults ──────────────────────────────────
+        assert!(cfg.profiling.enabled);
+        assert_eq!(cfg.profiling.keep_last_runs, 100);
+    }
+
+    #[test]
+    fn profiling_section_overridable() {
+        let env = TempEnvironment::builder().build();
+        env.fs
+            .write_file(
+                &env.dotfiles_root.join(".dodot.toml"),
+                b"[profiling]\nenabled = false\nkeep_last_runs = 25\n",
+            )
+            .unwrap();
+
+        let mgr = ConfigManager::new(&env.dotfiles_root).unwrap();
+        let cfg = mgr.root_config().unwrap();
+        assert!(!cfg.profiling.enabled);
+        assert_eq!(cfg.profiling.keep_last_runs, 25);
     }
 
     #[test]

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -64,6 +64,12 @@ pub trait Pather: Send + Sync {
     fn deployment_map_path(&self) -> PathBuf {
         self.data_dir().join("deployment-map.tsv")
     }
+
+    /// Directory where shell-init profile reports are written, one TSV
+    /// per shell start. See `docs/proposals/profiling.lex` §3.1.
+    fn probes_shell_init_dir(&self) -> PathBuf {
+        self.data_dir().join("probes").join("shell-init")
+    }
 }
 
 /// XDG-compliant path resolver.

--- a/crates/dodot-lib/src/probe/mod.rs
+++ b/crates/dodot-lib/src/probe/mod.rs
@@ -16,9 +16,14 @@
 
 pub mod data_dir_tree;
 pub mod deployment_map;
+pub mod shell_init;
 
 pub use data_dir_tree::{collect_data_dir_tree, TreeNode};
 pub use deployment_map::{
     collect_deployment_map, read_deployment_map, write_deployment_map, DeploymentKind,
     DeploymentMapEntry,
+};
+pub use shell_init::{
+    group_profile, parse_profile, read_latest_profile, rotate_profiles, GroupedProfile, Profile,
+    ProfileEntry, ProfileGroup,
 };

--- a/crates/dodot-lib/src/probe/shell_init.rs
+++ b/crates/dodot-lib/src/probe/shell_init.rs
@@ -225,7 +225,14 @@ pub struct ProfileGroup {
 }
 
 /// Roll up a profile into per-(pack, handler) groups for display.
-/// The pack-then-handler ordering matches the deployment-map view.
+///
+/// Groups are returned sorted by `(pack, handler)` so the rendered
+/// table ordering matches `dodot probe deployment-map` — eyeballing
+/// the two side-by-side should not require mental remapping. The init
+/// script emits PATH lines before shell sources (a phase-ordering
+/// concern of its own), so the raw entry order would otherwise show
+/// all `path` groups before any `shell` group, which is not what the
+/// user expects when reading a per-pack table.
 pub fn group_profile(profile: &Profile) -> GroupedProfile {
     let user_total_us = profile.entries_duration_us();
     let total_us = profile.total_duration_us.max(user_total_us);
@@ -250,6 +257,8 @@ pub fn group_profile(profile: &Profile) -> GroupedProfile {
             }),
         }
     }
+
+    groups.sort_by(|a, b| a.pack.cmp(&b.pack).then(a.handler.cmp(&b.handler)));
 
     GroupedProfile {
         groups,
@@ -391,9 +400,13 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
         let env = TempEnvironment::builder().build();
         let dir = env.paths.probes_shell_init_dir();
         env.fs.mkdir_all(&dir).unwrap();
-        env.fs
-            .write_file(&dir.join("profile-1-1-1.tsv"), b"")
-            .unwrap();
+        // Five profile files (more than `keep`), plus two non-profile
+        // files that the rotator must leave alone.
+        for i in 1..=5 {
+            env.fs
+                .write_file(&dir.join(format!("profile-{i}-1-1.tsv")), b"")
+                .unwrap();
+        }
         env.fs
             .write_file(&dir.join("README"), b"do not delete")
             .unwrap();
@@ -401,9 +414,19 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             .write_file(&dir.join("notes.txt"), b"keep me")
             .unwrap();
 
-        let removed = rotate_profiles(env.fs.as_ref(), env.paths.as_ref(), 0).unwrap();
-        assert_eq!(removed, 0);
-        // All non-profile files survive even if we asked to rotate.
+        // keep=2 forces the pruning path (5 profiles → 2 should remain).
+        let removed = rotate_profiles(env.fs.as_ref(), env.paths.as_ref(), 2).unwrap();
+        assert_eq!(removed, 3);
+
+        // The two newest profiles survive.
+        assert!(env.fs.exists(&dir.join("profile-4-1-1.tsv")));
+        assert!(env.fs.exists(&dir.join("profile-5-1-1.tsv")));
+        // The three oldest are gone.
+        assert!(!env.fs.exists(&dir.join("profile-1-1-1.tsv")));
+        assert!(!env.fs.exists(&dir.join("profile-2-1-1.tsv")));
+        assert!(!env.fs.exists(&dir.join("profile-3-1-1.tsv")));
+
+        // Non-profile files are untouched.
         assert!(env.fs.exists(&dir.join("README")));
         assert!(env.fs.exists(&dir.join("notes.txt")));
     }
@@ -443,13 +466,59 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
         };
         let g = group_profile(&p);
         assert_eq!(g.groups.len(), 2);
+        // Groups are sorted by (pack, handler), not by emission order:
+        // "path" comes before "shell" alphabetically within `vim`.
         assert_eq!(g.groups[0].pack, "vim");
-        assert_eq!(g.groups[0].handler, "shell");
-        assert_eq!(g.groups[0].group_total_us, 300);
-        assert_eq!(g.groups[1].handler, "path");
+        assert_eq!(g.groups[0].handler, "path");
+        assert_eq!(g.groups[0].group_total_us, 5);
+        assert_eq!(g.groups[1].handler, "shell");
+        assert_eq!(g.groups[1].group_total_us, 300);
         assert_eq!(g.user_total_us, 305);
         assert_eq!(g.total_us, 10_000);
         assert_eq!(g.framing_us, 9_695);
+    }
+
+    #[test]
+    fn group_profile_sorts_across_packs() {
+        // Entries arrive in deliberately scrambled order; the result
+        // must still be (pack, handler)-sorted.
+        let p = Profile {
+            filename: "x".into(),
+            shell: "bash".into(),
+            total_duration_us: 0,
+            entries: vec![
+                entry("vim", "shell", "/a", 1),
+                entry("git", "symlink", "/b", 1),
+                entry("vim", "path", "/c", 1),
+                entry("git", "shell", "/d", 1),
+            ],
+        };
+        let g = group_profile(&p);
+        let keys: Vec<(String, String)> = g
+            .groups
+            .iter()
+            .map(|gp| (gp.pack.clone(), gp.handler.clone()))
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                ("git".into(), "shell".into()),
+                ("git".into(), "symlink".into()),
+                ("vim".into(), "path".into()),
+                ("vim".into(), "shell".into()),
+            ]
+        );
+    }
+
+    fn entry(pack: &str, handler: &str, target: &str, dur_us: u64) -> ProfileEntry {
+        ProfileEntry {
+            phase: "source".into(),
+            pack: pack.into(),
+            handler: handler.into(),
+            target: target.into(),
+            duration_us: dur_us,
+            exit_status: 0,
+        }
     }
 
     #[test]

--- a/crates/dodot-lib/src/probe/shell_init.rs
+++ b/crates/dodot-lib/src/probe/shell_init.rs
@@ -1,0 +1,477 @@
+//! Shell-init profile reader, aggregator, and rotation.
+//!
+//! Profile files are written by the timing wrapper that
+//! [`crate::shell::generate_init_script`] embeds in `dodot-init.sh`.
+//! Each shell startup emits one TSV under
+//! `<data_dir>/probes/shell-init/profile-<unix_ts>-<pid>-<rand>.tsv`
+//! with the shape:
+//!
+//! ```text
+//! # dodot shell-init profile v1
+//! # shell\tbash 5.3.9(1)-release
+//! # start_t\t1714000000.123456
+//! # init_script\t/home/alice/.local/share/dodot/shell/dodot-init.sh
+//! # columns\tphase\tpack\thandler\ttarget\tstart_t\tend_t\texit_status
+//! path\tvim\tpath\t/home/alice/dotfiles/vim/bin\t1714000000.123500\t1714000000.123502\t0
+//! source\tvim\tshell\t/home/alice/dotfiles/vim/aliases.sh\t1714000000.123600\t1714000000.124900\t0
+//! # end_t\t1714000000.125100
+//! ```
+//!
+//! Both the reader and the rotator are tolerant of malformed input —
+//! a partial write from a crashed shell should leave the next `dodot
+//! probe shell-init` working, just with a short report.
+
+use serde::Serialize;
+
+use crate::fs::Fs;
+use crate::paths::Pather;
+use crate::Result;
+
+/// One parsed entry row from a profile TSV.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ProfileEntry {
+    /// `"path"` for an export, `"source"` for a sourced shell file.
+    pub phase: String,
+    pub pack: String,
+    pub handler: String,
+    pub target: String,
+    /// Microseconds the entry took to execute (computed from
+    /// `end_t - start_t` at parse time).
+    pub duration_us: u64,
+    /// Exit status reported by the source. Always `0` for `path`
+    /// entries (PATH export can't fail meaningfully).
+    pub exit_status: i32,
+}
+
+/// A whole profile file, post-parse.
+#[derive(Debug, Clone, Serialize)]
+pub struct Profile {
+    /// Source filename (basename only). Useful for showing "which
+    /// run am I looking at" in the rendered report.
+    pub filename: String,
+    /// `bash 5.3.9` etc; empty if the preamble was missing.
+    pub shell: String,
+    /// Whole-script wall time in microseconds, from `# start_t` to
+    /// `# end_t`. `0` if either marker is missing (e.g. crashed shell).
+    pub total_duration_us: u64,
+    pub entries: Vec<ProfileEntry>,
+}
+
+impl Profile {
+    /// Convenience: total time spent in the entry rows. Lets the
+    /// renderer show "user-sourced time" vs "dodot framing" by
+    /// subtracting this from `total_duration_us`.
+    pub fn entries_duration_us(&self) -> u64 {
+        self.entries.iter().map(|e| e.duration_us).sum()
+    }
+
+    /// `total_duration_us - entries_duration_us`, saturating at zero.
+    /// Represents the shell-side overhead of dodot's wrapper itself
+    /// (and any work between wrapper invocations).
+    pub fn framing_duration_us(&self) -> u64 {
+        self.total_duration_us
+            .saturating_sub(self.entries_duration_us())
+    }
+}
+
+/// Read the most recently written profile under `<data_dir>/probes/shell-init/`,
+/// or `None` if the directory is empty / missing.
+pub fn read_latest_profile(fs: &dyn Fs, paths: &dyn Pather) -> Result<Option<Profile>> {
+    let dir = paths.probes_shell_init_dir();
+    if !fs.is_dir(&dir) {
+        return Ok(None);
+    }
+    let mut entries = fs.read_dir(&dir)?;
+    // Filenames start with `profile-<unix_ts>-…`, so a lexical sort
+    // is equivalent to chronological order (the timestamp segment is
+    // fixed-width as long as we stay below year 2286 — fine).
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    let Some(latest) = entries
+        .into_iter()
+        .rfind(|e| e.is_file && e.name.starts_with("profile-") && e.name.ends_with(".tsv"))
+    else {
+        return Ok(None);
+    };
+    let content = fs.read_to_string(&latest.path)?;
+    Ok(Some(parse_profile(&latest.name, &content)))
+}
+
+/// Parse the textual content of a profile file. Tolerates missing
+/// preamble lines, unknown comments, and malformed rows (skipped).
+pub fn parse_profile(filename: &str, content: &str) -> Profile {
+    let mut shell = String::new();
+    let mut start_t: Option<f64> = None;
+    let mut end_t: Option<f64> = None;
+    let mut entries: Vec<ProfileEntry> = Vec::new();
+
+    for raw_line in content.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix('#') {
+            // Comment lines, format: `# key\tvalue` (the leading hash
+            // and one space are conventional).
+            let trimmed = rest.trim_start();
+            if let Some((key, val)) = trimmed.split_once('\t') {
+                match key {
+                    "shell" => shell = val.to_string(),
+                    "start_t" => start_t = val.parse::<f64>().ok(),
+                    "end_t" => end_t = val.parse::<f64>().ok(),
+                    _ => {} // unknown header — ignore
+                }
+            }
+            continue;
+        }
+        if let Some(entry) = parse_row(line) {
+            entries.push(entry);
+        }
+        // Otherwise: malformed row, silently dropped.
+    }
+
+    let total_duration_us = match (start_t, end_t) {
+        (Some(s), Some(e)) if e >= s => seconds_to_micros(e - s),
+        _ => 0,
+    };
+
+    Profile {
+        filename: filename.to_string(),
+        shell,
+        total_duration_us,
+        entries,
+    }
+}
+
+fn parse_row(line: &str) -> Option<ProfileEntry> {
+    let mut parts = line.splitn(7, '\t');
+    let phase = parts.next()?;
+    let pack = parts.next()?;
+    let handler = parts.next()?;
+    let target = parts.next()?;
+    let start = parts.next()?.parse::<f64>().ok()?;
+    let end = parts.next()?.parse::<f64>().ok()?;
+    let exit_status = parts.next()?.parse::<i32>().ok()?;
+    if !matches!(phase, "path" | "source") {
+        return None;
+    }
+    let duration_us = if end >= start {
+        seconds_to_micros(end - start)
+    } else {
+        0
+    };
+    Some(ProfileEntry {
+        phase: phase.to_string(),
+        pack: pack.to_string(),
+        handler: handler.to_string(),
+        target: target.to_string(),
+        duration_us,
+        exit_status,
+    })
+}
+
+fn seconds_to_micros(secs: f64) -> u64 {
+    if !secs.is_finite() || secs < 0.0 {
+        return 0;
+    }
+    (secs * 1_000_000.0).round() as u64
+}
+
+/// Prune `<data_dir>/probes/shell-init/` to the newest `keep` files
+/// (by filename). Returns the number of files removed. `keep == 0`
+/// is treated as "no pruning" — we don't want a stray miscalibrated
+/// config to wipe the whole profile history.
+pub fn rotate_profiles(fs: &dyn Fs, paths: &dyn Pather, keep: usize) -> Result<usize> {
+    if keep == 0 {
+        return Ok(0);
+    }
+    let dir = paths.probes_shell_init_dir();
+    if !fs.is_dir(&dir) {
+        return Ok(0);
+    }
+    let mut entries: Vec<_> = fs
+        .read_dir(&dir)?
+        .into_iter()
+        .filter(|e| e.is_file && e.name.starts_with("profile-") && e.name.ends_with(".tsv"))
+        .collect();
+    if entries.len() <= keep {
+        return Ok(0);
+    }
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    let to_remove = entries.len() - keep;
+    let mut removed = 0;
+    for entry in entries.into_iter().take(to_remove) {
+        if fs.remove_file(&entry.path).is_ok() {
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+/// Aggregate one profile by `(pack, handler)` for the rendered table.
+#[derive(Debug, Clone, Serialize)]
+pub struct GroupedProfile {
+    pub groups: Vec<ProfileGroup>,
+    pub user_total_us: u64,
+    pub framing_us: u64,
+    pub total_us: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProfileGroup {
+    pub pack: String,
+    pub handler: String,
+    pub rows: Vec<ProfileEntry>,
+    pub group_total_us: u64,
+}
+
+/// Roll up a profile into per-(pack, handler) groups for display.
+/// The pack-then-handler ordering matches the deployment-map view.
+pub fn group_profile(profile: &Profile) -> GroupedProfile {
+    let user_total_us = profile.entries_duration_us();
+    let total_us = profile.total_duration_us.max(user_total_us);
+    let framing_us = total_us.saturating_sub(user_total_us);
+
+    let mut groups: Vec<ProfileGroup> = Vec::new();
+    for entry in &profile.entries {
+        let key = (&entry.pack, &entry.handler);
+        let pos = groups
+            .iter()
+            .position(|g| (&g.pack, &g.handler) == (key.0, key.1));
+        match pos {
+            Some(i) => {
+                groups[i].rows.push(entry.clone());
+                groups[i].group_total_us += entry.duration_us;
+            }
+            None => groups.push(ProfileGroup {
+                pack: entry.pack.clone(),
+                handler: entry.handler.clone(),
+                rows: vec![entry.clone()],
+                group_total_us: entry.duration_us,
+            }),
+        }
+    }
+
+    GroupedProfile {
+        groups,
+        user_total_us,
+        framing_us,
+        total_us,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TempEnvironment;
+
+    fn write_profile(env: &TempEnvironment, name: &str, content: &str) -> std::path::PathBuf {
+        let dir = env.paths.probes_shell_init_dir();
+        env.fs.mkdir_all(&dir).unwrap();
+        let path = dir.join(name);
+        env.fs.write_file(&path, content.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn parser_extracts_preamble_and_rows() {
+        let content = "# dodot shell-init profile v1\n\
+# shell\tbash 5.2\n\
+# start_t\t1714000000.000000\n\
+# init_script\t/x/dodot-init.sh\n\
+# columns\tphase\tpack\thandler\ttarget\tstart_t\tend_t\texit_status\n\
+path\tvim\tpath\t/x/bin\t1714000000.001000\t1714000000.001005\t0\n\
+source\tgit\tshell\t/x/aliases.sh\t1714000000.002000\t1714000000.005000\t0\n\
+# end_t\t1714000000.010000\n";
+        let p = parse_profile("profile-1714000000-1-1.tsv", content);
+        assert_eq!(p.shell, "bash 5.2");
+        assert_eq!(p.entries.len(), 2);
+        assert_eq!(p.entries[0].phase, "path");
+        assert_eq!(p.entries[0].duration_us, 5);
+        assert_eq!(p.entries[1].duration_us, 3000);
+        assert_eq!(p.total_duration_us, 10_000);
+    }
+
+    #[test]
+    fn parser_skips_malformed_rows() {
+        let content = "# columns\tphase\tpack\thandler\ttarget\tstart_t\tend_t\texit_status\n\
+junk\trow\twith\ttoo\tfew\tcols\n\
+path\tvim\tpath\t/x\t1.0\t1.001\t0\n\
+weird\tphase\twrong\t/x\t1.0\t1.001\t0\n";
+        let p = parse_profile("p.tsv", content);
+        assert_eq!(p.entries.len(), 1);
+        assert_eq!(p.entries[0].phase, "path");
+    }
+
+    #[test]
+    fn parser_handles_missing_end_marker() {
+        // Crashed shell: writes start_t and rows, but never reaches the
+        // epilogue. We still want a usable Profile.
+        let content = "# start_t\t1714000000.000000\n\
+source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
+        let p = parse_profile("p.tsv", content);
+        assert_eq!(p.total_duration_us, 0); // no end_t → 0 total
+        assert_eq!(p.entries.len(), 1);
+        assert_eq!(p.entries[0].duration_us, 1000);
+    }
+
+    #[test]
+    fn read_latest_returns_none_when_dir_missing() {
+        let env = TempEnvironment::builder().build();
+        let r = read_latest_profile(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn read_latest_picks_highest_filename_lexicographically() {
+        let env = TempEnvironment::builder().build();
+        write_profile(&env, "profile-1000-1-1.tsv", "# shell\told\n");
+        write_profile(&env, "profile-2000-1-1.tsv", "# shell\tnew\n");
+        write_profile(&env, "profile-1500-1-1.tsv", "# shell\tmid\n");
+        let p = read_latest_profile(env.fs.as_ref(), env.paths.as_ref())
+            .unwrap()
+            .unwrap();
+        assert_eq!(p.shell, "new");
+        assert_eq!(p.filename, "profile-2000-1-1.tsv");
+    }
+
+    #[test]
+    fn rotate_keeps_newest_n() {
+        let env = TempEnvironment::builder().build();
+        for i in 0..10 {
+            write_profile(&env, &format!("profile-{i:04}-1-1.tsv"), "x");
+        }
+        let removed = rotate_profiles(env.fs.as_ref(), env.paths.as_ref(), 3).unwrap();
+        assert_eq!(removed, 7);
+        let remaining: Vec<String> = env
+            .fs
+            .read_dir(&env.paths.probes_shell_init_dir())
+            .unwrap()
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+        // The three highest-numbered (newest) files survive.
+        assert_eq!(
+            remaining,
+            vec![
+                "profile-0007-1-1.tsv".to_string(),
+                "profile-0008-1-1.tsv".to_string(),
+                "profile-0009-1-1.tsv".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn rotate_with_keep_zero_is_a_noop() {
+        // Defensive: a misconfigured keep_last_runs = 0 must not wipe
+        // the user's profile history. Treat as "no rotation".
+        let env = TempEnvironment::builder().build();
+        for i in 0..3 {
+            write_profile(&env, &format!("profile-{i}-1-1.tsv"), "x");
+        }
+        let removed = rotate_profiles(env.fs.as_ref(), env.paths.as_ref(), 0).unwrap();
+        assert_eq!(removed, 0);
+        let count = env
+            .fs
+            .read_dir(&env.paths.probes_shell_init_dir())
+            .unwrap()
+            .len();
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn rotate_below_threshold_is_a_noop() {
+        let env = TempEnvironment::builder().build();
+        write_profile(&env, "profile-1-1-1.tsv", "x");
+        let removed = rotate_profiles(env.fs.as_ref(), env.paths.as_ref(), 100).unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn rotate_ignores_non_profile_files() {
+        let env = TempEnvironment::builder().build();
+        let dir = env.paths.probes_shell_init_dir();
+        env.fs.mkdir_all(&dir).unwrap();
+        env.fs
+            .write_file(&dir.join("profile-1-1-1.tsv"), b"")
+            .unwrap();
+        env.fs
+            .write_file(&dir.join("README"), b"do not delete")
+            .unwrap();
+        env.fs
+            .write_file(&dir.join("notes.txt"), b"keep me")
+            .unwrap();
+
+        let removed = rotate_profiles(env.fs.as_ref(), env.paths.as_ref(), 0).unwrap();
+        assert_eq!(removed, 0);
+        // All non-profile files survive even if we asked to rotate.
+        assert!(env.fs.exists(&dir.join("README")));
+        assert!(env.fs.exists(&dir.join("notes.txt")));
+    }
+
+    #[test]
+    fn group_profile_aggregates_by_pack_handler() {
+        let p = Profile {
+            filename: "x".into(),
+            shell: "bash".into(),
+            total_duration_us: 10_000,
+            entries: vec![
+                ProfileEntry {
+                    phase: "source".into(),
+                    pack: "vim".into(),
+                    handler: "shell".into(),
+                    target: "/a".into(),
+                    duration_us: 100,
+                    exit_status: 0,
+                },
+                ProfileEntry {
+                    phase: "source".into(),
+                    pack: "vim".into(),
+                    handler: "shell".into(),
+                    target: "/b".into(),
+                    duration_us: 200,
+                    exit_status: 0,
+                },
+                ProfileEntry {
+                    phase: "path".into(),
+                    pack: "vim".into(),
+                    handler: "path".into(),
+                    target: "/bin".into(),
+                    duration_us: 5,
+                    exit_status: 0,
+                },
+            ],
+        };
+        let g = group_profile(&p);
+        assert_eq!(g.groups.len(), 2);
+        assert_eq!(g.groups[0].pack, "vim");
+        assert_eq!(g.groups[0].handler, "shell");
+        assert_eq!(g.groups[0].group_total_us, 300);
+        assert_eq!(g.groups[1].handler, "path");
+        assert_eq!(g.user_total_us, 305);
+        assert_eq!(g.total_us, 10_000);
+        assert_eq!(g.framing_us, 9_695);
+    }
+
+    #[test]
+    fn group_profile_clamps_framing_when_total_below_entries() {
+        // If `total_duration_us` is missing (parse left it at 0) but
+        // we have entries, framing_us must be 0 — not negative.
+        let p = Profile {
+            filename: "x".into(),
+            shell: "".into(),
+            total_duration_us: 0,
+            entries: vec![ProfileEntry {
+                phase: "source".into(),
+                pack: "vim".into(),
+                handler: "shell".into(),
+                target: "/a".into(),
+                duration_us: 500,
+                exit_status: 0,
+            }],
+        };
+        let g = group_profile(&p);
+        assert_eq!(g.user_total_us, 500);
+        assert_eq!(g.total_us, 500);
+        assert_eq!(g.framing_us, 0);
+    }
+}

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -18,9 +18,27 @@
 //!
 //! In the future, this can also be exposed as `dodot init-sh` or
 //! a minimal standalone binary for even faster shell startup.
+//!
+//! # Profiling wrapper (Phase 2 of profiling.lex)
+//!
+//! When the caller passes `profiling_enabled = true`, the generator
+//! wraps every `source` and PATH line with an inline `EPOCHREALTIME`
+//! capture and writes one `profile-*.tsv` per shell start under
+//! `<data_dir>/probes/shell-init/`. The wrapper is gated on a runtime
+//! check (`bash 5+` / `zsh` with `EPOCHREALTIME` available); shells
+//! without the variable fall through to the unchanged source/PATH
+//! path with a single `[ "$_dodot_prof" = "1" ]` test of overhead.
+//! When `profiling_enabled = false`, the generated script is
+//! byte-identical to the pre-Phase-2 form.
+//!
+//! Sources are *not* wrapped in a shell function: in zsh, `source`
+//! inside a function changes scoping for plain variable assignments
+//! in the sourced file, which is a behavioural surprise nobody asked
+//! for. We pay the price of a slightly longer script in exchange for
+//! semantic equivalence with the un-instrumented form.
 
 use std::fmt::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::fs::Fs;
 use crate::paths::Pather;
@@ -42,8 +60,14 @@ fn append_empty_notice(script: &mut String) {
 /// - `packs/*/shell/*` — symlinks to shell scripts → `source` lines
 /// - `packs/*/path/*` — symlinks to directories → `PATH=` lines
 ///
-/// Returns the script content as a string.
-pub fn generate_init_script(fs: &dyn Fs, paths: &dyn Pather) -> Result<String> {
+/// When `profiling_enabled` is true and there is at least one entry to
+/// emit, the script also carries the per-line timing wrapper described
+/// in the module docs.
+pub fn generate_init_script(
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+    profiling_enabled: bool,
+) -> Result<String> {
     let mut script = String::new();
 
     writeln!(script, "#!/bin/sh").unwrap();
@@ -107,12 +131,26 @@ pub fn generate_init_script(fs: &dyn Fs, paths: &dyn Pather) -> Result<String> {
         return Ok(script);
     }
 
+    // Profiling preamble (only when enabled and there's at least one entry).
+    let profiling_active = profiling_enabled;
+    if profiling_active {
+        emit_profiling_preamble(
+            &mut script,
+            &paths.probes_shell_init_dir(),
+            &paths.init_script_path(),
+        );
+    }
+
     // Emit PATH additions
     if !path_additions.is_empty() {
         writeln!(script, "# PATH additions").unwrap();
         for (pack, target) in &path_additions {
             writeln!(script, "# [{pack}]").unwrap();
-            writeln!(script, "export PATH=\"{}:$PATH\"", target.display()).unwrap();
+            if profiling_active {
+                emit_timed_path(&mut script, pack, target);
+            } else {
+                writeln!(script, "export PATH=\"{}:$PATH\"", target.display()).unwrap();
+            }
         }
         writeln!(script).unwrap();
     }
@@ -122,15 +160,24 @@ pub fn generate_init_script(fs: &dyn Fs, paths: &dyn Pather) -> Result<String> {
         writeln!(script, "# Shell scripts").unwrap();
         for (pack, target) in &shell_sources {
             writeln!(script, "# [{pack}]").unwrap();
-            writeln!(
-                script,
-                "[ -f \"{}\" ] && . \"{}\"",
-                target.display(),
-                target.display()
-            )
-            .unwrap();
+            if profiling_active {
+                emit_timed_source(&mut script, pack, target);
+            } else {
+                writeln!(
+                    script,
+                    "[ -f \"{}\" ] && . \"{}\"",
+                    target.display(),
+                    target.display()
+                )
+                .unwrap();
+            }
         }
         writeln!(script).unwrap();
+    }
+
+    // Profiling epilogue (close the report, scrub our state).
+    if profiling_active {
+        emit_profiling_epilogue(&mut script);
     }
 
     Ok(script)
@@ -139,8 +186,12 @@ pub fn generate_init_script(fs: &dyn Fs, paths: &dyn Pather) -> Result<String> {
 /// Generate and write the init script to `data_dir/shell/dodot-init.sh`.
 ///
 /// Returns the path where the script was written.
-pub fn write_init_script(fs: &dyn Fs, paths: &dyn Pather) -> Result<PathBuf> {
-    let script_content = generate_init_script(fs, paths)?;
+pub fn write_init_script(
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+    profiling_enabled: bool,
+) -> Result<PathBuf> {
+    let script_content = generate_init_script(fs, paths, profiling_enabled)?;
     let script_path = paths.init_script_path();
 
     fs.mkdir_all(paths.shell_dir())?;
@@ -148,6 +199,156 @@ pub fn write_init_script(fs: &dyn Fs, paths: &dyn Pather) -> Result<PathBuf> {
     fs.set_permissions(&script_path, 0o755)?;
 
     Ok(script_path)
+}
+
+// ── Profiling wrapper emitters ───────────────────────────────────────
+
+/// The runtime-detection preamble. Sets `_dodot_prof` to `1` when the
+/// current shell is bash 5+ or zsh with `EPOCHREALTIME` available;
+/// otherwise leaves it `0` (the wrapper falls through to the no-op
+/// path). All shell variables are namespaced `_dodot_*` so we don't
+/// stomp on the user's environment.
+fn emit_profiling_preamble(script: &mut String, profiles_dir: &Path, init_script_path: &Path) {
+    let dir = sh_quote(&profiles_dir.display().to_string());
+    let init_script = sh_quote(&init_script_path.display().to_string());
+    writeln!(script, "# ── dodot shell-init profiling (Phase 2) ──").unwrap();
+    writeln!(script, "_dodot_prof=0").unwrap();
+    writeln!(
+        script,
+        "if [ -n \"${{BASH_VERSION:-}}\" ] || [ -n \"${{ZSH_VERSION:-}}\" ]; then"
+    )
+    .unwrap();
+    // zsh exposes EPOCHREALTIME only after `zmodload zsh/datetime`. Load
+    // it eagerly here; bash 5+ has the variable built in and ignores
+    // unknown commands like `zmodload` (we suppress its `command not
+    // found` error). Doing this *inside* the bash/zsh guard keeps it off
+    // hot paths in plain sh.
+    writeln!(
+        script,
+        "  [ -n \"${{ZSH_VERSION:-}}\" ] && zmodload zsh/datetime 2>/dev/null"
+    )
+    .unwrap();
+    writeln!(script, "  if [ -n \"${{EPOCHREALTIME:-}}\" ]; then").unwrap();
+    writeln!(script, "    _dodot_prof_dir={dir}").unwrap();
+    writeln!(
+        script,
+        "    _dodot_prof_file=\"$_dodot_prof_dir/profile-${{EPOCHSECONDS:-0}}-$$-${{RANDOM}}.tsv\""
+    )
+    .unwrap();
+    writeln!(
+        script,
+        "    if mkdir -p \"$_dodot_prof_dir\" 2>/dev/null; then"
+    )
+    .unwrap();
+    writeln!(script, "      _dodot_prof_t0=$EPOCHREALTIME").unwrap();
+    writeln!(script, "      {{").unwrap();
+    writeln!(script, "        printf '# dodot shell-init profile v1\\n'").unwrap();
+    writeln!(
+        script,
+        "        printf '# shell\\t%s\\n' \"${{BASH_VERSION:+bash $BASH_VERSION}}${{ZSH_VERSION:+zsh $ZSH_VERSION}}\""
+    )
+    .unwrap();
+    writeln!(
+        script,
+        "        printf '# start_t\\t%s\\n' \"$_dodot_prof_t0\""
+    )
+    .unwrap();
+    writeln!(
+        script,
+        "        printf '# init_script\\t%s\\n' {init_script}"
+    )
+    .unwrap();
+    writeln!(
+        script,
+        "        printf '# columns\\tphase\\tpack\\thandler\\ttarget\\tstart_t\\tend_t\\texit_status\\n'"
+    )
+    .unwrap();
+    writeln!(
+        script,
+        "      }} > \"$_dodot_prof_file\" 2>/dev/null && _dodot_prof=1"
+    )
+    .unwrap();
+    writeln!(script, "    fi").unwrap();
+    writeln!(script, "  fi").unwrap();
+    writeln!(script, "fi").unwrap();
+    writeln!(script).unwrap();
+}
+
+/// One inline-timed `export PATH=…` row. The branch is one comparison
+/// at runtime — negligible on shells where the wrapper is inert.
+fn emit_timed_path(script: &mut String, pack: &str, target: &Path) {
+    let target_str = target.display().to_string();
+    let target_q = sh_quote(&target_str);
+    writeln!(script, "if [ \"$_dodot_prof\" = \"1\" ]; then").unwrap();
+    writeln!(
+        script,
+        "  _dodot_t0=$EPOCHREALTIME; export PATH=\"{target_str}:$PATH\"; _dodot_t1=$EPOCHREALTIME"
+    )
+    .unwrap();
+    writeln!(
+        script,
+        "  printf 'path\\t{pack}\\tpath\\t%s\\t%s\\t%s\\t0\\n' {target_q} \"$_dodot_t0\" \"$_dodot_t1\" >> \"$_dodot_prof_file\" 2>/dev/null"
+    )
+    .unwrap();
+    writeln!(script, "else").unwrap();
+    writeln!(script, "  export PATH=\"{target_str}:$PATH\"").unwrap();
+    writeln!(script, "fi").unwrap();
+}
+
+/// One inline-timed `[ -f X ] && . X` row, capturing the source's
+/// exit status. Same overhead profile as the PATH variant.
+fn emit_timed_source(script: &mut String, pack: &str, target: &Path) {
+    let target_str = target.display().to_string();
+    let target_q = sh_quote(&target_str);
+    writeln!(script, "if [ \"$_dodot_prof\" = \"1\" ]; then").unwrap();
+    writeln!(
+        script,
+        "  _dodot_t0=$EPOCHREALTIME; [ -f \"{target_str}\" ] && . \"{target_str}\"; _dodot_rc=$?; _dodot_t1=$EPOCHREALTIME"
+    )
+    .unwrap();
+    writeln!(
+        script,
+        "  printf 'source\\t{pack}\\tshell\\t%s\\t%s\\t%s\\t%s\\n' {target_q} \"$_dodot_t0\" \"$_dodot_t1\" \"$_dodot_rc\" >> \"$_dodot_prof_file\" 2>/dev/null"
+    )
+    .unwrap();
+    writeln!(script, "else").unwrap();
+    writeln!(script, "  [ -f \"{target_str}\" ] && . \"{target_str}\"").unwrap();
+    writeln!(script, "fi").unwrap();
+}
+
+/// Closes out the report (writes the `# end_t` marker) and clears
+/// every `_dodot_*` shell variable so we don't leak state into the
+/// user's interactive shell.
+fn emit_profiling_epilogue(script: &mut String) {
+    writeln!(script, "# ── dodot shell-init profiling epilogue ──").unwrap();
+    writeln!(script, "if [ \"$_dodot_prof\" = \"1\" ]; then").unwrap();
+    writeln!(
+        script,
+        "  printf '# end_t\\t%s\\n' \"$EPOCHREALTIME\" >> \"$_dodot_prof_file\" 2>/dev/null"
+    )
+    .unwrap();
+    writeln!(script, "fi").unwrap();
+    writeln!(
+        script,
+        "unset _dodot_prof _dodot_prof_dir _dodot_prof_file _dodot_prof_t0 _dodot_t0 _dodot_t1 _dodot_rc 2>/dev/null"
+    )
+    .unwrap();
+}
+
+/// Single-quote a string for safe use in POSIX shell. Embedded single
+/// quotes are escaped via the `'\''` idiom.
+fn sh_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
 }
 
 #[cfg(test)]
@@ -175,7 +376,7 @@ mod tests {
     #[test]
     fn empty_datastore_produces_helpful_script() {
         let env = TempEnvironment::builder().build();
-        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
 
         assert!(script.starts_with("#!/bin/sh"));
         assert!(script.contains("Generated by dodot"));
@@ -199,7 +400,7 @@ mod tests {
         let source = env.dotfiles_root.join("vim/aliases.sh");
         ds.create_data_link("vim", "shell", &source).unwrap();
 
-        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
 
         assert!(script.contains("# Shell scripts"), "script:\n{script}");
         assert!(script.contains("# [vim]"), "script:\n{script}");
@@ -225,7 +426,7 @@ mod tests {
         let source = env.dotfiles_root.join("vim/bin");
         ds.create_data_link("vim", "path", &source).unwrap();
 
-        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
 
         assert!(script.contains("# PATH additions"), "script:\n{script}");
         assert!(script.contains("# [vim]"), "script:\n{script}");
@@ -259,7 +460,7 @@ mod tests {
         ds.create_data_link("vim", "path", &env.dotfiles_root.join("vim/bin"))
             .unwrap();
 
-        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
 
         // Should have both shell sources
         assert!(script.contains("# [git]"), "script:\n{script}");
@@ -286,7 +487,7 @@ mod tests {
         ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
             .unwrap();
 
-        let script_path = write_init_script(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let script_path = write_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
 
         assert_eq!(script_path, env.paths.init_script_path());
         env.assert_exists(&script_path);
@@ -312,20 +513,20 @@ mod tests {
         let ds = make_datastore(&env);
 
         // Initially empty
-        let script1 = generate_init_script(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let script1 = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
         assert!(!script1.contains("aliases.sh"));
 
         // Deploy shell script
         ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
             .unwrap();
 
-        let script2 = generate_init_script(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let script2 = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
         assert!(script2.contains("aliases.sh"));
 
         // Remove state
         ds.remove_state("vim", "shell").unwrap();
 
-        let script3 = generate_init_script(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let script3 = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
         assert!(!script3.contains("aliases.sh"));
     }
 
@@ -340,7 +541,7 @@ mod tests {
             .write_file(&shell_dir.join("not-a-symlink"), b"noise")
             .unwrap();
 
-        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
         assert!(!script.contains("not-a-symlink"));
     }
 
@@ -359,7 +560,7 @@ mod tests {
         ds.create_data_link("vim", "path", &env.dotfiles_root.join("vim/bin"))
             .unwrap();
 
-        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
 
         let path_pos = script.find("# PATH additions").unwrap();
         let shell_pos = script.find("# Shell scripts").unwrap();
@@ -367,5 +568,126 @@ mod tests {
             path_pos < shell_pos,
             "PATH additions should come before shell sources"
         );
+    }
+
+    // ── Phase 2: profiling wrapper ──────────────────────────────────
+
+    #[test]
+    fn profiling_disabled_matches_phase1_byte_for_byte() {
+        // The contract: when profiling is off, the script must be the
+        // exact same bytes a Phase-1 generator would have produced. This
+        // protects users who don't want any change to their init script.
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "alias vi=vim")
+            .done()
+            .build();
+
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
+        assert!(!script.contains("_dodot_prof"));
+        assert!(!script.contains("EPOCHREALTIME"));
+        assert!(!script.contains("dodot shell-init profile"));
+    }
+
+    #[test]
+    fn profiling_enabled_emits_runtime_gated_preamble() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "alias vi=vim")
+            .done()
+            .build();
+
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
+
+        // Preamble feature-detects bash 5+ / zsh + EPOCHREALTIME
+        assert!(script.contains("BASH_VERSION"));
+        assert!(script.contains("ZSH_VERSION"));
+        assert!(script.contains("EPOCHREALTIME"));
+        // The profile dir comes from Pather, so the script should embed it.
+        assert!(script.contains(env.paths.probes_shell_init_dir().to_str().unwrap()));
+        // File naming includes pid + RANDOM for collision-resistance.
+        assert!(script.contains("$$"));
+        assert!(script.contains("RANDOM"));
+        // Header lines we always emit.
+        assert!(script.contains("# dodot shell-init profile v1"));
+        assert!(script.contains("columns\\tphase\\tpack\\thandler\\ttarget"));
+    }
+
+    #[test]
+    fn profiling_enabled_wraps_each_source_with_else_path() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "")
+            .file("bin/tool", "#!/bin/sh")
+            .done()
+            .build();
+
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+        ds.create_data_link("vim", "path", &env.dotfiles_root.join("vim/bin"))
+            .unwrap();
+
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
+
+        // Each entry has an if/else so unprofiled shells still source / set PATH.
+        // (One else per entry; the epilogue uses an if-only form, so counting
+        // `else` keeps us focused on the entry wrappers.)
+        let else_count = script.matches("else").count();
+        assert_eq!(
+            else_count, 2,
+            "expected one else-branch per entry; script:\n{script}"
+        );
+
+        // Source row carries the captured exit status; PATH row hard-codes 0.
+        assert!(script.contains("printf 'source\\tvim\\tshell\\t"));
+        assert!(script.contains("printf 'path\\tvim\\tpath\\t"));
+        assert!(script.contains("\"$_dodot_rc\""));
+    }
+
+    #[test]
+    fn profiling_epilogue_writes_end_marker_and_unsets_state() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "")
+            .done()
+            .build();
+
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
+        // End-of-run timestamp.
+        assert!(script.contains("# end_t"));
+        // We scrub our state to avoid leaking into the user's shell.
+        assert!(script.contains("unset _dodot_prof"));
+        assert!(script.contains("_dodot_prof_file"));
+    }
+
+    #[test]
+    fn profiling_enabled_with_empty_datastore_skips_preamble() {
+        // No deployed entries → empty notice only, no profiling boilerplate.
+        let env = TempEnvironment::builder().build();
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
+        assert!(script.contains("No shell scripts or PATH additions"));
+        assert!(!script.contains("_dodot_prof"));
+    }
+
+    #[test]
+    fn shell_quoting_handles_paths_with_single_quotes() {
+        // A path with a single quote in it must round-trip safely
+        // through the printf args. Embedded `'` becomes `'\''`.
+        assert_eq!(sh_quote("plain"), "'plain'");
+        assert_eq!(sh_quote("it's"), "'it'\\''s'");
+        assert_eq!(sh_quote(""), "''");
     }
 }

--- a/crates/dodot-lib/src/templates/probe.jinja
+++ b/crates/dodot-lib/src/templates/probe.jinja
@@ -20,4 +20,23 @@
 
 {% for line in lines %}{{ line.prefix }}{{ line.name }}{% if line.annotation %} [dim]{{ line.annotation }}[/dim]{% endif %}
 {% endfor %}
+{%- elif kind == "shell-init" -%}
+[header]Shell-init profile[/header]
+{% if has_profile %}  [dim]run:[/dim] {{ filename }}
+  [dim]shell:[/dim] {{ shell }}
+
+{% for g in groups %}  [pack-name]{{ g.pack }}[/pack-name] [description]/[/description] [handler-symbol]{{ g.handler }}[/handler-symbol] [dim]({{ g.group_total_label }})[/dim]
+{% for r in g.rows %}    {{ r.target | col(36) }} [{{ r.status_class }}]{{ r.duration_label | col(10) }}[/{{ r.status_class }}]{% if r.exit_status != 0 %} [error]exit {{ r.exit_status }}[/error]{% endif %}
+{% endfor %}{% endfor %}
+  [dim]──[/dim]
+  user-sourced total   [deployed]{{ user_total_us }} µs[/deployed]
+  dodot framing        [dim]{{ framing_us }} µs[/dim]
+  grand total          [header]{{ total_us }} µs[/header]
+{% else %}{% if profiling_enabled %}  [dim](no profile yet — open a new shell that sources `dodot-init.sh`,[/dim]
+  [dim] then re-run `dodot probe shell-init`)[/dim]
+{% else %}  [dim](profiling is disabled in config — set [profiling] enabled = true,[/dim]
+  [dim] run `dodot up`, then start a new shell)[/dim]
+{% endif %}{% endif %}
+  [dim]profiles dir:[/dim] {{ profiles_dir }}
+  [dim]for intra-file profiling, see `zprof` (zsh) or PS4 tracing (bash).[/dim]
 {%- endif -%}

--- a/docs/proposals/profiling.lex
+++ b/docs/proposals/profiling.lex
@@ -163,14 +163,14 @@ Design Specification: Profiling and the Probe Command
 
 7. Phased Implementation
 
-    Phase 1: deployment map and `probe show-data-dir`.
+    Phase 1: deployment map and `probe show-data-dir`. **(Shipped.)**
         No init-script changes. Wire `deployment-map.tsv` writing into the tail of `commands::up` and `commands::down` alongside `shell::write_init_script`. Ship `probe`, `probe show-data-dir`, and `probe deployment-map`. This alone unblocks `dodot refresh` from @./magic.lex.
 
-    Phase 2: shell-init timing.
-        Extend `shell::generate_init_script` to emit the per-file timing wrapper and the preamble writer. Wire `probe shell-init` reader and the default (single-run) view. Add the `profiling` config section.
+    Phase 2: shell-init timing. **(Shipped.)**
+        Extend `shell::generate_init_script` to emit the per-file timing wrapper and the preamble writer. Wire `probe shell-init` reader and the default (single-run) view. Add the `profiling` config section. Rotation also lands here (cheaper to ship together than to defer): the writer side has no rotation logic, but `dodot up` prunes `<data_dir>/probes/shell-init/` to `keep_last_runs` at the end of every run.
 
     Phase 3: aggregation.
-        Add `--runs N` and `--history` flags to `probe shell-init`. Rotation runs at `dodot up` time (prune `<data_dir>/probes/shell-init/` to `keep_last_runs` entries by filename sort).
+        Add `--runs N` and `--history` flags to `probe shell-init` for cross-run views (p50/p95/max per target, trend over recent runs). Rotation already runs in Phase 2, so this phase is purely additive on the reader side.
 
     Phase 4: regression hints (optional).
         If phase 3 reveals an appetite for it, teach `probe shell-init` to highlight targets whose current-run duration is above their historical p95. Pure presentation; same data. We do not plan this as table stakes.

--- a/tests/e2e/bats/test_shell_init_profiling.bats
+++ b/tests/e2e/bats/test_shell_init_profiling.bats
@@ -1,0 +1,181 @@
+#!/usr/bin/env bats
+# E2E tests for shell-init profiling (Phase 2):
+# - Generated init script is bash/zsh-compatible and writes a profile file
+# - `dodot probe shell-init` reads the latest profile back
+# - Profiling can be disabled via config
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+# ── Profile file is written when a shell sources the init script ──
+
+@test "bash sourcing dodot-init.sh writes a profile TSV" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    create_pack_bin "vim" "tool" '#!/bin/sh
+echo hi'
+    dodot up
+
+    # Source the init script in a real bash subshell.
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+    [ "$?" -eq 0 ]
+
+    # Exactly one profile file should have been written.
+    local profiles_dir="$XDG_DATA_HOME/dodot/probes/shell-init"
+    assert_dir_exists "$profiles_dir"
+    local count
+    count=$(find "$profiles_dir" -name 'profile-*.tsv' -type f | wc -l | tr -d ' ')
+    [ "$count" = "1" ]
+}
+
+@test "profile contains preamble, one row per entry, and an end marker" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    create_pack_bin "vim" "tool" '#!/bin/sh
+echo hi'
+    dodot up
+
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+
+    local profile
+    profile=$(find "$XDG_DATA_HOME/dodot/probes/shell-init" -name 'profile-*.tsv' -type f | head -1)
+    [ -n "$profile" ]
+
+    assert_file_contains "$profile" "# dodot shell-init profile v1"
+    assert_file_contains "$profile" "# shell"
+    assert_file_contains "$profile" "# start_t"
+    assert_file_contains "$profile" "# end_t"
+    # One PATH row + one source row.
+    assert_file_contains "$profile" "^path	vim	path"
+    assert_file_contains "$profile" "^source	vim	shell"
+}
+
+@test "concurrent shells get distinct profile files" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+
+    # Three sub-shells in quick succession — distinct PIDs + RANDOM
+    # should keep filenames unique even within the same EPOCHSECONDS.
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+
+    local count
+    count=$(find "$XDG_DATA_HOME/dodot/probes/shell-init" -name 'profile-*.tsv' -type f | wc -l | tr -d ' ')
+    [ "$count" = "3" ]
+}
+
+# ── `dodot probe shell-init` rendering ────────────────────────────
+
+@test "probe shell-init renders the latest profile" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+
+    run dodot probe shell-init
+    [ "$status" -eq 0 ]
+    assert_output_contains "Shell-init profile"
+    assert_output_contains "vim"
+    assert_output_contains "shell"
+    assert_output_contains "aliases.sh"
+    # Some duration label (µs / ms / s) should appear next to the row.
+    [[ "$output" == *"µs"* || "$output" == *"ms"* ]]
+}
+
+@test "probe shell-init shows hint when no profile has been written" {
+    # Profiling is on by default, but no shell has sourced the init
+    # script yet — so the dir is empty / missing.
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+
+    run dodot probe shell-init
+    [ "$status" -eq 0 ]
+    assert_output_contains "no profile yet"
+}
+
+@test "probe summary lists shell-init alongside the others" {
+    run dodot probe
+    [ "$status" -eq 0 ]
+    assert_output_contains "shell-init"
+    assert_output_contains "deployment-map"
+    assert_output_contains "show-data-dir"
+}
+
+@test "probe shell-init --output json has the right shape" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+
+    run dodot --output json probe shell-init
+    [ "$status" -eq 0 ]
+    assert_output_contains '"kind"'
+    assert_output_contains '"shell-init"'
+    assert_output_contains '"has_profile"'
+    assert_output_contains '"groups"'
+    assert_output_contains '"total_us"'
+}
+
+# ── Disabling profiling via config ────────────────────────────────
+
+@test "init script omits profiling wrapper when disabled in config" {
+    create_root_config '[profiling]\nenabled = false'
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+
+    local script="$XDG_DATA_HOME/dodot/shell/dodot-init.sh"
+    assert_exists "$script"
+    # No profiling boilerplate.
+    run grep -F "_dodot_prof" "$script"
+    [ "$status" -ne 0 ]
+    run grep -F "EPOCHREALTIME" "$script"
+    [ "$status" -ne 0 ]
+
+    # Sourcing it must not write a profile (no instrumentation present).
+    bash -c ". $script"
+    if [ -d "$XDG_DATA_HOME/dodot/probes/shell-init" ]; then
+        local count
+        count=$(find "$XDG_DATA_HOME/dodot/probes/shell-init" -name 'profile-*.tsv' -type f | wc -l | tr -d ' ')
+        [ "$count" = "0" ]
+    fi
+}
+
+@test "probe shell-init explains when profiling is disabled" {
+    create_root_config '[profiling]\nenabled = false'
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+
+    run dodot probe shell-init
+    [ "$status" -eq 0 ]
+    assert_output_contains "profiling is disabled"
+}
+
+# ── Rotation ──────────────────────────────────────────────────────
+
+@test "dodot up rotates old profiles to keep_last_runs" {
+    create_root_config '[profiling]\nkeep_last_runs = 2'
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+
+    # Hand-create five fake profile files older than today's
+    # rotation moment, then run `up` again to trigger pruning.
+    local d="$XDG_DATA_HOME/dodot/probes/shell-init"
+    mkdir -p "$d"
+    for i in 1 2 3 4 5; do
+        printf '# dodot shell-init profile v1\n' > "$d/profile-${i}-1-1.tsv"
+    done
+
+    dodot up
+
+    local count
+    count=$(find "$d" -name 'profile-*.tsv' -type f | wc -l | tr -d ' ')
+    [ "$count" = "2" ]
+
+    # The newest two (highest names) survive.
+    assert_exists "$d/profile-4-1-1.tsv"
+    assert_exists "$d/profile-5-1-1.tsv"
+    assert_not_exists "$d/profile-1-1-1.tsv"
+}


### PR DESCRIPTION
## Summary

Phase 2 of `docs/proposals/profiling.lex` — the part that actually measures shell startup. Builds on the Phase 1 `dodot probe` skeleton (#55) and turns the `shell-init` slot from "coming soon" into a working timing pipeline.

### What's in

- **Generated init script gains a runtime-detected timing wrapper.** When `[profiling] enabled = true` (the new default), every `source` and `PATH` line in `dodot-init.sh` is wrapped with `EPOCHREALTIME` start/end captures and an `exit_status` for sources. On bash 5+ / zsh, each shell startup writes one TSV under `<data_dir>/probes/shell-init/profile-<unix_ts>-<pid>-<rand>.tsv`. Older shells (`/bin/sh`, bash <5) fall through to the unchanged source/PATH path with one extra comparison of overhead.
- **`dodot probe shell-init`** — reads the most recent profile, groups it by `(pack, handler)`, prints per-row durations, per-group subtotals, and a `user-sourced / dodot-framing / grand total` breakdown. Useful "no profile yet" / "profiling disabled" hints when there is nothing to show. Also has `--output json`.
- **New `[profiling]` config section** (root-only): `enabled` (default `true`) and `keep_last_runs` (default `100`). `enabled = false` makes the generated script byte-identical to Phase 1.
- **Rotation** runs at the end of `dodot up`, not in the shell wrapper. `keep_last_runs = 0` is treated as a no-op rather than wiping history (defensive against a stray miscalibrated config).
- **Hidden failures become visible.** Today `[ -f X ] && . X` swallows source errors; the new wrapper records `exit_status` per source, and `probe shell-init` highlights non-zero rows.

### Design calls worth flagging

- **No shell function around `source`.** `source` inside a zsh function changes the scoping rules for plain variable assignments in the sourced file. Wrapping in a function would shrink the generated script but break user shells subtly. Inline if/else is the safer choice; you pay it in script size, not behaviour.
- **zsh `zmodload zsh/datetime`.** zsh exposes `EPOCHREALTIME` only after this module is loaded (unlike bash, which has it built in). The preamble loads it conditionally inside the `bash/zsh` guard; bash ignores the unknown command via stderr suppression.
- **Reader / rotator are tolerant.** Partial writes from a crashed shell, missing `# end_t`, malformed rows — all parse to a usable `Profile` rather than crashing.

### Test plan
- [x] 18 new unit tests (config: 1, shell init script generator: 6, probe::shell_init parser/rotator/aggregator: 11)
- [x] 10 new bats e2e tests (`tests/e2e/bats/test_shell_init_profiling.bats`) — actually run a real bash subshell, source the generated script, and verify the profile lands on disk and reads back through `dodot probe shell-init`. Includes concurrent-shells uniqueness, disabled-via-config no-instrumentation check, and rotation behavior.
- [x] `cargo test` — 458 pass (was 440 in Phase 1)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `bats tests/e2e/bats/` — 137 pass (was 127 in Phase 1)
- [x] Manually verified the generated script in real bash 5.3.9 and zsh 5.9 — both write profiles with microsecond timestamps. `/bin/sh` (bash 3 in posix mode) gracefully no-ops.

### Follow-ups (out of scope)
- Phase 3: `--runs N` aggregation, p50/p95, `--history` trend view
- Phase 4: optional regression hints (current run vs. historical p95)

🤖 Generated with [Claude Code](https://claude.com/claude-code)