### PR TITLE
Shell handler: error handling overhaul (3a + 3b + 3c)

### DIFF
--- a/crates/dodot-lib/src/commands/fill.rs
+++ b/crates/dodot-lib/src/commands/fill.rs
@@ -149,6 +149,7 @@ mod tests {
             datastore,
             paths: env.paths.clone() as Arc<dyn Pather>,
             config_manager,
+            syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
             dry_run: false,
             no_provision: false,
             provision_rerun: false,

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -224,7 +224,7 @@ fn verify_symlink(
 /// Checks: data link exists → points to source → source exists.
 /// For shell handler, also checks for a syntax-error sidecar from the
 /// pre-flight check that runs at `dodot up` time — its presence flips
-/// a healthy chain to `DeployedWithSyntaxError`.
+/// a healthy chain to `DeployedWithError`.
 fn verify_staged(
     source: &std::path::Path,
     pack: &str,
@@ -316,9 +316,13 @@ fn recent_runtime_failures(
     }
     let target_str = source.to_string_lossy();
 
+    // `profiles` is newest-first. We want the *most recent* non-zero
+    // exit for the label/footnote — set on the first failure we see
+    // and never overwritten. (An older failure is irrelevant to the
+    // user's current understanding of the file's state.)
     let mut runs_seen = 0;
     let mut runs_failed = 0;
-    let mut last_exit: i32 = 0;
+    let mut last_failure_exit: Option<i32> = None;
     for profile in &profiles {
         if let Some(entry) = profile
             .entries
@@ -328,17 +332,20 @@ fn recent_runtime_failures(
             runs_seen += 1;
             if entry.exit_status != 0 {
                 runs_failed += 1;
-                last_exit = entry.exit_status;
+                if last_failure_exit.is_none() {
+                    last_failure_exit = Some(entry.exit_status);
+                }
             }
         }
     }
+    let last_exit = last_failure_exit?;
     if runs_failed == 0 {
         return None;
     }
 
     let label = format!("exited {last_exit} ({runs_failed}/{runs_seen})");
     let reason = format!(
-        "non-zero exit in {runs_failed} of {runs_seen} recent shell startups (last exit: {last_exit}). \
+        "non-zero exit in {runs_failed} of {runs_seen} recent shell startups (last failure: exit {last_exit}). \
          See `dodot probe shell-init --history` for details."
     );
     Some((label, reason))

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -33,6 +33,11 @@ enum Health {
     PendingConflict { reason: String },
     /// Deployed and all links verified correct.
     Deployed,
+    /// Deployed and the chain is healthy, but the file has a known
+    /// quality issue: pre-flight syntax error or recurring runtime
+    /// failures observed by the profiling instrumentation. `label` is
+    /// the short status-column text, `reason` is the footnote body.
+    DeployedWithError { label: String, reason: String },
     /// Deployed but the chain is broken.
     Broken(String),
     /// Data link exists and is healthy, but the user link is not at the
@@ -47,6 +52,7 @@ impl Health {
             Health::Pending => "pending",
             Health::PendingConflict { .. } => "warning",
             Health::Deployed => "deployed",
+            Health::DeployedWithError { .. } => "broken",
             Health::Broken(_) => "broken",
             Health::Stale(_) => "stale",
         }
@@ -71,16 +77,18 @@ impl Health {
                 "homebrew" => "installed".into(),
                 _ => "deployed".into(),
             },
+            Health::DeployedWithError { label, .. } => label.clone(),
             Health::Broken(reason) => reason.clone(),
             Health::Stale(reason) => reason.clone(),
         }
     }
 
-    /// If this health represents a pending conflict, return the reason
-    /// (suitable for use as a footnote). `None` otherwise.
+    /// If this health carries a footnote-worthy reason (pending conflict,
+    /// deployed-with-error), return it. `None` otherwise.
     fn footnote_reason(&self) -> Option<&str> {
         match self {
             Health::PendingConflict { reason } => Some(reason.as_str()),
+            Health::DeployedWithError { reason, .. } => Some(reason.as_str()),
             _ => None,
         }
     }
@@ -214,6 +222,9 @@ fn verify_symlink(
 /// Verify shell/path handler chain for a single file.
 ///
 /// Checks: data link exists → points to source → source exists.
+/// For shell handler, also checks for a syntax-error sidecar from the
+/// pre-flight check that runs at `dodot up` time — its presence flips
+/// a healthy chain to `DeployedWithSyntaxError`.
 fn verify_staged(
     source: &std::path::Path,
     pack: &str,
@@ -246,7 +257,91 @@ fn verify_staged(
         return Health::Broken("broken: source file missing".into());
     }
 
+    // Shell handler only: layered post-deploy quality checks. Both
+    // signals fire only for shell sources. Syntax error wins over
+    // runtime failures — fix-the-parse is the more fundamental issue,
+    // and a file that doesn't parse can't have meaningful runtime
+    // exit-code data anyway.
+    if handler == "shell" {
+        let filename_str = filename.to_string_lossy();
+
+        // (1) Pre-flight syntax-error sidecar from `dodot up`.
+        let sidecar = crate::shell::error_sidecar_path(ctx.paths.as_ref(), pack, &filename_str);
+        if ctx.fs.exists(&sidecar) {
+            if let Ok(body) = ctx.fs.read_to_string(&sidecar) {
+                let reason = body.trim().to_string();
+                if !reason.is_empty() {
+                    return Health::DeployedWithError {
+                        label: "syntax error".into(),
+                        reason,
+                    };
+                }
+            }
+        }
+
+        // (2) Runtime exit-code data from the profiling instrumentation,
+        //     if any has been collected. Returns None when profiling is
+        //     off, when no profiles exist yet, or when this source has
+        //     run cleanly in every recent shell.
+        if let Some((label, reason)) = recent_runtime_failures(source, ctx) {
+            return Health::DeployedWithError { label, reason };
+        }
+    }
+
     Health::Deployed
+}
+
+/// How many recent shell-init profiles to scan for runtime failures.
+/// Five is enough to catch the "fails sometimes" case without making
+/// status I/O-heavy; users who want deeper history reach for
+/// `dodot probe shell-init --history`.
+const RUNTIME_FAILURE_WINDOW: usize = 5;
+
+/// Look at the last few shell-init profiles for any non-zero exit
+/// status from `source`. Returns `Some((short_label, footnote_body))`
+/// if at least one failure was seen; `None` otherwise (including when
+/// profiling is off, so no profiles exist).
+fn recent_runtime_failures(
+    source: &std::path::Path,
+    ctx: &ExecutionContext,
+) -> Option<(String, String)> {
+    let profiles = crate::probe::shell_init::read_recent_profiles(
+        ctx.fs.as_ref(),
+        ctx.paths.as_ref(),
+        RUNTIME_FAILURE_WINDOW,
+    )
+    .ok()?;
+    if profiles.is_empty() {
+        return None;
+    }
+    let target_str = source.to_string_lossy();
+
+    let mut runs_seen = 0;
+    let mut runs_failed = 0;
+    let mut last_exit: i32 = 0;
+    for profile in &profiles {
+        if let Some(entry) = profile
+            .entries
+            .iter()
+            .find(|e| e.phase == "source" && e.target == target_str)
+        {
+            runs_seen += 1;
+            if entry.exit_status != 0 {
+                runs_failed += 1;
+                last_exit = entry.exit_status;
+            }
+        }
+    }
+    if runs_failed == 0 {
+        return None;
+    }
+
+    let label = format!("exited {last_exit} ({runs_failed}/{runs_seen})");
+    let reason = format!(
+        "non-zero exit in {runs_failed} of {runs_seen} recent shell startups (last exit: {last_exit}). \
+         See `dodot probe shell-init --history` for details."
+    );
+    Some((label, reason))
 }
 
 /// Run the `status` command: scan packs and verify deployment chain per file.

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -368,6 +368,127 @@ fn up_generates_shell_init() {
 }
 
 #[test]
+fn status_surfaces_syntax_error_sidecar_for_deployed_shell_file() {
+    use crate::shell::{SyntaxCheckResult, SyntaxChecker};
+    use std::path::Path;
+
+    struct FlagAliases;
+    impl SyntaxChecker for FlagAliases {
+        fn check(&self, _interpreter: &str, file: &Path) -> SyntaxCheckResult {
+            if file.file_name().and_then(|s| s.to_str()) == Some("aliases.sh") {
+                SyntaxCheckResult::SyntaxError {
+                    stderr: "/path/aliases.sh: line 47: bad substitution\n".into(),
+                }
+            } else {
+                SyntaxCheckResult::Ok
+            }
+        }
+    }
+
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("aliases.sh", "echo ${broken")
+        .file("env.sh", "export FOO=bar")
+        .done()
+        .build();
+
+    let mut ctx = make_ctx(&env);
+    ctx.syntax_checker = Arc::new(FlagAliases);
+    commands::up::up(None, &ctx).unwrap();
+
+    // Now run status — should flag aliases.sh as broken and leave
+    // env.sh as plain deployed.
+    let result = commands::status::status(None, &ctx).unwrap();
+    let pack = &result.packs[0];
+
+    let aliases = pack
+        .files
+        .iter()
+        .find(|f| f.name == "aliases.sh")
+        .expect("aliases.sh row missing");
+    assert_eq!(aliases.status, "broken", "row: {aliases:?}");
+    assert_eq!(aliases.status_label, "syntax error");
+    let note_idx = aliases
+        .note_ref
+        .expect("aliases.sh should carry a note ref") as usize;
+    assert!(
+        result.notes[note_idx - 1].body.contains("bad substitution"),
+        "note: {:?}",
+        result.notes[note_idx - 1]
+    );
+
+    let env_row = pack
+        .files
+        .iter()
+        .find(|f| f.name == "env.sh")
+        .expect("env.sh row missing");
+    assert_eq!(env_row.status, "deployed");
+    assert_eq!(env_row.status_label, "sourced");
+}
+
+#[test]
+fn status_surfaces_runtime_failures_from_recent_profiles() {
+    // A clean source (passes syntax) that exits non-zero in 2 of the
+    // 3 most recent shell startups should be flagged as broken with a
+    // footnote summarizing the failure rate.
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("aliases.sh", "alias vi=vim")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    // Write three fake profile TSVs by hand: two with exit_status=1
+    // for aliases.sh, one with exit_status=0. Newer filenames sort
+    // last lexically; the reader walks newest-first.
+    let source_path = env.dotfiles_root.join("vim/aliases.sh");
+    let target = source_path.display().to_string();
+    let probes_dir = env.paths.probes_shell_init_dir();
+    env.fs.mkdir_all(&probes_dir).unwrap();
+    let make_profile = |t0: u64, exit: i32| {
+        let body = format!(
+            "# dodot shell-init profile v1\n\
+             # shell\tbash 5.0\n\
+             # start_t\t{t0}.000000\n\
+             source\tvim\tshell\t{target}\t{t0}.000100\t{t0}.000900\t{exit}\n\
+             # end_t\t{t0}.001000\n",
+        );
+        env.fs
+            .write_file(
+                &probes_dir.join(format!("profile-{t0:010}-100-1.tsv")),
+                body.as_bytes(),
+            )
+            .unwrap();
+    };
+    make_profile(1714000001, 1);
+    make_profile(1714000002, 0);
+    make_profile(1714000003, 1);
+
+    let result = commands::status::status(None, &ctx).unwrap();
+    let row = result.packs[0]
+        .files
+        .iter()
+        .find(|f| f.name == "aliases.sh")
+        .expect("aliases.sh row missing");
+
+    assert_eq!(row.status, "broken", "row: {row:?}");
+    assert!(
+        row.status_label.contains("exited 1") && row.status_label.contains("2/3"),
+        "status_label was: {}",
+        row.status_label
+    );
+    let note_idx = row.note_ref.expect("expected note ref") as usize;
+    let note = &result.notes[note_idx - 1];
+    assert!(
+        note.body.contains("2 of 3 recent shell startups"),
+        "note body: {}",
+        note.body
+    );
+}
+
+#[test]
 fn up_writes_syntax_error_sidecar_when_check_fails() {
     use crate::shell::{SyntaxCheckResult, SyntaxChecker};
     use std::path::Path;

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -440,9 +440,11 @@ fn status_surfaces_runtime_failures_from_recent_profiles() {
     let ctx = make_ctx(&env);
     commands::up::up(None, &ctx).unwrap();
 
-    // Write three fake profile TSVs by hand: two with exit_status=1
-    // for aliases.sh, one with exit_status=0. Newer filenames sort
-    // last lexically; the reader walks newest-first.
+    // Write three fake profile TSVs by hand. Distinct exit codes for
+    // the old vs. new failure — if the aggregator overwrites
+    // last_failure_exit while iterating newest→oldest, this test
+    // catches it: oldest=2, newest=1, so the label must say "exited 1"
+    // (the most-recent failure), not "exited 2".
     let source_path = env.dotfiles_root.join("vim/aliases.sh");
     let target = source_path.display().to_string();
     let probes_dir = env.paths.probes_shell_init_dir();
@@ -462,9 +464,9 @@ fn status_surfaces_runtime_failures_from_recent_profiles() {
             )
             .unwrap();
     };
-    make_profile(1714000001, 1);
-    make_profile(1714000002, 0);
-    make_profile(1714000003, 1);
+    make_profile(1714000001, 2); // oldest failure
+    make_profile(1714000002, 0); // clean run in the middle
+    make_profile(1714000003, 1); // most recent failure
 
     let result = commands::status::status(None, &ctx).unwrap();
     let row = result.packs[0]
@@ -474,9 +476,16 @@ fn status_surfaces_runtime_failures_from_recent_profiles() {
         .expect("aliases.sh row missing");
 
     assert_eq!(row.status, "broken", "row: {row:?}");
+    // Label must report the *most recent* failure's exit code (1),
+    // not the older one (2).
     assert!(
         row.status_label.contains("exited 1") && row.status_label.contains("2/3"),
         "status_label was: {}",
+        row.status_label
+    );
+    assert!(
+        !row.status_label.contains("exited 2"),
+        "status_label should report newest failure, not older: {}",
         row.status_label
     );
     let note_idx = row.note_ref.expect("expected note ref") as usize;
@@ -484,6 +493,11 @@ fn status_surfaces_runtime_failures_from_recent_profiles() {
     assert!(
         note.body.contains("2 of 3 recent shell startups"),
         "note body: {}",
+        note.body
+    );
+    assert!(
+        note.body.contains("last failure: exit 1"),
+        "note should mention most recent failure exit code: {}",
         note.body
     );
 }

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -38,6 +38,7 @@ fn make_ctx(env: &TempEnvironment) -> ExecutionContext {
         datastore,
         paths: env.paths.clone() as Arc<dyn Pather>,
         config_manager,
+        syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
         dry_run: false,
         no_provision: true,
         provision_rerun: false,
@@ -364,6 +365,48 @@ fn up_generates_shell_init() {
         init_content.contains("aliases.sh"),
         "init script: {init_content}"
     );
+}
+
+#[test]
+fn up_writes_syntax_error_sidecar_when_check_fails() {
+    use crate::shell::{SyntaxCheckResult, SyntaxChecker};
+    use std::path::Path;
+
+    // A checker that flags `aliases.sh` as broken so we can verify
+    // up wires the validation pass through correctly.
+    struct FlagAliases;
+    impl SyntaxChecker for FlagAliases {
+        fn check(&self, _interpreter: &str, file: &Path) -> SyntaxCheckResult {
+            if file.file_name().and_then(|s| s.to_str()) == Some("aliases.sh") {
+                SyntaxCheckResult::SyntaxError {
+                    stderr: "aliases.sh: line 1: unexpected token\n".into(),
+                }
+            } else {
+                SyntaxCheckResult::Ok
+            }
+        }
+    }
+
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("aliases.sh", "if [ x = y\nfi")
+        .file("env.sh", "export FOO=bar")
+        .done()
+        .build();
+
+    let mut ctx = make_ctx(&env);
+    ctx.syntax_checker = Arc::new(FlagAliases);
+    commands::up::up(None, &ctx).unwrap();
+
+    // Sidecar present for the failing file…
+    let bad = crate::shell::error_sidecar_path(env.paths.as_ref(), "vim", "aliases.sh");
+    assert!(env.fs.exists(&bad), "expected sidecar at {}", bad.display());
+    let body = env.fs.read_to_string(&bad).unwrap();
+    assert!(body.contains("unexpected token"), "sidecar:\n{body}");
+
+    // …and not for the clean file.
+    let good = crate::shell::error_sidecar_path(env.paths.as_ref(), "vim", "env.sh");
+    assert!(!env.fs.exists(&good));
 }
 
 #[test]

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -132,6 +132,35 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         if removed > 0 {
             debug!(removed, "pruned old shell-init profiles");
         }
+
+        // Pre-flight syntax check: parse-only run of bash/zsh against
+        // each deployed shell source so a typo in `aliases.sh` shows up
+        // here instead of silently breaking next shell startup. The
+        // sidecar files this writes are read back by `dodot status`.
+        // The checker is injected via context so tests can stub it out.
+        let report = shell::validate_shell_sources(
+            ctx.fs.as_ref(),
+            ctx.paths.as_ref(),
+            ctx.syntax_checker.as_ref(),
+        )?;
+        if !report.failures.is_empty() {
+            info!(
+                count = report.failures.len(),
+                "shell syntax check found failures"
+            );
+            eprintln!(
+                "dodot: {} shell file{} failed pre-flight syntax check (see `dodot status`)",
+                report.failures.len(),
+                if report.failures.len() == 1 { "" } else { "s" }
+            );
+        }
+        for interp in &report.missing_interpreters {
+            // One-line skip notice per missing interpreter, not per
+            // file. Doesn't fail the run — the file is still deployed.
+            eprintln!(
+                "dodot: `{interp}` not on PATH, skipped syntax check for matching shell files"
+            );
+        }
     }
 
     let has_failures = pack_results

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -28,6 +28,10 @@ pub struct ExecutionContext {
     pub datastore: Arc<dyn DataStore>,
     pub paths: Arc<dyn Pather>,
     pub config_manager: Arc<ConfigManager>,
+    /// Pre-flight syntax checker for shell sources. Production wires
+    /// up [`SystemSyntaxChecker`](crate::shell::SystemSyntaxChecker)
+    /// (spawns real `bash`/`zsh -n`); tests inject a mock.
+    pub syntax_checker: Arc<dyn crate::shell::SyntaxChecker>,
     pub dry_run: bool,
     pub no_provision: bool,
     pub provision_rerun: bool,
@@ -73,6 +77,7 @@ impl ExecutionContext {
             datastore,
             paths,
             config_manager,
+            syntax_checker: Arc::new(crate::shell::SystemSyntaxChecker),
             dry_run: false,
             no_provision: false,
             provision_rerun: false,
@@ -499,6 +504,7 @@ mod tests {
             datastore,
             paths: env.paths.clone() as Arc<dyn Pather>,
             config_manager,
+            syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
             dry_run: false,
             no_provision: true, // skip install/homebrew in tests
             provision_rerun: false,
@@ -655,6 +661,7 @@ mod tests {
             datastore,
             paths: env.paths.clone() as Arc<dyn Pather>,
             config_manager,
+            syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
             dry_run: true,
             no_provision: true,
             provision_rerun: false,

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -44,6 +44,12 @@ use crate::fs::Fs;
 use crate::paths::Pather;
 use crate::Result;
 
+pub mod validate;
+pub use validate::{
+    error_sidecar_path, validate_shell_sources, NoopSyntaxChecker, ShellValidationFailure,
+    ShellValidationReport, SyntaxCheckResult, SyntaxChecker, SystemSyntaxChecker, ERRORS_SUBDIR,
+};
+
 /// Append the "nothing to do" notice for an empty init script.
 fn append_empty_notice(script: &mut String) {
     writeln!(script, "# No shell scripts or PATH additions to load.").unwrap();

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -317,9 +317,13 @@ fn emit_timed_source(script: &mut String, pack: &str, target: &Path) {
     let target_str = target.display().to_string();
     let target_q = sh_quote(&target_str);
     writeln!(script, "if [ \"$_dodot_prof\" = \"1\" ]; then").unwrap();
+    // `_dodot_rc` is initialised to 0 *before* the source attempt so a
+    // missing file (the `[ -f … ]` test failing) does not get reported
+    // as "exited 1". The compound `&& { … }` only sets `_dodot_rc` from
+    // the actual `.` invocation; otherwise it stays 0.
     writeln!(
         script,
-        "  _dodot_t0=$EPOCHREALTIME; [ -f \"{target_str}\" ] && . \"{target_str}\"; _dodot_rc=$?; _dodot_t1=$EPOCHREALTIME"
+        "  _dodot_rc=0; _dodot_t0=$EPOCHREALTIME; [ -f \"{target_str}\" ] && {{ . \"{target_str}\"; _dodot_rc=$?; }}; _dodot_t1=$EPOCHREALTIME"
     )
     .unwrap();
     writeln!(
@@ -706,6 +710,39 @@ mod tests {
         let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
         assert!(script.contains("No shell scripts or PATH additions"));
         assert!(!script.contains("_dodot_prof"));
+    }
+
+    #[test]
+    fn profiled_source_initialises_rc_so_missing_file_isnt_reported_as_failure() {
+        // Regression: previously the profiled branch was
+        //
+        //   _dodot_rc=$?  # after `[ -f X ] && . X`
+        //
+        // which captured the file-test exit (1) when the file was
+        // absent — falsely classifying "file missing" as "source
+        // exited 1". The fix initialises _dodot_rc to 0 before the
+        // attempt, and only updates it inside the `&& { . X; rc=$?; }`
+        // group when the source actually ran.
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "alias vi=vim")
+            .done()
+            .build();
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
+        // Pre-attempt initialisation present.
+        assert!(
+            script.contains("_dodot_rc=0;"),
+            "profiled branch must seed _dodot_rc=0 before the source attempt:\n{script}"
+        );
+        // Source is wrapped so the rc only updates when `.` ran.
+        assert!(
+            script.contains("&& { . "),
+            "profiled branch must guard the rc update inside `&& {{ … }}`:\n{script}"
+        );
     }
 
     #[test]

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -163,11 +163,16 @@ pub fn generate_init_script(
             if profiling_active {
                 emit_timed_source(&mut script, pack, target);
             } else {
+                // Loud-failure wrapper: if the source command itself
+                // exits non-zero, print a dodot-attributed message to
+                // stderr alongside the shell's own error so the user
+                // can see *which* dodot-managed file failed. The
+                // shell's native message already carries the line
+                // number; we add the breadcrumb back to dodot.
                 writeln!(
                     script,
-                    "[ -f \"{}\" ] && . \"{}\"",
-                    target.display(),
-                    target.display()
+                    "[ -f \"{p}\" ] && {{ . \"{p}\" || echo \"dodot: shell source exited $?: {p}\" >&2; }}",
+                    p = target.display()
                 )
                 .unwrap();
             }
@@ -297,6 +302,11 @@ fn emit_timed_path(script: &mut String, pack: &str, target: &Path) {
 
 /// One inline-timed `[ -f X ] && . X` row, capturing the source's
 /// exit status. Same overhead profile as the PATH variant.
+///
+/// Both branches (profiling-active and unprofiled fallback) emit the
+/// loud-failure message on a non-zero source exit, so users see the
+/// dodot breadcrumb whether or not their shell supports the timing
+/// path.
 fn emit_timed_source(script: &mut String, pack: &str, target: &Path) {
     let target_str = target.display().to_string();
     let target_q = sh_quote(&target_str);
@@ -311,8 +321,17 @@ fn emit_timed_source(script: &mut String, pack: &str, target: &Path) {
         "  printf 'source\\t{pack}\\tshell\\t%s\\t%s\\t%s\\t%s\\n' {target_q} \"$_dodot_t0\" \"$_dodot_t1\" \"$_dodot_rc\" >> \"$_dodot_prof_file\" 2>/dev/null"
     )
     .unwrap();
+    writeln!(
+        script,
+        "  [ \"$_dodot_rc\" -ne 0 ] && echo \"dodot: shell source exited $_dodot_rc: {target_str}\" >&2"
+    )
+    .unwrap();
     writeln!(script, "else").unwrap();
-    writeln!(script, "  [ -f \"{target_str}\" ] && . \"{target_str}\"").unwrap();
+    writeln!(
+        script,
+        "  [ -f \"{target_str}\" ] && {{ . \"{target_str}\" || echo \"dodot: shell source exited $?: {target_str}\" >&2; }}"
+    )
+    .unwrap();
     writeln!(script, "fi").unwrap();
 }
 
@@ -404,11 +423,12 @@ mod tests {
 
         assert!(script.contains("# Shell scripts"), "script:\n{script}");
         assert!(script.contains("# [vim]"), "script:\n{script}");
+        // Loud-failure wrapper: existence-guarded source, with a
+        // dodot-attributed echo on non-zero exit.
         assert!(
             script.contains(&format!(
-                "[ -f \"{}\" ] && . \"{}\"",
-                source.display(),
-                source.display()
+                "[ -f \"{p}\" ] && {{ . \"{p}\" || echo \"dodot: shell source exited $?: {p}\" >&2; }}",
+                p = source.display()
             )),
             "script:\n{script}"
         );
@@ -680,6 +700,46 @@ mod tests {
         let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
         assert!(script.contains("No shell scripts or PATH additions"));
         assert!(!script.contains("_dodot_prof"));
+    }
+
+    #[test]
+    fn loud_failure_wrapper_present_in_both_modes() {
+        // A non-zero exit from a sourced file must surface as a
+        // dodot-attributed message on stderr, regardless of whether
+        // profiling is on. This is the user-facing breadcrumb that
+        // says "the dodot-managed source exited non-zero" alongside
+        // the shell's own line-numbered error.
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "alias vi=vim")
+            .done()
+            .build();
+
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+
+        // Profiling off: inline OR-echo form.
+        let plain = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
+        assert!(
+            plain.contains("dodot: shell source exited $?:"),
+            "plain script missing loud-failure echo:\n{plain}"
+        );
+
+        // Profiling on: timed branch echoes after the printf when
+        // _dodot_rc != 0; unprofiled fallback uses the same OR-echo
+        // form as the plain path.
+        let timed = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
+        assert!(
+            timed.contains(
+                "[ \"$_dodot_rc\" -ne 0 ] && echo \"dodot: shell source exited $_dodot_rc:"
+            ),
+            "timed script missing profiled-branch echo:\n{timed}"
+        );
+        assert!(
+            timed.contains("dodot: shell source exited $?:"),
+            "timed script missing fallback-branch echo:\n{timed}"
+        );
     }
 
     #[test]

--- a/crates/dodot-lib/src/shell/validate.rs
+++ b/crates/dodot-lib/src/shell/validate.rs
@@ -1,0 +1,430 @@
+//! Pre-flight syntax check for shell-sourced files.
+//!
+//! Runs `bash -n` / `zsh -n` against each deployed shell source so that
+//! syntax errors in `aliases.sh`, `profile.zsh` etc. surface at
+//! `dodot up` time instead of silently breaking the user's next shell
+//! startup. The interpreter's stderr (which carries `file: line N:
+//! error_message`) is preserved verbatim into a sidecar file under the
+//! handler datastore so `dodot status` can show it later (3c).
+//!
+//! This module does not invoke the staged file. It only parses it.
+//! `bash -n` / `zsh -n` are syntax-only — no commands run, no side
+//! effects on the user's environment.
+//!
+//! Sidecar layout: `<data_dir>/packs/<pack>/shell/.errors/<filename>.err`
+//! - Written on a fresh syntax failure.
+//! - Removed on a fresh syntax success (so a fix clears the prior error).
+//! - Untouched when the interpreter is missing (we have no info either way).
+//!
+//! Init-script generation already filters non-symlinks, so the
+//! `.errors` subdirectory does not end up sourced at shell startup.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use crate::fs::Fs;
+use crate::paths::Pather;
+use crate::Result;
+
+/// Run a syntax-only check on a shell file.
+///
+/// Implementations must not run the file or alter the environment;
+/// they invoke the interpreter in parse-only mode and return what it
+/// found.
+pub trait SyntaxChecker: Send + Sync {
+    fn check(&self, interpreter: &str, file: &Path) -> SyntaxCheckResult;
+}
+
+#[derive(Debug, Clone)]
+pub enum SyntaxCheckResult {
+    /// Interpreter parsed the file with no errors.
+    Ok,
+    /// Interpreter reported syntax errors. `stderr` carries the
+    /// raw output (with line/column information from the shell).
+    SyntaxError { stderr: String },
+    /// The interpreter binary was not found on PATH.
+    InterpreterMissing,
+}
+
+/// Production [`SyntaxChecker`] that spawns real subprocesses.
+pub struct SystemSyntaxChecker;
+
+/// [`SyntaxChecker`] that always returns [`SyntaxCheckResult::Ok`].
+/// Used in tests to keep the validation pass deterministic and
+/// hermetic (no real `bash`/`zsh` invocations).
+pub struct NoopSyntaxChecker;
+
+impl SyntaxChecker for NoopSyntaxChecker {
+    fn check(&self, _interpreter: &str, _file: &Path) -> SyntaxCheckResult {
+        SyntaxCheckResult::Ok
+    }
+}
+
+impl SyntaxChecker for SystemSyntaxChecker {
+    fn check(&self, interpreter: &str, file: &Path) -> SyntaxCheckResult {
+        match std::process::Command::new(interpreter)
+            .arg("-n")
+            .arg(file)
+            .output()
+        {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                SyntaxCheckResult::InterpreterMissing
+            }
+            Err(e) => SyntaxCheckResult::SyntaxError {
+                stderr: format!("dodot: failed to spawn {interpreter}: {e}\n"),
+            },
+            Ok(output) if output.status.success() => SyntaxCheckResult::Ok,
+            Ok(output) => SyntaxCheckResult::SyntaxError {
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            },
+        }
+    }
+}
+
+/// Pick the interpreter to validate `file` with based on its extension.
+/// Returns `None` for files we don't know how to syntax-check (the
+/// caller should skip those).
+fn interpreter_for(file: &Path) -> Option<&'static str> {
+    match file.extension().and_then(|e| e.to_str()) {
+        Some("zsh") => Some("zsh"),
+        Some("bash") => Some("bash"),
+        // bash is the most permissive POSIX-compatible parser. A user
+        // whose interactive shell is dash/sh and who relies on POSIX
+        // strictness will need to verify themselves; bash -n still
+        // catches the bulk of real-world syntax errors in `.sh` files.
+        Some("sh") => Some("bash"),
+        _ => None,
+    }
+}
+
+/// Summary of one validation pass over the deployed shell sources.
+#[derive(Debug, Default)]
+pub struct ShellValidationReport {
+    /// Total files inspected (matched a known shell extension).
+    pub checked: usize,
+    /// Per-failure detail for callers that want to render or log them.
+    pub failures: Vec<ShellValidationFailure>,
+    /// Interpreters we tried to spawn but couldn't find. Each entry is
+    /// recorded once even if many files needed it.
+    pub missing_interpreters: BTreeSet<String>,
+}
+
+/// One file that failed pre-flight syntax check.
+#[derive(Debug, Clone)]
+pub struct ShellValidationFailure {
+    pub pack: String,
+    pub source: PathBuf,
+    pub stderr: String,
+}
+
+/// Subdirectory (under each pack's shell handler dir) where sidecar
+/// `.err` files live. Public so 3c (`status`) can read it back.
+pub const ERRORS_SUBDIR: &str = ".errors";
+
+/// Path of the sidecar error file for one source.
+pub fn error_sidecar_path(paths: &dyn Pather, pack: &str, source_filename: &str) -> PathBuf {
+    paths
+        .handler_data_dir(pack, "shell")
+        .join(ERRORS_SUBDIR)
+        .join(format!("{source_filename}.err"))
+}
+
+/// Iterate every deployed shell source, run a syntax check, and update
+/// the per-file sidecar files. Idempotent across runs: a previously
+/// failing file that's been fixed gets its sidecar removed.
+pub fn validate_shell_sources(
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+    checker: &dyn SyntaxChecker,
+) -> Result<ShellValidationReport> {
+    let mut report = ShellValidationReport::default();
+
+    let packs_dir = paths.data_dir().join("packs");
+    if !fs.exists(&packs_dir) {
+        return Ok(report);
+    }
+
+    for pack_entry in fs.read_dir(&packs_dir)? {
+        if !pack_entry.is_dir {
+            continue;
+        }
+        let pack_name = &pack_entry.name;
+        let shell_dir = paths.handler_data_dir(pack_name, "shell");
+        if !fs.is_dir(&shell_dir) {
+            continue;
+        }
+        let errors_dir = shell_dir.join(ERRORS_SUBDIR);
+
+        let entries = match fs.read_dir(&shell_dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for entry in entries {
+            if !entry.is_symlink {
+                continue;
+            }
+            let source = match fs.readlink(&entry.path) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            let interpreter = match interpreter_for(&source) {
+                Some(i) => i,
+                None => continue,
+            };
+
+            let filename = source
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let err_path = errors_dir.join(format!("{filename}.err"));
+
+            report.checked += 1;
+            match checker.check(interpreter, &source) {
+                SyntaxCheckResult::Ok => {
+                    // Clear any stale sidecar from a previous failure.
+                    if fs.exists(&err_path) {
+                        let _ = fs.remove_file(&err_path);
+                    }
+                }
+                SyntaxCheckResult::SyntaxError { stderr } => {
+                    fs.mkdir_all(&errors_dir)?;
+                    fs.write_file(&err_path, stderr.as_bytes())?;
+                    report.failures.push(ShellValidationFailure {
+                        pack: pack_name.clone(),
+                        source: source.clone(),
+                        stderr,
+                    });
+                }
+                SyntaxCheckResult::InterpreterMissing => {
+                    report.missing_interpreters.insert(interpreter.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datastore::{CommandOutput, CommandRunner, DataStore, FilesystemDataStore};
+    use crate::testing::TempEnvironment;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    struct NoopRunner;
+    impl CommandRunner for NoopRunner {
+        fn run(&self, _: &str, _: &[String]) -> Result<CommandOutput> {
+            Ok(CommandOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    fn make_datastore(env: &TempEnvironment) -> FilesystemDataStore {
+        FilesystemDataStore::new(env.fs.clone(), env.paths.clone(), Arc::new(NoopRunner))
+    }
+
+    /// Test checker: returns canned results keyed by source filename
+    /// (basename), so tests can target individual files without caring
+    /// about absolute paths.
+    #[derive(Default)]
+    struct CannedChecker {
+        results: Mutex<HashMap<String, SyntaxCheckResult>>,
+        calls: Mutex<Vec<(String, PathBuf)>>,
+    }
+    impl CannedChecker {
+        fn set(&self, filename: &str, result: SyntaxCheckResult) {
+            self.results
+                .lock()
+                .unwrap()
+                .insert(filename.to_string(), result);
+        }
+        fn calls(&self) -> Vec<(String, PathBuf)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+    impl SyntaxChecker for CannedChecker {
+        fn check(&self, interpreter: &str, file: &Path) -> SyntaxCheckResult {
+            let basename = file
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            self.calls
+                .lock()
+                .unwrap()
+                .push((interpreter.to_string(), file.to_path_buf()));
+            self.results
+                .lock()
+                .unwrap()
+                .get(&basename)
+                .cloned()
+                .unwrap_or(SyntaxCheckResult::Ok)
+        }
+    }
+
+    #[test]
+    fn interpreter_picked_per_extension() {
+        assert_eq!(interpreter_for(Path::new("a.sh")), Some("bash"));
+        assert_eq!(interpreter_for(Path::new("a.bash")), Some("bash"));
+        assert_eq!(interpreter_for(Path::new("a.zsh")), Some("zsh"));
+        assert_eq!(interpreter_for(Path::new("a.fish")), None);
+        assert_eq!(interpreter_for(Path::new("Makefile")), None);
+    }
+
+    #[test]
+    fn validates_each_deployed_shell_file() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "alias vi=vim")
+            .file("env.zsh", "export FOO=bar")
+            .done()
+            .build();
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/env.zsh"))
+            .unwrap();
+
+        let checker = CannedChecker::default();
+        let report = validate_shell_sources(env.fs.as_ref(), env.paths.as_ref(), &checker).unwrap();
+
+        assert_eq!(report.checked, 2);
+        assert!(report.failures.is_empty());
+        assert!(report.missing_interpreters.is_empty());
+
+        let calls = checker.calls();
+        let interpreters: Vec<&String> = calls.iter().map(|(i, _)| i).collect();
+        assert!(interpreters.contains(&&"bash".to_string()));
+        assert!(interpreters.contains(&&"zsh".to_string()));
+    }
+
+    #[test]
+    fn syntax_failure_writes_sidecar_with_stderr() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "if [ x = y\nfi\n")
+            .done()
+            .build();
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+
+        let checker = CannedChecker::default();
+        checker.set(
+            "aliases.sh",
+            SyntaxCheckResult::SyntaxError {
+                stderr: "aliases.sh: line 2: syntax error near `fi'\n".into(),
+            },
+        );
+
+        let report = validate_shell_sources(env.fs.as_ref(), env.paths.as_ref(), &checker).unwrap();
+
+        assert_eq!(report.checked, 1);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].pack, "vim");
+
+        let sidecar = error_sidecar_path(env.paths.as_ref(), "vim", "aliases.sh");
+        assert!(env.fs.exists(&sidecar));
+        let body = env.fs.read_to_string(&sidecar).unwrap();
+        assert!(body.contains("syntax error near"), "sidecar:\n{body}");
+    }
+
+    #[test]
+    fn fixed_syntax_clears_stale_sidecar() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "alias vi=vim")
+            .done()
+            .build();
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+
+        // First run: failure → sidecar written.
+        let bad = CannedChecker::default();
+        bad.set(
+            "aliases.sh",
+            SyntaxCheckResult::SyntaxError {
+                stderr: "aliases.sh: line 1: oops\n".into(),
+            },
+        );
+        validate_shell_sources(env.fs.as_ref(), env.paths.as_ref(), &bad).unwrap();
+        let sidecar = error_sidecar_path(env.paths.as_ref(), "vim", "aliases.sh");
+        assert!(env.fs.exists(&sidecar));
+
+        // Second run: success → sidecar removed.
+        let good = CannedChecker::default();
+        let report = validate_shell_sources(env.fs.as_ref(), env.paths.as_ref(), &good).unwrap();
+        assert_eq!(report.checked, 1);
+        assert!(report.failures.is_empty());
+        assert!(!env.fs.exists(&sidecar));
+    }
+
+    #[test]
+    fn missing_interpreter_recorded_and_sidecar_left_alone() {
+        // If we previously had a sidecar (e.g., from a prior failure)
+        // and the interpreter goes missing, we don't clobber the
+        // sidecar — we have no fresh info, so we leave the old verdict.
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.zsh", "alias vi=vim")
+            .done()
+            .build();
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.zsh"))
+            .unwrap();
+
+        // Prime a stale sidecar.
+        let sidecar = error_sidecar_path(env.paths.as_ref(), "vim", "aliases.zsh");
+        env.fs.mkdir_all(sidecar.parent().unwrap()).unwrap();
+        env.fs.write_file(&sidecar, b"old failure\n").unwrap();
+
+        let checker = CannedChecker::default();
+        checker.set("aliases.zsh", SyntaxCheckResult::InterpreterMissing);
+
+        let report = validate_shell_sources(env.fs.as_ref(), env.paths.as_ref(), &checker).unwrap();
+
+        assert_eq!(report.checked, 1);
+        assert!(report.failures.is_empty());
+        assert!(report.missing_interpreters.contains("zsh"));
+        // Sidecar untouched.
+        assert!(env.fs.exists(&sidecar));
+        assert_eq!(env.fs.read_to_string(&sidecar).unwrap(), "old failure\n");
+    }
+
+    #[test]
+    fn unknown_extensions_are_skipped() {
+        // A file the symlink handler caught (because it didn't match
+        // shell mappings) ends up under handler dir "symlink", not
+        // "shell" — so this test really only covers the case where
+        // someone manually places a non-shell-extension file under the
+        // shell handler. We still avoid running bash on a `.fish` file.
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("config.fish", "set -x FOO bar")
+            .done()
+            .build();
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/config.fish"))
+            .unwrap();
+
+        let checker = CannedChecker::default();
+        let report = validate_shell_sources(env.fs.as_ref(), env.paths.as_ref(), &checker).unwrap();
+
+        assert_eq!(report.checked, 0);
+        assert!(checker.calls().is_empty());
+    }
+
+    #[test]
+    fn empty_datastore_is_ok() {
+        let env = TempEnvironment::builder().build();
+        let checker = CannedChecker::default();
+        let report = validate_shell_sources(env.fs.as_ref(), env.paths.as_ref(), &checker).unwrap();
+        assert_eq!(report.checked, 0);
+    }
+}

--- a/docs/proposals/pack-ordering.lex
+++ b/docs/proposals/pack-ordering.lex
@@ -1,0 +1,299 @@
+Design Specification: Pack Ordering
+
+    This document specifies how dodot orders the application of packs across a dotfiles repository. The current behaviour — strict lexicographic order by directory name — is a de-facto contract that has never been written down, and users have no idiomatic way to express "this pack must run before that one" when bootstrap dependencies require it.
+
+    The proposal is small on purpose. It documents the existing contract, adds a recognised numeric prefix grammar for pack directories, and explicitly defers richer ordering surfaces (priority fields, dependency graphs, phase buckets) until real usage shows the prefix is insufficient. The handlers spec [./preprocessing-pipeline.lex] already covers within-pack handler phases; this document covers the gap above that — order across packs.
+
+
+1. Motivation
+
+    1.1. Bootstrap Is the Common Case
+
+        Three real situations have surfaced from early adoption, all variations of the same shape:
+
+            - The Homebrew shell environment must be evaluated before any pack that uses brew. Today this lives in raw shell rc above the dodot eval, because dodot has no way to express "this pack first".
+            - `compinit` must run after all completion-providing plugins are loaded but before `fzf-tab`. The cross-pack ordering between a `completion` pack and an `fzf-tab` pack is undefined unless the user knows the lex-order trick.
+            - On a fresh macOS install, baseline setup (xcode-select, license acceptance, etc.) is a precondition for anything that compiles. Today users either run `dodot up <bootstrap-pack>` manually first or push the work outside dodot entirely.
+
+        These are not requests for a dependency graph. They are requests for an ordering primitive. The distinction matters; see §6.
+
+    1.2. The Undocumented Contract
+
+        dodot already orders packs lexicographically by directory name [../crates/dodot-lib/src/packs/mod.rs]. Shell init files are emitted across packs in that same order [../crates/dodot-lib/src/shell/mod.rs]. Pack name validation accepts digits, hyphens, underscores, and dots, so users can already prefix a directory with `001-` and observe the ordering effect. What is missing is:
+
+            - Documentation that this contract exists and can be relied on.
+            - A recognised, opinionated grammar so the prefix is treated as ordering metadata rather than as part of the pack's logical name.
+            - A getting-started note explaining what belongs in raw shell rc (the bootstrap-before-init zone) versus what belongs in a pack.
+
+        The first item is free. The second is small. The third is documentation only. None of this requires a new ordering engine.
+
+
+2. Principles
+
+    2.1. The Filesystem Should Tell the Truth
+
+        A user listing their dotfiles directory should be able to see the order packs will apply. This is dodot's house style: explicit over magical, visible over configured. A `priority = 30` field buried in a `.dodot.toml` is invisible to anyone scanning the directory; a directory named `030-nvim` is not. The cost is that the order is encoded in the name, which couples identity to position. We accept that cost.
+
+    2.2. One Mechanism, Not Three
+
+        Numeric prefixes, an `_` bootstrap convention, a `priority` field, and a `requires:` dependency list are all candidates. Shipping any two of them in the same release creates a conflict-of-rules problem (which wins when they disagree?) and forces every user to learn both. This proposal ships exactly one mechanism — the numeric prefix — and reserves the others as future work, gated on real demand. See §6.
+
+    2.3. Ordering Is Not Dependency
+
+        systemd's split between `Before=`/`After=` (ordering) and `Requires=`/`Wants=` (dependency strength) is the right primitive, and conflating them is the documented failure mode of every system that has tried. dodot's prefix is purely an ordering primitive: it says "A applies before B", not "A is required for B to make sense". A pack with a missing dependency is the user's problem, not the framework's. We do not detect, validate, or react to it.
+
+
+3. The Current State
+
+    3.1. What dodot Does Today
+
+        - `scan_packs()` reads the dotfiles directory, builds a `Pack` per subdirectory, and sorts by directory name [../crates/dodot-lib/src/packs/mod.rs].
+        - The shell handler iterates packs in scan order and emits one source line per shell file per pack [../crates/dodot-lib/src/shell/mod.rs]. Across packs, the lex order is the source order.
+        - `dodot up <name>` resolves the argument by exact directory-name match [../crates/dodot-lib/src/packs/orchestration.rs]. There is no fuzzy match, no alias system, no prefix stripping.
+        - Pack name validation [../crates/dodot-lib/src/packs/mod.rs] accepts `[A-Za-z0-9._-]+`, so `001-brew`, `010_nvim`, and `99.late` are all currently legal pack names.
+
+    3.2. What Breaks Without This Proposal
+
+        Nothing breaks. A user can rename their packs to `001-brew`, `010-nvim`, `100-starship` today and ordering will work as expected. The cost they pay is that:
+
+            - Every CLI invocation uses the prefixed name: `dodot up 010-nvim`, not `dodot up nvim`.
+            - Every status output, error message, and log line shows the prefix.
+            - The convention is theirs, not dodot's; another user reading their repo has to infer it.
+
+        This proposal pays those costs once, in the framework, so users don't pay them on every interaction.
+
+
+4. Survey of Prior Art
+
+    The decision space has been explored extensively by adjacent tools. We summarise rather than enumerate; the full survey informs the trade-offs but the conclusion is what matters.
+
+    4.1. Dotfiles Managers
+
+        chezmoi:
+            Filename grammar: `run_once_before_NN-name.sh`. Phase encoded in the name (`before`, `after`, `once`); within a phase, lexical order. The closest analog to what we're proposing. Bootstrap is solved cleanly. Cost: filename grammar is dense and easy to typo, and the `once` hash key is the filename, so renaming breaks idempotency.
+
+        dotbot:
+            YAML list order is the order. No deps, no priorities. Refactoring means rewriting the giant ordered list. Works, but the ordering surface is one global file rather than per-pack metadata.
+
+        yadm:
+            One user-authored bootstrap script. Punts the problem to the user.
+
+        rcm:
+            `pre-up.d/` and `post-up.d/` directories with run-parts-style lex order. Two phases plus lex within. Coarse but adequate for the bootstrap case.
+
+        home-manager (Nix):
+            Full DAG. Solves everything. Requires buying into Nix.
+
+        Ansible roles:
+            `meta/main.yml` `dependencies:`. Named, explicit, transitively resolved. The gold standard for declared deps, also the most expensive in machinery.
+
+    4.2. Adjacent Ordering Systems
+
+        SysV `S01foo`, `S99bar`:
+            The original NN-prefix pattern. Works in practice; the documented pain is renumbering cascades and the implicit-meaning problem (`S30` doesn't say *why* it's before `S40`). The 10/20/30 gap convention exists precisely to mitigate the renumbering pain.
+
+        run-parts (`/etc/cron.d`, `/etc/logrotate.d`):
+            Lexical order with conventional prefixes `00-`, `50-`, `99-`. Pitfall: filenames with dots are silently skipped by run-parts itself. Universal gap convention.
+
+        systemd:
+            `Before=` / `After=` for ordering, `Requires=` / `Wants=` for dependency. Decoupling the two is the lesson worth stealing.
+
+        zsh plugin managers (zinit, antigen):
+            `.zshrc` line order. `compinit` → `fzf-tab` is the canonical "ordering matters" example in the entire shell ecosystem.
+
+        Vim plugin/after, Emacs use-package :after:
+            Phase buckets and named "load after" deps respectively. The vim two-phase model (plugin/, after/plugin/) is a reminder that two buckets cover surprisingly many cases.
+
+    4.3. What the Survey Says
+
+        Three families:
+
+            - Numeric prefix + lex sort (SysV, run-parts, chezmoi-in-practice). Zero learning, visible, painful to renumber.
+            - Named deps + topo-sort (Ansible, use-package, Nix). Refactor-safe, requires config, edge cases in the graph.
+            - Phase buckets (vim plugin/after, chezmoi before/after, rcm pre/post). Coarse, adequate for ~90% of bootstrap cases, almost no machinery.
+
+        The chezmoi precedent is the strongest argument for prefix-based ordering specifically in dotfiles tooling: the model is proven on the same problem we're solving. The systemd precedent is the strongest argument for *not* conflating ordering with dependency.
+
+
+5. Proposal
+
+    5.1. The Contract (Document What Already Exists)
+
+        Add to `docs/reference/handlers.lex`, a new "Cross-pack ordering" section with this contract:
+
+            dodot processes packs in lexicographic order of their on-disk directory names. Within a pack, handlers run in their fixed phase order. Across packs, this lex order determines the relative order of every cross-pack effect — shell init source order, PATH entry order, install/provision execution order.
+
+        This sentence resolves the original feedback at zero implementation cost. Ship it before any code change.
+
+    5.2. The Prefix Grammar
+
+        A pack directory matching the regex `^(\d+)[-_](.+)$` has its prefix recognised as ordering metadata:
+
+            On disk:
+                The directory is named with the prefix: `010-nvim`, `020_zsh`, `100-starship`.
+
+            Logical pack name:
+                The portion after the separator: `nvim`, `zsh`, `starship`. This is what every user-facing surface uses — `dodot up <name>`, status output, error messages, generated shell-init comments, log lines.
+
+            Sort key:
+                The full on-disk directory name. Lexicographic sort over the full name produces the intended numeric order *as long as users follow the digit-width convention* (see §5.4).
+
+            Unprefixed packs:
+                Sort lexically among themselves and interleave naturally with prefixed ones. `010-brew` < `020-zsh` < `nvim` < `starship`, so prefixed packs run before unprefixed ones in this example.
+
+    5.3. Collision Rules
+
+        Three classes of collision are possible. All are scan-time errors with both offending paths reported:
+
+            Logical-name collision:
+                Both `nvim` and `010-nvim` exist. The logical name `nvim` is ambiguous. Hard error.
+
+            Multi-prefix collision:
+                Both `010-nvim` and `020-nvim` exist. The logical name `nvim` resolves to two packs. Hard error.
+
+            Empty stem:
+                `010-` or `010_` (no name after the separator). Hard error: a pack must have a name.
+
+        The non-collision case — two packs with the same prefix and different stems (`010-brew` and `010-zsh`) — is permitted; lex order on the stem decides between them. We do not enforce the gap convention; it is documented but not validated.
+
+    5.4. Recommended Convention
+
+        Document, do not enforce:
+
+            - Three-digit prefixes with leading zeros: `010`, `020`, `050`, `100`. Two digits work but break sort once you cross 99 to 100.
+            - Gap convention: 10/20/30/.../100, leaving room to insert without renumbering. This is the universal lesson from SysV and run-parts.
+            - Reserved range by convention: `000–099` for bootstrap-y things (PATH setup, package manager install, OS-level prereqs). `100–899` for normal packs. `900–999` for late-loading things (prompt, autosuggestions, anything that wants to see the fully-populated environment).
+            - Hyphen separator preferred over underscore. Both work; hyphen reads better and matches existing dodot conventions.
+
+        These are conventions for the docs and the canonical example, not validation rules. A user who wants `5-foo` and `99-bar` is not wrong; they have just bought themselves a renumbering hazard, and that is their business.
+
+
+6. What This Proposal Does Not Build
+
+    Each of these is a reasonable extension. None ships in this proposal.
+
+    6.1. No `priority` Field in `.dodot.toml`
+
+        A `priority = 30` field per pack would decouple order from directory name and make refactoring easier (move a pack between order positions without renaming). The cost is that order becomes invisible: you can no longer answer "what runs first?" by listing the directory. Per principle 2.1, the filesystem should tell the truth. Defer until a concrete case shows the prefix can't handle it.
+
+    6.2. No Dependency Graph (`requires:`, `after:`)
+
+        An explicit `after: [pack-name]` field, with topo-sort and cycle detection, is the Ansible/use-package model. It is refactor-safe and expresses intent precisely. It is also a multi-week project (graph construction, cycle detection, error UX, doc churn) for a problem that the prefix solves for the 90% case. If real usage produces a case where two packs need to be relatively ordered without caring about their global position, revisit. The prefix and an `after:` field compose without contradiction; we are not painting ourselves into a corner.
+
+    6.3. No Phase Buckets (`bootstrap/`, `main/`, `late/`)
+
+        Either as parent directories or as a frontmatter field. The prefix already provides finer-grained control than three buckets, and the convention in §5.4 (000–099 / 100–899 / 900–999) gives the same coarse-grained intuition without a second mechanism. Per principle 2.2.
+
+    6.4. No `_` Prefix as a Bootstrap Signal
+
+        "Anything prefixed with `_` runs first" was considered. It is a one-bit phase bucket layered on top of the lex-order rule, which means two ordering rules that interact. Two rules > one rule. The `0NN-` prefix range covers the same intent.
+
+    6.5. No Validation of Bootstrap Hygiene
+
+        dodot does not detect "you put a brew-using pack before the brew-installing pack". That is a runtime failure of the user's pack scripts, surfaced through normal exit codes. Validating it would require dodot to understand what each pack actually does, which is out of scope by a wide margin.
+
+
+7. Implementation Sketch
+
+    Approximate scope: one struct field, one regex, one collision check, one display swap, plus tests and docs.
+
+    7.1. Pack Struct Changes
+
+        The `Pack` struct gains a `display_name: String` alongside the existing `name: String`. The `name` field continues to hold the raw on-disk directory name and continues to be the sort key; `display_name` holds the stripped form.
+
+        For unprefixed packs, `display_name == name`. For prefixed packs, `display_name` is the stem.
+
+    7.2. Scan-Time Changes
+
+        `scan_packs()` [../crates/dodot-lib/src/packs/mod.rs] gains:
+
+            - Regex match for the prefix grammar; populate `display_name`.
+            - Collision detection (§5.3) implemented as a pass over the scanned packs after sort: hash by `display_name`, error on duplicates with both source paths in the message.
+
+        Sort behaviour is unchanged: still by `name`, still lex.
+
+    7.3. Lookup Changes
+
+        `dodot up <arg>` [../crates/dodot-lib/src/packs/orchestration.rs] resolves `<arg>` against `display_name` first. Exact match on `display_name` wins. As a fallback, exact match on `name` (raw) is also accepted, so users with muscle memory or scripts referencing the prefixed form are not broken.
+
+        If `<arg>` matches multiple packs (only possible if the user disabled collision detection, which they cannot — see §5.3), the same scan-time error fires.
+
+    7.4. Display Surfaces
+
+        Every user-facing surface switches to `display_name`:
+
+            - `dodot status` table rows
+            - `dodot list` output
+            - Error messages ("pack `nvim` not found")
+            - Generated shell-init comments (`# pack: nvim`)
+            - Log lines
+
+        Internal surfaces (datastore paths, sentinel keys, anything keyed by directory identity) continue to use `name`. The directory on disk is still `010-nvim`; the datastore subtree is still `010-nvim/`. Only display changes.
+
+    7.5. Tests
+
+        - Round-trip: scan a fixture with mixed prefixed/unprefixed packs, assert sort order and `display_name` values.
+        - Collision detection: each of the three collision classes produces the expected error.
+        - Lookup: `dodot up <stripped>` and `dodot up <raw>` both find the right pack.
+        - Display: fixture with `010-nvim` produces output containing `nvim`, not `010-nvim`, in the rendered template.
+
+
+8. Documentation Deliverables
+
+    The proposal's user value is roughly half code and half docs. The doc work is:
+
+    8.1. Cross-Pack Ordering Section in handlers.lex
+
+        Per §5.1. One paragraph stating the lex-order contract, with a concrete example.
+
+    8.2. Bootstrap Zone Note in getting-started.lex
+
+        One sentence: anything that must exist before dodot can run (Homebrew shellenv that puts dodot on PATH, OS-level prereqs that block any pack from succeeding) belongs in raw shell rc above the dodot eval line, not in a pack. Resolves the third user feedback item.
+
+    8.3. Pack Ordering How-To
+
+        New short doc under `docs/reference/` (or wherever how-tos live) covering:
+
+            - The prefix grammar
+            - The 10/20/30 gap convention and why it matters
+            - The 000–099 / 100–899 / 900–999 reserved-range convention
+            - The canonical example: `010-brew`, `020-zsh`, `030-compinit`, `040-fzf-tab`, `100-starship`, `900-zsh-autosuggestions`
+            - A note that prefixes are optional — unprefixed packs work fine and most users will never need them
+
+    8.4. Migration Note
+
+        Existing users with prefixed packs (today, manually, paying the CLI ergonomics cost) should be told their pack names are about to change in CLI output. This is a behaviour change, not a breaking one (the raw-name fallback in §7.3 keeps scripts working), but worth a CHANGELOG line.
+
+
+9. Phased Implementation
+
+    Phase 1: Documentation. **(Independent of all code.)**
+        Land §8.1 and §8.2 immediately. Resolves the original feedback's items 2 and 3 with zero code risk. Optional: §8.3 with the canonical example, even before the prefix grammar is recognised by the code — the example works today via plain lex order.
+
+    Phase 2: Prefix grammar.
+        Implement §7.1 through §7.4. Tests per §7.5. CHANGELOG note per §8.4. Full §8.3 documenting the recognised grammar.
+
+    Phase 3: Deferred.
+        Revisit only on concrete user demand. Candidates, in rough order of likelihood:
+
+            - `priority` field as an alternative to prefix (if users complain about renames).
+            - `after:` field for relative ordering without global position (if compinit/fzf-tab style cases multiply).
+            - Validation hooks that warn when a known-bootstrap pack is positioned after a known-consumer pack (low priority; almost certainly never).
+
+
+10. What This Costs the User
+
+    Being honest about the price tag:
+
+        - One new convention to learn (the prefix grammar). Optional — unprefixed packs continue to work.
+        - A small renumbering hazard if the gap convention is ignored. The convention is documented; the user owns the consequences.
+        - One behaviour change in CLI output: a pack named `010-nvim` on disk now displays as `nvim`. Pre-existing scripts referencing the raw name still work via the fallback in §7.3.
+
+    Being honest about what this does not cost:
+
+        - No change to existing packs that don't use prefixes.
+        - No new config file, no new schema, no new CLI flags.
+        - No background processing, no cache invalidation, no migration script.
+        - No dependency resolution, no graph, no cycle detection, no failure modes that didn't already exist.
+
+    The proposal is small because the problem is small. dodot already orders packs; we are giving the existing order a name and a recognised grammar, and writing down what was previously folklore. That is the shape this feature should have.


### PR DESCRIPTION
Closes #60. Three commits, layered fixes for the gap that issue identifies. Also bundles the pack-ordering proposal doc that was drafted alongside (`docs/proposals/pack-ordering.lex`) — it's design-only, no code, and was on this branch when review was requested.

## The problem (one-line refresher)

A user with a broken `aliases.sh` runs broken shell startup forever and `dodot status` says "deployed." Before this PR, shell-sourced files were a silent class compared to install/homebrew: failures scrolled past once at shell startup, no persistent record, no reflection in `status`.

## Three commits, conceptually one fix

Each commit ships independently and adds value on its own. They build cleanly:

### 78ac2a9 — 3a: loud-failure wrapper at shell startup

Old emission:
```sh
[ -f "PATH" ] && . "PATH"
```
New emission:
```sh
[ -f "PATH" ] && { . "PATH" || echo "dodot: shell source exited $?: PATH" >&2; }
```

User-visible change at shell startup when `aliases.sh` exits 1:
```
/path/aliases.sh: line 47: bad substitution
dodot: shell source exited 1: /path/aliases.sh
```

The shell's native error (with line number) still flows through; the dodot line is the breadcrumb back to the manager. Both the unprofiled emission path and the profiling-active path get the wrapper.

Verified across bash / zsh / dash. Runtime errors that don't halt the source (e.g., a typo'd command in the middle of a file with no `set -e`) correctly stay silent — the source as a whole succeeded; the shell already printed the line-N error.

### 0a76817 — 3b: pre-flight syntax check on `dodot up`

After execution and init-script regeneration, `dodot up` runs a parse-only pass over each deployed shell source:

- `bash -n` for `*.sh` / `*.bash`
- `zsh -n` for `*.zsh`

The interpreter's stderr (which carries `file: line N: error_message`) is captured verbatim into a sidecar file at `<data_dir>/packs/<pack>/shell/.errors/<filename>.err`. The init-script generator already filters non-symlinks so the `.errors` subdirectory does not get sourced at startup. A successful recheck removes the stale sidecar, so a fix clears the prior verdict.

The check is non-fatal: a missing interpreter logs one line and moves on; a syntax-failing file is still deployed (the user may want to fix it from a fresh shell). A summary line on stderr names the failure count and points at `dodot status`.

The `SyntaxChecker` is injected via `ExecutionContext`, with `SystemSyntaxChecker` (real subprocess) in production and `NoopSyntaxChecker` in tests, so the test suite stays hermetic — no actual `bash -n` invocations during 488 tests.

### 9fb3e00 — 3c: `dodot status` surfaces both signals

Two layered checks for shell-handler files:

1. **Pre-flight syntax-error sidecars** from 3b. A row that would have rendered "sourced" now renders "syntax error" with the captured `file: line N: …` body in the footnote.
2. **Recurring runtime failures** from the profiling instrumentation (Phase 3 history). When profiling is on and any of the last five shell startups recorded a non-zero exit_status for a sourced file, the row renders e.g. `exited 1 (2/3)` with a footnote pointing at `dodot probe shell-init --history`.

Syntax errors win over runtime failures when both are present — a file that doesn't parse can't have meaningful runtime exit-code data.

`Health` gains one variant — `DeployedWithError { label, reason }` — that covers both cases through the existing `footnote_reason()` plumbing already used by `PendingConflict`. Visually it renders with the existing `broken` style (red).

### 64bd296 — review fixes

Addresses Copilot's review on this PR: missing-file false-positive in profiling rc capture (3a regression), most-recent-non-zero exit selection in `recent_runtime_failures` (3c bug), and one stale doc comment.

### 8523656 — pack-ordering proposal doc

Design-only, drafted as a sibling proposal to the shell error work. Adds `docs/proposals/pack-ordering.lex` covering the cross-pack ordering grammar and the prefix mechanism (3-digit, lex-sort, stripped from logical name). No code; reviewed for direction not implementation.

## Side-by-side: status output before / after

A pack with `aliases.sh` (broken syntax) and `env.sh` (clean):

**Before:**
```
[vim]
  aliases.sh   ⊕  sourced
  env.sh       ⊕  sourced
```

**After:**
```
[vim]
  aliases.sh   ⊕  syntax error  [1]
  env.sh       ⊕  sourced

[1] /path/aliases.sh: line 47: bad substitution
```

Same pack with a clean `aliases.sh` that exits 1 in 2 of the last 3 shell startups (profiling on):

```
[vim]
  aliases.sh   ⊕  exited 1 (2/3)  [1]
  env.sh       ⊕  sourced

[1] non-zero exit in 2 of 3 recent shell startups (last failure: exit 1).
    See `dodot probe shell-init --history` for details.
```

## Tests

- 7 new unit tests in `shell::validate` covering interpreter selection, sidecar write/clear behaviour, missing interpreter handling, and no-op cases.
- 1 new test asserting the loud-failure wrapper is present in both modes.
- 1 new regression test asserting the profiled-branch initialises rc=0 so missing files don't false-alarm.
- 3 new integration tests in `commands::tests` covering: `up` writes sidecar via injected checker, `status` surfaces the sidecar with the right label and footnote, and `status` aggregates runtime failures from hand-written profile TSVs (with distinct exit codes for old/new failures so the most-recent-failure selection is locked in).

477 → 488 lib tests, all passing.

## What this PR does not build (future work)

- **Running sourced files during `dodot up`.** Considered and rejected — shell-init files routinely have side effects (`eval "$(starship init zsh)"`, `eval "$(ssh-agent)"`, network calls, agent spawning). The interpreter-selection problem compounds. The errors that running-during-up would catch beyond syntax errors require running the *full* init chain in order — that's `dodot test-shell`, not per-file source-during-up. See the issue thread.
- **`dodot test-shell` / `--measure`.** Spawn `$SHELL -lc 'exit'`, capture stderr, render. Same machinery would double as `dodot probe shell-init --measure` (#59 staleness banner). Deferred until someone asks.
- **Runtime stderr capture during shell startup.** Would require `tee` / process substitution (not fully POSIX) and would blow the profiling overhead budget (§profiling.lex 2.1: "less than a few microseconds per sourced file, no forks"). The loud-failure wrapper (3a) is enough — the user sees the failure prominently and can investigate.
- **Line-by-line execution.** Bash and zsh already emit `file: line N: error` for both runtime and syntax errors; we don't lose line numbers. Line-by-line breaks on multi-line constructs (`if`, `for`, here-docs, function bodies) anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)