### PR TITLE
feat(probe): --runs and --history aggregation (profiling Phase 3)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -7,3 +7,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
 `### Removed`, `### Fixed`, `### Security`) so they nest cleanly under the
 `## [version]` heading the release workflow inserts.
+
+### Added
+
+- **`dodot probe shell-init --runs N`** — aggregate the last N
+  shell-startup profiles into a per-target table of `p50 / p95 / max`
+  durations plus a `runs_seen / runs_total` ratio. Targets sort by
+  `(pack, handler, target)` to match the deployment-map view.
+  Percentiles use nearest-rank (no interpolation), which is the right
+  resolution for sub-millisecond shell timings. When fewer than `N`
+  profiles exist on disk the renderer warns "(requested N)" so the
+  user can tell the data is sparse.
+- **`dodot probe shell-init --history`** — one summary row per recent
+  shell startup, oldest first, capped at 50 rows. Each row carries the
+  parsed unix timestamp, shell label, total / user-sourced durations,
+  entry count, and the count of entries with a non-zero
+  `exit_status` — turning the once-silent "this source failed" signal
+  into a single column on a trend view.
+- Both new views honour `--output json` and serialize as
+  `kind = "shell-init-aggregate"` / `kind = "shell-init-history"`.
+  The JSON also includes raw `_us` fields alongside the humanised
+  labels for programmatic consumers.

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -242,12 +242,27 @@ pub fn probe_show_data_dir_handler(
 }
 
 /// `dodot probe shell-init` — most recent shell-startup profile.
+///
+/// Three views, switched by mutually-exclusive flags:
+/// - default: single-run detail (most recent profile)
+/// - `--runs N`: per-target percentile aggregate over the last N runs
+/// - `--history`: one-row-per-run trend, oldest first
 pub fn probe_shell_init_handler(
     matches: &clap::ArgMatches,
     _ctx: &CommandContext,
 ) -> HandlerResult<commands::probe::ProbeResult> {
     let ctx = build_readonly_ctx(matches)?;
-    Ok(Output::Render(commands::probe::shell_init(&ctx)?))
+    let runs = matches.get_one::<usize>("runs").copied();
+    let history = flag_or_false(matches, "history");
+
+    let result = if let Some(n) = runs {
+        commands::probe::shell_init_aggregate(&ctx, n)?
+    } else if history {
+        commands::probe::shell_init_history(&ctx, commands::probe::DEFAULT_HISTORY_LIMIT)?
+    } else {
+        commands::probe::shell_init(&ctx)?
+    };
+    Ok(Output::Render(result))
 }
 
 // ── Passthrough handlers (bypass standout rendering) ────────────

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -361,9 +361,24 @@ fn build_clap_command() -> ClapCommand {
                         ),
                 )
                 .subcommand(
-                    ClapCommand::new("shell-init").about(
-                        "Per-source timings for the most recent shell startup",
-                    ),
+                    ClapCommand::new("shell-init")
+                        .about("Per-source timings for the most recent shell startup")
+                        .arg(
+                            Arg::new("runs")
+                                .long("runs")
+                                .help(
+                                    "Aggregate the last N runs into per-target p50/p95/max",
+                                )
+                                .value_parser(clap::value_parser!(usize))
+                                .num_args(1)
+                                .conflicts_with("history"),
+                        )
+                        .arg(
+                            Arg::new("history")
+                                .long("history")
+                                .help("Show one summary row per recent run, oldest first")
+                                .action(ArgAction::SetTrue),
+                        ),
                 ),
         )
 }

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -367,10 +367,13 @@ fn build_clap_command() -> ClapCommand {
                             Arg::new("runs")
                                 .long("runs")
                                 .help(
-                                    "Aggregate the last N runs into per-target p50/p95/max",
+                                    "Aggregate the last N runs into per-target p50/p95/max (defaults to 10 if N is omitted)",
                                 )
                                 .value_parser(clap::value_parser!(usize))
-                                .num_args(1)
+                                // Optional value: `--runs` alone uses
+                                // DEFAULT_RUNS, `--runs 5` overrides.
+                                .num_args(0..=1)
+                                .default_missing_value("10")
                                 .conflicts_with("history"),
                         )
                         .arg(

--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -13,8 +13,9 @@ use serde::Serialize;
 
 use crate::packs::orchestration::ExecutionContext;
 use crate::probe::{
-    collect_data_dir_tree, collect_deployment_map, group_profile, read_latest_profile,
-    DeploymentMapEntry, GroupedProfile, TreeNode,
+    aggregate_profiles, collect_data_dir_tree, collect_deployment_map, group_profile,
+    read_latest_profile, read_recent_profiles, summarize_history, AggregatedTarget,
+    DeploymentMapEntry, GroupedProfile, HistoryEntry, TreeNode,
 };
 use crate::Result;
 
@@ -85,6 +86,78 @@ pub enum ProbeResult {
     /// `dodot probe shell-init` — the most recent shell-startup profile,
     /// grouped by pack and handler.
     ShellInit(ShellInitView),
+    /// `dodot probe shell-init --runs N` — per-target percentile stats
+    /// across the last N runs.
+    ShellInitAggregate(ShellInitAggregateView),
+    /// `dodot probe shell-init --history` — one summary line per recent
+    /// run, oldest run first (so the latest is closest to the eye in a
+    /// terminal where output scrolls down).
+    ShellInitHistory(ShellInitHistoryView),
+}
+
+/// Display payload for `--runs N`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitAggregateView {
+    /// How many profiles were actually loaded (may be smaller than the
+    /// requested N if there aren't enough on disk yet).
+    pub runs: usize,
+    /// User-requested N (echoed back so the renderer can say
+    /// "showing 4 of last 10 requested").
+    pub requested_runs: usize,
+    pub profiling_enabled: bool,
+    pub profiles_dir: String,
+    pub rows: Vec<ShellInitAggregateRow>,
+}
+
+/// One per-target aggregate row, durations pre-humanised for the
+/// template.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitAggregateRow {
+    pub pack: String,
+    pub handler: String,
+    pub target: String,
+    pub p50_label: String,
+    pub p95_label: String,
+    pub max_label: String,
+    pub p50_us: u64,
+    pub p95_us: u64,
+    pub max_us: u64,
+    /// e.g. `"7/10"` — formatted at the lib so JSON consumers and the
+    /// template both render identically.
+    pub seen_label: String,
+    pub runs_seen: usize,
+    pub runs_total: usize,
+}
+
+/// Display payload for `--history`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitHistoryView {
+    pub profiling_enabled: bool,
+    pub profiles_dir: String,
+    pub rows: Vec<ShellInitHistoryRow>,
+}
+
+/// One per-run row in `--history`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitHistoryRow {
+    /// Filename of the underlying TSV — useful for cross-reference and
+    /// keeps history rows traceable to the on-disk artefact.
+    pub filename: String,
+    /// Unix timestamp parsed from the filename (or `0` when the
+    /// filename doesn't follow the expected pattern). Surfaced in JSON
+    /// so machine consumers can do their own date math without
+    /// re-parsing `filename`.
+    pub unix_ts: u64,
+    /// Compact `YYYY-MM-DD HH:MM` formatted from the unix timestamp in
+    /// the filename. Empty when the timestamp couldn't be parsed.
+    pub when: String,
+    pub shell: String,
+    pub total_label: String,
+    pub user_total_label: String,
+    pub total_us: u64,
+    pub user_total_us: u64,
+    pub failed_entries: usize,
+    pub entry_count: usize,
 }
 
 /// Display payload for `probe shell-init`. Pulled into its own struct
