### PR TITLE
feat(packs): recognise NNN- ordering prefix as pack metadata

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,6 +8,25 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
 `### Removed`, `### Fixed`, `### Security`) so they nest cleanly under the
 `## [version]` heading the release workflow inserts.
 
+### Added
+
+- **Pack ordering: numeric-prefix grammar.** Pack directories matching
+  `^(\d+)[-_](.+)$` (e.g. `010-brew`, `100_zsh`, `900-starship`) now
+  have their prefix recognised as ordering metadata. The full
+  directory name remains the sort key (so prefixed packs apply in
+  lex order), but the stem after the separator is treated as the
+  pack's *display name* — what `dodot status`, `dodot list`, error
+  messages, generated shell-init comments, and log lines all use.
+  CLI arguments resolve against the display name first
+  (`dodot up brew`) and fall back to the raw on-disk directory name
+  (`dodot up 010-brew`). Symlink targets follow the display name too,
+  so `010-nvim/init.lua` deploys to `~/.config/nvim/init.lua`. Three
+  classes of collision are rejected at scan time with both offending
+  paths in the error: logical-name (`nvim` + `010-nvim`),
+  multi-prefix (`010-nvim` + `020-nvim`), and empty-stem (`010-` /
+  `010_`). The internal datastore subtree continues to be keyed by
+  the raw on-disk directory name.
+
 ### Changed
 
 - Documented the cross-pack ordering contract: dodot processes packs in
@@ -16,4 +35,8 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
   install/homebrew execution order. Added a "Cross-Pack Ordering"
   section to `docs/reference/handlers.lex` and a bootstrap-zone note to
   `docs/user/getting-started.lex` covering what belongs above the
-  `eval "$(dodot init-sh)"` line. No behavior change.
+  `eval "$(dodot init-sh)"` line.
+- `dodot status`, `dodot list`, `dodot up`, and `dodot down` output
+  now displays the stripped form for prefixed packs (a pack on disk
+  as `010-nvim` shows as `nvim`). Scripts that referenced the raw
+  form continue to work via the lookup fallback.

--- a/crates/dodot-lib/src/commands/addignore.rs
+++ b/crates/dodot-lib/src/commands/addignore.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 
-use crate::packs::orchestration::ExecutionContext;
+use crate::packs::orchestration::{self, ExecutionContext};
 use crate::{DodotError, Result};
 
 #[derive(Debug, Clone, Serialize)]
