### PR TITLE
feat(cli): interactive `dodot tutorial` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -456,6 +456,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -631,8 +656,10 @@ dependencies = [
  "clap",
  "clapfig",
  "dodot-lib",
+ "inquire",
  "serde",
  "standout",
+ "tempfile",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -672,6 +699,12 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "encode_unicode"
@@ -864,6 +897,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1021,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,7 +1106,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1058,6 +1126,15 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1131,6 +1208,27 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1212,6 +1310,29 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "phf"
@@ -1409,6 +1530,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
@@ -1528,6 +1658,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1662,6 +1798,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,7 +1949,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "standout-bbparser",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2139,6 +2296,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/crates/dodot-cli/Cargo.toml
+++ b/crates/dodot-cli/Cargo.toml
@@ -16,7 +16,12 @@ clapfig = "0.16"
 clap = { version = "4", features = ["derive"] }
 dodot-lib = { version = "0.21.0", path = "../dodot-lib" }
 serde = { version = "1", features = ["derive"] }
+inquire = "0.7"
 standout = "7.5"
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+dodot-lib = { version = "0.20.0", path = "../dodot-lib", features = ["test-utils"] }
+tempfile = "3"

--- a/crates/dodot-cli/Cargo.toml
+++ b/crates/dodot-cli/Cargo.toml
@@ -23,5 +23,5 @@ tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-dodot-lib = { version = "0.20.0", path = "../dodot-lib", features = ["test-utils"] }
+dodot-lib = { version = "0.21.0", path = "../dodot-lib", features = ["test-utils"] }
 tempfile = "3"

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -6,6 +6,7 @@ use dodot_lib::render;
 
 mod handlers;
 mod logging;
+mod tutorial;
 
 fn main() {
     let app = build_app();
@@ -52,6 +53,23 @@ fn main() {
     // Passthrough: init-sh (raw stdout for shell eval)
     if matches.subcommand_matches("init-sh").is_some() {
         if let Err(e) = handlers::init_sh_passthrough() {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
+    // Passthrough: tutorial (interactive — multiple prompts and outputs,
+    // doesn't fit standout's one-shot render-and-print dispatch).
+    if let Some(("tutorial", sub)) = matches.subcommand() {
+        let opts = tutorial::Options {
+            reset: sub.get_flag("reset"),
+            from: sub.get_one::<String>("from").cloned(),
+            mode: standout::OutputMode::Auto,
+        };
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        if let Err(e) = tutorial::run(opts, &mut handle) {
             eprintln!("error: {e}");
             std::process::exit(1);
         }
@@ -163,6 +181,7 @@ fn build_app() -> App {
                 title: "Misc".into(),
                 help: None,
                 commands: vec![
+                    Some("tutorial".into()),
                     Some("init-sh".into()),
                     Some("config".into()),
                     Some("help".into()),
@@ -339,6 +358,23 @@ fn build_clap_command() -> ClapCommand {
         )
         .subcommand(
             ClapCommand::new("init-sh").about("Print shell init script for eval in .zshrc/.bashrc"),
+        )
+        .subcommand(
+            ClapCommand::new("tutorial")
+                .about("Interactive walkthrough using your real dotfiles")
+                .arg(
+                    Arg::new("reset")
+                        .long("reset")
+                        .help("Discard saved tutorial state and start over")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("from")
+                        .long("from")
+                        .help("Jump to a specific step (intro|check_root|pick_pack|...)")
+                        .value_name("STEP")
+                        .num_args(1),
+                ),
         )
         .subcommand(
             ClapCommand::new("probe")

--- a/crates/dodot-cli/src/tutorial.rs
+++ b/crates/dodot-cli/src/tutorial.rs
@@ -1,0 +1,1002 @@
+//! Interactive tutorial driver (`dodot tutorial`).
+//!
+//! Walks a new user through their first pack deployment using their
+//! actual dotfiles repo. The flow is a hand-rolled state machine over
+//! named steps, each step rendering a templated body (via
+//! `standout_render`) and asking one question through the [`Prompts`]
+//! trait.
+//!
+//! `Prompts` is the test seam: production runs use [`InquirePrompts`]
+//! (real TUI prompts via the `inquire` crate); tests inject
+//! [`ScriptedPrompts`] with a queue of canned answers, exercising the
+//! whole driver in-process with no TTY.
+
+#[cfg(test)]
+use std::collections::VecDeque;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex;
+
+use anyhow::{anyhow, Result};
+use standout::OutputMode;
+
+use dodot_lib::commands::tutorial::{self as lib_tut, TutorialCtx, TutorialState};
+use dodot_lib::commands::{self, GroupMode, ViewMode};
+use dodot_lib::config::ConfigManager;
+use dodot_lib::datastore::DataStore;
+use dodot_lib::fs::Fs;
+use dodot_lib::packs::orchestration::ExecutionContext;
+use dodot_lib::paths::{Pather, XdgPather};
+use dodot_lib::render;
+use dodot_lib::shell::SyntaxChecker;
+
+// ── Prompt seam ─────────────────────────────────────────────────
+
+/// Prompt I/O abstraction. The driver only knows about this trait —
+/// the production path uses [`InquirePrompts`], tests use
+/// [`ScriptedPrompts`].
+pub trait Prompts {
+    /// Yes/no prompt. `default` is the highlighted choice; `Cancel` /
+    /// Ctrl-C surfaces as `Err`.
+    fn confirm(&self, message: &str, default: bool) -> Result<bool>;
+
+    /// Single-choice select. Returns the chosen label.
+    fn select(&self, message: &str, options: Vec<String>) -> Result<String>;
+
+    /// "Press enter to continue" — non-cancelling, no value.
+    fn press_enter(&self) -> Result<()>;
+}
+
+/// Real interactive prompts (production path).
+pub struct InquirePrompts;
+
+/// Build the inquire `RenderConfig` for tutorial prompts.
+///
+/// The prompt question line is rendered in italic so it visually
+/// stands apart from the (heavier-weight) step body above it. This
+/// mirrors the `tutorial-prompt` style in dodot's theme YAML — the
+/// theme entry is the documented knob; this function applies it to
+/// inquire (which doesn't read the dodot theme directly). Keep both
+/// in sync.
+fn tutorial_render_config() -> inquire::ui::RenderConfig<'static> {
+    use inquire::ui::{Attributes, RenderConfig, StyleSheet};
+
+    let mut cfg = RenderConfig::default_colored();
+    cfg.prompt = StyleSheet::new().with_attr(Attributes::ITALIC);
+    cfg.help_message = StyleSheet::new().with_attr(Attributes::ITALIC);
+    cfg
+}
+
+/// Print a blank line before every prompt so the question is visually
+/// separated from the step body that just rendered.
+fn pad_before_prompt() {
+    println!();
+}
+
+impl Prompts for InquirePrompts {
+    fn confirm(&self, message: &str, default: bool) -> Result<bool> {
+        pad_before_prompt();
+        match inquire::Confirm::new(message)
+            .with_default(default)
+            .with_render_config(tutorial_render_config())
+            .prompt()
+        {
+            Ok(b) => Ok(b),
+            Err(inquire::InquireError::OperationCanceled)
+            | Err(inquire::InquireError::OperationInterrupted) => Err(anyhow!("cancelled")),
+            Err(e) => Err(anyhow!("{e}")),
+        }
+    }
+
+    fn select(&self, message: &str, options: Vec<String>) -> Result<String> {
+        pad_before_prompt();
+        match inquire::Select::new(message, options)
+            .with_render_config(tutorial_render_config())
+            .prompt()
+        {
+            Ok(s) => Ok(s),
+            Err(inquire::InquireError::OperationCanceled)
+            | Err(inquire::InquireError::OperationInterrupted) => Err(anyhow!("cancelled")),
+            Err(e) => Err(anyhow!("{e}")),
+        }
+    }
+
+    fn press_enter(&self) -> Result<()> {
+        pad_before_prompt();
+        // Inquire's Text returns an error on empty submit by default;
+        // with_default("") makes empty acceptable so just hitting
+        // enter advances.
+        let _ = inquire::Text::new("(press enter to continue)")
+            .with_default("")
+            .with_render_config(tutorial_render_config())
+            .prompt();
+        Ok(())
+    }
+}
+
+/// Scripted prompts for tests. Pop one queued response per call and
+/// validate kind so wizard-reorder bugs surface at the offending step
+/// rather than as silent wrong-data assertions later.
+#[cfg(test)]
+pub enum ScriptedAnswer {
+    Confirm(bool),
+    /// 0-based index into the options vec passed to `select`.
+    Choice(usize),
+    /// Equivalent of pressing enter.
+    Enter,
+}
+
+#[cfg(test)]
+pub struct ScriptedPrompts {
+    queue: Mutex<VecDeque<ScriptedAnswer>>,
+}
+
+#[cfg(test)]
+impl ScriptedPrompts {
+    pub fn new(answers: impl IntoIterator<Item = ScriptedAnswer>) -> Self {
+        Self {
+            queue: Mutex::new(answers.into_iter().collect()),
+        }
+    }
+
+    pub fn remaining(&self) -> usize {
+        self.queue.lock().unwrap().len()
+    }
+
+    fn next(&self, expected: &str, msg: &str) -> Result<ScriptedAnswer> {
+        self.queue.lock().unwrap().pop_front().ok_or_else(|| {
+            anyhow!("ScriptedPrompts: ran out of answers; next was a `{expected}` prompt: {msg:?}")
+        })
+    }
+}
+
+#[cfg(test)]
+impl Prompts for ScriptedPrompts {
+    fn confirm(&self, message: &str, _default: bool) -> Result<bool> {
+        match self.next("confirm", message)? {
+            ScriptedAnswer::Confirm(b) => Ok(b),
+            other => Err(anyhow!(
+                "ScriptedPrompts: expected Confirm for {message:?}, got {other:?}"
+            )),
+        }
+    }
+
+    fn select(&self, message: &str, options: Vec<String>) -> Result<String> {
+        match self.next("select", message)? {
+            ScriptedAnswer::Choice(i) => options.get(i).cloned().ok_or_else(|| {
+                anyhow!(
+                    "ScriptedPrompts: Choice({i}) out of range for select with {} option(s) ({message:?})",
+                    options.len()
+                )
+            }),
+            other => Err(anyhow!(
+                "ScriptedPrompts: expected Choice for {message:?}, got {other:?}"
+            )),
+        }
+    }
+
+    fn press_enter(&self) -> Result<()> {
+        match self.next("enter", "press enter")? {
+            ScriptedAnswer::Enter => Ok(()),
+            other => Err(anyhow!("ScriptedPrompts: expected Enter, got {other:?}")),
+        }
+    }
+}
+
+#[cfg(test)]
+impl std::fmt::Debug for ScriptedAnswer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScriptedAnswer::Confirm(b) => write!(f, "Confirm({b})"),
+            ScriptedAnswer::Choice(i) => write!(f, "Choice({i})"),
+            ScriptedAnswer::Enter => write!(f, "Enter"),
+        }
+    }
+}
+
+// ── Environment ────────────────────────────────────────────────
+
+/// Filesystem + paths + datastore the tutorial needs. In production
+/// built by [`TutorialEnv::from_process_env`]; tests construct one
+/// directly from a `TempEnvironment` so the whole flow runs against
+/// a temp dir.
+pub struct TutorialEnv {
+    pub fs: Arc<dyn Fs>,
+    pub paths: Arc<dyn Pather>,
+    pub datastore: Arc<dyn DataStore>,
+    pub config_manager: Arc<ConfigManager>,
+    pub syntax_checker: Arc<dyn SyntaxChecker>,
+    /// Where the dotfiles root came from (for the check_root step
+    /// template) — `"DOTFILES_ROOT env var"` / `"git toplevel"` / etc.
+    pub root_origin: String,
+}
+
+impl TutorialEnv {
+    /// Build from real process environment — same wiring as
+    /// `ExecutionContext::production`, but the parts are kept so we
+    /// can derive multiple ExecutionContexts with different
+    /// `dry_run` flags without rebuilding everything.
+    pub fn from_process_env() -> Result<Self> {
+        let (root, origin) = discover_root_with_origin();
+        let paths = Arc::new(
+            XdgPather::builder()
+                .dotfiles_root(&root)
+                .build()
+                .map_err(|e| anyhow!("paths: {e}"))?,
+        );
+        let fs: Arc<dyn Fs> = Arc::new(dodot_lib::fs::OsFs::new());
+        let runner: Arc<dyn dodot_lib::datastore::CommandRunner> =
+            Arc::new(dodot_lib::datastore::ShellCommandRunner);
+        let datastore: Arc<dyn DataStore> = Arc::new(
+            dodot_lib::datastore::FilesystemDataStore::new(fs.clone(), paths.clone(), runner),
+        );
+        let config_manager =
+            Arc::new(ConfigManager::new(&root).map_err(|e| anyhow!("config: {e}"))?);
+        Ok(Self {
+            fs,
+            paths,
+            datastore,
+            config_manager,
+            syntax_checker: Arc::new(dodot_lib::shell::SystemSyntaxChecker),
+            root_origin: origin,
+        })
+    }
+
+    fn make_ctx(&self, dry_run: bool) -> ExecutionContext {
+        ExecutionContext {
+            fs: self.fs.clone(),
+            datastore: self.datastore.clone(),
+            paths: self.paths.clone(),
+            config_manager: self.config_manager.clone(),
+            syntax_checker: self.syntax_checker.clone(),
+            dry_run,
+            no_provision: false,
+            provision_rerun: false,
+            force: false,
+            view_mode: ViewMode::Full,
+            group_mode: GroupMode::Name,
+        }
+    }
+}
+
+// ── Options & entry ─────────────────────────────────────────────
+
+pub struct Options {
+    pub reset: bool,
+    pub from: Option<String>,
+    /// Output mode for templates. `OutputMode::Auto` in production,
+    /// `OutputMode::Text` in tests.
+    pub mode: OutputMode,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            reset: false,
+            from: None,
+            mode: OutputMode::Auto,
+        }
+    }
+}
+
+/// Production entry point — uses real Inquire prompts and stdout.
+pub fn run(opts: Options, out: &mut impl Write) -> Result<()> {
+    let env = TutorialEnv::from_process_env()?;
+    run_with_prompts(&env, opts, &InquirePrompts, out)
+}
+
+/// Test-friendly entry point. Use [`ScriptedPrompts`] to drive a
+/// deterministic flow without a TTY, against an env wired to a
+/// `TempEnvironment` fixture.
+pub fn run_with_prompts(
+    env: &TutorialEnv,
+    opts: Options,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<()> {
+    let xdg = env.paths.clone();
+
+    if opts.reset {
+        let _ = lib_tut::clear_state(xdg.as_ref());
+    }
+
+    let mut ctx = build_initial_ctx(env)?;
+
+    let mut step: &'static str = "intro";
+    if opts.from.is_none() && !opts.reset {
+        if let Some(saved) = lib_tut::load_state(xdg.as_ref()) {
+            match prompt_resume(prompts, &saved)? {
+                ResumeChoice::Resume => {
+                    step = step_id_to_static(&saved.step_id).unwrap_or("intro");
+                    if let Some(p) = saved.pack {
+                        ctx.chosen_pack = Some(p);
+                    }
+                }
+                ResumeChoice::Restart => {
+                    let _ = lib_tut::clear_state(xdg.as_ref());
+                }
+                ResumeChoice::Quit => return Ok(()),
+            }
+        }
+    }
+    if let Some(from) = opts.from.as_deref() {
+        if let Some(s) = step_id_to_static(from) {
+            step = s;
+        }
+    }
+
+    loop {
+        save_step(xdg.as_ref(), step, &ctx);
+        match run_step(step, &mut ctx, &opts, env, prompts, out)? {
+            Next::Go(next) => step = next,
+            Next::Done => {
+                let _ = lib_tut::clear_state(xdg.as_ref());
+                return Ok(());
+            }
+            Next::Quit => {
+                writeln!(
+                    out,
+                    "\nExited tutorial. Resume any time with: dodot tutorial"
+                )?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Next {
+    Go(&'static str),
+    Done,
+    Quit,
+}
+
+#[derive(Debug)]
+enum ResumeChoice {
+    Resume,
+    Restart,
+    Quit,
+}
+
+fn prompt_resume(prompts: &dyn Prompts, saved: &TutorialState) -> Result<ResumeChoice> {
+    let pack_label = saved.pack.as_deref().unwrap_or("(no pack picked yet)");
+    let label = format!(
+        "Found a saved tutorial at step '{}' (pack: {})",
+        saved.step_id, pack_label
+    );
+    let choice = prompts.select(
+        &label,
+        vec!["Resume".into(), "Start over".into(), "Quit".into()],
+    )?;
+    Ok(match choice.as_str() {
+        "Resume" => ResumeChoice::Resume,
+        "Start over" => ResumeChoice::Restart,
+        _ => ResumeChoice::Quit,
+    })
+}
+
+fn save_step(paths: &dyn Pather, step: &str, ctx: &TutorialCtx) {
+    let state = TutorialState {
+        step_id: step.to_string(),
+        pack: ctx.chosen_pack.clone(),
+        started_at: None,
+    };
+    let _ = lib_tut::save_state(paths, &state);
+}
+
+// ── Steps ──────────────────────────────────────────────────────
+
+fn run_step(
+    step: &str,
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    env: &TutorialEnv,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    match step {
+        "intro" => step_intro(ctx, opts, prompts, out),
+        "check_root" => step_check_root(ctx, opts, prompts, out),
+        "list_packs" => step_list_packs(ctx, opts, prompts, out),
+        "no_packs" => step_no_packs(ctx, opts, prompts, out),
+        "pick_pack" => step_pick_pack(ctx, opts, prompts, out),
+        "show_status" => step_show_status(ctx, opts, env, prompts, out),
+        "annotate_status" => step_annotate_status(ctx, opts, prompts, out),
+        "concept_targets" => step_concept_targets(ctx, opts, prompts, out),
+        "concept_shell" => step_concept_shell(ctx, opts, env, prompts, out),
+        "dry_run" => step_dry_run(ctx, opts, env, prompts, out),
+        "real_up" => step_real_up(ctx, opts, env, prompts, out),
+        "outro" => step_outro(ctx, opts, prompts, out),
+        other => Err(anyhow!("unknown tutorial step: {other}")),
+    }
+}
+
+fn step_id_to_static(id: &str) -> Option<&'static str> {
+    Some(match id {
+        "intro" => "intro",
+        "check_root" => "check_root",
+        "list_packs" => "list_packs",
+        "no_packs" => "no_packs",
+        "pick_pack" => "pick_pack",
+        "show_status" => "show_status",
+        "annotate_status" => "annotate_status",
+        "concept_targets" => "concept_targets",
+        "concept_shell" => "concept_shell",
+        "dry_run" => "dry_run",
+        "real_up" => "real_up",
+        "outro" => "outro",
+        _ => return None,
+    })
+}
+
+fn step_intro(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    print_step("tutorial.intro", ctx, opts, out)?;
+    if prompts.confirm("Ready to begin?", true)? {
+        Ok(Next::Go("check_root"))
+    } else {
+        Ok(Next::Quit)
+    }
+}
+
+fn step_check_root(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    print_step("tutorial.check_root", ctx, opts, out)?;
+    if prompts.confirm("Is this your dotfiles repo?", true)? {
+        Ok(Next::Go("list_packs"))
+    } else {
+        writeln!(
+            out,
+            "\nOK — exit, cd into your dotfiles repo, and re-run `dodot tutorial`."
+        )?;
+        Ok(Next::Quit)
+    }
+}
+
+fn step_list_packs(
+    ctx: &mut TutorialCtx,
+    _opts: &Options,
+    _prompts: &dyn Prompts,
+    _out: &mut impl Write,
+) -> Result<Next> {
+    if ctx.packs.is_empty() {
+        Ok(Next::Go("no_packs"))
+    } else {
+        Ok(Next::Go("pick_pack"))
+    }
+}
+
+fn step_no_packs(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    _prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    print_step("tutorial.no_packs", ctx, opts, out)?;
+    Ok(Next::Done)
+}
+
+fn step_pick_pack(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    print_step("tutorial.pick_pack", ctx, opts, out)?;
+
+    let mut packs = ctx.packs.clone();
+    packs.sort_by_key(|p| !p.recommended);
+    let labels: Vec<String> = packs
+        .iter()
+        .map(|p| {
+            if p.recommended {
+                format!("{}  ← recommended ({})", p.name, p.kind)
+            } else {
+                format!("{}  ({})", p.name, p.kind)
+            }
+        })
+        .collect();
+    let choice = prompts.select("Pick a pack to start with:", labels)?;
+
+    let chosen = choice.split_whitespace().next().unwrap_or("").to_string();
+    let pack = packs
+        .into_iter()
+        .find(|p| p.name == chosen)
+        .ok_or_else(|| anyhow!("internal: chosen pack not in list"))?;
+    ctx.chosen_pack = Some(pack.name.clone());
+    ctx.chosen_pack_kind = Some(pack.kind.clone());
+    ctx.has_shell_files = pack.kind.contains("shell");
+    ctx.has_install_files = pack.kind.contains("install");
+
+    Ok(Next::Go("show_status"))
+}
+
+fn step_show_status(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    env: &TutorialEnv,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    let pack = ctx
+        .chosen_pack
+        .clone()
+        .ok_or_else(|| anyhow!("no pack chosen"))?;
+    let status = render_dodot_status(env, &pack, opts.mode)?;
+    ctx.status_output = Some(status);
+    print_step("tutorial.show_status", ctx, opts, out)?;
+    prompts.press_enter()?;
+    Ok(Next::Go("annotate_status"))
+}
+
+fn step_annotate_status(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    print_step("tutorial.annotate_status", ctx, opts, out)?;
+    prompts.press_enter()?;
+    Ok(Next::Go("concept_targets"))
+}
+
+fn step_concept_targets(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    print_step("tutorial.concept_targets", ctx, opts, out)?;
+    if !prompts.confirm("Targets look right?", true)? {
+        writeln!(
+            out,
+            "\nOK — exit and edit your pack (or its `.dodot.toml`) to set explicit targets, then re-run."
+        )?;
+        return Ok(Next::Quit);
+    }
+
+    if ctx.has_shell_files || ctx.has_install_files {
+        Ok(Next::Go("concept_shell"))
+    } else {
+        Ok(Next::Go("dry_run"))
+    }
+}
+
+fn step_concept_shell(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    env: &TutorialEnv,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    let integ = lib_tut::detect_shell_integration(env.paths.home_dir());
+    ctx.eval_line = integ.eval_line.clone();
+    ctx.shell_integration = Some(integ.clone());
+
+    print_step("tutorial.concept_shell", ctx, opts, out)?;
+
+    if integ.line_present {
+        return Ok(Next::Go("dry_run"));
+    }
+
+    let action = prompts.select(
+        "What do you want me to do?",
+        vec![
+            "Append it to my rc file".into(),
+            "Copy to clipboard".into(),
+            "Nothing — I'll handle it".into(),
+        ],
+    )?;
+    match action.as_str() {
+        "Append it to my rc file" => {
+            lib_tut::append_shell_integration(&integ).map_err(|e| anyhow!("{e}"))?;
+            writeln!(
+                out,
+                "\n  ✓ appended to {} (open a new shell to pick it up)",
+                integ.rc_path
+            )?;
+        }
+        "Copy to clipboard" => match copy_to_clipboard(&integ.eval_line) {
+            Ok(()) => writeln!(out, "\n  ✓ copied to clipboard")?,
+            Err(e) => writeln!(
+                out,
+                "\n  ! couldn't copy to clipboard ({e}); paste manually:\n  {}",
+                integ.eval_line
+            )?,
+        },
+        _ => writeln!(
+            out,
+            "\n  Add to {} when you're ready:\n  {}",
+            integ.rc_path, integ.eval_line
+        )?,
+    }
+    Ok(Next::Go("dry_run"))
+}
+
+fn step_dry_run(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    env: &TutorialEnv,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    let pack = ctx
+        .chosen_pack
+        .clone()
+        .ok_or_else(|| anyhow!("no pack chosen"))?;
+    let preview = render_dodot_up(env, &pack, true, opts.mode)?;
+    ctx.dry_run_output = Some(preview);
+    print_step("tutorial.dry_run", ctx, opts, out)?;
+    if prompts.confirm("Apply for real?", true)? {
+        Ok(Next::Go("real_up"))
+    } else {
+        writeln!(out, "\nNothing was applied. Run again any time.")?;
+        Ok(Next::Quit)
+    }
+}
+
+fn step_real_up(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    env: &TutorialEnv,
+    prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    let pack = ctx
+        .chosen_pack
+        .clone()
+        .ok_or_else(|| anyhow!("no pack chosen"))?;
+    let up_out = render_dodot_up(env, &pack, false, opts.mode)?;
+    ctx.up_output = Some(up_out);
+    let new_status = render_dodot_status(env, &pack, opts.mode)?;
+    ctx.status_output = Some(new_status);
+    print_step("tutorial.real_up", ctx, opts, out)?;
+    prompts.press_enter()?;
+    Ok(Next::Go("outro"))
+}
+
+fn step_outro(
+    ctx: &mut TutorialCtx,
+    opts: &Options,
+    _prompts: &dyn Prompts,
+    out: &mut impl Write,
+) -> Result<Next> {
+    print_step("tutorial.outro", ctx, opts, out)?;
+    Ok(Next::Done)
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+fn print_step(
+    template: &str,
+    ctx: &TutorialCtx,
+    opts: &Options,
+    out: &mut impl Write,
+) -> Result<()> {
+    let body =
+        render::render_tutorial_step(template, ctx, opts.mode).map_err(|e| anyhow!("{e}"))?;
+    writeln!(out, "\n{body}")?;
+    Ok(())
+}
+
+fn build_initial_ctx(env: &TutorialEnv) -> Result<TutorialCtx> {
+    let exec_ctx = env.make_ctx(false);
+    let packs = lib_tut::discover_and_classify(&exec_ctx)
+        .map_err(|e| anyhow!("pack discovery failed: {e}"))?;
+
+    Ok(TutorialCtx {
+        dotfiles_root: env.paths.dotfiles_root().display().to_string(),
+        via: env.root_origin.clone(),
+        packs,
+        ..Default::default()
+    })
+}
+
+fn discover_root_with_origin() -> (PathBuf, String) {
+    if let Ok(s) = std::env::var("DOTFILES_ROOT") {
+        let p = PathBuf::from(&s);
+        if p.exists() {
+            return (p, "DOTFILES_ROOT env var".into());
+        }
+    }
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+    {
+        if output.status.success() {
+            let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !s.is_empty() {
+                return (PathBuf::from(s), "git toplevel".into());
+            }
+        }
+    }
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    (cwd, "current directory".into())
+}
+
+fn render_dodot_status(env: &TutorialEnv, pack: &str, mode: OutputMode) -> Result<String> {
+    let exec_ctx = env.make_ctx(false);
+    let result = commands::status::status(Some(&[pack.to_string()]), &exec_ctx)
+        .map_err(|e| anyhow!("status: {e}"))?;
+    let s = render::render("pack-status", &result, mode).map_err(|e| anyhow!("render: {e}"))?;
+    Ok(indent(&s, "  "))
+}
+
+fn render_dodot_up(
+    env: &TutorialEnv,
+    pack: &str,
+    dry_run: bool,
+    mode: OutputMode,
+) -> Result<String> {
+    let exec_ctx = env.make_ctx(dry_run);
+    let result = commands::up::up_or_status_for_conflict(Some(&[pack.to_string()]), &exec_ctx)
+        .map_err(|e| anyhow!("up: {e}"))?;
+    let s = render::render("pack-status", &result, mode).map_err(|e| anyhow!("render: {e}"))?;
+    Ok(indent(&s, "  "))
+}
+
+fn indent(s: &str, prefix: &str) -> String {
+    s.lines()
+        .map(|l| format!("{prefix}{l}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn copy_to_clipboard(text: &str) -> Result<()> {
+    use std::io::Write as IoWrite;
+    use std::process::{Command, Stdio};
+
+    let candidates: &[(&str, &[&str])] = &[
+        ("pbcopy", &[]),
+        ("wl-copy", &[]),
+        ("xclip", &["-selection", "clipboard"]),
+        ("xsel", &["--clipboard", "--input"]),
+    ];
+
+    for (cmd, args) in candidates {
+        if which_cmd(cmd).is_some() {
+            let mut child = Command::new(cmd)
+                .args(*args)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()?;
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(text.as_bytes())?;
+            }
+            let status = child.wait()?;
+            if status.success() {
+                return Ok(());
+            }
+        }
+    }
+    Err(anyhow!("no clipboard tool found"))
+}
+
+fn which_cmd(cmd: &str) -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("PATH") {
+        for dir in path.split(':') {
+            let candidate = PathBuf::from(dir).join(cmd);
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use dodot_lib::config::ConfigManager;
+    use dodot_lib::datastore::{CommandOutput, CommandRunner, FilesystemDataStore};
+    use dodot_lib::shell::NoopSyntaxChecker;
+    use dodot_lib::testing::TempEnvironment;
+
+    /// Stub command runner — every install / homebrew shell-out
+    /// returns success without doing anything. Tests for the tutorial
+    /// shouldn't actually invoke external programs.
+    struct NoopCommandRunner;
+    impl CommandRunner for NoopCommandRunner {
+        fn run(&self, _: &str, _: &[String]) -> Result<CommandOutput, dodot_lib::DodotError> {
+            Ok(CommandOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    fn env_from(temp: &TempEnvironment) -> TutorialEnv {
+        let runner: Arc<dyn CommandRunner> = Arc::new(NoopCommandRunner);
+        let datastore: Arc<dyn DataStore> = Arc::new(FilesystemDataStore::new(
+            temp.fs.clone(),
+            temp.paths.clone(),
+            runner,
+        ));
+        let config_manager = Arc::new(ConfigManager::new(&temp.dotfiles_root).unwrap());
+        TutorialEnv {
+            fs: temp.fs.clone() as Arc<dyn Fs>,
+            paths: temp.paths.clone() as Arc<dyn Pather>,
+            datastore,
+            config_manager,
+            syntax_checker: Arc::new(NoopSyntaxChecker),
+            root_origin: "test fixture".into(),
+        }
+    }
+
+    fn opts_text() -> Options {
+        Options {
+            reset: true, // discard any leftover state file
+            from: None,
+            mode: OutputMode::Text,
+        }
+    }
+
+    /// Happy path: config-only pack, user accepts every prompt, ends
+    /// with the pack actually deployed.
+    #[test]
+    fn tutorial_deploys_a_config_only_pack_end_to_end() {
+        let temp = TempEnvironment::builder()
+            .pack("vim")
+            .file("vimrc", "set nocompatible\n")
+            .done()
+            .build();
+        let env = env_from(&temp);
+
+        let prompts = ScriptedPrompts::new([
+            ScriptedAnswer::Confirm(true), // intro: ready?
+            ScriptedAnswer::Confirm(true), // check_root: is this your repo?
+            ScriptedAnswer::Choice(0),     // pick_pack: vim
+            ScriptedAnswer::Enter,         // show_status
+            ScriptedAnswer::Enter,         // annotate_status
+            ScriptedAnswer::Confirm(true), // concept_targets: looks right?
+            ScriptedAnswer::Confirm(true), // dry_run: apply for real?
+            ScriptedAnswer::Enter,         // real_up
+        ]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        run_with_prompts(&env, opts_text(), &prompts, &mut buf).unwrap();
+
+        let out = String::from_utf8(buf).unwrap();
+
+        // The driver visited every step we expected.
+        assert!(out.contains("Welcome to dodot"), "missing intro: {out}");
+        assert!(
+            out.contains("Step 1 — find your dotfiles repo"),
+            "missing check_root: {out}"
+        );
+        assert!(
+            out.contains("Step 2 — pick a pack"),
+            "missing pick_pack: {out}"
+        );
+        assert!(
+            out.contains("Step 3 — what dodot would do"),
+            "missing show_status: {out}"
+        );
+        assert!(
+            out.contains("Step 7 — make it real"),
+            "missing real_up: {out}"
+        );
+        assert!(out.contains("You're set up."), "missing outro: {out}");
+
+        // No prompt answers should be left over.
+        assert_eq!(
+            prompts.remaining(),
+            0,
+            "tutorial consumed fewer prompts than scripted"
+        );
+
+        // Pack actually got deployed — symlink chain exists.
+        let user_target = temp.config_home.join("vim").join("vimrc");
+        assert!(
+            temp.fs.is_symlink(&user_target),
+            "expected vim/vimrc to be a symlink at {}",
+            user_target.display()
+        );
+    }
+
+    /// Quitting at the intro should not deploy anything and should
+    /// leave the saved-state file behind so the user can resume.
+    #[test]
+    fn tutorial_quit_at_intro_does_nothing() {
+        let temp = TempEnvironment::builder()
+            .pack("vim")
+            .file("vimrc", "x")
+            .done()
+            .build();
+        let env = env_from(&temp);
+
+        let prompts = ScriptedPrompts::new([
+            ScriptedAnswer::Confirm(false), // intro: not ready
+        ]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        run_with_prompts(&env, opts_text(), &prompts, &mut buf).unwrap();
+
+        // Pack was not deployed.
+        let user_target = temp.config_home.join("vim").join("vimrc");
+        assert!(
+            !temp.fs.exists(&user_target),
+            "should NOT deploy when user quits at intro"
+        );
+    }
+
+    /// No packs in the repo → tutorial offers `dodot init` and exits.
+    #[test]
+    fn tutorial_handles_empty_repo_gracefully() {
+        let temp = TempEnvironment::builder().build();
+        let env = env_from(&temp);
+
+        let prompts = ScriptedPrompts::new([
+            ScriptedAnswer::Confirm(true), // intro
+            ScriptedAnswer::Confirm(true), // check_root
+        ]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        run_with_prompts(&env, opts_text(), &prompts, &mut buf).unwrap();
+
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("No packs yet"), "should hit no_packs: {out}");
+        assert!(
+            out.contains("dodot init"),
+            "should suggest dodot init: {out}"
+        );
+    }
+
+    /// User picks the recommended starter when there are multiple
+    /// packs of different kinds.
+    #[test]
+    fn tutorial_recommendation_orders_config_only_first() {
+        let temp = TempEnvironment::builder()
+            .pack("dev-tools")
+            .file("install.sh", "echo")
+            .done()
+            .pack("vim")
+            .file("vimrc", "x")
+            .done()
+            .build();
+        let env = env_from(&temp);
+
+        // Tutorial sorts recommended pack first in the select; vim
+        // (config-only) should be index 0 even though dev-tools comes
+        // first alphabetically.
+        let prompts = ScriptedPrompts::new([
+            ScriptedAnswer::Confirm(true), // intro
+            ScriptedAnswer::Confirm(true), // check_root
+            ScriptedAnswer::Choice(0),     // pick the first (vim, recommended)
+            ScriptedAnswer::Enter,         // show_status
+            ScriptedAnswer::Enter,         // annotate_status
+            ScriptedAnswer::Confirm(true), // concept_targets
+            ScriptedAnswer::Confirm(true), // dry_run
+            ScriptedAnswer::Enter,         // real_up
+        ]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        run_with_prompts(&env, opts_text(), &prompts, &mut buf).unwrap();
+
+        let user_target = temp.config_home.join("vim").join("vimrc");
+        assert!(
+            temp.fs.exists(&user_target),
+            "vim should have been deployed (it was the recommended pick)"
+        );
+        let dev_target = temp.config_home.join("dev-tools").join("install.sh");
+        assert!(
+            !temp.fs.exists(&dev_target),
+            "dev-tools should NOT have been deployed"
+        );
+    }
+}

--- a/crates/dodot-cli/src/tutorial.rs
+++ b/crates/dodot-cli/src/tutorial.rs
@@ -107,12 +107,19 @@ impl Prompts for InquirePrompts {
         pad_before_prompt();
         // Inquire's Text returns an error on empty submit by default;
         // with_default("") makes empty acceptable so just hitting
-        // enter advances.
-        let _ = inquire::Text::new("(press enter to continue)")
+        // enter advances. Ctrl-C / Esc still surface as a cancel so
+        // the driver can exit cleanly — the intro promises Ctrl-C
+        // works at *any* prompt, including these.
+        match inquire::Text::new("(press enter to continue)")
             .with_default("")
             .with_render_config(tutorial_render_config())
-            .prompt();
-        Ok(())
+            .prompt()
+        {
+            Ok(_) => Ok(()),
+            Err(inquire::InquireError::OperationCanceled)
+            | Err(inquire::InquireError::OperationInterrupted) => Err(anyhow!("cancelled")),
+            Err(e) => Err(anyhow!("{e}")),
+        }
     }
 }
 
@@ -565,7 +572,11 @@ fn step_concept_targets(
         return Ok(Next::Quit);
     }
 
-    if ctx.has_shell_files || ctx.has_install_files {
+    // The shell-integration step explains the `eval "$(dodot init-sh)"`
+    // line, which is what makes shell snippets get sourced and `bin/`
+    // dirs get added to PATH. Install scripts and Brewfile run once
+    // and don't need init-sh, so they don't trigger this step.
+    if ctx.has_shell_files {
         Ok(Next::Go("concept_shell"))
     } else {
         Ok(Next::Go("dry_run"))

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod init;
 pub mod list;
 pub mod probe;
 pub mod status;
+pub mod tutorial;
 pub mod up;
 
 #[cfg(test)]

--- a/crates/dodot-lib/src/commands/tutorial.rs
+++ b/crates/dodot-lib/src/commands/tutorial.rs
@@ -1,9 +1,13 @@
 //! `tutorial` — data and introspection for the interactive tutorial.
 //!
 //! The interactive driver lives in `dodot-cli`; this module provides
-//! the side-effect-free building blocks: pack classification, shell-
-//! integration detection, state persistence, and a serializable
-//! [`TutorialCtx`] that the CLI passes to step templates.
+//! the building blocks it composes: pack classification, shell-
+//! integration detection (read-only inspection plus an explicit
+//! append helper), JSON state persistence for resume, and the
+//! serializable [`TutorialCtx`] that the CLI passes to step
+//! templates. Reads are pure; writes (`append_shell_integration`,
+//! `save_state`, `clear_state`) only run on explicit user consent
+//! from the driver.
 
 use std::path::{Path, PathBuf};
 
@@ -70,7 +74,6 @@ pub fn classify_pack(pack: &packs::Pack) -> PackKind {
 
     let mut has_install = false;
     let mut has_shell = false;
-    let mut has_other = false;
     let mut any = false;
 
     for entry in entries.flatten() {
@@ -84,27 +87,22 @@ pub fn classify_pack(pack: &packs::Pack) -> PackKind {
         let is_dir = path.is_dir();
 
         if !is_dir {
-            if matches!(name.as_str(), "install.sh" | "install.bash" | "install.zsh") {
+            if matches!(
+                name.as_str(),
+                "install.sh" | "install.bash" | "install.zsh" | "Brewfile"
+            ) {
                 has_install = true;
-                continue;
-            }
-            if name == "Brewfile" {
-                has_install = true;
-                continue;
-            }
-            if is_shell_filename(&name) {
+            } else if is_shell_filename(&name) {
                 has_shell = true;
-                continue;
             }
-            has_other = true;
+            // Otherwise it's a default-symlink file — no flag to set;
+            // any non-empty pack with no shell/install evidence falls
+            // through to ConfigOnly below.
         } else if name == "bin" {
             has_shell = true;
-        } else {
-            has_other = true;
         }
     }
 
-    let _ = has_other;
     if !any {
         return PackKind::Empty;
     }

--- a/crates/dodot-lib/src/commands/tutorial.rs
+++ b/crates/dodot-lib/src/commands/tutorial.rs
@@ -1,0 +1,406 @@
+//! `tutorial` — data and introspection for the interactive tutorial.
+//!
+//! The interactive driver lives in `dodot-cli`; this module provides
+//! the side-effect-free building blocks: pack classification, shell-
+//! integration detection, state persistence, and a serializable
+//! [`TutorialCtx`] that the CLI passes to step templates.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::packs;
+use crate::packs::orchestration::ExecutionContext;
+use crate::paths::Pather;
+use crate::Result;
+
+// ── Pack classification ─────────────────────────────────────────
+
+/// Coarse categorisation of a pack used by the tutorial to pick a
+/// good starter. Names match human prose: "config-only" / "shell" /
+/// "install".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackKind {
+    /// Only files that map to the default symlink handler.
+    ConfigOnly,
+    /// Has shell-integration files (`aliases.sh`, …) and/or `bin/`.
+    ConfigPlusShell,
+    /// Has install scripts and/or `Brewfile`.
+    ConfigPlusInstall,
+    /// Has both shell-integration and provisioning files.
+    ConfigPlusShellAndInstall,
+    /// Pack is essentially empty (no top-level files at all).
+    Empty,
+}
+
+impl PackKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            PackKind::ConfigOnly => "config only",
+            PackKind::ConfigPlusShell => "config + shell",
+            PackKind::ConfigPlusInstall => "config + install",
+            PackKind::ConfigPlusShellAndInstall => "config + shell + install",
+            PackKind::Empty => "empty",
+        }
+    }
+
+    /// Lower number = better starter pack for a first-time user.
+    fn starter_rank(self) -> u8 {
+        match self {
+            PackKind::ConfigOnly => 0,
+            PackKind::ConfigPlusShell => 1,
+            PackKind::ConfigPlusInstall => 2,
+            PackKind::ConfigPlusShellAndInstall => 3,
+            PackKind::Empty => 99,
+        }
+    }
+}
+
+/// Classify a pack by inspecting its top-level files.
+///
+/// Mirrors the default rules in `config::mappings_to_rules` rather
+/// than re-running the rules scanner, because the tutorial only
+/// needs a coarse summary and we want to stay independent of any
+/// custom rules a user may have added.
+pub fn classify_pack(pack: &packs::Pack) -> PackKind {
+    let entries = match std::fs::read_dir(&pack.path) {
+        Ok(e) => e,
+        Err(_) => return PackKind::Empty,
+    };
+
+    let mut has_install = false;
+    let mut has_shell = false;
+    let mut has_other = false;
+    let mut any = false;
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        any = true;
+        let path = entry.path();
+        let is_dir = path.is_dir();
+
+        if !is_dir {
+            if matches!(name.as_str(), "install.sh" | "install.bash" | "install.zsh") {
+                has_install = true;
+                continue;
+            }
+            if name == "Brewfile" {
+                has_install = true;
+                continue;
+            }
+            if is_shell_filename(&name) {
+                has_shell = true;
+                continue;
+            }
+            has_other = true;
+        } else if name == "bin" {
+            has_shell = true;
+        } else {
+            has_other = true;
+        }
+    }
+
+    let _ = has_other;
+    if !any {
+        return PackKind::Empty;
+    }
+    match (has_shell, has_install) {
+        (false, false) => PackKind::ConfigOnly,
+        (true, false) => PackKind::ConfigPlusShell,
+        (false, true) => PackKind::ConfigPlusInstall,
+        (true, true) => PackKind::ConfigPlusShellAndInstall,
+    }
+}
+
+fn is_shell_filename(name: &str) -> bool {
+    let stems = ["aliases", "profile", "login", "env"];
+    let exts = [".sh", ".bash", ".zsh"];
+    for stem in stems {
+        for ext in exts {
+            if name == format!("{stem}{ext}") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// ── Discover & recommend ────────────────────────────────────────
+
+/// Summary line for one pack as shown in the tutorial.
+#[derive(Debug, Clone, Serialize)]
+pub struct TutorialPack {
+    pub name: String,
+    pub kind: String,
+    pub recommended: bool,
+}
+
+/// Discover packs in the active context and classify each one.
+///
+/// Returns the list in scan order with the recommended starter pack
+/// flagged. If no pack is recommendable (only empty packs), no entry
+/// has `recommended = true`.
+pub fn discover_and_classify(ctx: &ExecutionContext) -> Result<Vec<TutorialPack>> {
+    let root_config = ctx.config_manager.root_config()?;
+    let scanned = packs::scan_packs(
+        ctx.fs.as_ref(),
+        ctx.paths.dotfiles_root(),
+        &root_config.pack.ignore,
+    )?;
+
+    let mut entries: Vec<(String, PackKind, packs::Pack)> = scanned
+        .packs
+        .into_iter()
+        .map(|p| {
+            let kind = classify_pack(&p);
+            (p.display_name.clone(), kind, p)
+        })
+        .collect();
+
+    // Pick the recommended starter — best rank wins. Ties broken
+    // by scan order (which is alphabetical).
+    let recommended_idx = entries
+        .iter()
+        .enumerate()
+        .filter(|(_, (_, kind, _))| !matches!(kind, PackKind::Empty))
+        .min_by_key(|(_, (_, kind, _))| kind.starter_rank())
+        .map(|(i, _)| i);
+
+    let result = entries
+        .drain(..)
+        .enumerate()
+        .map(|(i, (name, kind, _))| TutorialPack {
+            name,
+            kind: kind.label().to_string(),
+            recommended: Some(i) == recommended_idx,
+        })
+        .collect();
+
+    Ok(result)
+}
+
+// ── Shell integration detection ─────────────────────────────────
+
+/// What we found out about the `eval "$(dodot init-sh)"` line.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellIntegration {
+    /// Detected user shell (`zsh`, `bash`, `fish`, `unknown`).
+    pub shell_kind: String,
+    /// Path to the rc file we'd suggest editing (display form).
+    pub rc_path: String,
+    /// Absolute path of the rc file, for actual writes.
+    #[serde(skip)]
+    pub rc_path_abs: PathBuf,
+    /// True if the eval line is already present in the rc file.
+    pub line_present: bool,
+    /// The full eval line we'd suggest adding.
+    pub eval_line: String,
+}
+
+/// Detect the shell init situation for the user.
+///
+/// Reads `$SHELL`, picks a likely rc file, checks whether the
+/// `dodot init-sh` eval line is already there. Pure read-only.
+pub fn detect_shell_integration(home: &Path) -> ShellIntegration {
+    let shell_env = std::env::var("SHELL").unwrap_or_default();
+    let shell_kind = shell_env.rsplit('/').next().unwrap_or("").to_lowercase();
+
+    let (kind, rc_rel) = match shell_kind.as_str() {
+        "zsh" => ("zsh", ".zshrc"),
+        "bash" => ("bash", ".bashrc"),
+        "fish" => ("fish", ".config/fish/config.fish"),
+        _ => ("unknown", ".profile"),
+    };
+
+    let rc_path_abs = home.join(rc_rel);
+    let display = format!("~/{rc_rel}");
+    let eval_line = if kind == "fish" {
+        "dodot init-sh | source".to_string()
+    } else {
+        r#"eval "$(dodot init-sh)""#.to_string()
+    };
+
+    let line_present = std::fs::read_to_string(&rc_path_abs)
+        .map(|c| c.contains("dodot init-sh"))
+        .unwrap_or(false);
+
+    ShellIntegration {
+        shell_kind: kind.to_string(),
+        rc_path: display,
+        rc_path_abs,
+        line_present,
+        eval_line,
+    }
+}
+
+/// Append the eval line to the user's rc file with a header comment.
+/// Idempotent: returns Ok without writing if the line is already there.
+pub fn append_shell_integration(integ: &ShellIntegration) -> Result<()> {
+    if integ.line_present {
+        return Ok(());
+    }
+    if let Some(parent) = integ.rc_path_abs.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| crate::DodotError::Other(format!("create rc parent: {e}")))?;
+        }
+    }
+    let existing = std::fs::read_to_string(&integ.rc_path_abs).unwrap_or_default();
+    let mut new = existing;
+    if !new.is_empty() && !new.ends_with('\n') {
+        new.push('\n');
+    }
+    new.push_str("\n# dodot — load packs into this shell session\n");
+    new.push_str(&integ.eval_line);
+    new.push('\n');
+    std::fs::write(&integ.rc_path_abs, new)
+        .map_err(|e| crate::DodotError::Other(format!("write rc: {e}")))?;
+    Ok(())
+}
+
+// ── State persistence ───────────────────────────────────────────
+
+/// Persisted between tutorial invocations so users can resume.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TutorialState {
+    pub step_id: String,
+    pub pack: Option<String>,
+    pub started_at: Option<String>,
+}
+
+/// Path where tutorial state is stored.
+pub fn state_path(paths: &dyn Pather) -> PathBuf {
+    paths.data_dir().join("tutorial.json")
+}
+
+pub fn load_state(paths: &dyn Pather) -> Option<TutorialState> {
+    let path = state_path(paths);
+    let contents = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+pub fn save_state(paths: &dyn Pather, state: &TutorialState) -> Result<()> {
+    let path = state_path(paths);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| crate::DodotError::Other(format!("create state dir: {e}")))?;
+    }
+    let s = serde_json::to_string_pretty(state)
+        .map_err(|e| crate::DodotError::Other(format!("serialize state: {e}")))?;
+    std::fs::write(&path, s).map_err(|e| crate::DodotError::Other(format!("write state: {e}")))?;
+    Ok(())
+}
+
+pub fn clear_state(paths: &dyn Pather) -> Result<()> {
+    let path = state_path(paths);
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .map_err(|e| crate::DodotError::Other(format!("remove state: {e}")))?;
+    }
+    Ok(())
+}
+
+// ── Tutorial Ctx ────────────────────────────────────────────────
+
+/// Serializable context passed to step templates. The CLI driver
+/// mutates this between steps; templates read fields by name.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct TutorialCtx {
+    pub dotfiles_root: String,
+    pub via: String,
+    pub packs: Vec<TutorialPack>,
+    pub chosen_pack: Option<String>,
+    pub chosen_pack_kind: Option<String>,
+    pub has_shell_files: bool,
+    pub has_install_files: bool,
+    pub status_output: Option<String>,
+    pub dry_run_output: Option<String>,
+    pub up_output: Option<String>,
+    pub shell_integration: Option<ShellIntegration>,
+    pub eval_line: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    fn write(p: &PathBuf, body: &str) {
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(p, body).unwrap();
+    }
+
+    #[test]
+    fn classify_config_only_pack() {
+        let dir = tempfile::tempdir().unwrap();
+        let pack_path = dir.path().join("vim");
+        std::fs::create_dir_all(&pack_path).unwrap();
+        write(&pack_path.join("vimrc"), "set nu");
+        let pack = packs::Pack::new(
+            "vim".into(),
+            pack_path,
+            crate::handlers::HandlerConfig::default(),
+        );
+        assert_eq!(classify_pack(&pack), PackKind::ConfigOnly);
+    }
+
+    #[test]
+    fn classify_config_plus_shell_pack() {
+        let dir = tempfile::tempdir().unwrap();
+        let pack_path = dir.path().join("zsh");
+        std::fs::create_dir_all(&pack_path).unwrap();
+        write(&pack_path.join("aliases.sh"), "alias ll='ls -l'");
+        let pack = packs::Pack::new(
+            "zsh".into(),
+            pack_path,
+            crate::handlers::HandlerConfig::default(),
+        );
+        assert_eq!(classify_pack(&pack), PackKind::ConfigPlusShell);
+    }
+
+    #[test]
+    fn classify_config_plus_install_pack() {
+        let dir = tempfile::tempdir().unwrap();
+        let pack_path = dir.path().join("dev");
+        std::fs::create_dir_all(&pack_path).unwrap();
+        write(&pack_path.join("install.sh"), "echo");
+        write(&pack_path.join("config"), "k=v");
+        let pack = packs::Pack::new(
+            "dev".into(),
+            pack_path,
+            crate::handlers::HandlerConfig::default(),
+        );
+        assert_eq!(classify_pack(&pack), PackKind::ConfigPlusInstall);
+    }
+
+    #[test]
+    fn classify_empty_pack() {
+        let dir = tempfile::tempdir().unwrap();
+        let pack_path = dir.path().join("empty");
+        std::fs::create_dir_all(&pack_path).unwrap();
+        let pack = packs::Pack::new(
+            "empty".into(),
+            pack_path,
+            crate::handlers::HandlerConfig::default(),
+        );
+        assert_eq!(classify_pack(&pack), PackKind::Empty);
+    }
+
+    #[test]
+    fn detect_shell_with_no_rc_file_reports_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        // Force a known shell — .zshrc doesn't exist in this temp HOME.
+        std::env::set_var("SHELL", "/bin/zsh");
+        let integ = detect_shell_integration(dir.path());
+        assert_eq!(integ.shell_kind, "zsh");
+        assert!(!integ.line_present);
+        assert!(integ.eval_line.contains("dodot init-sh"));
+    }
+}

--- a/crates/dodot-lib/src/render/mod.rs
+++ b/crates/dodot-lib/src/render/mod.rs
@@ -98,6 +98,14 @@ group-banner-error:
 group-banner-ignored:
   dim: true
   bold: true
+
+# Tutorial prompt question text. The interactive `dodot tutorial`
+# uses inquire for the prompt UI; this style is mirrored by hand into
+# its `RenderConfig` (see `tutorial.rs::tutorial_render_config`). Keep
+# attributes here in sync with that function so users have one place
+# to change the look.
+tutorial-prompt:
+  italic: true
 "#;
 
 // ── Templates ───────────────────────────────────────────────────
@@ -119,6 +127,70 @@ pub const TEMPLATE_MESSAGE: &str = include_str!("../templates/message.jinja");
 /// Probe — deployment map, data-dir tree, summary. Branches on the
 /// `kind` field of the serialized result.
 pub const TEMPLATE_PROBE: &str = include_str!("../templates/probe.jinja");
+
+// ── Tutorial step templates ─────────────────────────────────────
+//
+// One per step of the interactive tutorial. The CLI driver renders
+// the appropriate template before each prompt.
+
+pub const TEMPLATE_TUTORIAL_INTRO: &str = include_str!("../templates/tutorial/intro.jinja");
+pub const TEMPLATE_TUTORIAL_CHECK_ROOT: &str =
+    include_str!("../templates/tutorial/check_root.jinja");
+pub const TEMPLATE_TUTORIAL_PICK_PACK: &str = include_str!("../templates/tutorial/pick_pack.jinja");
+pub const TEMPLATE_TUTORIAL_NO_PACKS: &str = include_str!("../templates/tutorial/no_packs.jinja");
+pub const TEMPLATE_TUTORIAL_SHOW_STATUS: &str =
+    include_str!("../templates/tutorial/show_status.jinja");
+pub const TEMPLATE_TUTORIAL_ANNOTATE_STATUS: &str =
+    include_str!("../templates/tutorial/annotate_status.jinja");
+pub const TEMPLATE_TUTORIAL_CONCEPT_TARGETS: &str =
+    include_str!("../templates/tutorial/concept_targets.jinja");
+pub const TEMPLATE_TUTORIAL_CONCEPT_SHELL: &str =
+    include_str!("../templates/tutorial/concept_shell.jinja");
+pub const TEMPLATE_TUTORIAL_DRY_RUN: &str = include_str!("../templates/tutorial/dry_run.jinja");
+pub const TEMPLATE_TUTORIAL_REAL_UP: &str = include_str!("../templates/tutorial/real_up.jinja");
+pub const TEMPLATE_TUTORIAL_OUTRO: &str = include_str!("../templates/tutorial/outro.jinja");
+
+/// Pairs of (name, body) for every tutorial step template. The CLI
+/// driver registers all of these on a single `Renderer` once at
+/// startup; step bodies render by name.
+pub const TUTORIAL_STEP_TEMPLATES: &[(&str, &str)] = &[
+    ("tutorial.intro", TEMPLATE_TUTORIAL_INTRO),
+    ("tutorial.check_root", TEMPLATE_TUTORIAL_CHECK_ROOT),
+    ("tutorial.pick_pack", TEMPLATE_TUTORIAL_PICK_PACK),
+    ("tutorial.no_packs", TEMPLATE_TUTORIAL_NO_PACKS),
+    ("tutorial.show_status", TEMPLATE_TUTORIAL_SHOW_STATUS),
+    (
+        "tutorial.annotate_status",
+        TEMPLATE_TUTORIAL_ANNOTATE_STATUS,
+    ),
+    (
+        "tutorial.concept_targets",
+        TEMPLATE_TUTORIAL_CONCEPT_TARGETS,
+    ),
+    ("tutorial.concept_shell", TEMPLATE_TUTORIAL_CONCEPT_SHELL),
+    ("tutorial.dry_run", TEMPLATE_TUTORIAL_DRY_RUN),
+    ("tutorial.real_up", TEMPLATE_TUTORIAL_REAL_UP),
+    ("tutorial.outro", TEMPLATE_TUTORIAL_OUTRO),
+];
+
+/// Render a tutorial step template with the dodot theme.
+///
+/// `mode` controls colour output: `OutputMode::Term` for ANSI in a
+/// real terminal, `OutputMode::Text` for tests / non-TTY.
+pub fn render_tutorial_step<T: serde::Serialize>(
+    step: &str,
+    data: &T,
+    mode: OutputMode,
+) -> Result<String> {
+    let body = TUTORIAL_STEP_TEMPLATES
+        .iter()
+        .find_map(|(name, body)| (*name == step).then_some(*body))
+        .ok_or_else(|| crate::DodotError::Other(format!("unknown tutorial template: {step}")))?;
+
+    let theme = create_theme();
+    render_with_output(body, data, &theme, mode)
+        .map_err(|e| crate::DodotError::Other(format!("tutorial render: {e}")))
+}
 
 // ── Renderer ────────────────────────────────────────────────────
 
@@ -228,6 +300,51 @@ mod tests {
         assert!(output.contains("vim"));
         assert!(output.contains("vimrc"));
         assert!(output.contains("deployed"));
+    }
+
+    #[test]
+    fn all_tutorial_templates_render_in_text_mode() {
+        // Every tutorial step template must parse and render with a
+        // populated context — this catches Jinja-syntax mistakes at
+        // build time rather than mid-tutorial.
+        use crate::commands::tutorial::{TutorialCtx, TutorialPack};
+
+        let ctx = TutorialCtx {
+            dotfiles_root: "/home/example/dotfiles".into(),
+            via: "DOTFILES_ROOT env var".into(),
+            packs: vec![
+                TutorialPack {
+                    name: "vim".into(),
+                    kind: "config only".into(),
+                    recommended: true,
+                },
+                TutorialPack {
+                    name: "zsh".into(),
+                    kind: "config + shell".into(),
+                    recommended: false,
+                },
+            ],
+            chosen_pack: Some("vim".into()),
+            chosen_pack_kind: Some("config only".into()),
+            status_output: Some("(rendered status would go here)".into()),
+            dry_run_output: Some("(dry-run output)".into()),
+            up_output: Some("(up output)".into()),
+            shell_integration: Some(crate::commands::tutorial::ShellIntegration {
+                shell_kind: "zsh".into(),
+                rc_path: "~/.zshrc".into(),
+                rc_path_abs: std::path::PathBuf::new(),
+                line_present: false,
+                eval_line: r#"eval "$(dodot init-sh)""#.into(),
+            }),
+            eval_line: r#"eval "$(dodot init-sh)""#.into(),
+            ..Default::default()
+        };
+
+        for (name, _) in TUTORIAL_STEP_TEMPLATES {
+            let out = render_tutorial_step(name, &ctx, OutputMode::Text)
+                .unwrap_or_else(|e| panic!("template {name} failed: {e}"));
+            assert!(!out.is_empty(), "template {name} produced empty output");
+        }
     }
 
     #[test]

--- a/crates/dodot-lib/src/render/mod.rs
+++ b/crates/dodot-lib/src/render/mod.rs
@@ -150,9 +150,12 @@ pub const TEMPLATE_TUTORIAL_DRY_RUN: &str = include_str!("../templates/tutorial/
 pub const TEMPLATE_TUTORIAL_REAL_UP: &str = include_str!("../templates/tutorial/real_up.jinja");
 pub const TEMPLATE_TUTORIAL_OUTRO: &str = include_str!("../templates/tutorial/outro.jinja");
 
-/// Pairs of (name, body) for every tutorial step template. The CLI
-/// driver registers all of these on a single `Renderer` once at
-/// startup; step bodies render by name.
+/// Pairs of `(name, body)` for every tutorial step template.
+///
+/// `render_tutorial_step` looks up the body by name and renders
+/// against a fresh theme each call — no shared `Renderer` is
+/// retained, since each tutorial run renders fewer than a dozen
+/// templates and the per-call cost is negligible.
 pub const TUTORIAL_STEP_TEMPLATES: &[(&str, &str)] = &[
     ("tutorial.intro", TEMPLATE_TUTORIAL_INTRO),
     ("tutorial.check_root", TEMPLATE_TUTORIAL_CHECK_ROOT),

--- a/crates/dodot-lib/src/templates/tutorial/annotate_status.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/annotate_status.jinja
@@ -1,0 +1,13 @@
+[header]Reading that output[/header]
+
+  [handler-symbol]➞[/handler-symbol]  symlink (default — file appears at the listed target)
+  [handler-symbol]⚙[/handler-symbol]  shell snippet (sourced) or [pack-name]Brewfile[/pack-name] (installed)
+  [handler-symbol]+[/handler-symbol]  [pack-name]bin/[/pack-name] directory (added to $PATH)
+  [handler-symbol]×[/handler-symbol]  [pack-name]install.sh[/pack-name] (run-once script)
+
+  [pending]pending[/pending]   not deployed yet
+  [deployed]deployed[/deployed]  already linked / sourced / installed
+  [error]error[/error]     something is wrong — read the message at the bottom
+
+If your status above looks wrong (missing files, surprising targets), exit now and
+adjust file names or add a [pack-name].dodot.toml[/pack-name] in the pack — then re-run.

--- a/crates/dodot-lib/src/templates/tutorial/check_root.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/check_root.jinja
@@ -1,0 +1,7 @@
+[header]Step 1 — find your dotfiles repo[/header]
+
+dodot needs to know where your dotfiles live. I detected:
+
+  [pack-name]{{ dotfiles_root }}[/pack-name]  [dim]({{ via }})[/dim]
+
+If that's not your dotfiles repo, exit, [dim]cd[/dim] into the right place and re-run.

--- a/crates/dodot-lib/src/templates/tutorial/concept_shell.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/concept_shell.jinja
@@ -1,0 +1,10 @@
+[header]Step 5 — shell integration[/header]
+
+This pack has shell snippets or a [pack-name]bin/[/pack-name] directory. To make them take
+effect in your shell, add this line to [pack-name]{{ shell_integration.rc_path }}[/pack-name]:
+
+  [message]{{ shell_integration.eval_line }}[/message]
+
+{% if shell_integration.line_present %}[deployed]✓ already present — nothing to do.[/deployed]
+{% else %}[warning]Not present yet.[/warning] You can have me write it for you, copy it to clipboard,
+or skip and add it manually.{% endif %}

--- a/crates/dodot-lib/src/templates/tutorial/concept_targets.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/concept_targets.jinja
@@ -1,0 +1,9 @@
+[header]Step 4 — where files will land[/header]
+
+By default, dodot symlinks files into [pack-name]$XDG_CONFIG_HOME/<pack>/<file>[/pack-name]
+(usually [pack-name]~/.config/<pack>/<file>[/pack-name]) — [warning]not[/warning] [pack-name]~/.<file>[/pack-name].
+
+If a tool needs [pack-name]~/.<file>[/pack-name] (like [pack-name].zshrc[/pack-name] or [pack-name].gitconfig[/pack-name]),
+prefix the filename with [message]home.[/message] in the pack: [pack-name]git/home.gitconfig[/pack-name] →
+[pack-name]~/.gitconfig[/pack-name]. Most modern tools (nvim, helix, fish, ghostty)
+already read XDG paths, so the default usually just works.

--- a/crates/dodot-lib/src/templates/tutorial/dry_run.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/dry_run.jinja
@@ -1,0 +1,5 @@
+[header]Step 6 — preview what [message]up[/message] will do[/header]
+
+[message]dodot up --dry-run[/message] shows the writes [warning]without performing them[/warning]:
+
+{{ dry_run_output }}

--- a/crates/dodot-lib/src/templates/tutorial/intro.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/intro.jinja
@@ -1,0 +1,5 @@
+[header]Welcome to dodot[/header]
+
+In about 10 minutes we'll get one [pack-name]pack[/pack-name] live on your system.
+At any prompt: pick the option you want, or hit [dim]Ctrl-C[/dim] to quit. Your config
+is never modified without your explicit say-so.

--- a/crates/dodot-lib/src/templates/tutorial/no_packs.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/no_packs.jinja
@@ -1,0 +1,7 @@
+[header]No packs yet[/header]
+
+Your repo doesn't have any packs. Create one with:
+
+  [message]dodot init <name>[/message]
+
+Then re-run [message]dodot tutorial[/message] to continue.

--- a/crates/dodot-lib/src/templates/tutorial/outro.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/outro.jinja
@@ -1,0 +1,12 @@
+[header]You're set up.[/header]
+
+The everyday loop:
+  [message]1.[/message] Group files into a directory (the pack)
+  [message]2.[/message] [message]dodot status <pack>[/message] — see what dodot will do
+  [message]3.[/message] Adjust file names / [pack-name].dodot.toml[/pack-name] until status looks right
+  [message]4.[/message] [message]dodot up <pack>[/message] — apply
+
+When something looks wrong: [message]dodot status[/message]. To undo: [message]dodot down <pack>[/message].
+To import existing config files into a pack: [message]dodot adopt <pack> <file>...[/message].
+
+Run [message]dodot --help[/message] anytime. Happy hacking.

--- a/crates/dodot-lib/src/templates/tutorial/pick_pack.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/pick_pack.jinja
@@ -1,0 +1,9 @@
+[header]Step 2 — pick a pack to start with[/header]
+
+A [pack-name]pack[/pack-name] is just a top-level directory in your repo. Group related
+config there ([pack-name]vim/[/pack-name], [pack-name]git/[/pack-name], …) and dodot handles the rest.
+
+I found {{ packs | length }} pack{% if packs|length != 1 %}s{% endif %}:
+
+{% for p in packs %}  {{ p.name | col(20) }} [dim]{{ p.kind }}[/dim]{% if p.recommended %}  [deployed]← recommended starter[/deployed]{% endif %}
+{% endfor %}

--- a/crates/dodot-lib/src/templates/tutorial/real_up.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/real_up.jinja
@@ -1,0 +1,9 @@
+[header]Step 7 — make it real[/header]
+
+[message]dodot up {{ chosen_pack }}[/message]:
+
+{{ up_output }}
+
+Re-running [message]status[/message] confirms the flip from [pending]pending[/pending] → [deployed]deployed[/deployed]:
+
+{{ status_output }}

--- a/crates/dodot-lib/src/templates/tutorial/show_status.jinja
+++ b/crates/dodot-lib/src/templates/tutorial/show_status.jinja
@@ -1,0 +1,11 @@
+[header]Step 3 — what dodot would do with [pack-name]{{ chosen_pack }}[/pack-name][/header]
+
+dodot has three core commands:
+  [message]up[/message]      deploy a pack (symlinks, shell snippets, install scripts)
+  [message]down[/message]    undo deployment (provisioning artifacts left alone)
+  [message]status[/message]  show what each file in a pack will become
+
+Always start with [message]status[/message] — it tells you what [message]up[/message] is going to do
+without touching anything. Here's [message]dodot status {{ chosen_pack }}[/message]:
+
+{{ status_output }}


### PR DESCRIPTION
## Summary

- Adds `dodot tutorial`, an interactive walkthrough that takes a new user through their first pack deployment using their actual dotfiles repo (not a sandbox).
- 12-step state machine: detect repo → list/recommend a pack → run `status` → annotate output → explain XDG targets → optional shell-integration step → dry-run → real `up` → outro. Branches for empty repo, config-only packs (skip shell step), and three-way write/clipboard/skip on the rc-file eval line.
- Built on a small `Prompts` trait so the whole flow is testable in-process: `InquirePrompts` for production (with italic prompt styling tied to a new `tutorial-prompt` theme key), `ScriptedPrompts` for tests with kind-validated answers. Migrating to `standout-input`'s `PromptResponder` is mechanical once 7.6 ships.
- Resume state at `$XDG_DATA_HOME/dodot/tutorial.json`; cleared on a clean finish.

## Test plan

- [x] `cargo test --workspace` — 519 tests pass
- [x] 4 in-process tutorial tests via `ScriptedPrompts`: happy path (verifies actual symlink created), quit-at-intro (no deploy), empty repo (offers `dodot init`), recommendation ordering (config-only pack picked over install-only)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `dodot tutorial --help` renders
- [x] Manual run: tutorial runs end-to-end with real prompts; appears in `dodot --help` under MISC
- [ ] Reviewer: please sanity-check the prose tone in the step templates (`crates/dodot-lib/src/templates/tutorial/*.jinja`) — it's the user-facing copy

## Notes

- `dry-run` tag bleed in the rendered status output during the dry-run step is existing pack-status behavior (same in `dodot up --dry-run`), not introduced here.
- The `tutorial-prompt` theme key in the YAML and the inquire `RenderConfig` need to be kept in sync by hand — comment in both places. A future improvement is bridging the dodot theme directly into inquire's StyleSheet, but it wasn't worth the plumbing for "make it italic".

🤖 Generated with [Claude Code](https://claude.com/claude-code)