@@ -280,6 +353,119 @@ pub fn humanize_us(us: u64) -> String {
     } else {
         format!("{:.2} s", us as f64 / 1_000_000.0)
     }
+}
+
+/// Default `--runs` value when the flag is supplied without one.
+/// Picked to be larger than typical day-to-day usage but cheap to load.
+pub const DEFAULT_RUNS: usize = 10;
+
+/// Aggregate the last `runs` profiles into per-target percentile stats.
+pub fn shell_init_aggregate(ctx: &ExecutionContext, runs: usize) -> Result<ProbeResult> {
+    let root_config = ctx.config_manager.root_config()?;
+    let profiling_enabled = root_config.profiling.enabled;
+    let profiles = read_recent_profiles(ctx.fs.as_ref(), ctx.paths.as_ref(), runs)?;
+    let view = aggregate_profiles(&profiles);
+    let profiles_dir = ctx.paths.probes_shell_init_dir().display().to_string();
+
+    Ok(ProbeResult::ShellInitAggregate(ShellInitAggregateView {
+        runs: view.runs,
+        requested_runs: runs,
+        profiling_enabled,
+        profiles_dir,
+        rows: view.targets.into_iter().map(into_aggregate_row).collect(),
+    }))
+}
+
+fn into_aggregate_row(t: AggregatedTarget) -> ShellInitAggregateRow {
+    ShellInitAggregateRow {
+        pack: t.pack,
+        handler: t.handler,
+        target: short_target(&t.target),
+        p50_label: humanize_us(t.p50_us),
+        p95_label: humanize_us(t.p95_us),
+        max_label: humanize_us(t.max_us),
+        p50_us: t.p50_us,
+        p95_us: t.p95_us,
+        max_us: t.max_us,
+        seen_label: format!("{}/{}", t.runs_seen, t.runs_total),
+        runs_seen: t.runs_seen,
+        runs_total: t.runs_total,
+    }
+}
+
+/// Default cap on the number of history rows emitted, so a user with
+/// hundreds of profiles doesn't get a page-fillingrace down their
+/// terminal.
+pub const DEFAULT_HISTORY_LIMIT: usize = 50;
+
+/// Render the per-run history view (one summary line per profile).
+pub fn shell_init_history(ctx: &ExecutionContext, limit: usize) -> Result<ProbeResult> {
+    let root_config = ctx.config_manager.root_config()?;
+    let profiling_enabled = root_config.profiling.enabled;
+    let mut profiles = read_recent_profiles(ctx.fs.as_ref(), ctx.paths.as_ref(), limit)?;
+    // read_recent_profiles returns newest-first; reverse so output reads
+    // chronologically (oldest at top, latest at the bottom near the
+    // user's prompt).
+    profiles.reverse();
+    let history = summarize_history(&profiles);
+    let profiles_dir = ctx.paths.probes_shell_init_dir().display().to_string();
+
+    Ok(ProbeResult::ShellInitHistory(ShellInitHistoryView {
+        profiling_enabled,
+        profiles_dir,
+        rows: history.into_iter().map(into_history_row).collect(),
+    }))
+}
+
+fn into_history_row(h: HistoryEntry) -> ShellInitHistoryRow {
+    ShellInitHistoryRow {
+        filename: h.filename,
+        unix_ts: h.unix_ts,
+        when: format_unix_ts(h.unix_ts),
+        shell: h.shell,
+        total_label: humanize_us(h.total_us),
+        user_total_label: humanize_us(h.user_total_us),
+        total_us: h.total_us,
+        user_total_us: h.user_total_us,
+        failed_entries: h.failed_entries,
+        entry_count: h.entry_count,
+    }
+}
+
+/// Format a unix timestamp as `YYYY-MM-DD HH:MM` in UTC. Returns an
+/// empty string for `0` (parse-failure sentinel) so the renderer can
+/// just print a blank cell.
+///
+/// Does the calendar math by hand to avoid pulling a dep — chrono is
+/// overkill for one display string. Algorithm: Howard Hinnant's
+/// civil_from_days.
+pub fn format_unix_ts(ts: u64) -> String {
+    if ts == 0 {
+        return String::new();
+    }
+    let secs_per_day: u64 = 86_400;
+    let days = (ts / secs_per_day) as i64;
+    let secs_of_day = ts % secs_per_day;
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+    let (y, m, d) = civil_from_days(days);
+    format!("{y:04}-{m:02}-{d:02} {hour:02}:{minute:02}")
+}
+
+/// Howard Hinnant's `civil_from_days`: convert days since 1970-01-01
+/// (UTC) into `(year, month, day)`. Public-domain algorithm.
+fn civil_from_days(z: i64) -> (i32, u32, u32) {
+    let z = z + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u64; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m as u32, d as u32)
 }
 
 /// Render the data-dir tree.

--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -355,11 +355,13 @@ pub fn humanize_us(us: u64) -> String {
     }
 }
 
-/// Default `--runs` value when the flag is supplied without one.
-/// Picked to be larger than typical day-to-day usage but cheap to load.
-pub const DEFAULT_RUNS: usize = 10;
-
 /// Aggregate the last `runs` profiles into per-target percentile stats.