@@ -13,7 +13,10 @@ pub struct AddIgnoreResult {
 
 /// Create a `.dodotignore` file in the pack directory.
 pub fn addignore(pack_name: &str, ctx: &ExecutionContext) -> Result<AddIgnoreResult> {
-    let pack_path = ctx.paths.pack_path(pack_name);
+    // Resolve the user's input (display name or raw directory name) to
+    // the on-disk directory name; the datastore is keyed by the latter.
+    let pack_dir = orchestration::resolve_pack_dir_name(pack_name, ctx)?;
+    let pack_path = ctx.paths.pack_path(&pack_dir);
 
     if !ctx.fs.exists(&pack_path) {
         return Err(DodotError::PackNotFound {
@@ -21,11 +24,12 @@ pub fn addignore(pack_name: &str, ctx: &ExecutionContext) -> Result<AddIgnoreRes
         });
     }
 
+    let display = crate::packs::display_name_for(&pack_dir);
     let ignore_path = pack_path.join(".dodotignore");
 
     if ctx.fs.exists(&ignore_path) {
         return Ok(AddIgnoreResult {
-            message: format!("Pack '{pack_name}' is already ignored."),
+            message: format!("Pack '{display}' is already ignored."),
             details: vec![],
         });
     }
@@ -33,17 +37,17 @@ pub fn addignore(pack_name: &str, ctx: &ExecutionContext) -> Result<AddIgnoreRes
     ctx.fs.write_file(&ignore_path, b"")?;
 
     // Check if pack is currently deployed and warn (#18)
-    let handlers = ctx.datastore.list_pack_handlers(pack_name)?;
+    let handlers = ctx.datastore.list_pack_handlers(&pack_dir)?;
     let mut details = vec![format!("Created {}", ignore_path.display())];
     if !handlers.is_empty() {
         details.push(format!(
             "Warning: pack '{}' is currently deployed. Run 'dodot down {}' to clean up.",
-            pack_name, pack_name
+            display, display
         ));
     }
 
     Ok(AddIgnoreResult {
-        message: format!("Pack '{pack_name}' marked as ignored."),
+        message: format!("Pack '{display}' marked as ignored."),
         details,
     })
 }

--- a/crates/dodot-lib/src/commands/adopt.rs
+++ b/crates/dodot-lib/src/commands/adopt.rs
@@ -61,7 +61,12 @@ pub fn adopt(
         return Err(DodotError::Other("no files specified".into()));
     }
 
-    let pack_path = ctx.paths.pack_path(pack_name);
+    // Resolve the user's input (display name `nvim` or raw `010-nvim`)
+    // to the on-disk directory; the pack subtree is keyed by the raw
+    // form, every status/display surface by the display form.
+    let pack_dir = orchestration::resolve_pack_dir_name(pack_name, ctx)?;
+    let pack_display = packs::display_name_for(&pack_dir).to_string();
+    let pack_path = ctx.paths.pack_path(&pack_dir);
     if !ctx.fs.exists(&pack_path) {
         return Err(DodotError::PackNotFound {
             name: pack_name.into(),
@@ -75,11 +80,11 @@ pub fn adopt(
     }
 
     let (plans, skipped_already_adopted) =
-        preflight(pack_name, &pack_path, sources, force, no_follow, ctx)?;
+        preflight(&pack_dir, &pack_path, sources, force, no_follow, ctx)?;
 
     // If every input was already adopted, there's nothing to do.
     if plans.is_empty() {
-        let mut result = status::status(Some(&[pack_name.to_string()]), ctx)?;
+        let mut result = status::status(Some(std::slice::from_ref(&pack_display)), ctx)?;
         result.dry_run = dry_run;
         for msg in skipped_already_adopted {
             result.warnings.push(msg);
@@ -102,7 +107,7 @@ pub fn adopt(
     // Dry-run stops here: we've verified the plan is viable, now unwind.
     if dry_run {
         cleanup_pack_copies(&plans, ctx.fs.as_ref());
-        let mut result = status::status(Some(&[pack_name.to_string()]), ctx)?;
+        let mut result = status::status(Some(std::slice::from_ref(&pack_display)), ctx)?;
         result.dry_run = true;
         for msg in skipped_already_adopted {
             result.warnings.push(msg);
@@ -113,7 +118,7 @@ pub fn adopt(
     // Phase 2 — per-source atomic swap. Failures are recorded, not fatal.
     let failures = swap_all(&plans, ctx.fs.as_ref());
 
-    let mut result = status::status(Some(&[pack_name.to_string()]), ctx)?;
+    let mut result = status::status(Some(std::slice::from_ref(&pack_display)), ctx)?;
     result.dry_run = false;
     for msg in skipped_already_adopted {
         result.warnings.push(msg);
@@ -137,7 +142,7 @@ pub fn adopt(
             hint: None,
         });
         let note_ref = Some(result.notes.len() as u32);
-        if let Some(pack) = result.packs.iter_mut().find(|p| p.name == pack_name) {
+        if let Some(pack) = result.packs.iter_mut().find(|p| p.name == pack_display) {
             pack.files.push(DisplayFile {
                 name: src_name,
                 symbol: "×".into(),
@@ -525,7 +530,7 @@ fn check_deploy_conflicts(ctx: &ExecutionContext) -> Result<()> {
         // rather than risk a false negative that lets us mutate into a
         // state `dodot up` will later reject.
         let intents = orchestration::collect_pack_intents(&pack, ctx)?;
-        pack_intents.push((pack.name.clone(), intents));
+        pack_intents.push((pack.display_name.clone(), intents));
     }
 
     let conflicts = conflicts::detect_cross_pack_conflicts(&pack_intents, ctx.fs.as_ref());

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -38,7 +38,7 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
     info!(count = all_packs.len(), "discovered packs");
 
     if let Some(names) = pack_filter {
-        all_packs.retain(|p| names.iter().any(|n| n == &p.name));
+        all_packs.retain(|p| names.iter().any(|n| n == &p.display_name || n == &p.name));
     }
 
     let mut affected_packs = Vec::new();
@@ -46,16 +46,19 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
     let mut any_removed = false;
 
     for pack in &all_packs {
+        // Datastore is keyed by the on-disk directory name, not the
+        // display name — the directory `010-nvim` keeps its `010-nvim/`
+        // subtree in the datastore.
         let handlers = ctx.datastore.list_pack_handlers(&pack.name)?;
 
         if handlers.is_empty() {
-            debug!(pack = %pack.name, "already down, skipping");
+            debug!(pack = %pack.display_name, "already down, skipping");
             continue;
         }
 
-        info!(pack = %pack.name, handlers = ?handlers, "removing pack state");
+        info!(pack = %pack.display_name, handlers = ?handlers, "removing pack state");
         any_removed = true;
-        affected_packs.push(pack.name.clone());
+        affected_packs.push(pack.display_name.clone());
 
         if ctx.dry_run {
             dry_run_display.push(build_dry_run_display(pack, &handlers, ctx)?);
@@ -142,5 +145,5 @@ fn build_dry_run_display(
             });
         }
     }
-    Ok(DisplayPack::new(pack.name.clone(), files))
+    Ok(DisplayPack::new(pack.display_name.clone(), files))
 }

--- a/crates/dodot-lib/src/commands/fill.rs
+++ b/crates/dodot-lib/src/commands/fill.rs
@@ -5,7 +5,7 @@
 
 use serde::Serialize;
 
-use crate::packs::orchestration::ExecutionContext;
+use crate::packs::orchestration::{self, ExecutionContext};
 use crate::{DodotError, Result};
 
 #[derive(Debug, Clone, Serialize)]
@@ -75,13 +75,20 @@ echo "Installing PACK_NAME..."
 /// Skips files that already exist. Replaces `PACK_NAME` in templates
 /// with the actual pack name.
 pub fn fill(pack_name: &str, ctx: &ExecutionContext) -> Result<FillResult> {
-    let pack_path = ctx.paths.dotfiles_root().join(pack_name);
+    // Resolve the user's input (display or raw on-disk name) to the
+    // actual directory.
+    let pack_dir = orchestration::resolve_pack_dir_name(pack_name, ctx)?;
+    let pack_path = ctx.paths.pack_path(&pack_dir);
 
     if !ctx.fs.exists(&pack_path) {
         return Err(DodotError::PackNotFound {
             name: pack_name.into(),
         });
     }
+
+    // Templates substitute `PACK_NAME` with the pack's *display name* —
+    // a user-facing identifier in shell snippets and install scripts.
+    let display = crate::packs::display_name_for(&pack_dir);
 
     let mut details = Vec::new();
     let mut created = 0;
@@ -94,7 +101,7 @@ pub fn fill(pack_name: &str, ctx: &ExecutionContext) -> Result<FillResult> {
             continue;
         }
 
-        let content = template.content.replace("PACK_NAME", pack_name);
+        let content = template.content.replace("PACK_NAME", display);
         ctx.fs.write_file(&file_path, content.as_bytes())?;
 
         // Make install.sh executable
@@ -107,9 +114,9 @@ pub fn fill(pack_name: &str, ctx: &ExecutionContext) -> Result<FillResult> {
     }
 
     let message = if created == 0 {
-        format!("Pack '{pack_name}' already has all template files.")
+        format!("Pack '{display}' already has all template files.")
     } else {
-        format!("Added {created} template file(s) to '{pack_name}'.")
+        format!("Added {created} template file(s) to '{display}'.")
     };
 
     Ok(FillResult { message, details })

--- a/crates/dodot-lib/src/commands/list.rs
+++ b/crates/dodot-lib/src/commands/list.rs
@@ -2,6 +2,7 @@
 
 use serde::Serialize;
 
+use crate::packs;
 use crate::packs::orchestration::ExecutionContext;
 use crate::Result;
 
@@ -12,37 +13,45 @@ pub struct ListResult {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ListPack {
+    /// User-facing pack name. For prefixed packs (`010-nvim`) this is
+    /// the stripped form (`nvim`); for unprefixed packs it equals the
+    /// directory name.
     pub name: String,
     pub ignored: bool,
 }
 
 /// List all packs in the dotfiles root.
+///
+/// Packs appear in the order dodot would apply them (lexicographic by
+/// on-disk directory name); see the `packs` module docs for the pack
+/// ordering contract.
 pub fn list(ctx: &ExecutionContext) -> Result<ListResult> {
     let _root_config = ctx.config_manager.root_config()?;
 
     // Get all directories (including ignored ones for display)
     let entries = ctx.fs.read_dir(ctx.paths.dotfiles_root())?;
-    let mut packs = Vec::new();
+    let mut entries: Vec<_> = entries
+        .into_iter()
+        .filter(|e| {
+            e.is_dir
+                && (!e.name.starts_with('.') || e.name == ".config")
+                && is_valid_pack_name(&e.name)
+        })
+        .collect();
 
-    for entry in entries {
-        if !entry.is_dir {
-            continue;
-        }
-        if entry.name.starts_with('.') && entry.name != ".config" {
-            continue;
-        }
-        if !is_valid_pack_name(&entry.name) {
-            continue;
-        }
+    // Sort by raw on-disk name so the displayed order matches deploy order.
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
 
-        let ignored = ctx.fs.exists(&entry.path.join(".dodotignore"));
-        packs.push(ListPack {
-            name: entry.name,
-            ignored,
-        });
-    }
-
-    packs.sort_by(|a, b| a.name.cmp(&b.name));
+    let packs = entries
+        .into_iter()
+        .map(|entry| {
+            let ignored = ctx.fs.exists(&entry.path.join(".dodotignore"));
+            ListPack {
+                name: packs::display_name_for(&entry.name).to_string(),
+                ignored,
+            }
+        })
+        .collect();
 
     Ok(ListResult { packs })
 }

--- a/crates/dodot-lib/src/commands/list.rs
+++ b/crates/dodot-lib/src/commands/list.rs
@@ -24,41 +24,46 @@ pub struct ListPack {
 ///
 /// Packs appear in the order dodot would apply them (lexicographic by
 /// on-disk directory name); see the `packs` module docs for the pack
-/// ordering contract.
+/// ordering contract. Goes through [`packs::scan_packs`] so list
+/// output respects the same `pack.ignore` patterns and surfaces the
+/// same scan-time errors (empty-stem prefix directories, ordering
+/// collisions) that every other command does — `dodot list` should
+/// never show ambiguous duplicates that `dodot up` would refuse.
 pub fn list(ctx: &ExecutionContext) -> Result<ListResult> {
-    let _root_config = ctx.config_manager.root_config()?;
+    let root_config = ctx.config_manager.root_config()?;
+    let scanned = packs::scan_packs(
+        ctx.fs.as_ref(),
+        ctx.paths.dotfiles_root(),
+        &root_config.pack.ignore,
+    )?;
 
-    // Get all directories (including ignored ones for display)
-    let entries = ctx.fs.read_dir(ctx.paths.dotfiles_root())?;
-    let mut entries: Vec<_> = entries
-        .into_iter()
-        .filter(|e| {
-            e.is_dir
-                && (!e.name.starts_with('.') || e.name == ".config")
-                && is_valid_pack_name(&e.name)
-        })
-        .collect();
-
-    // Sort by raw on-disk name so the displayed order matches deploy order.
-    entries.sort_by(|a, b| a.name.cmp(&b.name));
-
-    let packs = entries
-        .into_iter()
-        .map(|entry| {
-            let ignored = ctx.fs.exists(&entry.path.join(".dodotignore"));
+    // Two streams in: active packs (already carry display_name) and
+    // dodotignore-marked dirs (raw names). Merge into one list with
+    // the `ignored` flag, preserving lex order on the on-disk name
+    // so the displayed order still matches deploy order.
+    let mut entries: Vec<(String, ListPack)> = Vec::new();
+    for p in scanned.packs {
+        entries.push((
+            p.name.clone(),
             ListPack {
-                name: packs::display_name_for(&entry.name).to_string(),
-                ignored,
-            }
-        })
-        .collect();
+                name: p.display_name,
+                ignored: false,
+            },
+        ));
+    }
+    for dir in scanned.ignored {
+        let display = packs::display_name_for(&dir).to_string();
+        entries.push((
+            dir,
+            ListPack {
+                name: display,
+                ignored: true,
+            },
+        ));
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
 
-    Ok(ListResult { packs })
-}
-
-fn is_valid_pack_name(name: &str) -> bool {
-    !name.is_empty()
-        && name
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.')
+    Ok(ListResult {
+        packs: entries.into_iter().map(|(_, p)| p).collect(),
+    })
 }

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -539,6 +539,15 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         debug!("no cross-pack conflicts");
     }
 
+    // Surface ignored packs by their display name, not the raw
+    // on-disk directory — the prefix grammar must stay invisible to
+    // the rendered "Ignored Packs" section just like every other
+    // user-facing surface.
+    let ignored_display: Vec<String> = ignored_packs
+        .iter()
+        .map(|d| crate::packs::display_name_for(d).to_string())
+        .collect();
+
     Ok(PackStatusResult {
         message: None,
         dry_run: false,
@@ -546,7 +555,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         warnings,
         notes,
         conflicts: display_conflicts,
-        ignored_packs,
+        ignored_packs: ignored_display,
         view_mode: ctx.view_mode.as_str().into(),
         group_mode: ctx.group_mode.as_str().into(),
     })

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -376,8 +376,12 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
     info!(count = all_packs.len(), "discovered packs");
 
     if let Some(names) = pack_filter {
-        all_packs.retain(|p| names.iter().any(|n| n == &p.name));
-        ignored_packs.retain(|name| names.iter().any(|n| n == name));
+        all_packs.retain(|p| names.iter().any(|n| n == &p.display_name || n == &p.name));
+        ignored_packs.retain(|name| {
+            names
+                .iter()
+                .any(|n| n == name || n == crate::packs::display_name_for(name))
+        });
     }
 
     let registry = handlers::create_registry(ctx.fs.as_ref());
@@ -388,7 +392,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
     let mut pack_intents = Vec::new();
 
     for mut pack in all_packs {
-        info!(pack = %pack.name, "checking pack status");
+        info!(pack = %pack.display_name, "checking pack status");
         let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
         pack.config = pack_config.to_handler_config();
         let rules = mappings_to_rules(&pack_config.mappings);
@@ -421,7 +425,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
                         // intent-collection attempt below.
                         warnings.push(format!(
                             "preprocessing failed for pack '{}': {}",
-                            pack.name, err
+                            pack.display_name, err
                         ));
                         crate::preprocessing::pipeline::PreprocessResult::passthrough(Vec::new())
                     }
@@ -435,15 +439,18 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         let all_entries = preprocess_result.merged_entries();
         let matches = scanner.match_entries(&all_entries, &rules, &pack.name);
 
-        // Collect intents for conflict detection
+        // Collect intents for conflict detection. The first tuple
+        // element is the user-facing label that surfaces in any
+        // resulting `DisplayConflict.claimants` entry, so it tracks
+        // the pack's display name rather than its raw on-disk name.
         match orchestration::collect_pack_intents(&pack, ctx) {
             Ok(intents) => {
-                pack_intents.push((pack.name.clone(), intents));
+                pack_intents.push((pack.display_name.clone(), intents));
             }
             Err(err) => {
                 warnings.push(format!(
                     "could not collect intents for pack '{}'; conflict detection may be incomplete: {}",
-                    pack.name, err
+                    pack.display_name, err
                 ));
             }
         }
@@ -513,7 +520,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
             });
         }
 
-        display_packs.push(DisplayPack::new(pack.name.clone(), files));
+        display_packs.push(DisplayPack::new(pack.display_name.clone(), files));
     }
 
     // Detect and surface cross-pack conflicts as structured display data

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -57,12 +57,12 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     for pack in &packs {
         match orchestration::collect_pack_intents(pack, ctx) {
             Ok(intents) => {
-                pack_intents.push((pack.name.clone(), intents));
+                pack_intents.push((pack.display_name.clone(), intents));
             }
             Err(e) => {
-                info!(pack = %pack.name, error = %e, "intent collection failed");
+                info!(pack = %pack.display_name, error = %e, "intent collection failed");
                 intent_errors.push(PackResult {
-                    pack_name: pack.name.clone(),
+                    pack_name: pack.display_name.clone(),
                     success: false,
                     operations: Vec::new(),
                     error: Some(format!("intent collection error: {e}")),
@@ -181,7 +181,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     let (display_packs, notes) = if ctx.dry_run {
         render_intents(&pack_results, ctx.paths.home_dir())
     } else {
-        let pack_names: Vec<String> = packs.iter().map(|p| p.name.clone()).collect();
+        let pack_names: Vec<String> = packs.iter().map(|p| p.display_name.clone()).collect();
         let status_result = status::status(Some(&pack_names), ctx)?;
         // status::status() may have populated notes (PendingConflict etc.);
         // preserve them and continue numbering from there.

--- a/crates/dodot-lib/src/error.rs
+++ b/crates/dodot-lib/src/error.rs
@@ -26,6 +26,12 @@ pub enum DodotError {
     #[error("pack is invalid: {name}: {reason}")]
     PackInvalid { name: String, reason: String },
 
+    #[error("pack ordering collision: display name `{display_name}` resolves to multiple packs:\n{}", .paths.iter().map(|p| format!("  - {}", p.display())).collect::<Vec<_>>().join("\n"))]
+    PackOrderingCollision {
+        display_name: String,
+        paths: Vec<PathBuf>,
+    },
+
     #[error("handler not found: {name}")]
     HandlerNotFound { name: String },
 

--- a/crates/dodot-lib/src/handlers/symlink.rs
+++ b/crates/dodot-lib/src/handlers/symlink.rs
@@ -421,6 +421,39 @@ mod tests {
         assert_eq!(target, PathBuf::from("/home/alice/.config/warp/themes"));
     }
 
+    // ── Pack ordering: prefix is stripped before path computation ─
+
+    #[test]
+    fn prefixed_pack_deploys_under_display_name_dir() {
+        // `010-nvim/init.lua` deploys to `~/.config/nvim/init.lua` —
+        // where neovim actually reads its config — not under
+        // `~/.config/010-nvim/`. The ordering prefix lives on disk
+        // and on the sort axis; it must not leak into the user's
+        // filesystem.
+        let config = HandlerConfig::default();
+        let target = resolve_target("010-nvim", "init.lua", &config, &test_pather());
+        assert_eq!(target, PathBuf::from("/home/alice/.config/nvim/init.lua"));
+    }
+
+    #[test]
+    fn prefixed_pack_works_with_underscore_separator() {
+        let config = HandlerConfig::default();
+        let target = resolve_target("020_zsh", "zshrc", &config, &test_pather());
+        // `force_home` defaults are off here; default-rule path holds.
+        assert_eq!(target, PathBuf::from("/home/alice/.config/zsh/zshrc"));
+    }
+
+    #[test]
+    fn prefixed_pack_with_force_home_still_strips_prefix() {
+        // The `force_home` matching is keyed on the pack-relative
+        // path (`ssh/config`), not the pack name, so this test mostly
+        // confirms that prefix stripping doesn't perturb that path —
+        // and that nested resolution still lands at `~/.ssh/config`
+        // regardless of how the pack directory is named.
+        let target = resolve_target("030-net", "ssh/config", &default_config(), &test_pather());
+        assert_eq!(target, PathBuf::from("/home/alice/.ssh/config"));
+    }
+
     /// Regression for the 0.16.0 pilot: pack `ghostty` with top-level
     /// file `config` used to resolve to `$HOME/.config` (collision with
     /// XDG_CONFIG_HOME directory). Under #48 it goes under the pack.

--- a/crates/dodot-lib/src/handlers/symlink.rs
+++ b/crates/dodot-lib/src/handlers/symlink.rs
@@ -241,6 +241,13 @@ pub(crate) fn resolve_target(
     config: &HandlerConfig,
     paths: &dyn Pather,
 ) -> PathBuf {
+    // Strip any `NNN-` ordering prefix from the pack name before
+    // computing the deployed path. The pack's *display name* — not its
+    // on-disk directory name — is what the user expects in
+    // `~/.config/<pack>/`. A pack `010-nvim/init.lua` deploys to
+    // `~/.config/nvim/init.lua` (which is where `nvim` actually reads
+    // its config), not `~/.config/010-nvim/init.lua`.
+    let pack = crate::packs::display_name_for(pack);
     let home = paths.home_dir();
     let xdg_config = paths.xdg_config_home();
 

--- a/crates/dodot-lib/src/packs/mod.rs
+++ b/crates/dodot-lib/src/packs/mod.rs
@@ -2,22 +2,79 @@
 //!
 //! A pack is a directory of related dotfiles (e.g. `vim/`, `git/`, `zsh/`).
 //! It is the unit of organisation, deployment, and removal.
+//!
+//! # Pack ordering
+//!
+//! Packs are processed in lexicographic order of their on-disk directory
+//! names. That order determines every cross-pack effect: shell init
+//! source order, `$PATH` entry order, install/homebrew execution order.
+//! See [`docs/reference/handlers.lex`](../../../../docs/reference/handlers.lex)
+//! "Cross-Pack Ordering" for the user-facing contract.
+//!
+//! For the small minority of packs where ordering actually matters,
+//! dodot recognises a numeric prefix on the directory name as ordering
+//! metadata: `010-brew`, `020_zsh`, `100-starship`. The grammar is
+//! `^(\d+)[-_](.+)$`. The portion after the separator is the pack's
+//! *display name* — what every user-facing surface shows
+//! (`dodot status`, `dodot list`, error messages, shell-init comments,
+//! log lines). The full directory name is the pack's *sort key* and
+//! the identity used for every internal surface (datastore subtree,
+//! sentinel keys, paths).
+//!
+//! Three classes of collision are rejected at scan time, with both
+//! offending paths reported:
+//!
+//! - **Logical-name collision** — `nvim` and `010-nvim` both exist;
+//!   the display name `nvim` is ambiguous.
+//! - **Multi-prefix collision** — `010-nvim` and `020-nvim` both exist;
+//!   the display name `nvim` resolves to two packs.
+//! - **Empty stem** — `010-` or `010_` with no name after the separator.
+//!
+//! The non-collision case where two packs share a prefix but differ
+//! on the stem (`010-brew` and `010-zsh`) is permitted; lex order on
+//! the stem decides between them. The 10/20/30 gap convention is
+//! documented but not enforced.
+//!
+//! ## Why no formal dependency graph?
+//!
+//! A `priority = 30` field, a `requires:` / `after:` declaration, or a
+//! phase-bucket directory layout were all considered and explicitly
+//! rejected for this iteration (see `docs/proposals/pack-ordering.lex`
+//! §6). The systemd lesson — that conflating ordering with dependency
+//! is the documented failure mode of every system that has tried — is
+//! the reason. The prefix is purely an ordering primitive; it says
+//! "A applies before B", not "A is required for B to make sense".
+//! A pack with a missing dependency is the user's problem, not the
+//! framework's.
 
 pub mod orchestration;
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
 use crate::fs::Fs;
 use crate::handlers::HandlerConfig;
-use crate::Result;
+use crate::{DodotError, Result};
 
 /// A dotfile pack — a directory of related configuration files.
 #[derive(Debug, Clone, Serialize)]
 pub struct Pack {
-    /// Directory name (e.g. `"vim"`).
+    /// On-disk directory name (e.g. `"vim"`, `"010-nvim"`). This is the
+    /// sort key that drives cross-pack ordering, and the identity used
+    /// by every internal surface (datastore subtree, sentinel keys,
+    /// path resolution).
     pub name: String,
+
+    /// User-facing pack name. For unprefixed packs this equals
+    /// [`name`](Self::name); for packs whose directory matches the
+    /// `^(\d+)[-_](.+)$` ordering grammar, this is the portion after
+    /// the separator (e.g. `010-nvim` → `nvim`). Used by every
+    /// user-facing surface: `dodot status`, `dodot list`, error
+    /// messages, generated shell-init comments, log lines, CLI
+    /// argument resolution.
+    pub display_name: String,
 
     /// Absolute path to the pack directory.
     pub path: PathBuf,
@@ -25,6 +82,97 @@ pub struct Pack {
     /// Handler-relevant configuration for this pack (merged from
     /// app defaults + root config + pack config).
     pub config: HandlerConfig,
+}
+
+impl Pack {
+    /// Construct a `Pack` from its on-disk directory name. Derives
+    /// [`display_name`](Self::display_name) by stripping a recognised
+    /// numeric prefix (`010-foo` → `foo`); for names without a prefix,
+    /// `display_name == name`.
+    ///
+    /// Pack name validation (alphanumerics, `_`, `-`, `.`) is the
+    /// caller's responsibility — typically [`scan_packs`].
+    pub fn new(name: String, path: PathBuf, config: HandlerConfig) -> Self {
+        let display_name = match parse_prefix(&name) {
+            Ok(Some(stem)) => stem.to_string(),
+            // Empty-stem (`010-`) is rejected upstream by scan_packs;
+            // if a caller bypasses that, fall back to the raw name
+            // rather than silently producing an empty display name.
+            Ok(None) | Err(_) => name.clone(),
+        };
+        Pack {
+            name,
+            display_name,
+            path,
+            config,
+        }
+    }
+}
+
+/// Compute the user-facing pack name for an on-disk directory name.
+/// Strips a recognised numeric prefix (`010-foo` → `foo`); for
+/// directories without a prefix, returns the full name.
+///
+/// For empty-stem inputs (`010-`, `010_`), returns the full name —
+/// scan-time validation rejects those before they reach this function,
+/// but the fallback keeps the helper total.
+pub fn display_name_for(dir_name: &str) -> &str {
+    match parse_prefix(dir_name) {
+        Ok(Some(stem)) => stem,
+        _ => dir_name,
+    }
+}
+
+/// Outcome of parsing a pack directory name against the ordering
+/// prefix grammar `^(\d+)[-_](.+)$`.
+///
+/// - `Ok(Some(stem))` — the name has a recognised prefix; the returned
+///   `&str` is the user-facing portion (e.g. `"010-nvim"` → `"nvim"`).
+/// - `Ok(None)` — the name does not match the grammar; treat it as
+///   unprefixed (display name equals the directory name).
+/// - `Err(())` — the name looks like a prefix (`010-` / `010_`) but
+///   nothing follows the separator. A scan-time error: a pack must
+///   have a name.
+fn parse_prefix(name: &str) -> std::result::Result<Option<&str>, ()> {
+    let bytes = name.as_bytes();
+    let digits_len = bytes.iter().take_while(|b| b.is_ascii_digit()).count();
+    if digits_len == 0 {
+        return Ok(None);
+    }
+    match bytes.get(digits_len) {
+        Some(b'-') | Some(b'_') => {}
+        _ => return Ok(None),
+    }
+    let stem = &name[digits_len + 1..];
+    if stem.is_empty() {
+        return Err(());
+    }
+    Ok(Some(stem))
+}
+
+/// Detect collisions between recognised display names. Reports the
+/// three classes covered in the module docs; returns the first
+/// collision encountered (deterministic, since `packs` is sorted by
+/// directory name on entry).
+fn detect_display_collisions(packs: &[Pack]) -> Result<()> {
+    let mut by_display: HashMap<&str, Vec<&Pack>> = HashMap::new();
+    for pack in packs {
+        by_display.entry(&pack.display_name).or_default().push(pack);
+    }
+
+    // Walk in sort order so the error is deterministic across runs.
+    for pack in packs {
+        if let Some(group) = by_display.get(pack.display_name.as_str()) {
+            if group.len() > 1 {
+                let paths: Vec<PathBuf> = group.iter().map(|p| p.path.clone()).collect();
+                return Err(DodotError::PackOrderingCollision {
+                    display_name: pack.display_name.clone(),
+                    paths,
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Result of scanning the dotfiles root: active packs + names of
@@ -40,7 +188,18 @@ pub struct DiscoveredPacks {
 /// Directories filtered out entirely (hidden, matching `ignore_patterns`,
 /// invalid names) appear in neither list — they aren't pack-shaped.
 ///
-/// Both lists are returned sorted alphabetically.
+/// Both lists are returned sorted lexicographically by on-disk
+/// directory name. That sort order is the contract that drives every
+/// cross-pack effect (shell init source order, `$PATH` order,
+/// install/homebrew execution order); see the module docs.
+///
+/// Errors:
+///
+/// - [`DodotError::PackInvalid`] for an empty-stem prefix
+///   (e.g. `010-` or `010_`) — a pack must have a name.
+/// - [`DodotError::PackOrderingCollision`] when two or more packs
+///   resolve to the same display name (`nvim` + `010-nvim`, or
+///   `010-nvim` + `020-nvim`).
 pub fn scan_packs(
     fs: &dyn Fs,
     dotfiles_root: &Path,
@@ -69,20 +228,35 @@ pub fn scan_packs(
             continue;
         }
 
+        // Reject pack directories that look like an ordering prefix
+        // but have no name after the separator (e.g. `010-`, `010_`).
+        // Done here so the error carries the offending path.
+        if parse_prefix(name).is_err() {
+            return Err(DodotError::PackInvalid {
+                name: name.clone(),
+                reason:
+                    "directory looks like an ordering prefix but has no name after the separator"
+                        .into(),
+            });
+        }
+
         if fs.exists(&entry.path.join(".dodotignore")) {
             ignored.push(name.clone());
             continue;
         }
 
-        packs.push(Pack {
-            name: name.clone(),
-            path: entry.path.clone(),
-            config: HandlerConfig::default(),
-        });
+        packs.push(Pack::new(
+            name.clone(),
+            entry.path.clone(),
+            HandlerConfig::default(),
+        ));
     }
 
     packs.sort_by(|a, b| a.name.cmp(&b.name));
     ignored.sort();
+
+    detect_display_collisions(&packs)?;
+
     Ok(DiscoveredPacks { packs, ignored })
 }
 
@@ -275,5 +449,201 @@ mod tests {
         assert!(!is_valid_pack_name(""));
         assert!(!is_valid_pack_name("has space"));
         assert!(!is_valid_pack_name("path/traversal"));
+    }
+
+    // ── Pack ordering: prefix grammar ──────────────────────────────
+
+    #[test]
+    fn parse_prefix_recognises_dash_separator() {
+        assert_eq!(parse_prefix("010-nvim"), Ok(Some("nvim")));
+        assert_eq!(parse_prefix("1-a"), Ok(Some("a")));
+        assert_eq!(parse_prefix("100-fzf-tab"), Ok(Some("fzf-tab")));
+    }
+
+    #[test]
+    fn parse_prefix_recognises_underscore_separator() {
+        assert_eq!(parse_prefix("020_zsh"), Ok(Some("zsh")));
+        assert_eq!(parse_prefix("99_late"), Ok(Some("late")));
+    }
+
+    #[test]
+    fn parse_prefix_passes_through_unprefixed_names() {
+        assert_eq!(parse_prefix("vim"), Ok(None));
+        assert_eq!(parse_prefix("my-pack"), Ok(None));
+        // Digits without a separator → not a prefix.
+        assert_eq!(parse_prefix("vim2"), Ok(None));
+        // Non-digit prefix → not a prefix.
+        assert_eq!(parse_prefix("a01-foo"), Ok(None));
+        // Separator at position 0 (no digits) → not a prefix.
+        assert_eq!(parse_prefix("-foo"), Ok(None));
+        assert_eq!(parse_prefix("_foo"), Ok(None));
+    }
+
+    #[test]
+    fn parse_prefix_rejects_empty_stem() {
+        assert_eq!(parse_prefix("010-"), Err(()));
+        assert_eq!(parse_prefix("010_"), Err(()));
+        assert_eq!(parse_prefix("1-"), Err(()));
+    }
+
+    #[test]
+    fn pack_new_strips_prefix_for_display_name() {
+        let p = Pack::new(
+            "010-nvim".into(),
+            PathBuf::from("/x/010-nvim"),
+            HandlerConfig::default(),
+        );
+        assert_eq!(p.name, "010-nvim");
+        assert_eq!(p.display_name, "nvim");
+    }
+
+    #[test]
+    fn pack_new_keeps_unprefixed_name_for_display_name() {
+        let p = Pack::new(
+            "vim".into(),
+            PathBuf::from("/x/vim"),
+            HandlerConfig::default(),
+        );
+        assert_eq!(p.name, "vim");
+        assert_eq!(p.display_name, "vim");
+    }
+
+    #[test]
+    fn display_name_for_helper_handles_both_forms() {
+        assert_eq!(display_name_for("010-nvim"), "nvim");
+        assert_eq!(display_name_for("020_zsh"), "zsh");
+        assert_eq!(display_name_for("vim"), "vim");
+        // Empty-stem inputs fall back to the raw name (callers should
+        // have rejected them at scan time).
+        assert_eq!(display_name_for("010-"), "010-");
+    }
+
+    #[test]
+    fn scan_sorts_prefixed_packs_numerically_via_lex_when_zero_padded() {
+        let env = TempEnvironment::builder()
+            .pack("100-zsh")
+            .file("zshrc", "x")
+            .done()
+            .pack("010-brew")
+            .file("Brewfile", "x")
+            .done()
+            .pack("020-git")
+            .file("gitconfig", "x")
+            .done()
+            .build();
+
+        let packs = discover_packs(env.fs.as_ref(), &env.dotfiles_root, &[]).unwrap();
+        let dirs: Vec<&str> = packs.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(dirs, vec!["010-brew", "020-git", "100-zsh"]);
+        let displays: Vec<&str> = packs.iter().map(|p| p.display_name.as_str()).collect();
+        assert_eq!(displays, vec!["brew", "git", "zsh"]);
+    }
+
+    #[test]
+    fn scan_interleaves_prefixed_and_unprefixed_via_lex() {
+        // `010-brew` < `020-zsh` < `nvim` < `starship`.
+        let env = TempEnvironment::builder()
+            .pack("nvim")
+            .file("init.lua", "x")
+            .done()
+            .pack("starship")
+            .file("starship.toml", "x")
+            .done()
+            .pack("010-brew")
+            .file("Brewfile", "x")
+            .done()
+            .pack("020-zsh")
+            .file("zshrc", "x")
+            .done()
+            .build();
+
+        let packs = discover_packs(env.fs.as_ref(), &env.dotfiles_root, &[]).unwrap();
+        let dirs: Vec<&str> = packs.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(dirs, vec!["010-brew", "020-zsh", "nvim", "starship"]);
+    }
+
+    #[test]
+    fn scan_rejects_logical_name_collision_between_prefixed_and_unprefixed() {
+        let env = TempEnvironment::builder()
+            .pack("nvim")
+            .file("init.lua", "x")
+            .done()
+            .pack("010-nvim")
+            .file("init.lua", "x")
+            .done()
+            .build();
+
+        let err = discover_packs(env.fs.as_ref(), &env.dotfiles_root, &[]).unwrap_err();
+        match err {
+            DodotError::PackOrderingCollision {
+                display_name,
+                paths,
+            } => {
+                assert_eq!(display_name, "nvim");
+                assert_eq!(paths.len(), 2);
+                let path_strs: Vec<String> =
+                    paths.iter().map(|p| p.display().to_string()).collect();
+                assert!(path_strs.iter().any(|s| s.ends_with("nvim")));
+                assert!(path_strs.iter().any(|s| s.ends_with("010-nvim")));
+            }
+            other => panic!("expected PackOrderingCollision, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scan_rejects_multi_prefix_collision() {
+        let env = TempEnvironment::builder()
+            .pack("010-nvim")
+            .file("init.lua", "x")
+            .done()
+            .pack("020-nvim")
+            .file("init.lua", "x")
+            .done()
+            .build();
+
+        let err = discover_packs(env.fs.as_ref(), &env.dotfiles_root, &[]).unwrap_err();
+        assert!(matches!(
+            err,
+            DodotError::PackOrderingCollision { ref display_name, .. } if display_name == "nvim"
+        ));
+    }
+
+    #[test]
+    fn scan_allows_same_prefix_with_different_stems() {
+        // `010-brew` and `010-zsh` both legal — display names differ
+        // (`brew`, `zsh`), and lex order on the stem decides between
+        // them.
+        let env = TempEnvironment::builder()
+            .pack("010-brew")
+            .file("Brewfile", "x")
+            .done()
+            .pack("010-zsh")
+            .file("zshrc", "x")
+            .done()
+            .build();
+
+        let packs = discover_packs(env.fs.as_ref(), &env.dotfiles_root, &[]).unwrap();
+        let dirs: Vec<&str> = packs.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(dirs, vec!["010-brew", "010-zsh"]);
+        let displays: Vec<&str> = packs.iter().map(|p| p.display_name.as_str()).collect();
+        assert_eq!(displays, vec!["brew", "zsh"]);
+    }
+
+    #[test]
+    fn scan_rejects_empty_stem_directory() {
+        let env = TempEnvironment::builder()
+            .pack("010-")
+            .file("placeholder", "x")
+            .done()
+            .build();
+
+        let err = discover_packs(env.fs.as_ref(), &env.dotfiles_root, &[]).unwrap_err();
+        match err {
+            DodotError::PackInvalid { name, reason } => {
+                assert_eq!(name, "010-");
+                assert!(reason.contains("ordering prefix"));
+            }
+            other => panic!("expected PackInvalid, got: {other:?}"),
+        }
     }
 }

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -168,7 +168,7 @@ pub fn execute(
         let _warnings = validate_pack_names(names, ctx)?;
         // Warnings are handled by the calling command (status/up/down)
         debug!(filter = ?names, "applying pack filter");
-        all_packs.retain(|p| names.iter().any(|n| n == &p.name));
+        all_packs.retain(|p| names.iter().any(|n| n == &p.display_name || n == &p.name));
         info!(count = all_packs.len(), "packs after filter");
     }
 
@@ -258,7 +258,7 @@ pub fn prepare_packs(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> 
     if let Some(names) = pack_filter {
         let _warnings = validate_pack_names(names, ctx)?;
         debug!(filter = ?names, "applying pack filter");
-        all_packs.retain(|p| names.iter().any(|n| n == &p.name));
+        all_packs.retain(|p| names.iter().any(|n| n == &p.display_name || n == &p.name));
         info!(count = all_packs.len(), "packs after filter");
     }
 
@@ -443,18 +443,75 @@ pub fn run_handler_pipeline(pack: &Pack, ctx: &ExecutionContext) -> Result<Vec<O
     execute_intents(intents, ctx)
 }
 
+/// Resolve a user-typed pack identifier to its on-disk directory
+/// name. Tries display name first, falls back to the raw on-disk
+/// name — so `dodot adopt nvim` and `dodot adopt 010-nvim` both find
+/// the same pack on disk.
+///
+/// Use this in commands that take a single pack-name argument and
+/// then need the directory path for filesystem or datastore work
+/// (`adopt`, `addignore`, `fill`). Errors with [`DodotError::PackNotFound`]
+/// when no match exists, and resolves through both active and ignored
+/// packs (the caller decides whether being ignored is fatal).
+pub fn resolve_pack_dir_name(input: &str, ctx: &ExecutionContext) -> crate::Result<String> {
+    let root_config = ctx.config_manager.root_config()?;
+    let scanned = packs::scan_packs(
+        ctx.fs.as_ref(),
+        ctx.paths.dotfiles_root(),
+        &root_config.pack.ignore,
+    )?;
+    if let Some(p) = scanned
+        .packs
+        .iter()
+        .find(|p| p.display_name == *input || p.name == *input)
+    {
+        return Ok(p.name.clone());
+    }
+    if let Some(dir) = scanned
+        .ignored
+        .iter()
+        .find(|d| d.as_str() == input || packs::display_name_for(d) == input)
+    {
+        return Ok(dir.clone());
+    }
+    Err(crate::DodotError::PackNotFound { name: input.into() })
+}
+
 /// Validate that requested pack names exist. Returns error for nonexistent
 /// packs and collects warnings for ignored packs.
+///
+/// Names resolve against the pack's *display name* (e.g. `nvim` for an
+/// on-disk `010-nvim`) first, then fall back to the raw on-disk name —
+/// so `dodot up nvim` and `dodot up 010-nvim` both find the same pack.
+/// The display name is the recommended form.
 pub fn validate_pack_names(names: &[String], ctx: &ExecutionContext) -> crate::Result<Vec<String>> {
+    let root_config = ctx.config_manager.root_config()?;
+    let scanned = packs::scan_packs(
+        ctx.fs.as_ref(),
+        ctx.paths.dotfiles_root(),
+        &root_config.pack.ignore,
+    )?;
+
     let mut warnings = Vec::new();
-    for name in names {
-        let pack_dir = ctx.paths.pack_path(name);
-        if !ctx.fs.exists(&pack_dir) {
-            return Err(crate::DodotError::PackNotFound { name: name.clone() });
+    for input in names {
+        if scanned
+            .packs
+            .iter()
+            .any(|p| p.display_name == *input || p.name == *input)
+        {
+            continue;
         }
-        if ctx.fs.exists(&pack_dir.join(".dodotignore")) {
-            warnings.push(format!("warning: pack '{}' is ignored, skipping", name));
+        if scanned
+            .ignored
+            .iter()
+            .any(|dir| dir == input || packs::display_name_for(dir) == input)
+        {
+            warnings.push(format!("warning: pack '{}' is ignored, skipping", input));
+            continue;
         }
+        return Err(crate::DodotError::PackNotFound {
+            name: input.clone(),
+        });
     }
     Ok(warnings)
 }
@@ -525,8 +582,11 @@ mod tests {
         fn execute_for_pack(&self, pack: &Pack, ctx: &ExecutionContext) -> Result<PackResult> {
             let operations = run_handler_pipeline(pack, ctx)?;
             let success = operations.iter().all(|r| r.success);
+            // Mirror what the real up/down commands do: the user-facing
+            // pack identifier carried in `PackResult.pack_name` is the
+            // pack's display name, not its raw on-disk directory.
             Ok(PackResult {
-                pack_name: pack.name.clone(),
+                pack_name: pack.display_name.clone(),
                 success,
                 operations,
                 error: None,
@@ -594,6 +654,87 @@ mod tests {
     }
 
     #[test]
+    fn execute_filter_resolves_display_name_to_prefixed_pack() {
+        let env = TempEnvironment::builder()
+            .pack("010-brew")
+            .file("Brewfile", "x")
+            .done()
+            .pack("nvim")
+            .file("init.lua", "x")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let filter = vec!["brew".into()];
+        let result = execute(&TestUpCommand, Some(&filter), &ctx).unwrap();
+
+        // Filter `brew` resolves to the on-disk `010-brew` pack via display name.
+        assert_eq!(result.total_packs, 1);
+        assert_eq!(result.pack_results[0].pack_name, "brew");
+    }
+
+    #[test]
+    fn execute_filter_accepts_raw_directory_name_as_fallback() {
+        let env = TempEnvironment::builder()
+            .pack("010-brew")
+            .file("Brewfile", "x")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let filter = vec!["010-brew".into()];
+        let result = execute(&TestUpCommand, Some(&filter), &ctx).unwrap();
+
+        // The raw directory name is a valid fallback for muscle memory or scripts.
+        assert_eq!(result.total_packs, 1);
+        // PackResult.pack_name surfaces the display-name form regardless of how
+        // the user typed the filter — that's what every render path expects.
+        assert_eq!(result.pack_results[0].pack_name, "brew");
+    }
+
+    #[test]
+    fn resolve_pack_dir_name_finds_pack_by_display_name() {
+        let env = TempEnvironment::builder()
+            .pack("010-nvim")
+            .file("init.lua", "x")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let resolved = resolve_pack_dir_name("nvim", &ctx).unwrap();
+        assert_eq!(resolved, "010-nvim");
+    }
+
+    #[test]
+    fn resolve_pack_dir_name_finds_pack_by_raw_directory_name() {
+        let env = TempEnvironment::builder()
+            .pack("010-nvim")
+            .file("init.lua", "x")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let resolved = resolve_pack_dir_name("010-nvim", &ctx).unwrap();
+        assert_eq!(resolved, "010-nvim");
+    }
+
+    #[test]
+    fn resolve_pack_dir_name_errors_on_unknown_pack() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("vimrc", "x")
+            .done()
+            .build();
+
+        let ctx = make_context(&env);
+        let err = resolve_pack_dir_name("nope", &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::DodotError::PackNotFound { ref name } if name == "nope"
+        ));
+    }
+
+    #[test]
     fn execute_skips_dodotignored_packs() {
         let env = TempEnvironment::builder()
             .pack("vim")
@@ -622,15 +763,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "vim".into(),
-            path: env.dotfiles_root.join("vim"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "vim".into(),
+            env.dotfiles_root.join("vim"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("vim"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let results = run_handler_pipeline(&pack, &ctx).unwrap();
         assert!(results.iter().all(|r| r.success));
@@ -690,15 +830,14 @@ mod tests {
 
         let ctx = make_context(&env); // no_provision = true
 
-        let pack = Pack {
-            name: "vim".into(),
-            path: env.dotfiles_root.join("vim"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "vim".into(),
+            env.dotfiles_root.join("vim"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("vim"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let results = run_handler_pipeline(&pack, &ctx).unwrap();
 
@@ -722,15 +861,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let mut registry = crate::preprocessing::PreprocessorRegistry::new();
         registry.register(Box::new(
@@ -779,15 +917,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let mut registry = crate::preprocessing::PreprocessorRegistry::new();
         registry.register(Box::new(
@@ -835,15 +972,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let mut registry = crate::preprocessing::PreprocessorRegistry::new();
         registry.register(Box::new(
@@ -875,15 +1011,14 @@ mod tests {
             .unwrap();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let mut registry = crate::preprocessing::PreprocessorRegistry::new();
         registry.register(Box::new(
@@ -917,15 +1052,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "vim".into(),
-            path: env.dotfiles_root.join("vim"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "vim".into(),
+            env.dotfiles_root.join("vim"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("vim"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         // No preprocessor registry at all
         let intents = collect_pack_intents_with_preprocessors(&pack, &ctx, None).unwrap();
@@ -953,15 +1087,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let mut registry = crate::preprocessing::PreprocessorRegistry::new();
         registry.register(Box::new(
@@ -1017,15 +1150,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "tools".into(),
-            path: env.dotfiles_root.join("tools"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "tools".into(),
+            env.dotfiles_root.join("tools"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("tools"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let mut registry = crate::preprocessing::PreprocessorRegistry::new();
         registry.register(Box::new(
@@ -1049,15 +1181,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         // Register both identity and unarchive preprocessors
         let mut registry = crate::preprocessing::PreprocessorRegistry::new();
@@ -1114,15 +1245,14 @@ mod tests {
         enc.finish().unwrap();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "tools".into(),
-            path: env.dotfiles_root.join("tools"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "tools".into(),
+            env.dotfiles_root.join("tools"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("tools"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         // Call the real production entrypoint — no explicit registry.
         let intents = collect_pack_intents(&pack, &ctx).unwrap();
@@ -1157,15 +1287,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let intents = collect_pack_intents(&pack, &ctx).unwrap();
         let user_path = match &intents[0] {
@@ -1195,15 +1324,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "tools".into(),
-            path: env.dotfiles_root.join("tools"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "tools".into(),
+            env.dotfiles_root.join("tools"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("tools"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let intents = collect_pack_intents(&pack, &ctx).unwrap();
         assert_eq!(intents.len(), 1);
@@ -1239,15 +1367,14 @@ mod tests {
             .unwrap();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let intents = collect_pack_intents(&pack, &ctx).unwrap();
         match &intents[0] {
@@ -1275,15 +1402,14 @@ mod tests {
             .unwrap();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let intents = collect_pack_intents(&pack, &ctx).unwrap();
         // With preprocessing disabled, the .tmpl file is treated as a
@@ -1317,15 +1443,14 @@ mod tests {
             .build();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let err = collect_pack_intents(&pack, &ctx).unwrap_err();
         match err {
@@ -1358,15 +1483,14 @@ mod tests {
             .unwrap();
 
         let ctx = make_context(&env);
-        let pack = Pack {
-            name: "app".into(),
-            path: env.dotfiles_root.join("app"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("app"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let err = collect_pack_intents(&pack, &ctx).unwrap_err();
         assert!(
@@ -1393,15 +1517,14 @@ mod tests {
         let mut ctx = make_context(&env);
         ctx.no_provision = false; // actually run install this time
 
-        let pack = Pack {
-            name: "setup".into(),
-            path: env.dotfiles_root.join("setup"),
-            config: ctx
-                .config_manager
+        let pack = Pack::new(
+            "setup".into(),
+            env.dotfiles_root.join("setup"),
+            ctx.config_manager
                 .config_for_pack(&env.dotfiles_root.join("setup"))
                 .unwrap()
                 .to_handler_config(),
-        };
+        );
 
         let intents = collect_pack_intents(&pack, &ctx).unwrap();
         let (sentinel, rendered_path) = match &intents[0] {

--- a/crates/dodot-lib/src/preprocessing/pipeline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline.rs
@@ -295,11 +295,7 @@ mod tests {
     use std::sync::Arc;
 
     fn make_pack(name: &str, path: PathBuf) -> Pack {
-        Pack {
-            name: name.into(),
-            path,
-            config: HandlerConfig::default(),
-        }
+        Pack::new(name.into(), path, HandlerConfig::default())
     }
 
     fn make_registry() -> PreprocessorRegistry {

--- a/crates/dodot-lib/src/rules/mod.rs
+++ b/crates/dodot-lib/src/rules/mod.rs
@@ -461,11 +461,7 @@ mod tests {
     use crate::testing::TempEnvironment;
 
     fn make_pack(name: &str, path: PathBuf) -> Pack {
-        Pack {
-            name: name.into(),
-            path,
-            config: HandlerConfig::default(),
-        }
+        Pack::new(name.into(), path, HandlerConfig::default())
     }
 
     fn default_rules() -> Vec<Rule> {

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -99,10 +99,16 @@ pub fn generate_init_script(
         if !pack_entry.is_dir {
             continue;
         }
-        let pack_name = &pack_entry.name;
+        // The datastore subtree is keyed by the on-disk directory
+        // name (e.g. `010-nvim`), but the comment we emit in the
+        // generated init script uses the pack's display name
+        // (`nvim`) — that's what the user sees in `dodot status` and
+        // expects to recognise here.
+        let pack_dir = &pack_entry.name;
+        let pack_display = crate::packs::display_name_for(pack_dir).to_string();
 
         // Shell handler: source scripts
-        let shell_dir = paths.handler_data_dir(pack_name, "shell");
+        let shell_dir = paths.handler_data_dir(pack_dir, "shell");
         if fs.is_dir(&shell_dir) {
             if let Ok(entries) = fs.read_dir(&shell_dir) {
                 for entry in entries {
@@ -111,13 +117,13 @@ pub fn generate_init_script(
                     }
                     // Follow the symlink to get the actual file path
                     let target = fs.readlink(&entry.path)?;
-                    shell_sources.push((pack_name.clone(), target));
+                    shell_sources.push((pack_display.clone(), target));
                 }
             }
         }
 
         // Path handler: add to PATH
-        let path_dir = paths.handler_data_dir(pack_name, "path");
+        let path_dir = paths.handler_data_dir(pack_dir, "path");
         if fs.is_dir(&path_dir) {
             if let Ok(entries) = fs.read_dir(&path_dir) {
                 for entry in entries {
@@ -125,7 +131,7 @@ pub fn generate_init_script(
                         continue;
                     }
                     let target = fs.readlink(&entry.path)?;
-                    path_additions.push((pack_name.clone(), target));
+                    path_additions.push((pack_display.clone(), target));
                 }
             }
         }

--- a/docs/reference/handlers.lex
+++ b/docs/reference/handlers.lex
@@ -91,6 +91,26 @@ Handlers
 
     :: note :: dodot does not have, and is not planning to add, a formal dependency graph or `before` / `after` declarations. The cost of getting those right is high, and the lex-order escape hatch handles the real cases.
 
+    4.1. The Prefix Grammar
+
+        When a pack directory matches `^(\d+)[-_](.+)$` — that is, a run of digits followed by `-` or `_` followed by a non-empty stem — dodot treats the prefix as ordering metadata, not as part of the pack's logical name. Three things follow:
+
+            - The full directory name is the *sort key*: `010-brew` < `020-zsh` < `nvim` < `starship`. Prefixed packs interleave with unprefixed ones via lex order, no special casing.
+            - The *display name* is the stripped stem: `010-brew` → `brew`. That's what `dodot status`, `dodot list`, error messages, generated shell-init comments, and log lines all use. The prefix is invisible to every user-facing surface.
+            - CLI arguments resolve against the display name first and fall back to the raw on-disk directory: `dodot up brew` and `dodot up 010-brew` find the same pack. The display form is the recommended one; the raw form keeps muscle-memory and scripts working.
+
+        Symlink targets follow the display name too: a `010-nvim/init.lua` deploys to `~/.config/nvim/init.lua` (where `nvim` actually reads its config), not `~/.config/010-nvim/init.lua`. The prefix lives on disk and on the sort axis; it does not leak into the user's filesystem.
+
+        The 10/20/30 gap convention from `/etc/init.d` carries over: leave room between numbers so you can insert without renumbering. Three digits with leading zeros (`010`, `020`, `100`, `900`) keeps lex order matching numeric order past the 99 → 100 boundary; two digits work but break sort once you cross.
+
+        Three classes of collision are rejected at scan time, with both offending paths in the error message:
+
+            - A pack `nvim` and a pack `010-nvim` both exist — the display name `nvim` is ambiguous.
+            - Both `010-nvim` and `020-nvim` exist — the display name `nvim` resolves to two packs.
+            - A directory like `010-` or `010_` with no stem after the separator — a pack must have a name.
+
+        Two packs with the same prefix and different stems (`010-brew` and `010-zsh`) are fine; lex order on the stem decides between them.
+
     See [./../user/getting-started.lex] (Shell Integration) for what belongs *above* the dodot init line in your shell rc — the small set of bootstrap concerns that have to exist before dodot itself can run, and therefore can't live in a pack at all.
 
 5. Configuration vs Code Execution

--- a/tests/e2e/bats/test_pack_ordering.bats
+++ b/tests/e2e/bats/test_pack_ordering.bats
@@ -1,0 +1,196 @@
+#!/usr/bin/env bats
+# E2E tests for the cross-pack ordering prefix grammar.
+#
+# Covers: directory-name lex order drives apply order; recognised
+# `NNN-` / `NNN_` prefixes are stripped for display and CLI argument
+# resolution (canonical form is the stripped name); both forms
+# (`dodot up nvim` and `dodot up 010-nvim`) resolve to the same pack;
+# scan-time collisions (logical-name + multi-prefix) are surfaced as
+# errors with both offending paths in the message.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "lex order drives shell-source order across prefixed packs" {
+    instrumented_shell "010-brew" "aliases.sh" 'export PROBE_ORDER="${PROBE_ORDER:+$PROBE_ORDER,}brew"'
+    instrumented_shell "100-zsh" "aliases.sh" 'export PROBE_ORDER="${PROBE_ORDER:+$PROBE_ORDER,}zsh"'
+    instrumented_shell "900-prompt" "aliases.sh" 'export PROBE_ORDER="${PROBE_ORDER:+$PROBE_ORDER,}prompt"'
+
+    dodot up
+    eval_init_sh
+
+    # Source order matches lex order on the directory names, which —
+    # with the zero-padded prefix — happens to match numeric order.
+    [ "$PROBE_ORDER" = "brew,zsh,prompt" ]
+}
+
+@test "dodot list shows display names, not raw directory names" {
+    create_pack_file "010-brew" "Brewfile" "brew 'rg'"
+    create_pack_file "100-zsh" "zshrc" "echo zsh"
+    create_pack_file "vim" "vimrc" "set nocompatible"
+
+    run dodot list
+    [ "$status" -eq 0 ]
+    # Display names — no `010-` / `100-` prefixes leaked through.
+    assert_output_contains "brew"
+    assert_output_contains "zsh"
+    assert_output_contains "vim"
+    assert_output_not_contains "010-brew"
+    assert_output_not_contains "100-zsh"
+}
+
+@test "dodot status shows display names for prefixed packs" {
+    create_pack_file "010-brew" "Brewfile" "brew 'rg'"
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "brew"
+    # The raw directory form must not surface in the status table.
+    assert_output_not_contains "010-brew"
+}
+
+@test "dodot up <display-name> finds the prefixed pack" {
+    instrumented_shell "010-brew" "aliases.sh" 'alias brewup="brew upgrade"'
+
+    run dodot up brew
+    [ "$status" -eq 0 ]
+    assert_output_contains "deployed"
+
+    # The shell source landed in the datastore under the raw
+    # directory key (010-brew), per the proposal's invariant — the
+    # display layer is the only place the prefix is hidden.
+    assert_exists "$XDG_DATA_HOME/dodot/packs/010-brew/shell"
+
+    # Status confirms the canonical form is `brew`.
+    run dodot status brew
+    [ "$status" -eq 0 ]
+    assert_output_contains "brew"
+    assert_output_not_contains "010-brew"
+}
+
+@test "dodot up <raw-directory-name> still works as a fallback" {
+    instrumented_shell "010-brew" "aliases.sh" 'alias brewup="brew upgrade"'
+
+    # Raw directory form: muscle-memory / scripts using the on-disk name.
+    run dodot up 010-brew
+    [ "$status" -eq 0 ]
+    assert_output_contains "deployed"
+    assert_exists "$XDG_DATA_HOME/dodot/packs/010-brew/shell"
+}
+
+@test "dodot down resolves both display and raw forms" {
+    instrumented_shell "010-brew" "aliases.sh" 'alias brewup="brew upgrade"'
+
+    dodot up
+
+    # down by display name
+    run dodot down brew
+    [ "$status" -eq 0 ]
+    assert_output_contains "deactivated"
+    assert_no_handler_state "010-brew" "shell"
+
+    dodot up
+    # down by raw directory name
+    run dodot down 010-brew
+    [ "$status" -eq 0 ]
+    assert_output_contains "deactivated"
+    assert_no_handler_state "010-brew" "shell"
+}
+
+@test "shell init script emits comments with the display name" {
+    instrumented_shell "010-brew" "aliases.sh" 'alias brewup="brew upgrade"'
+
+    dodot up
+
+    local init_script="$XDG_DATA_HOME/dodot/shell/dodot-init.sh"
+    assert_exists "$init_script"
+    # Comment uses the display name, not the raw directory.
+    assert_file_contains "$init_script" "# \[brew\]"
+    if grep -q '# \[010-brew\]' "$init_script"; then
+        echo "init script leaked raw prefix in pack comment:" >&2
+        cat "$init_script" >&2
+        return 1
+    fi
+}
+
+@test "symlink target uses the display name, not the raw directory" {
+    # `010-nvim/init.lua` should land at `~/.config/nvim/init.lua` —
+    # which is where neovim actually reads its config, regardless of
+    # what the dodot pack directory is named.
+    create_pack_file "010-nvim" "init.lua" "-- nvim config"
+
+    dodot up
+    assert_exists "$XDG_CONFIG_HOME/nvim/init.lua"
+    assert_not_exists "$XDG_CONFIG_HOME/010-nvim"
+}
+
+@test "symlink target follows display name when user invokes by raw form" {
+    create_pack_file "010-nvim" "init.lua" "-- nvim config"
+
+    dodot up 010-nvim
+    # Same target — canonicalisation applies regardless of how the
+    # user spelt the pack on the CLI.
+    assert_exists "$XDG_CONFIG_HOME/nvim/init.lua"
+    assert_not_exists "$XDG_CONFIG_HOME/010-nvim"
+}
+
+@test "logical-name collision is rejected with both paths in the message" {
+    create_pack_file "nvim" "init.lua" "x"
+    create_pack_file "010-nvim" "init.lua" "y"
+
+    run dodot status
+    # The CLI surfaces scan-time errors via stdout + Error: prefix;
+    # the canonical signal is the message body, not exit code.
+    assert_output_contains "collision"
+    assert_output_contains "nvim"
+    assert_output_contains "010-nvim"
+}
+
+@test "multi-prefix collision is rejected" {
+    create_pack_file "010-nvim" "init.lua" "x"
+    create_pack_file "020-nvim" "init.lua" "y"
+
+    run dodot status
+    assert_output_contains "collision"
+    assert_output_contains "010-nvim"
+    assert_output_contains "020-nvim"
+}
+
+@test "empty-stem prefix directory is rejected" {
+    mkdir -p "$DOTFILES_ROOT/010-"
+    # Add a placeholder so the directory survives as scan-eligible.
+    touch "$DOTFILES_ROOT/010-/keep"
+
+    run dodot status
+    # The error mentions the empty-stem reason and the raw directory.
+    assert_output_contains "010-"
+    assert_output_contains "ordering prefix"
+}
+
+@test "same prefix with different stems is allowed" {
+    create_pack_file "010-brew" "Brewfile" "brew 'rg'"
+    create_pack_file "010-zsh" "zshrc" "echo zsh"
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "brew"
+    assert_output_contains "zsh"
+}
+
+@test "unprefixed packs interleave with prefixed ones in lex order" {
+    # Lex: 010-brew < 020-zsh < nvim < starship
+    instrumented_shell "010-brew" "aliases.sh" 'export PROBE_ORDER="${PROBE_ORDER:+$PROBE_ORDER,}brew"'
+    instrumented_shell "020-zsh" "aliases.sh" 'export PROBE_ORDER="${PROBE_ORDER:+$PROBE_ORDER,}zsh"'
+    instrumented_shell "nvim" "aliases.sh" 'export PROBE_ORDER="${PROBE_ORDER:+$PROBE_ORDER,}nvim"'
+    instrumented_shell "starship" "aliases.sh" 'export PROBE_ORDER="${PROBE_ORDER:+$PROBE_ORDER,}starship"'
+
+    dodot up
+    eval_init_sh
+    [ "$PROBE_ORDER" = "brew,zsh,nvim,starship" ]
+}


### PR DESCRIPTION
**Stacked on top of #62.** Phase 2 of the pack-ordering proposal ([`docs/proposals/pack-ordering.lex`](https://github.com/arthur-debert/dodot/blob/main/docs/proposals/pack-ordering.lex) §7).

## Summary

Pack directories matching `^(\d+)[-_](.+)$` (e.g. `010-brew`, `100_zsh`, `900-starship`) now have their prefix recognised as ordering metadata, separate from the pack's logical identity.

**Two names per pack now:**
- `name` — on-disk directory (`010-nvim`); sort key, datastore key, identity for every internal surface.
- `display_name` — stripped stem (`nvim`); used by `dodot status`, `dodot list`, error messages, generated shell-init comments, log lines, and CLI argument resolution.

**Lookup is bidirectional:** `dodot up nvim` and `dodot up 010-nvim` both find the same pack — the display form is recommended; the raw form keeps muscle-memory and scripts working.

**Symlink targets follow the display name:** a `010-nvim/init.lua` deploys to `~/.config/nvim/init.lua` (which is where `nvim` actually reads its config), not `~/.config/010-nvim/init.lua`.

**Collisions rejected at scan time, with both offending paths in the error:**
- logical-name (`nvim` + `010-nvim` both exist)
- multi-prefix (`010-nvim` + `020-nvim` both exist)
- empty-stem (`010-` / `010_` with no name after the separator)

`010-brew` and `010-zsh` are fine — same prefix, different stems, lex order on the stem decides. The 10/20/30 gap convention from `/etc/init.d` is documented but not enforced.

## Implementation

- `Pack` gains `display_name: String`; `Pack::new` derives it.
- New `parse_prefix` (private) and `display_name_for` (public) helpers.
- `scan_packs` rejects empty-stem dirs and runs collision detection after sort.
- New `DodotError::PackOrderingCollision` variant.
- New `orchestration::resolve_pack_dir_name` for single-pack-arg commands (`adopt`, `addignore`, `fill`).
- `validate_pack_names` and pack-filter `.retain()` calls accept both display and raw forms.
- `commands/{up, down, status, list, adopt}.rs` switch user-facing strings to `display_name`; internal datastore/path keys stay raw.
- `shell::generate_init_script` emits `# [pack]` comments using display name.
- `handlers::symlink::resolve_target` strips the prefix internally.

## Tests

- **18 new unit tests** in `packs::tests` and `packs::orchestration::tests`: prefix parsing, display computation, collision detection (3 classes), sort behaviour with mixed prefixed/unprefixed packs, lookup canonicalisation (both forms).
- **New `tests/e2e/bats/test_pack_ordering.bats` (14 tests)** covering the full surface: lex order drives shell-source order, `dodot list`/`status` show display names, `up`/`down` accept both forms, shell-init comments use display names, symlink targets use display names, all three collision classes are surfaced, same-prefix different-stem allowed, prefixed and unprefixed packs interleave.

Total: lib 488 → 506 tests, e2e 145 → 159 tests. All passing.

## Docs

- Module-level rustdoc on `packs/mod.rs` covering the design (including the systemd lesson on not conflating ordering with dependency).
- Rustdoc on every new/changed public function.
- `docs/reference/handlers.lex` Cross-Pack Ordering section gains a §4.1 "The Prefix Grammar" subsection.
- CHANGELOG entries: `### Added` for the new behaviour, `### Changed` note for users with already-prefixed packs (output now drops the prefix; raw-name lookup still works).

## Test plan

- [x] Unit tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy --all-targets`)
- [x] E2E pack-ordering tests pass (`scripts/e2e --local test_pack_ordering.bats`)
- [x] Full e2e suite passes (`scripts/e2e --local`)
- [ ] Reviewer: confirm display-vs-internal split is correct and the framing in handlers.lex §4.1 holds up

🤖 Generated with [Claude Code](https://claude.com/claude-code)