+///
+/// The CLI applies a default of 10 when the user passes `--runs`
+/// without a value (see `clap`'s `default_missing_value` in
+/// `dodot-cli/src/main.rs`); this function takes the resolved count
+/// directly so it stays useful from external callers (tests, custom
+/// harnesses) that pick their own N.
 pub fn shell_init_aggregate(ctx: &ExecutionContext, runs: usize) -> Result<ProbeResult> {
     let root_config = ctx.config_manager.root_config()?;
     let profiling_enabled = root_config.profiling.enabled;
@@ -394,7 +396,7 @@ fn into_aggregate_row(t: AggregatedTarget) -> ShellInitAggregateRow {
 }
 
 /// Default cap on the number of history rows emitted, so a user with
-/// hundreds of profiles doesn't get a page-fillingrace down their
+/// hundreds of profiles doesn't get a page-filling race down their
 /// terminal.
 pub const DEFAULT_HISTORY_LIMIT: usize = 50;
 
@@ -440,11 +442,18 @@ fn into_history_row(h: HistoryEntry) -> ShellInitHistoryRow {
 /// overkill for one display string. Algorithm: Howard Hinnant's
 /// civil_from_days.
 pub fn format_unix_ts(ts: u64) -> String {
-    if ts == 0 {
+    // 0 is the parse-failure sentinel from `parse_unix_ts_from_filename`;
+    // anything past year 9999 is also nonsense in a shell-startup
+    // profile (the file format itself is the giveaway). Returning an
+    // empty string keeps the renderer predictable even in the face of
+    // a tampered-with filename, and bounds the i64 cast on `days`
+    // safely below i64::MAX regardless of input.
+    const MAX_REASONABLE_TS: u64 = 253_402_300_799; // 9999-12-31T23:59:59 UTC.
+    if ts == 0 || ts > MAX_REASONABLE_TS {
         return String::new();
     }
     let secs_per_day: u64 = 86_400;
-    let days = (ts / secs_per_day) as i64;
+    let days = (ts / secs_per_day) as i64; // safe: ts < 2.5e11 → days < 3e6
     let secs_of_day = ts % secs_per_day;
     let hour = secs_of_day / 3600;
     let minute = (secs_of_day % 3600) / 60;
@@ -627,6 +636,21 @@ mod tests {
         assert_eq!(humanize_bytes(1024), "1.0 KB");
         assert_eq!(humanize_bytes(1024 * 1024), "1.0 MB");
         assert_eq!(humanize_bytes(1024 * 1024 * 1024), "1.0 GB");
+    }
+
+    #[test]
+    fn format_unix_ts_handles_zero_and_out_of_range() {
+        // Sentinel for parse-failure → empty, not a date.
+        assert_eq!(format_unix_ts(0), "");
+        // Real timestamp → formatted.
+        assert_eq!(format_unix_ts(1_714_000_000), "2024-04-24 23:06");
+        // Past year 9999 → empty (defensive ceiling so a tampered
+        // filename doesn't produce a nonsense date or risk overflow
+        // during the i64 cast on `days`).
+        assert_eq!(format_unix_ts(u64::MAX), "");
+        assert_eq!(format_unix_ts(253_402_300_800), ""); // 1s past year 9999.
+                                                         // Right below the ceiling still renders.
+        assert_eq!(format_unix_ts(253_402_300_799), "9999-12-31 23:59");
     }
 
     #[test]

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -3214,6 +3214,164 @@ fn probe_deployment_map_json_mode_is_kind_tagged() {
     assert!(parsed["entries"].is_array());
 }
 
+// ── probe shell-init Phase 3 (--runs / --history) ─────────────────
+
+fn write_fake_profile(env: &TempEnvironment, name: &str, lines: &[&str]) {
+    let dir = env.paths.probes_shell_init_dir();
+    env.fs.mkdir_all(&dir).unwrap();
+    let mut content =
+        String::from("# columns\tphase\tpack\thandler\ttarget\tstart_t\tend_t\texit_status\n");
+    for l in lines {
+        content.push_str(l);
+        content.push('\n');
+    }
+    env.fs
+        .write_file(&dir.join(name), content.as_bytes())
+        .unwrap();
+}
+
+#[test]
+fn probe_shell_init_aggregate_renders_percentile_table() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    // Three fake profiles with the same target; verify p50/p95/max
+    // surface in the rendered text.
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &["source\tvim\tshell\t/x/aliases.sh\t1.000000\t1.000100\t0"],
+    );
+    write_fake_profile(
+        &env,
+        "profile-1714000002-1-1.tsv",
+        &["source\tvim\tshell\t/x/aliases.sh\t1.000000\t1.000200\t0"],
+    );
+    write_fake_profile(
+        &env,
+        "profile-1714000003-1-1.tsv",
+        &["source\tvim\tshell\t/x/aliases.sh\t1.000000\t1.000300\t0"],
+    );
+    let result = commands::probe::shell_init_aggregate(&ctx, 5).unwrap();
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        output.contains("aggregate"),
+        "header missing; got:\n{output}"
+    );
+    assert!(output.contains("aliases.sh"), "row missing; got:\n{output}");
+    assert!(output.contains("3/3"), "seen-label missing; got:\n{output}");
+}
+
+#[test]
+fn probe_shell_init_aggregate_warns_when_fewer_runs_than_requested() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &["source\tvim\tshell\t/x.sh\t1.000000\t1.000100\t0"],
+    );
+    // Asked for 10, only 1 on disk.
+    let result = commands::probe::shell_init_aggregate(&ctx, 10).unwrap();
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        output.contains("requested 10"),
+        "expected mismatch warning; got:\n{output}"
+    );
+}
+
+#[test]
+fn probe_shell_init_aggregate_empty_state_shows_hint() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    let result = commands::probe::shell_init_aggregate(&ctx, 5).unwrap();
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        output.contains("no profiles yet"),
+        "expected empty hint; got:\n{output}"
+    );
+}
+
+#[test]
+fn probe_shell_init_history_renders_one_row_per_run_oldest_first() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    // Three profiles with distinct timestamps in their filenames.
+    write_fake_profile(
+        &env,
+        "profile-1714000000-1-1.tsv",
+        &["source\tvim\tshell\t/a.sh\t1.000000\t1.000100\t0"],
+    );
+    write_fake_profile(
+        &env,
+        "profile-1714003600-1-1.tsv",
+        &["source\tvim\tshell\t/a.sh\t1.000000\t1.000200\t1"],
+    );
+    write_fake_profile(
+        &env,
+        "profile-1714007200-1-1.tsv",
+        &["source\tvim\tshell\t/a.sh\t1.000000\t1.000300\t0"],
+    );
+    let result = commands::probe::shell_init_history(&ctx, 50).unwrap();
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(output.contains("history"), "header missing; got:\n{output}");
+    // Date stamps from the timestamps (1714000000 ≈ 2024-04-24 23:06 UTC).
+    assert!(
+        output.contains("2024-04-24"),
+        "date missing; got:\n{output}"
+    );
+    // Three rendered rows; ordering check via JSON because the text
+    // template's column padding makes substring offsets fragile.
+    let json = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let rows = parsed["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 3);
+    // Oldest unix_ts first, newest last.
+    let timestamps: Vec<u64> = rows
+        .iter()
+        .map(|r| r["unix_ts"].as_u64().unwrap_or(0))
+        .collect();
+    assert_eq!(timestamps, vec![1714000000, 1714003600, 1714007200]);
+    // Middle row had a non-zero exit_status.
+    assert_eq!(rows[1]["failed_entries"].as_u64().unwrap(), 1);
+    assert_eq!(rows[0]["failed_entries"].as_u64().unwrap(), 0);
+    assert_eq!(rows[2]["failed_entries"].as_u64().unwrap(), 0);
+}
+
+#[test]
+fn probe_shell_init_history_empty_state_shows_hint() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    let result = commands::probe::shell_init_history(&ctx, 50).unwrap();
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        output.contains("no profiles yet"),
+        "expected empty hint; got:\n{output}"
+    );
+}
+
+#[test]
+fn probe_shell_init_aggregate_json_is_kind_tagged() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    let result = commands::probe::shell_init_aggregate(&ctx, 1).unwrap();
+    let output = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["kind"], "shell-init-aggregate");
+    assert!(parsed["rows"].is_array());
+    assert!(parsed["requested_runs"].is_number());
+}
+
+#[test]
+fn probe_shell_init_history_json_is_kind_tagged() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    let result = commands::probe::shell_init_history(&ctx, 1).unwrap();
+    let output = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["kind"], "shell-init-history");
+    assert!(parsed["rows"].is_array());
+}
+
 // ── deployment map (written on up/down alongside the init script) ──
 
 #[test]

--- a/crates/dodot-lib/src/probe/mod.rs
+++ b/crates/dodot-lib/src/probe/mod.rs
@@ -24,6 +24,7 @@ pub use deployment_map::{
     DeploymentMapEntry,
 };
 pub use shell_init::{
-    group_profile, parse_profile, read_latest_profile, rotate_profiles, GroupedProfile, Profile,
-    ProfileEntry, ProfileGroup,
+    aggregate_profiles, group_profile, parse_profile, read_latest_profile, read_recent_profiles,
+    rotate_profiles, summarize_history, AggregatedTarget, AggregatedView, GroupedProfile,
+    HistoryEntry, Profile, ProfileEntry, ProfileGroup,
 };

--- a/crates/dodot-lib/src/probe/shell_init.rs
+++ b/crates/dodot-lib/src/probe/shell_init.rs
@@ -86,21 +86,24 @@ pub fn read_latest_profile(fs: &dyn Fs, paths: &dyn Pather) -> Result<Option<Pro
 /// Profiles are returned in reverse chronological order (newest first).
 /// The cap exists because callers know how much they need — `--runs 5`
 /// asks for five — and the directory may have hundreds of files.
-/// Filenames are lexically sorted, which is equivalent to chronological
-/// since the leading `profile-<unix_ts>` segment is monotonic.
+///
+/// Implementation: `Fs::read_dir` already returns entries sorted by
+/// name, and `profile-<unix_ts>-…` is fixed-prefix monotonic, so
+/// lexical-ascending == chronological-ascending. We `.rev()` the
+/// iterator to walk newest-first, filter, and `take(limit)` so we
+/// only allocate the rows we'll actually return.
 pub fn read_recent_profiles(fs: &dyn Fs, paths: &dyn Pather, limit: usize) -> Result<Vec<Profile>> {
     let dir = paths.probes_shell_init_dir();
     if !fs.is_dir(&dir) || limit == 0 {
         return Ok(Vec::new());
     }
-    let mut entries: Vec<_> = fs
+    let entries: Vec<_> = fs
         .read_dir(&dir)?
         .into_iter()
+        .rev()
         .filter(|e| e.is_file && e.name.starts_with("profile-") && e.name.ends_with(".tsv"))
+        .take(limit)
         .collect();
-    // Sort newest-first by filename (lex == chrono per filename format).
-    entries.sort_by(|a, b| b.name.cmp(&a.name));
-    entries.truncate(limit);
 
     let mut profiles = Vec::with_capacity(entries.len());
     for entry in entries {
@@ -202,7 +205,10 @@ pub fn rotate_profiles(fs: &dyn Fs, paths: &dyn Pather, keep: usize) -> Result<u
     if !fs.is_dir(&dir) {
         return Ok(0);
     }
-    let mut entries: Vec<_> = fs
+    // `Fs::read_dir` returns entries already sorted by name, and
+    // `profile-<unix_ts>-…` is fixed-prefix monotonic, so the result
+    // is chronological-ascending; oldest entries are at the front.
+    let entries: Vec<_> = fs
         .read_dir(&dir)?
         .into_iter()
         .filter(|e| e.is_file && e.name.starts_with("profile-") && e.name.ends_with(".tsv"))
@@ -210,7 +216,6 @@ pub fn rotate_profiles(fs: &dyn Fs, paths: &dyn Pather, keep: usize) -> Result<u
     if entries.len() <= keep {
         return Ok(0);
     }
-    entries.sort_by(|a, b| a.name.cmp(&b.name));
     let to_remove = entries.len() - keep;
     let mut removed = 0;
     for entry in entries.into_iter().take(to_remove) {

--- a/crates/dodot-lib/src/probe/shell_init.rs
+++ b/crates/dodot-lib/src/probe/shell_init.rs
@@ -77,23 +77,37 @@ impl Profile {
 /// Read the most recently written profile under `<data_dir>/probes/shell-init/`,
 /// or `None` if the directory is empty / missing.
 pub fn read_latest_profile(fs: &dyn Fs, paths: &dyn Pather) -> Result<Option<Profile>> {
+    let mut profiles = read_recent_profiles(fs, paths, 1)?;
+    Ok(profiles.pop())
+}
+
+/// Read up to `limit` most recent profiles, newest first.
+///
+/// Profiles are returned in reverse chronological order (newest first).
+/// The cap exists because callers know how much they need — `--runs 5`
+/// asks for five — and the directory may have hundreds of files.
+/// Filenames are lexically sorted, which is equivalent to chronological
+/// since the leading `profile-<unix_ts>` segment is monotonic.
+pub fn read_recent_profiles(fs: &dyn Fs, paths: &dyn Pather, limit: usize) -> Result<Vec<Profile>> {
     let dir = paths.probes_shell_init_dir();
-    if !fs.is_dir(&dir) {
-        return Ok(None);
+    if !fs.is_dir(&dir) || limit == 0 {
+        return Ok(Vec::new());
     }
-    let mut entries = fs.read_dir(&dir)?;
-    // Filenames start with `profile-<unix_ts>-…`, so a lexical sort
-    // is equivalent to chronological order (the timestamp segment is
-    // fixed-width as long as we stay below year 2286 — fine).
-    entries.sort_by(|a, b| a.name.cmp(&b.name));
-    let Some(latest) = entries
+    let mut entries: Vec<_> = fs
+        .read_dir(&dir)?
         .into_iter()
-        .rfind(|e| e.is_file && e.name.starts_with("profile-") && e.name.ends_with(".tsv"))
-    else {
-        return Ok(None);
-    };
-    let content = fs.read_to_string(&latest.path)?;
-    Ok(Some(parse_profile(&latest.name, &content)))
+        .filter(|e| e.is_file && e.name.starts_with("profile-") && e.name.ends_with(".tsv"))
+        .collect();
+    // Sort newest-first by filename (lex == chrono per filename format).
+    entries.sort_by(|a, b| b.name.cmp(&a.name));
+    entries.truncate(limit);
+
+    let mut profiles = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let content = fs.read_to_string(&entry.path)?;
+        profiles.push(parse_profile(&entry.name, &content));
+    }
+    Ok(profiles)
 }
 
 /// Parse the textual content of a profile file. Tolerates missing
@@ -266,6 +280,142 @@ pub fn group_profile(profile: &Profile) -> GroupedProfile {
         framing_us,
         total_us,
     }
+}
+
+// ── Multi-run aggregation (`probe shell-init --runs N`) ───────────────
+
+/// Per-target stats across N runs.
+#[derive(Debug, Clone, Serialize)]
+pub struct AggregatedTarget {
+    pub pack: String,
+    pub handler: String,
+    pub target: String,
+    pub p50_us: u64,
+    pub p95_us: u64,
+    pub max_us: u64,
+    /// How many of the considered runs had this target. Surfaced because
+    /// targets can appear/disappear across deploys; "p95 from 2/10 runs"
+    /// is a different signal than "p95 from 10/10".
+    pub runs_seen: usize,
+    pub runs_total: usize,
+}
+
+/// Aggregate output, one row per `(pack, handler, target)` keyed by all
+/// the profiles passed in.
+#[derive(Debug, Clone, Serialize)]
+pub struct AggregatedView {
+    pub runs: usize,
+    pub targets: Vec<AggregatedTarget>,
+}
+
+/// Roll up a slice of profiles into per-target percentile stats.
+///
+/// Targets are returned sorted by `(pack, handler, target)` for
+/// readability (matches `group_profile`'s ordering convention).
+pub fn aggregate_profiles(profiles: &[Profile]) -> AggregatedView {
+    use std::collections::BTreeMap;
+
+    // Bucket durations by (pack, handler, target).
+    let mut buckets: BTreeMap<(String, String, String), Vec<u64>> = BTreeMap::new();
+    for p in profiles {
+        for e in &p.entries {
+            buckets
+                .entry((e.pack.clone(), e.handler.clone(), e.target.clone()))
+                .or_default()
+                .push(e.duration_us);
+        }
+    }
+
+    let runs_total = profiles.len();
+    let targets = buckets
+        .into_iter()
+        .map(|((pack, handler, target), mut durs)| {
+            durs.sort_unstable();
+            AggregatedTarget {
+                pack,
+                handler,
+                target,
+                p50_us: percentile(&durs, 50),
+                p95_us: percentile(&durs, 95),
+                max_us: *durs.last().unwrap_or(&0),
+                runs_seen: durs.len(),
+                runs_total,
+            }
+        })
+        .collect();
+
+    AggregatedView {
+        runs: runs_total,
+        targets,
+    }
+}
+
+/// Nearest-rank percentile (no interpolation): the smallest value at
+/// or above the cumulative-frequency threshold. For p95 over 1 sample
+/// returns that sample; over 10 samples returns the 10th (max).
+///
+/// `sorted` must be sorted ascending. Returns 0 for an empty slice.
+fn percentile(sorted: &[u64], pct: u8) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let n = sorted.len();
+    // ceil(p/100 * n) maps to a 1-indexed rank; subtract 1 for 0-indexed.
+    // Saturate at n-1 to handle any rounding edge cases.
+    let rank = ((pct as f64 / 100.0) * n as f64).ceil() as usize;
+    let idx = rank.saturating_sub(1).min(n - 1);
+    sorted[idx]
+}
+
+// ── History (`probe shell-init --history`) ────────────────────────────
+
+/// One row in the history view: a single run's headline metrics.
+#[derive(Debug, Clone, Serialize)]
+pub struct HistoryEntry {
+    pub filename: String,
+    /// Best-effort unix timestamp parsed from the filename. `0` if the
+    /// filename doesn't match `profile-<unix_ts>-…`.
+    pub unix_ts: u64,
+    pub shell: String,
+    pub total_us: u64,
+    pub user_total_us: u64,
+    /// Count of entries with non-zero exit_status — surfaces silent
+    /// breakage at a glance.
+    pub failed_entries: usize,
+    pub entry_count: usize,
+}
+
+/// Build a history view from a slice of profiles (newest-first input,
+/// preserved order in the output — caller decides cadence).
+pub fn summarize_history(profiles: &[Profile]) -> Vec<HistoryEntry> {
+    profiles.iter().map(history_entry_from).collect()
+}
+
+fn history_entry_from(profile: &Profile) -> HistoryEntry {
+    HistoryEntry {
+        filename: profile.filename.clone(),
+        unix_ts: parse_unix_ts_from_filename(&profile.filename),
+        shell: profile.shell.clone(),
+        total_us: profile.total_duration_us,
+        user_total_us: profile.entries_duration_us(),
+        failed_entries: profile
+            .entries
+            .iter()
+            .filter(|e| e.exit_status != 0)
+            .count(),
+        entry_count: profile.entries.len(),
+    }
+}
+
+/// Extract the leading `<unix_ts>` from `profile-<unix_ts>-<pid>-<rand>.tsv`,
+/// returning `0` for any unparseable filename. The renderer formats this
+/// into a date string; storing it as an integer keeps JSON output stable.
+fn parse_unix_ts_from_filename(filename: &str) -> u64 {
+    filename
+        .strip_prefix("profile-")
+        .and_then(|rest| rest.split('-').next())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -542,5 +692,182 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
         assert_eq!(g.user_total_us, 500);
         assert_eq!(g.total_us, 500);
         assert_eq!(g.framing_us, 0);
+    }
+
+    // ── read_recent_profiles ──────────────────────────────────────
+
+    #[test]
+    fn read_recent_returns_newest_first_capped_at_limit() {
+        let env = TempEnvironment::builder().build();
+        for i in 1..=5 {
+            write_profile(
+                &env,
+                &format!("profile-{i}-1-1.tsv"),
+                "# columns\tphase\tpack\thandler\ttarget\tstart_t\tend_t\texit_status\n",
+            );
+        }
+        let recent = read_recent_profiles(env.fs.as_ref(), env.paths.as_ref(), 3).unwrap();
+        let names: Vec<&str> = recent.iter().map(|p| p.filename.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "profile-5-1-1.tsv",
+                "profile-4-1-1.tsv",
+                "profile-3-1-1.tsv",
+            ]
+        );
+    }
+
+    #[test]
+    fn read_recent_with_limit_zero_returns_empty() {
+        let env = TempEnvironment::builder().build();
+        write_profile(&env, "profile-1-1-1.tsv", "x");
+        let recent = read_recent_profiles(env.fs.as_ref(), env.paths.as_ref(), 0).unwrap();
+        assert!(recent.is_empty());
+    }
+
+    #[test]
+    fn read_recent_handles_fewer_files_than_limit() {
+        let env = TempEnvironment::builder().build();
+        write_profile(&env, "profile-1-1-1.tsv", "");
+        let recent = read_recent_profiles(env.fs.as_ref(), env.paths.as_ref(), 100).unwrap();
+        assert_eq!(recent.len(), 1);
+    }
+
+    // ── percentile + aggregate ────────────────────────────────────
+
+    #[test]
+    fn percentile_nearest_rank_basic_cases() {
+        // Ten samples 1..=10. p50 = 5 (lower-median, nearest-rank
+        // doesn't interpolate); p95 = 10 (max-ish, since ceil(0.95*10)=10).
+        let v: Vec<u64> = (1..=10).collect();
+        assert_eq!(percentile(&v, 50), 5);
+        assert_eq!(percentile(&v, 95), 10);
+        // Single sample → all percentiles return it.
+        assert_eq!(percentile(&[42], 50), 42);
+        assert_eq!(percentile(&[42], 95), 42);
+        // Empty slice safely returns 0.
+        assert_eq!(percentile(&[], 50), 0);
+    }
+
+    #[test]
+    fn aggregate_profiles_buckets_by_pack_handler_target() {
+        let p1 = Profile {
+            filename: "profile-1-1-1.tsv".into(),
+            shell: "bash".into(),
+            total_duration_us: 0,
+            entries: vec![
+                entry("vim", "shell", "/a", 100),
+                entry("vim", "shell", "/b", 200),
+            ],
+        };
+        let p2 = Profile {
+            filename: "profile-2-1-1.tsv".into(),
+            shell: "bash".into(),
+            total_duration_us: 0,
+            entries: vec![
+                entry("vim", "shell", "/a", 110),
+                entry("vim", "shell", "/b", 250),
+            ],
+        };
+        let p3 = Profile {
+            filename: "profile-3-1-1.tsv".into(),
+            shell: "bash".into(),
+            total_duration_us: 0,
+            entries: vec![entry("vim", "shell", "/a", 120)],
+            // /b absent in this run (sparse target presence).
+        };
+        let agg = aggregate_profiles(&[p1, p2, p3]);
+        assert_eq!(agg.runs, 3);
+        assert_eq!(agg.targets.len(), 2);
+        let a = agg.targets.iter().find(|t| t.target == "/a").unwrap();
+        assert_eq!(a.runs_seen, 3);
+        assert_eq!(a.runs_total, 3);
+        assert_eq!(a.p50_us, 110); // sorted: 100,110,120 → idx ceil(0.5*3)-1=1
+        assert_eq!(a.max_us, 120);
+        let b = agg.targets.iter().find(|t| t.target == "/b").unwrap();
+        assert_eq!(b.runs_seen, 2);
+        assert_eq!(b.runs_total, 3);
+        assert_eq!(b.max_us, 250);
+    }
+
+    #[test]
+    fn aggregate_empty_profiles_returns_empty_view() {
+        let agg = aggregate_profiles(&[]);
+        assert_eq!(agg.runs, 0);
+        assert!(agg.targets.is_empty());
+    }
+
+    #[test]
+    fn aggregate_targets_sort_by_pack_handler_target() {
+        // Inputs scrambled; output must be (pack, handler, target)-sorted.
+        let p = Profile {
+            filename: "p".into(),
+            shell: "".into(),
+            total_duration_us: 0,
+            entries: vec![
+                entry("vim", "shell", "/z", 1),
+                entry("git", "shell", "/a", 1),
+                entry("vim", "path", "/x", 1),
+                entry("git", "shell", "/y", 1),
+            ],
+        };
+        let agg = aggregate_profiles(&[p]);
+        let keys: Vec<(&str, &str, &str)> = agg
+            .targets
+            .iter()
+            .map(|t| (t.pack.as_str(), t.handler.as_str(), t.target.as_str()))
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                ("git", "shell", "/a"),
+                ("git", "shell", "/y"),
+                ("vim", "path", "/x"),
+                ("vim", "shell", "/z"),
+            ]
+        );
+    }
+
+    // ── history ───────────────────────────────────────────────────
+
+    #[test]
+    fn summarize_history_pulls_basic_metrics_per_run() {
+        let p1 = Profile {
+            filename: "profile-1714000000-12-34.tsv".into(),
+            shell: "bash 5.3".into(),
+            total_duration_us: 500,
+            entries: vec![
+                entry("vim", "shell", "/a", 100),
+                ProfileEntry {
+                    phase: "source".into(),
+                    pack: "gh".into(),
+                    handler: "shell".into(),
+                    target: "/x".into(),
+                    duration_us: 50,
+                    exit_status: 1, // hidden failure
+                },
+            ],
+        };
+        let h = summarize_history(&[p1]);
+        assert_eq!(h.len(), 1);
+        assert_eq!(h[0].unix_ts, 1714000000);
+        assert_eq!(h[0].shell, "bash 5.3");
+        assert_eq!(h[0].total_us, 500);
+        assert_eq!(h[0].user_total_us, 150);
+        assert_eq!(h[0].failed_entries, 1);
+        assert_eq!(h[0].entry_count, 2);
+    }
+
+    #[test]
+    fn parse_unix_ts_handles_unparseable_filenames() {
+        // Best-effort: an unrecognised filename returns 0 rather than
+        // crashing the history view.
+        assert_eq!(
+            parse_unix_ts_from_filename("profile-1714000000-1-1.tsv"),
+            1714000000
+        );
+        assert_eq!(parse_unix_ts_from_filename("garbage.txt"), 0);
+        assert_eq!(parse_unix_ts_from_filename("profile-notanum-1-1.tsv"), 0);
     }
 }

--- a/crates/dodot-lib/src/templates/probe.jinja
+++ b/crates/dodot-lib/src/templates/probe.jinja
@@ -39,4 +39,26 @@
 {% endif %}{% endif %}
   [dim]profiles dir:[/dim] {{ profiles_dir }}
   [dim]for intra-file profiling, see `zprof` (zsh) or PS4 tracing (bash).[/dim]
+{%- elif kind == "shell-init-aggregate" -%}
+[header]Shell-init aggregate[/header]
+  [dim]runs:[/dim] {{ runs }}{% if runs != requested_runs %} [warning](requested {{ requested_runs }})[/warning]{% endif %}
+
+{% if rows %}  [dim]{{ "pack" | col(14) }} {{ "handler" | col(8) }} {{ "target" | col(28) }} {{ "p50" | col(10) }} {{ "p95" | col(10) }} {{ "max" | col(10) }} runs[/dim]
+{% for r in rows %}  [pack-name]{{ r.pack | col(14) }}[/pack-name] [handler-symbol]{{ r.handler | col(8) }}[/handler-symbol] {{ r.target | col(28) }} [deployed]{{ r.p50_label | col(10) }}[/deployed] {{ r.p95_label | col(10) }} {{ r.max_label | col(10) }} [dim]{{ r.seen_label }}[/dim]
+{% endfor %}{% else %}{% if profiling_enabled %}  [dim](no profiles yet — open a few shells that source `dodot-init.sh`,[/dim]
+  [dim] then re-run with `--runs N`)[/dim]
+{% else %}  [dim](profiling is disabled in config — set [profiling] enabled = true,[/dim]
+  [dim] run `dodot up`, then start a new shell)[/dim]
+{% endif %}{% endif %}
+  [dim]profiles dir:[/dim] {{ profiles_dir }}
+{%- elif kind == "shell-init-history" -%}
+[header]Shell-init history[/header]
+
+{% if rows %}  [dim]{{ "when (UTC)" | col(18) }} {{ "shell" | col(20) }} {{ "total" | col(10) }} {{ "user" | col(10) }} {{ "entries" | col(8) }} fail[/dim]
+{% for r in rows %}  {{ r.when | col(18) }} {{ r.shell | col(20) }} [deployed]{{ r.total_label | col(10) }}[/deployed] {{ r.user_total_label | col(10) }} {{ r.entry_count | string | col(8) }} {% if r.failed_entries > 0 %}[error]{{ r.failed_entries }}[/error]{% else %}[dim]0[/dim]{% endif %}
+{% endfor %}{% else %}{% if profiling_enabled %}  [dim](no profiles yet — open a shell that sources `dodot-init.sh`)[/dim]
+{% else %}  [dim](profiling is disabled in config — set [profiling] enabled = true,[/dim]
+  [dim] run `dodot up`, then start a new shell)[/dim]
+{% endif %}{% endif %}
+  [dim]profiles dir:[/dim] {{ profiles_dir }}
 {%- endif -%}

--- a/docs/proposals/profiling.lex
+++ b/docs/proposals/profiling.lex
@@ -169,11 +169,11 @@ Design Specification: Profiling and the Probe Command
     Phase 2: shell-init timing. **(Shipped.)**
         Extend `shell::generate_init_script` to emit the per-file timing wrapper and the preamble writer. Wire `probe shell-init` reader and the default (single-run) view. Add the `profiling` config section. Rotation also lands here (cheaper to ship together than to defer): the writer side has no rotation logic, but `dodot up` prunes `<data_dir>/probes/shell-init/` to `keep_last_runs` at the end of every run.
 
-    Phase 3: aggregation.
-        Add `--runs N` and `--history` flags to `probe shell-init` for cross-run views (p50/p95/max per target, trend over recent runs). Rotation already runs in Phase 2, so this phase is purely additive on the reader side.
+    Phase 3: aggregation. **(Shipped.)**
+        `--runs N` and `--history` flags on `probe shell-init` for cross-run views — p50/p95/max per target (nearest-rank, no interpolation) and a per-run trend table. Rotation already ran in Phase 2, so this phase was purely additive on the reader side. The history row's `failed_entries` column also subsumes part of what regression-hints (phase 4) would have done: silent source failures across runs are visible at a glance.
 
-    Phase 4: regression hints (optional).
-        If phase 3 reveals an appetite for it, teach `probe shell-init` to highlight targets whose current-run duration is above their historical p95. Pure presentation; same data. We do not plan this as table stakes.
+    Phase 4: regression hints (optional, deferred).
+        Would highlight targets whose current-run duration is above their historical p95. Pure presentation; same data. Skipped for now — phase 3's tabular view of p95 next to current run already tells the story for users who care to look, and adding automatic flagging is the kind of thing that's better implemented after observing real usage.
 
 
 8. What This Costs the User

--- a/tests/e2e/bats/test_shell_init_profiling.bats
+++ b/tests/e2e/bats/test_shell_init_profiling.bats
@@ -179,3 +179,90 @@ echo hi'
     assert_exists "$d/profile-5-1-1.tsv"
     assert_not_exists "$d/profile-1-1-1.tsv"
 }
+
+# ── Phase 3: --runs N (aggregate) and --history ───────────────────
+
+@test "probe shell-init --runs aggregates over recent profiles" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+    # Three sub-shells → three profiles.
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+
+    run dodot probe shell-init --runs 3
+    [ "$status" -eq 0 ]
+    assert_output_contains "Shell-init aggregate"
+    assert_output_contains "p50"
+    assert_output_contains "p95"
+    assert_output_contains "aliases.sh"
+    # All three runs saw the target.
+    assert_output_contains "3/3"
+}
+
+@test "probe shell-init --runs warns when fewer profiles than requested" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+
+    # Asked for 10, only one exists.
+    run dodot probe shell-init --runs 10
+    [ "$status" -eq 0 ]
+    assert_output_contains "requested 10"
+}
+
+@test "probe shell-init --runs with no profiles shows empty hint" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+
+    run dodot probe shell-init --runs 5
+    [ "$status" -eq 0 ]
+    assert_output_contains "no profiles yet"
+}
+
+@test "probe shell-init --history lists per-run summaries" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+
+    run dodot probe shell-init --history
+    [ "$status" -eq 0 ]
+    assert_output_contains "Shell-init history"
+    assert_output_contains "when (UTC)"
+    # Two rows → at least two rendered lines under the header.
+    local row_count
+    row_count=$(echo "$output" | grep -cE '^\s+20[0-9]{2}-[0-9]{2}-[0-9]{2}' || true)
+    [ "$row_count" -ge 2 ]
+}
+
+@test "probe shell-init --runs and --history are mutually exclusive" {
+    run dodot probe shell-init --runs 3 --history
+    # clap's conflicts_with should make this fail.
+    [ "$status" -ne 0 ]
+}
+
+@test "probe shell-init --runs --output json has the right shape" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+
+    run dodot --output json probe shell-init --runs 5
+    [ "$status" -eq 0 ]
+    assert_output_contains '"kind"'
+    assert_output_contains '"shell-init-aggregate"'
+    assert_output_contains '"requested_runs"'
+    assert_output_contains '"rows"'
+}
+
+@test "probe shell-init --history --output json has the right shape" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+
+    run dodot --output json probe shell-init --history
+    [ "$status" -eq 0 ]
+    assert_output_contains '"kind"'
+    assert_output_contains '"shell-init-history"'
+    assert_output_contains '"unix_ts"'
+}

--- a/tests/e2e/bats/test_shell_init_profiling.bats
+++ b/tests/e2e/bats/test_shell_init_profiling.bats
@@ -200,6 +200,21 @@ echo hi'
     assert_output_contains "3/3"
 }
 
+@test "probe shell-init --runs without value defaults to 10" {
+    create_pack_file "vim" "aliases.sh" "alias vi=vim"
+    dodot up
+    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+
+    # `--runs` with no value should aggregate over up to 10 runs (the
+    # clap default_missing_value), not error or require an explicit N.
+    run dodot probe shell-init --runs
+    [ "$status" -eq 0 ]
+    assert_output_contains "Shell-init aggregate"
+    # Only one profile exists, but we requested 10, so the renderer
+    # warns about the mismatch.
+    assert_output_contains "requested 10"
+}
+
 @test "probe shell-init --runs warns when fewer profiles than requested" {
     create_pack_file "vim" "aliases.sh" "alias vi=vim"
     dodot up


### PR DESCRIPTION
## Summary

Phase 3 of `docs/proposals/profiling.lex`. Two new flags on `dodot probe shell-init`, both pulling from the existing on-disk profile TSVs — purely additive on the reader side, no shell-script changes.

```
$ dodot probe shell-init --runs 5
Shell-init aggregate
  runs: 5

  pack         handler  target              p50      p95      max      runs
  vim          shell    aliases.sh          47 µs    197 µs   197 µs   5/5
  ...
```

```
$ dodot probe shell-init --history
Shell-init history

  when (UTC)         shell                total      user       entries  fail
  2026-04-25 04:35   bash 5.3.9            534 µs    216 µs    2        0
  2026-04-25 04:36   bash 5.3.9            441 µs    57 µs     2        1
  ...
```

### What's in

- **`--runs N`**: aggregate the last N profiles into per-(pack, handler, target) p50/p95/max plus a `runs_seen / runs_total` ratio. Targets sort by `(pack, handler, target)` to match the deployment-map view. Nearest-rank percentiles (no interpolation) — the right resolution for sub-millisecond shell timings. When fewer than N profiles exist on disk the renderer warns "(requested N)".
- **`--history`**: one-row-per-run trend, oldest first, capped at 50 rows. Each row carries the parsed unix timestamp, shell label, total / user-sourced durations, entry count, and a `failed_entries` column that surfaces silent non-zero source exits across runs at a glance.
- Both flags are mutually exclusive (clap's `conflicts_with`).
- Both serialise as `kind = "shell-init-aggregate"` / `kind = "shell-init-history"` in JSON mode.

### Why phase 4 is dropping out of scope

The history view's `failed_entries` column already surfaces the most actionable regression signal (silent failures across runs), and the aggregate view shows p95 sitting next to current-run durations — users who care about regressions can see them. Shipping automatic flagging without observing real usage felt premature; we can add it later as pure presentation if needed.

Updated `profiling.lex §7` to mark Phase 3 as **Shipped** and Phase 4 as **deferred**.

### Test plan
- [x] 17 new unit tests (9 in `probe::shell_init` for percentile math / aggregation / history, 7 in `commands::tests` for rendering, 1 sort-order regression in `aggregate_targets_sort_by_pack_handler_target`)
- [x] 7 new bats e2e tests — actually run real bash subshells to produce 1–10 profiles, then verify both views and the JSON shapes
- [x] `cargo test` — 475 pass (was 458 in Phase 2)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `bats tests/e2e/bats/` — 144 pass (was 137 in Phase 2)
- [x] Manually exercised both views against bash 5.3.9 with multiple shell startups

### Notable design calls

- **Hand-rolled date formatting** (`civil_from_days`) instead of pulling chrono. One display string shouldn't justify a dependency. Algorithm is Howard Hinnant's, public-domain.
- **`unix_ts` exposed in the JSON `--history` row** alongside the formatted `when` string, so machine consumers can do their own date arithmetic without re-parsing the filename.
- **Default history cap of 50 rows** picked because anything more wouldn't fit a typical terminal — users with hundreds of profiles still get the latest 50, which is plenty of context for a trend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)