### PR TITLE
refactor(handlers): unify ignore/skip into Filter-phase handlers

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,10 +10,17 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
 
 ### Added
 
-- `mappings.exclude` config list: filenames matched here are surfaced in
-  `dodot status` as `ignored` instead of being claimed by the catchall
-  symlink handler. Defaults cover documentation/legal files (`README`,
-  `LICENSE`, `CHANGELOG`, `CONTRIBUTING`, `AUTHORS`, `NOTICE`, `COPYING`
-  and their `.*` variants), matched case-insensitively. Override per-pack
-  by setting `[mappings] exclude = []` (or a different list) in the
-  pack's `.dodot.toml`.
+- `[mappings] ignore` and `[mappings] skip` config lists, backed by two
+  new filter handlers in a dedicated execution phase that runs before
+  every other phase:
+  - `ignore` (default `[]`): silently drops matching files, mirroring
+    `.gitignore` — nothing surfaces in `dodot status`.
+  - `skip` (defaults: `README`, `LICENSE`, `CHANGELOG`, `CONTRIBUTING`,
+    `AUTHORS`, `NOTICE`, `COPYING` and their `.*` variants, matched
+    case-insensitively): listed in `dodot status` as `skipped`, but no
+    handler runs on them. Override per-pack with `[mappings] skip = []`
+    to deploy a README intentionally.
+  Filter handlers are real registered handlers (no synthetic-name
+  dispatch) and win over precise mappings and the catchall via ordinary
+  rule priority. The pack-level `.dodotignore` marker is unchanged but
+  is now referred to as the "pack-ignore" mechanism in docs.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ All conventions can be overridden via `.dodot.toml` in the pack or the dotfiles 
 | `init`       | Create a new pack with template files            |
 | `adopt`      | Move existing files into a pack, symlink back    |
 | `fill`       | Add template files to an existing pack           |
-| `addignore`  | Mark a pack as ignored                           |
+| `addignore`  | Drop a `.dodotignore` marker (pack-ignore)       |
 | `init-sh`    | Print shell init script for `eval`               |
 | `config`     | Inspect and modify configuration                 |
 
@@ -132,8 +132,11 @@ dodot uses a layered TOML configuration:
 # git/.dodot.toml
 [mappings]
 shell = ["aliases.sh", "profile.sh"]
-skip = ["README.md"]
+ignore = ["scratch.txt"]   # drop entirely (silent, like .gitignore)
+skip   = []                # clear defaults to deploy README/LICENSE
 ```
+
+`mappings.ignore` matches files dodot should drop without a trace; `mappings.skip` matches files that show up in `dodot status` as `skipped` but aren't deployed (defaults cover `README`, `LICENSE`, `CHANGELOG`, and friends).
 
 Generate a starter config with `dodot config gen -o .dodot.toml`.
 

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -348,7 +348,7 @@ fn build_clap_command() -> ClapCommand {
         )
         .subcommand(
             ClapCommand::new("addignore")
-                .about("Mark a pack as ignored")
+                .about("Mark a pack as pack-ignored (drops a .dodotignore marker)")
                 .arg(Arg::new("pack").help("Pack name").required(true)),
         )
         .subcommand(

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -31,7 +31,7 @@ pub fn handler_symbol(handler: &str) -> &'static str {
         "path" => "+",
         "homebrew" => "⚙",
         "install" => "×",
-        "excluded" => "·",
+        "skip" => "·",
         _ => "?",
     }
 }
@@ -63,7 +63,7 @@ pub fn handler_description(handler: &str, rel_path: &str, user_target: Option<&s
         "path" => format!("$PATH/{rel_path}"),
         "install" => "run script".into(),
         "homebrew" => "brew install".into(),
-        "excluded" => "not deployed".into(),
+        "skip" => "not deployed".into(),
         _ => String::new(),
     }
 }

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -17,7 +17,7 @@ use crate::commands::{
 use crate::config::mappings_to_rules;
 use crate::conflicts;
 use crate::handlers::symlink::resolve_target;
-use crate::handlers::{self, HANDLER_SYMLINK};
+use crate::handlers::{self, HANDLER_IGNORE, HANDLER_SKIP, HANDLER_SYMLINK};
 use crate::packs::orchestration::{self, ExecutionContext};
 use crate::packs::{self};
 use crate::rules::Scanner;
@@ -466,7 +466,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
             // The `ignore` filter handler claims files only to keep them
             // off the catchall and out of status. Drop them here so the
             // user sees nothing — same contract as `.gitignore`.
-            if m.handler == "ignore" {
+            if m.handler == HANDLER_IGNORE {
                 continue;
             }
 
@@ -474,7 +474,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
 
             // Per-file chain verification based on handler type
             let health = match m.handler.as_str() {
-                "skip" => Health::Skipped,
+                h if h == HANDLER_SKIP => Health::Skipped,
                 "symlink" => {
                     verify_symlink(&m.absolute_path, &pack.name, &rel_str, &pack.config, ctx)
                 }

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -43,10 +43,10 @@ enum Health {
     /// Data link exists and is healthy, but the user link is not at the
     /// path that current config would produce. A re-deploy would move it.
     Stale(String),
-    /// File matched the `mappings.exclude` list (README, LICENSE, …).
+    /// File matched the `mappings.skip` list (README, LICENSE, …).
     /// No handler runs on it, but it surfaces in status so users can see
     /// the rule applied rather than wondering why the file is "missing."
-    Ignored,
+    Skipped,
 }
 
 impl Health {
@@ -59,7 +59,7 @@ impl Health {
             Health::DeployedWithError { .. } => "broken",
             Health::Broken(_) => "broken",
             Health::Stale(_) => "stale",
-            Health::Ignored => "ignored",
+            Health::Skipped => "skipped",
         }
     }
 
@@ -85,7 +85,7 @@ impl Health {
             Health::DeployedWithError { label, .. } => label.clone(),
             Health::Broken(reason) => reason.clone(),
             Health::Stale(reason) => reason.clone(),
-            Health::Ignored => "ignored".into(),
+            Health::Skipped => "skipped".into(),
         }
     }
 
@@ -463,11 +463,18 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
 
         let mut files = Vec::new();
         for m in &matches {
+            // The `ignore` filter handler claims files only to keep them
+            // off the catchall and out of status. Drop them here so the
+            // user sees nothing — same contract as `.gitignore`.
+            if m.handler == "ignore" {
+                continue;
+            }
+
             let rel_str = m.relative_path.to_string_lossy().into_owned();
 
             // Per-file chain verification based on handler type
             let health = match m.handler.as_str() {
-                "excluded" => Health::Ignored,
+                "skip" => Health::Skipped,
                 "symlink" => {
                     verify_symlink(&m.absolute_path, &pack.name, &rel_str, &pack.config, ctx)
                 }

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -76,10 +76,10 @@ fn status_shows_pending_before_up() {
 }
 
 #[test]
-fn status_marks_readme_and_license_as_ignored() {
-    // Files matched by `mappings.exclude` (defaults: README, LICENSE,
-    // CHANGELOG, …) should appear in status with handler "excluded"
-    // and status "ignored" rather than being silently dropped or
+fn status_marks_readme_and_license_as_skipped() {
+    // Files matched by `mappings.skip` (defaults: README, LICENSE,
+    // CHANGELOG, …) should appear in status with handler "skip"
+    // and status "skipped" rather than being silently dropped or
     // routed to the symlink catchall.
     let env = TempEnvironment::builder()
         .pack("vim")
@@ -98,15 +98,15 @@ fn status_marks_readme_and_license_as_ignored() {
         pack.files.iter().map(|f| (f.name.as_str(), f)).collect();
 
     let readme = by_name.get("README.md").expect("README.md in status");
-    assert_eq!(readme.handler, "excluded");
-    assert_eq!(readme.status, "ignored");
-    assert_eq!(readme.status_label, "ignored");
+    assert_eq!(readme.handler, "skip");
+    assert_eq!(readme.status, "skipped");
+    assert_eq!(readme.status_label, "skipped");
 
     let license = by_name.get("license").expect("license in status");
-    assert_eq!(license.handler, "excluded", "case-insensitive match");
+    assert_eq!(license.handler, "skip", "case-insensitive match");
 
     let changelog = by_name.get("CHANGELOG").expect("CHANGELOG in status");
-    assert_eq!(changelog.handler, "excluded");
+    assert_eq!(changelog.handler, "skip");
 
     let vimrc = by_name.get("vimrc").expect("vimrc in status");
     assert_eq!(vimrc.handler, "symlink");

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -200,14 +200,17 @@ pub struct MappingsSection {
     #[config(default = "Brewfile")]
     pub homebrew: String,
 
-    /// Additional filename patterns to exclude from handler processing
-    /// within a pack. Distinct from [pack] ignore which controls discovery.
+    /// Filename patterns to drop from handler processing entirely.
+    /// Matches are silent: nothing surfaces in `dodot status`, mirroring
+    /// `.gitignore`'s mental model. Defaults are empty; common build /
+    /// VCS clutter is already covered by `[pack] ignore` (which also
+    /// stops discovery).
     #[config(default = [])]
-    pub skip: Vec<String>,
+    pub ignore: Vec<String>,
 
     /// Filename patterns the catchall symlink handler should not pick up.
     /// Matched case-insensitively against the basename. Files that match
-    /// are surfaced in `dodot status` as "ignored" but no handler runs on
+    /// are surfaced in `dodot status` as "skipped" but no handler runs on
     /// them. The defaults cover the common documentation/legal files that
     /// packs ship alongside real config; clear the list (or override
     /// per-pack) to deploy a README intentionally.
@@ -220,7 +223,7 @@ pub struct MappingsSection {
         "NOTICE", "NOTICE.*",
         "COPYING", "COPYING.*",
     ])]
-    pub exclude: Vec<String>,
+    pub skip: Vec<String>,
 }
 
 // ── Conversions ─────────────────────────────────────────────────
@@ -258,6 +261,7 @@ pub fn mappings_to_rules(mappings: &MappingsSection) -> Vec<Rule> {
             pattern,
             handler: "path".into(),
             priority: 10,
+            case_insensitive: false,
             options: HashMap::new(),
         });
     }
@@ -269,6 +273,7 @@ pub fn mappings_to_rules(mappings: &MappingsSection) -> Vec<Rule> {
                 pattern: pattern.clone(),
                 handler: "install".into(),
                 priority: 10,
+                case_insensitive: false,
                 options: HashMap::new(),
             });
         }
@@ -281,6 +286,7 @@ pub fn mappings_to_rules(mappings: &MappingsSection) -> Vec<Rule> {
                 pattern: pattern.clone(),
                 handler: "shell".into(),
                 priority: 10,
+                case_insensitive: false,
                 options: HashMap::new(),
             });
         }
@@ -292,34 +298,40 @@ pub fn mappings_to_rules(mappings: &MappingsSection) -> Vec<Rule> {
             pattern: mappings.homebrew.clone(),
             handler: "homebrew".into(),
             priority: 10,
+            case_insensitive: false,
             options: HashMap::new(),
         });
     }
 
-    // Skip patterns (exclusion rules)
-    for pattern in &mappings.skip {
+    // Ignore patterns: route to the `ignore` filter handler. Priority
+    // 100 means they win over every other rule, including the catchall
+    // and the visible `skip` filter — a file the user said to drop is
+    // dropped, full stop.
+    for pattern in &mappings.ignore {
         if !pattern.is_empty() {
             rules.push(Rule {
-                pattern: format!("!{pattern}"),
-                handler: "exclude".into(),
-                priority: 100, // exclusions checked first
+                pattern: pattern.clone(),
+                handler: crate::handlers::HANDLER_IGNORE.into(),
+                priority: 100,
+                case_insensitive: false,
                 options: HashMap::new(),
             });
         }
     }
 
-    // Exclude patterns: matched case-insensitively, route to the
-    // synthetic "excluded" handler (no registry entry — produces no
-    // intent, surfaces in `dodot status` as ignored). Priority 50 sits
-    // above precise mappings (10) so README-like files cannot be
-    // accidentally claimed by `mappings.shell` or similar, but below
-    // skip exclusions (100) so silent-skip still wins when both apply.
-    for pattern in &mappings.exclude {
+    // Skip patterns: route to the `skip` filter handler. Matched
+    // case-insensitively so README/Readme/readme all hit one rule.
+    // Priority 50 sits above precise mappings (10) so README-like
+    // files cannot be accidentally claimed by `mappings.shell` or
+    // similar, but below `ignore` (100) so silent-drop wins when
+    // both apply. Files surface in `dodot status` as `skipped`.
+    for pattern in &mappings.skip {
         if !pattern.is_empty() {
             rules.push(Rule {
                 pattern: pattern.clone(),
-                handler: "excluded".into(),
+                handler: crate::handlers::HANDLER_SKIP.into(),
                 priority: 50,
+                case_insensitive: true,
                 options: HashMap::new(),
             });
         }
@@ -330,6 +342,7 @@ pub fn mappings_to_rules(mappings: &MappingsSection) -> Vec<Rule> {
         pattern: "*".into(),
         handler: "symlink".into(),
         priority: 0,
+        case_insensitive: false,
         options: HashMap::new(),
     });
 
@@ -492,7 +505,12 @@ mod tests {
                 "env.zsh",
             ]
         );
-        assert!(cfg.mappings.skip.is_empty());
+        assert!(cfg.mappings.ignore.is_empty());
+        assert!(
+            cfg.mappings.skip.iter().any(|p| p == "README"),
+            "skip defaults should include documentation/legal patterns: {:?}",
+            cfg.mappings.skip
+        );
 
         // ── profiling defaults ──────────────────────────────────
         assert!(cfg.profiling.enabled);
@@ -590,13 +608,13 @@ homebrew = "RootBrewfile"
             install: vec!["install.sh".into(), "install.zsh".into()],
             shell: vec!["aliases.sh".into(), "profile.sh".into()],
             homebrew: "Brewfile".into(),
-            skip: vec!["*.tmp".into()],
-            exclude: vec![],
+            ignore: vec!["*.tmp".into()],
+            skip: vec![],
         };
 
         let rules = mappings_to_rules(&mappings);
 
-        // Should have: path, 2x install, 2x shell, homebrew, 1x exclude, catchall = 8
+        // Should have: path, 2x install, 2x shell, homebrew, 1x ignore, catchall = 8
         assert_eq!(rules.len(), 8, "rules: {rules:#?}");
 
         let handler_names: Vec<&str> = rules.iter().map(|r| r.handler.as_str()).collect();
@@ -604,12 +622,15 @@ homebrew = "RootBrewfile"
         assert!(handler_names.contains(&"install"));
         assert!(handler_names.contains(&"shell"));
         assert!(handler_names.contains(&"homebrew"));
-        assert!(handler_names.contains(&"exclude"));
+        assert!(handler_names.contains(&"ignore"));
         assert!(handler_names.contains(&"symlink"));
 
-        // Exclusion rule should have ! prefix
-        let exclude = rules.iter().find(|r| r.handler == "exclude").unwrap();
-        assert!(exclude.pattern.starts_with('!'));
+        // Ignore rule sits at the highest priority tier and is a plain
+        // pattern (no `!` prefix exists anymore).
+        let ignore = rules.iter().find(|r| r.handler == "ignore").unwrap();
+        assert_eq!(ignore.priority, 100);
+        assert!(!ignore.pattern.starts_with('!'));
+        assert!(!ignore.case_insensitive);
 
         // Catchall should be lowest priority
         let catchall = rules.iter().find(|r| r.pattern == "*").unwrap();
@@ -617,21 +638,22 @@ homebrew = "RootBrewfile"
     }
 
     #[test]
-    fn mappings_exclude_emits_priority_50_excluded_rules() {
+    fn mappings_skip_emits_priority_50_skip_rules() {
         let mappings = MappingsSection {
             path: String::new(),
             install: vec![],
             shell: vec![],
             homebrew: String::new(),
-            skip: vec![],
-            exclude: vec!["README".into(), "README.*".into(), "LICENSE".into()],
+            ignore: vec![],
+            skip: vec!["README".into(), "README.*".into(), "LICENSE".into()],
         };
 
         let rules = mappings_to_rules(&mappings);
-        let excluded: Vec<&Rule> = rules.iter().filter(|r| r.handler == "excluded").collect();
-        assert_eq!(excluded.len(), 3);
-        for rule in &excluded {
+        let skip_rules: Vec<&Rule> = rules.iter().filter(|r| r.handler == "skip").collect();
+        assert_eq!(skip_rules.len(), 3);
+        for rule in &skip_rules {
             assert_eq!(rule.priority, 50);
+            assert!(rule.case_insensitive);
             assert!(!rule.pattern.starts_with('!'));
         }
     }

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -208,10 +208,13 @@ pub struct MappingsSection {
     #[config(default = [])]
     pub ignore: Vec<String>,
 
-    /// Filename patterns the catchall symlink handler should not pick up.
-    /// Matched case-insensitively against the basename. Files that match
-    /// are surfaced in `dodot status` as "skipped" but no handler runs on
-    /// them. The defaults cover the common documentation/legal files that
+    /// Filename patterns routed to the `skip` filter handler.
+    /// Matched case-insensitively against the basename. Sits at
+    /// priority 50, above every precise mapping (priority 10) and the
+    /// catchall symlink (priority 0), so a match suppresses *all*
+    /// downstream handlers — not just the catchall. Matches surface in
+    /// `dodot status` as "skipped"; no executable intent is produced.
+    /// The defaults cover the common documentation/legal files that
     /// packs ship alongside real config; clear the list (or override
     /// per-pack) to deploy a README intentionally.
     #[config(default = [

--- a/crates/dodot-lib/src/handlers/filter.rs
+++ b/crates/dodot-lib/src/handlers/filter.rs
@@ -1,0 +1,100 @@
+//! Filter handlers — claim files that should not be processed.
+//!
+//! Two handlers share the [`ExecutionPhase::Filter`] slot:
+//!
+//! - [`IgnoreHandler`] — match wins, file is dropped from the pipeline,
+//!   nothing surfaces in `dodot status`. Mirrors `.gitignore`'s mental
+//!   model: "I don't want to see this."
+//! - [`SkipHandler`] — match wins, no executable intent is produced,
+//!   but the file is listed in `dodot status` with a `skipped` label.
+//!   Mirrors a test marked skipped: "I saw it and chose not to act."
+//!
+//! Both produce zero [`HandlerIntent`]s. The difference is purely a
+//! display contract enforced by the status renderer, which inspects the
+//! handler name on each [`RuleMatch`].
+
+use std::path::Path;
+
+use crate::datastore::DataStore;
+use crate::fs::Fs;
+use crate::handlers::{
+    ExecutionPhase, Handler, HandlerConfig, HandlerStatus, HANDLER_IGNORE, HANDLER_SKIP,
+};
+use crate::operations::HandlerIntent;
+use crate::paths::Pather;
+use crate::rules::RuleMatch;
+use crate::Result;
+
+pub struct IgnoreHandler;
+
+impl Handler for IgnoreHandler {
+    fn name(&self) -> &str {
+        HANDLER_IGNORE
+    }
+
+    fn phase(&self) -> ExecutionPhase {
+        ExecutionPhase::Filter
+    }
+
+    fn to_intents(
+        &self,
+        _matches: &[RuleMatch],
+        _config: &HandlerConfig,
+        _paths: &dyn Pather,
+        _fs: &dyn Fs,
+    ) -> Result<Vec<HandlerIntent>> {
+        Ok(Vec::new())
+    }
+
+    fn check_status(
+        &self,
+        file: &Path,
+        _pack: &str,
+        _datastore: &dyn DataStore,
+    ) -> Result<HandlerStatus> {
+        // Status is computed directly from rule matches by the renderer
+        // for filter handlers; this is here to satisfy the trait.
+        Ok(HandlerStatus {
+            file: file.to_string_lossy().into_owned(),
+            handler: HANDLER_IGNORE.into(),
+            deployed: false,
+            message: String::new(),
+        })
+    }
+}
+
+pub struct SkipHandler;
+
+impl Handler for SkipHandler {
+    fn name(&self) -> &str {
+        HANDLER_SKIP
+    }
+
+    fn phase(&self) -> ExecutionPhase {
+        ExecutionPhase::Filter
+    }
+
+    fn to_intents(
+        &self,
+        _matches: &[RuleMatch],
+        _config: &HandlerConfig,
+        _paths: &dyn Pather,
+        _fs: &dyn Fs,
+    ) -> Result<Vec<HandlerIntent>> {
+        Ok(Vec::new())
+    }
+
+    fn check_status(
+        &self,
+        file: &Path,
+        _pack: &str,
+        _datastore: &dyn DataStore,
+    ) -> Result<HandlerStatus> {
+        Ok(HandlerStatus {
+            file: file.to_string_lossy().into_owned(),
+            handler: HANDLER_SKIP.into(),
+            deployed: false,
+            message: String::new(),
+        })
+    }
+}

--- a/crates/dodot-lib/src/handlers/mod.rs
+++ b/crates/dodot-lib/src/handlers/mod.rs
@@ -10,6 +10,7 @@
 //! linking) but must not mutate anything — mutations are the executor's
 //! job. This keeps planning idempotent and safe to re-run.
 
+pub mod filter;
 pub mod homebrew;
 pub mod install;
 pub mod path;
@@ -49,6 +50,10 @@ pub enum HandlerCategory {
 ///
 /// # Why this order
 ///
+/// - [`Filter`](Self::Filter) claims files that should not be processed
+///   (ignore, skip). It runs first so its matches sit higher in priority
+///   than every other handler — a file the user said to drop must never
+///   be claimed by a precise mapping or the catchall.
 /// - [`Provision`](Self::Provision) installs packages. Anything later
 ///   (including user `install.sh` scripts) may depend on the tools it
 ///   put on PATH.
@@ -63,6 +68,9 @@ pub enum HandlerCategory {
 ///   must have already claimed their files.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub enum ExecutionPhase {
+    /// Claim files to drop or list-but-not-act-on (ignore, skip). No
+    /// executable intent is produced.
+    Filter,
     /// Install packages (homebrew).
     Provision,
     /// Run user setup scripts (install).
@@ -83,7 +91,9 @@ impl ExecutionPhase {
     pub fn category(self) -> HandlerCategory {
         match self {
             Self::Provision | Self::Setup => HandlerCategory::CodeExecution,
-            Self::PathExport | Self::ShellInit | Self::Link => HandlerCategory::Configuration,
+            Self::Filter | Self::PathExport | Self::ShellInit | Self::Link => {
+                HandlerCategory::Configuration
+            }
         }
     }
 }
@@ -238,6 +248,8 @@ pub const HANDLER_SHELL: &str = "shell";
 pub const HANDLER_PATH: &str = "path";
 pub const HANDLER_INSTALL: &str = "install";
 pub const HANDLER_HOMEBREW: &str = "homebrew";
+pub const HANDLER_IGNORE: &str = "ignore";
+pub const HANDLER_SKIP: &str = "skip";
 
 /// Create the default handler registry.
 ///
@@ -246,6 +258,8 @@ pub const HANDLER_HOMEBREW: &str = "homebrew";
 /// computation.
 pub fn create_registry(fs: &dyn Fs) -> HashMap<String, Box<dyn Handler + '_>> {
     let mut registry: HashMap<String, Box<dyn Handler>> = HashMap::new();
+    registry.insert(HANDLER_IGNORE.into(), Box::new(filter::IgnoreHandler));
+    registry.insert(HANDLER_SKIP.into(), Box::new(filter::SkipHandler));
     registry.insert(HANDLER_SYMLINK.into(), Box::new(symlink::SymlinkHandler));
     registry.insert(HANDLER_SHELL.into(), Box::new(shell::ShellHandler));
     registry.insert(HANDLER_PATH.into(), Box::new(path::PathHandler));
@@ -309,6 +323,7 @@ mod tests {
 
     #[test]
     fn execution_phase_declaration_order_drives_ord() {
+        assert!(ExecutionPhase::Filter < ExecutionPhase::Provision);
         assert!(ExecutionPhase::Provision < ExecutionPhase::Setup);
         assert!(ExecutionPhase::Setup < ExecutionPhase::PathExport);
         assert!(ExecutionPhase::PathExport < ExecutionPhase::ShellInit);
@@ -317,6 +332,10 @@ mod tests {
 
     #[test]
     fn execution_phase_category_mapping() {
+        assert_eq!(
+            ExecutionPhase::Filter.category(),
+            HandlerCategory::Configuration
+        );
         assert_eq!(
             ExecutionPhase::Provision.category(),
             HandlerCategory::CodeExecution
@@ -343,6 +362,8 @@ mod tests {
     fn builtin_handler_phases() {
         let fs = crate::fs::OsFs::new();
         let registry = create_registry(&fs);
+        assert_eq!(registry[HANDLER_IGNORE].phase(), ExecutionPhase::Filter);
+        assert_eq!(registry[HANDLER_SKIP].phase(), ExecutionPhase::Filter);
         assert_eq!(
             registry[HANDLER_HOMEBREW].phase(),
             ExecutionPhase::Provision

--- a/crates/dodot-lib/src/render/mod.rs
+++ b/crates/dodot-lib/src/render/mod.rs
@@ -43,6 +43,9 @@ broken:
 stale:
   fg: yellow
 
+skipped:
+  dim: true
+
 warning:
   fg: yellow
 

--- a/crates/dodot-lib/src/rules/mod.rs
+++ b/crates/dodot-lib/src/rules/mod.rs
@@ -2,8 +2,10 @@
 //!
 //! A rule pairs a file pattern with a handler name. The [`Scanner`]
 //! walks a pack directory and matches each file against the rule set.
-//! Exclusion rules are checked first, then inclusion rules by priority
-//! (descending). The first match wins.
+//! Rules are checked in descending priority order; the first match
+//! wins. Filter handlers (`ignore`, `skip`) sit at the highest priority
+//! tier so a file the user wants dropped never gets claimed by a
+//! precise mapping or the catchall.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -20,7 +22,6 @@ use crate::Result;
 #[derive(Debug, Clone, Serialize)]
 pub struct Rule {
     /// Pattern to match against (e.g. `"install.sh"`, `"*.sh"`, `"bin/"`).
-    /// Prefixed with `!` for exclusion rules (e.g. `"!*.tmp"`).
     pub pattern: String,
 
     /// Handler to use for matching files (e.g. `"symlink"`, `"install"`).
@@ -29,9 +30,20 @@ pub struct Rule {
     /// Higher priority rules are checked first. Default is 0.
     pub priority: i32,
 
+    /// Match the basename case-insensitively. Set by `mappings.skip`
+    /// patterns so README/Readme/readme all hit the same rule without
+    /// forcing every config writer to enumerate every casing. Defaults
+    /// to false (case-sensitive, matches glob conventions).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub case_insensitive: bool,
+
     /// Handler-specific options passed through from config.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub options: HashMap<String, String>,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 /// A raw file entry discovered during directory walking (before rule matching).
@@ -132,11 +144,9 @@ enum CompiledPattern {
 #[derive(Debug)]
 struct CompiledRule {
     pattern: CompiledPattern,
-    is_exclusion: bool,
-    /// Match case-insensitively against the basename. Set for the
-    /// synthetic `"excluded"` handler so README/Readme/readme all hit
-    /// the same rule without forcing every config writer to enumerate
-    /// every casing.
+    /// Mirror of [`Rule::case_insensitive`]. The pattern itself is
+    /// already lowercased at compile time when this is true; the
+    /// matcher lowercases the candidate filename to match.
     case_insensitive: bool,
     handler: String,
     priority: i32,
@@ -147,13 +157,8 @@ fn compile_rules(rules: &[Rule]) -> Vec<CompiledRule> {
     rules
         .iter()
         .map(|rule| {
-            let (raw_pattern, is_exclusion) = if let Some(rest) = rule.pattern.strip_prefix('!') {
-                (rest.to_string(), true)
-            } else {
-                (rule.pattern.clone(), false)
-            };
-
-            let case_insensitive = rule.handler == "excluded";
+            let raw_pattern = rule.pattern.clone();
+            let case_insensitive = rule.case_insensitive;
 
             // For case-insensitive rules, lowercase the pattern at
             // compile time; the matcher lowercases the filename to mirror.
@@ -182,7 +187,6 @@ fn compile_rules(rules: &[Rule]) -> Vec<CompiledRule> {
 
             CompiledRule {
                 pattern,
-                is_exclusion,
                 case_insensitive,
                 handler: rule.handler.clone(),
                 priority: rule.priority,
@@ -298,6 +302,10 @@ impl<'a> Scanner<'a> {
         // requested case-insensitive matching, match_file can skip the
         // per-entry `to_lowercase` allocation entirely.
         let has_ci_rules = compiled.iter().any(|r| r.case_insensitive);
+        // Sort once per scan, then reuse the ordered slice for every entry.
+        let mut sorted: Vec<&CompiledRule> = compiled.iter().collect();
+        sorted.sort_by(|a, b| b.priority.cmp(&a.priority));
+
         let mut matches = Vec::new();
 
         for entry in entries {
@@ -308,7 +316,7 @@ impl<'a> Scanner<'a> {
                 .unwrap_or_default();
 
             if let Some(rule_match) = match_file(
-                &compiled,
+                &sorted,
                 has_ci_rules,
                 &filename,
                 entry.is_dir,
@@ -420,10 +428,13 @@ impl<'a> Scanner<'a> {
 
 /// Match a single file against the compiled rules.
 ///
-/// 1. Check exclusion rules first — if any match, file is skipped.
-/// 2. Check inclusion rules by priority (descending), first match wins.
-fn match_file(
-    compiled: &[CompiledRule],
+/// Walks rules in descending priority order; first match wins. There
+/// is no separate "exclusion" phase — filter handlers (`ignore`, `skip`)
+/// win because they sit at the highest priority tier set by
+/// [`mappings_to_rules`](crate::config::mappings_to_rules), not because
+/// the matcher knows their names.
+fn match_file<'a>(
+    sorted: &'a [&'a CompiledRule],
     has_ci_rules: bool,
     filename: &str,
     is_dir: bool,
@@ -432,8 +443,8 @@ fn match_file(
     pack: &str,
 ) -> Option<RuleMatch> {
     // Only allocate the lowercased form when at least one rule actually
-    // wants case-insensitive matching. The common case — no `excluded`
-    // rules at all, or the user has set `mappings.exclude = []` — pays
+    // wants case-insensitive matching. The common case — no `skip`
+    // rules at all, or the user has set `mappings.skip = []` — pays
     // zero allocations here.
     let lowered = if has_ci_rules {
         Some(filename.to_lowercase())
@@ -448,20 +459,7 @@ fn match_file(
         }
     };
 
-    // Phase 1: check exclusions
-    for rule in compiled {
-        if rule.is_exclusion && matches_entry(&rule.pattern, pick(rule), is_dir) {
-            return None;
-        }
-    }
-
-    // Phase 2: find first matching inclusion rule (sorted by priority desc)
-    // We sort a copy so we don't modify the original
-    let mut inclusion_rules: Vec<&CompiledRule> =
-        compiled.iter().filter(|r| !r.is_exclusion).collect();
-    inclusion_rules.sort_by(|a, b| b.priority.cmp(&a.priority));
-
-    for rule in inclusion_rules {
+    for rule in sorted {
         if matches_entry(&rule.pattern, pick(rule), is_dir) {
             return Some(RuleMatch {
                 relative_path: rel_path.to_path_buf(),
@@ -509,36 +507,42 @@ mod tests {
                 pattern: "bin/".into(),
                 handler: "path".into(),
                 priority: 10,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "install.sh".into(),
                 handler: "install".into(),
                 priority: 10,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "aliases.sh".into(),
                 handler: "shell".into(),
                 priority: 10,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "profile.sh".into(),
                 handler: "shell".into(),
                 priority: 10,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "Brewfile".into(),
                 handler: "homebrew".into(),
                 priority: 10,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "*".into(),
                 handler: "symlink".into(),
                 priority: 0,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
         ]
@@ -552,6 +556,7 @@ mod tests {
             pattern: "install.sh".into(),
             handler: "install".into(),
             priority: 0,
+            case_insensitive: false,
             options: HashMap::new(),
         }]);
         assert!(matches_entry(&compiled[0].pattern, "install.sh", false));
@@ -564,6 +569,7 @@ mod tests {
             pattern: "*.sh".into(),
             handler: "shell".into(),
             priority: 0,
+            case_insensitive: false,
             options: HashMap::new(),
         }]);
         assert!(matches_entry(&compiled[0].pattern, "aliases.sh", false));
@@ -577,6 +583,7 @@ mod tests {
             pattern: "bin/".into(),
             handler: "path".into(),
             priority: 0,
+            case_insensitive: false,
             options: HashMap::new(),
         }]);
         assert!(matches_entry(&compiled[0].pattern, "bin", true));
@@ -585,15 +592,18 @@ mod tests {
     }
 
     #[test]
-    fn exclusion_prefix() {
+    fn case_insensitive_pattern_lowercases_at_compile_time() {
         let compiled = compile_rules(&[Rule {
-            pattern: "!*.tmp".into(),
-            handler: "exclude".into(),
-            priority: 100,
+            pattern: "README.*".into(),
+            handler: "skip".into(),
+            priority: 50,
+            case_insensitive: true,
             options: HashMap::new(),
         }]);
-        assert!(compiled[0].is_exclusion);
-        assert!(matches_entry(&compiled[0].pattern, "scratch.tmp", false));
+        assert!(compiled[0].case_insensitive);
+        // Pattern is lowercased at compile time; matcher lowercases the
+        // candidate filename to mirror.
+        assert!(matches_entry(&compiled[0].pattern, "readme.md", false));
     }
 
     #[test]
@@ -602,6 +612,7 @@ mod tests {
             pattern: "*".into(),
             handler: "symlink".into(),
             priority: 0,
+            case_insensitive: false,
             options: HashMap::new(),
         }]);
         assert!(matches_entry(&compiled[0].pattern, "anything", false));
@@ -724,7 +735,12 @@ mod tests {
     }
 
     #[test]
-    fn scan_pack_exclusion_rules_override_catchall() {
+    fn scan_pack_ignore_rule_outranks_catchall() {
+        // The ignore filter handler at priority 100 wins over the
+        // priority-0 catchall, and emits a match with handler="ignore".
+        // Status display filters those out before rendering, but at the
+        // matcher level they ARE matches — the catchall must not also
+        // claim them.
         let env = TempEnvironment::builder()
             .pack("test")
             .file("good.txt", "yes")
@@ -737,27 +753,34 @@ mod tests {
 
         let rules = vec![
             Rule {
-                pattern: "!*.tmp".into(),
-                handler: "exclude".into(),
+                pattern: "*.tmp".into(),
+                handler: "ignore".into(),
                 priority: 100,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "*".into(),
                 handler: "symlink".into(),
                 priority: 0,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
         ];
 
         let matches = scanner.scan_pack(&pack, &rules, &[]).unwrap();
-        let names: Vec<String> = matches
-            .iter()
-            .map(|m| m.relative_path.to_string_lossy().to_string())
-            .collect();
 
-        assert!(names.contains(&"good.txt".to_string()));
-        assert!(!names.contains(&"bad.tmp".to_string()));
+        let bad = matches
+            .iter()
+            .find(|m| m.relative_path.to_string_lossy() == "bad.tmp")
+            .expect("bad.tmp must still appear as a match");
+        assert_eq!(bad.handler, "ignore");
+
+        let good = matches
+            .iter()
+            .find(|m| m.relative_path.to_string_lossy() == "good.txt")
+            .expect("good.txt must appear as a match");
+        assert_eq!(good.handler, "symlink");
     }
 
     #[test]
@@ -777,18 +800,21 @@ mod tests {
                 pattern: "*.sh".into(),
                 handler: "generic-shell".into(),
                 priority: 5,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "aliases.sh".into(),
                 handler: "specific-shell".into(),
                 priority: 10,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "*".into(),
                 handler: "symlink".into(),
                 priority: 0,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
         ];
@@ -799,7 +825,7 @@ mod tests {
     }
 
     #[test]
-    fn excluded_handler_matches_case_insensitively() {
+    fn skip_handler_matches_case_insensitively() {
         // Note: case-only filename variants like "README" and "Readme"
         // collide on case-insensitive filesystems (macOS HFS+/APFS
         // default), so the fixture uses different basenames + casings
@@ -819,26 +845,30 @@ mod tests {
         let rules = vec![
             Rule {
                 pattern: "README".into(),
-                handler: "excluded".into(),
+                handler: "skip".into(),
                 priority: 50,
+                case_insensitive: true,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "README.*".into(),
-                handler: "excluded".into(),
+                handler: "skip".into(),
                 priority: 50,
+                case_insensitive: true,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "LICENSE.*".into(),
-                handler: "excluded".into(),
+                handler: "skip".into(),
                 priority: 50,
+                case_insensitive: true,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "*".into(),
                 handler: "symlink".into(),
                 priority: 0,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
         ];
@@ -852,19 +882,19 @@ mod tests {
                 acc
             });
 
-        let mut excluded = by_handler.get("excluded").cloned().unwrap_or_default();
-        excluded.sort();
-        assert_eq!(excluded, vec!["License.txt", "README", "readme.md"]);
+        let mut skipped = by_handler.get("skip").cloned().unwrap_or_default();
+        skipped.sort();
+        assert_eq!(skipped, vec!["License.txt", "README", "readme.md"]);
 
         let symlinked = by_handler.get("symlink").cloned().unwrap_or_default();
         assert_eq!(symlinked, vec!["notes.md"]);
     }
 
     #[test]
-    fn excluded_handler_outranks_precise_handler() {
-        // Priority 50 (excluded) must beat the priority 10 mappings
-        // routes — otherwise a `mappings.shell = ["README.sh"]` mistake
-        // would silently source a README as a shell file.
+    fn skip_handler_outranks_precise_handler() {
+        // Priority 50 (skip) must beat the priority 10 mappings routes
+        // — otherwise a `mappings.shell = ["README.sh"]` mistake would
+        // silently source a README as a shell file.
         let env = TempEnvironment::builder()
             .pack("test")
             .file("README.sh", "x")
@@ -877,28 +907,30 @@ mod tests {
         let rules = vec![
             Rule {
                 pattern: "README.*".into(),
-                handler: "excluded".into(),
+                handler: "skip".into(),
                 priority: 50,
+                case_insensitive: true,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "*.sh".into(),
                 handler: "shell".into(),
                 priority: 10,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
         ];
 
         let matches = scanner.scan_pack(&pack, &rules, &[]).unwrap();
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].handler, "excluded");
+        assert_eq!(matches[0].handler, "skip");
     }
 
     #[test]
-    fn skip_rule_outranks_excluded() {
-        // mappings.skip (priority 100, exclusion phase) must still win
-        // over excluded (priority 50, inclusion phase) — the silent
-        // exclusion is the stronger signal.
+    fn ignore_rule_outranks_skip() {
+        // mappings.ignore (priority 100) must win over mappings.skip
+        // (priority 50) — silent-drop is the stronger signal than
+        // listed-but-not-acted-on.
         let env = TempEnvironment::builder()
             .pack("test")
             .file("README.md", "x")
@@ -910,30 +942,31 @@ mod tests {
 
         let rules = vec![
             Rule {
-                pattern: "!README.md".into(),
-                handler: "exclude".into(),
+                pattern: "README.md".into(),
+                handler: "ignore".into(),
                 priority: 100,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "README.*".into(),
-                handler: "excluded".into(),
+                handler: "skip".into(),
                 priority: 50,
+                case_insensitive: true,
                 options: HashMap::new(),
             },
             Rule {
                 pattern: "*".into(),
                 handler: "symlink".into(),
                 priority: 0,
+                case_insensitive: false,
                 options: HashMap::new(),
             },
         ];
 
         let matches = scanner.scan_pack(&pack, &rules, &[]).unwrap();
-        assert!(
-            matches.is_empty(),
-            "skip should fully suppress: {matches:?}"
-        );
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].handler, "ignore");
     }
 
     #[test]

--- a/docs/dev/types-and-structure.lex
+++ b/docs/dev/types-and-structure.lex
@@ -71,15 +71,16 @@ Types and Structure
         Rule:
 
             pub struct Rule {
-                pub pattern: String,           // "install.sh", "*.sh", "bin/", "!*.tmp"
+                pub pattern: String,           // "install.sh", "*.sh", "bin/"
                 pub handler: String,           // handler name
                 pub priority: i32,             // higher wins
+                pub case_insensitive: bool,    // lowercase pattern + filename before match
                 pub options: HashMap<String, String>,
             }
 
         :: rust ::
 
-        Patterns with `!` prefix are exclusions and run before positive matches. Equal priority falls back to first-match order.
+        Rules are sorted once per scan by descending priority; the first matching rule wins. Equal priority falls back to first-match order. Filter handlers (`ignore`, `skip`) sit at the highest priority tier (100, 50) so they always beat the precise mappings (10) and the catchall symlink (0).
 
     4.2. `PackEntry` and `RuleMatch`
 

--- a/docs/proposals/preprocessing-pipeline.lex
+++ b/docs/proposals/preprocessing-pipeline.lex
@@ -293,9 +293,9 @@ Design Specification: Preprocessing Pipeline
 
         Per-file:
             [mappings]
-            skip = ["config.toml.tmpl"]
+            ignore = ["config.toml.tmpl"]
 
-        The existing skip mechanism in [mappings] works because preprocessing files go through the scan phase where skip patterns are honored.
+        The `mappings.ignore` filter handler runs in the Filter phase, before any preprocessor — matched files are dropped from the pipeline entirely.
 
 8. Testability
 

--- a/docs/proposals/secrets.lex
+++ b/docs/proposals/secrets.lex
@@ -301,9 +301,9 @@ Design Specification: Secret Handling
             [secret.providers.op]
             enabled = false
 
-        Per-file (via existing mappings skip):
+        Per-file (via the `mappings.ignore` filter handler):
             [mappings]
-            skip = ["config.toml.tmpl"]
+            ignore = ["config.toml.tmpl"]
 
         When secrets are globally disabled, any `secret()` call in a rendered template produces a render-time error rather than a silent empty string.
 

--- a/docs/reference/architecture.lex
+++ b/docs/reference/architecture.lex
@@ -26,11 +26,11 @@ Architecture
 
     2.1. Pack Discovery
 
-        dodot enumerates top-level directories of the dotfiles root, skipping any that contain `.dodotignore` and any that match global ignore patterns (`.git`, `node_modules`, etc.). The result is the set of packs to process. When a command is invoked with explicit pack names (`dodot up git nvim`), only those are discovered.
+        dodot enumerates top-level directories of the dotfiles root, skipping any that contain `.dodotignore` (the pack-ignore marker) and any that match global ignore patterns (`.git`, `node_modules`, etc.). The result is the set of packs to process. When a command is invoked with explicit pack names (`dodot up git nvim`), only those are discovered.
 
     2.2. Rule Matching
 
-        Each pack's top-level entries (files and directories immediately under the pack root) are matched against the rule set. Rules declare patterns, the handler that should claim a match, and a priority. Higher priority wins; first match wins at equal priority. Exclusion rules (prefixed `!`) remove entries from consideration before any handler sees them.
+        Each pack's top-level entries (files and directories immediately under the pack root) are matched against the rule set. Rules declare patterns, the handler that should claim a match, and a priority. Higher priority wins; first match wins at equal priority. The two filter handlers (`ignore`, `skip`) sit at the highest priority tier so a file the user wants dropped never gets claimed by a precise mapping or the catchall.
 
         The scanner is top-level only. It does _not_ recurse into subdirectories. A handler that receives a directory entry decides for itself what to do with the contents.
 

--- a/docs/reference/handlers.lex
+++ b/docs/reference/handlers.lex
@@ -6,7 +6,7 @@ Handlers
 
 1. The Built-in Handlers
 
-    dodot ships with five handlers, covering the overwhelming majority of what dotfile repositories need.
+    dodot ships with seven handlers: five that deploy files (symlink, shell, path, install, homebrew) and two that drop files from processing (ignore, skip). All seven share the same `Handler` trait and run from the same registry.
 
     1.1. symlink
 
@@ -36,6 +36,16 @@ Handlers
 
         Runs `brew bundle` against a `Brewfile`, once per content-hash. macOS-only in practice. Functionally a specialization of install, but more ergonomic for its common case.
 
+    1.6. ignore (filter)
+
+        Claims matches and drops them silently — same contract as `.gitignore`. No executable intent, no entry in `dodot status`. Configured via `[mappings] ignore` (default empty). Useful for build artifacts, scratch files, anything you don't want dodot to know about.
+
+    1.7. skip (filter)
+
+        Claims matches, surfaces them in `dodot status` as `skipped`, but produces no executable intent. Configured via `[mappings] skip`. Defaults cover the common documentation/legal files (`README`, `LICENSE`, `CHANGELOG`, `CONTRIBUTING`, `AUTHORS`, `NOTICE`, `COPYING` and their `.*` variants), matched case-insensitively. Override per-pack with `skip = []` to deploy a README intentionally.
+
+        The two filter handlers exist because three things were previously different mechanisms — a pack-level marker, a silent skip, and a visible "excluded" — and unifying the intra-pack cases into real handlers means there's one matching model and one config grammar instead of three. Pack-level `.dodotignore` (the "pack-ignore" mechanism) stays separate at the discovery layer.
+
 2. Matching Model
 
     Handlers are classified along two axes that together decide how matches flow.
@@ -56,16 +66,20 @@ Handlers
 
     Phases, in order:
 
-        | Phase         | Handler   | Why here                                                           |
-        | `Provision`   | homebrew  | Installs packages. Anything later may depend on tools it exposes.  |
-        | `Setup`       | install   | User-authored scripts that can lean on Provision completing first. |
-        | `PathExport`  | path      | Stages `bin/` onto PATH; runs before ShellInit.                    |
-        | `ShellInit`   | shell     | Shell startup files that may reference binaries from PathExport.   |
-        | `Link`        | symlink   | Catchall; must be last so precise handlers claim their files.      |
+        | Phase         | Handler         | Why here                                                                |
+        | `Filter`      | ignore, skip    | Drop files before any deploying handler can claim them.                 |
+        | `Provision`   | homebrew        | Installs packages. Anything later may depend on tools it exposes.       |
+        | `Setup`       | install         | User-authored scripts that can lean on Provision completing first.      |
+        | `PathExport`  | path            | Stages `bin/` onto PATH; runs before ShellInit.                         |
+        | `ShellInit`   | shell           | Shell startup files that may reference binaries from PathExport.        |
+        | `Link`        | symlink         | Catchall; must be last so precise handlers claim their files.           |
 
     :: table align=lll ::
 
-    Two design invariants pin this order down.
+    Three design invariants pin this order down.
+
+    The filter phase is always first.
+        `ignore` and `skip` exist to keep matched files away from deploying handlers. If they ran later, a precise mapping (priority 10) or the catchall (priority 0) could already have claimed the file and emitted intents — so filter handlers sit at the highest priority tier (100, 50) and run before anything else has a chance.
 
     The catchall phase is always last.
         `symlink` is the only catchall handler (`MatchMode::Catchall`). Running it before any precise handler would let it claim files that belong elsewhere. `Link` sitting at the bottom of the enum is not a convention — it's the shape of "precise before catchall" written into the type.
@@ -137,6 +151,8 @@ Handlers
     Handler summary (rows in execution order):
 
         | Handler  | Phase       | Category       | Default claims                                     | Effect                              |
+        | ignore   | Filter      | Configuration  | None (user-configured via `[mappings] ignore`)     | Silently drop; no status entry      |
+        | skip     | Filter      | Configuration  | `README.*`, `LICENSE.*`, `CHANGELOG.*`, etc.       | List in status as `skipped`         |
         | homebrew | Provision   | Code Execution | `Brewfile`                                         | `brew bundle` once per content hash |
         | install  | Setup       | Code Execution | `install.{sh,bash,zsh}`                            | Run once per content hash           |
         | path     | PathExport  | Configuration  | `bin/`                                             | Prepended to `$PATH`                |

--- a/docs/reference/pre-processors.lex
+++ b/docs/reference/pre-processors.lex
@@ -96,6 +96,6 @@ Preprocessors
 
     - Global: `[preprocessor] enabled = false` in the root `.dodot.toml`. All preprocessing is skipped; `.tmpl` files deploy verbatim.
     - Per preprocessor: `[preprocessor.template] enabled = false` disables template rendering but leaves other preprocessors active.
-    - Per file: add the filename to `[mappings] skip` and the file is ignored entirely.
+    - Per file: add the filename to `[mappings] ignore` and the file is dropped entirely (silent — same contract as `.gitignore`). Use `[mappings] skip` instead if you'd like the file to remain visible in `dodot status` as `skipped`.
 
     Pack-level `.dodot.toml` overrides the root for any of these keys, so you can flip a setting on or off for a single pack.

--- a/docs/reference/terms-and-concepts.lex
+++ b/docs/reference/terms-and-concepts.lex
@@ -70,8 +70,8 @@ Terms and Concepts
     `_home/` and `_xdg/` directories:
         Explicit routing overrides. Files under `<pack>/_home/` deploy to `$HOME` regardless of XDG settings; files under `<pack>/_xdg/` deploy to `$XDG_CONFIG_HOME`. See [./symlink-paths.lex].
 
-    `.dodotignore`:
-        A marker file that tells dodot to skip a pack entirely. Useful for directories that live in the dotfiles root but aren't meant to be deployed (scratch, notes, README-only packs).
+    `.dodotignore` (pack-ignore):
+        A marker file that tells dodot to skip a pack entirely — the "pack-ignore" mechanism. Pure file-presence check; the file's contents are never read. Useful for directories that live in the dotfiles root but aren't meant to be deployed (scratch, notes, README-only packs). Distinct from the intra-pack `[mappings] ignore`/`skip` keys, which drop individual files inside a known pack.
 
     `.dodot.toml`:
         Per-pack or root-level configuration. Overrides defaults for mappings, symlink targets, preprocessor settings, and more. Root config applies to all packs; pack config overrides root for that pack.

--- a/docs/user/commands.lex
+++ b/docs/user/commands.lex
@@ -92,7 +92,7 @@ Commands
 
     2.4. addignore
 
-        Add a `.dodotignore` marker to a pack, causing dodot to skip it during discovery. Idempotent — safe to run repeatedly. Useful for directories that live in your dotfiles root but aren't meant to be deployed.
+        Add a `.dodotignore` marker to a pack — the "pack-ignore" mechanism — causing dodot to skip the directory during discovery. Idempotent: safe to run repeatedly. Useful for directories that live in your dotfiles root but aren't meant to be deployed.
 
         Usage:
 

--- a/docs/user/configuration.lex
+++ b/docs/user/configuration.lex
@@ -44,7 +44,7 @@ Configuration
 
     `ignore` is glob patterns that dodot skips during pack discovery and file scanning. Matching files are not considered for any handler. The defaults cover version-control noise, editor swapfiles, and a few directories that are notoriously never meant to be deployed.
 
-    Note: to skip an _entire pack_, drop a `.dodotignore` marker file in that pack's directory. `[pack] ignore` is for patterns within a pack.
+    Note: to skip an _entire pack_, drop a `.dodotignore` marker file in that pack's directory (the "pack-ignore" mechanism). `[pack] ignore` is for patterns within a pack.
 
 3. The `[symlink]` Section
 
@@ -129,7 +129,8 @@ Configuration
             "env.sh",     "env.bash",     "env.zsh",
         ]
         homebrew = "Brewfile"
-        skip = []
+        ignore = []
+        skip = ["README", "README.*", "LICENSE", "LICENSE.*", "CHANGELOG", "CHANGELOG.*", "CONTRIBUTING", "CONTRIBUTING.*", "AUTHORS", "AUTHORS.*", "NOTICE", "NOTICE.*", "COPYING", "COPYING.*"]
 
     :: toml ::
 
@@ -137,7 +138,14 @@ Configuration
 
     `install` is list-only: even a single install script must be written as a TOML array (`install = ["install.sh"]`). The older single-string form (`install = "install.sh"`) no longer parses — update any older configs that use it.
 
-    The `skip` key is the odd one out. It is _not_ a handler; it is a list of patterns that should be excluded from handler processing entirely. Distinct from `[pack] ignore`: `skip` applies only to handler dispatch, while `ignore` affects pack discovery and scanning.
+    Two of the keys do not run a handler — they tell the pipeline to drop a file:
+
+    - `ignore` — matching files are silently dropped, mirroring `.gitignore`. Nothing surfaces in `dodot status`.
+    - `skip` — matching files appear in `dodot status` as `skipped` but no handler runs on them. Defaults cover the documentation/legal files (`README`, `LICENSE`, `CHANGELOG`, `CONTRIBUTING`, `AUTHORS`, `NOTICE`, `COPYING` and their `.*` variants), matched case-insensitively. Override per-pack with `skip = []` to deploy a README intentionally.
+
+    `ignore` wins over `skip` when both match, and both win over precise mappings (`shell`, `install`, …) and the catchall symlink — so a file the user said to drop is dropped, full stop.
+
+    Distinct from `[pack] ignore`: `[mappings] ignore`/`skip` apply only to handler dispatch within a known pack, while `[pack] ignore` affects pack discovery and scanning. To skip an entire pack, drop a `.dodotignore` marker file (the "pack-ignore" mechanism).
 
 5. The `[preprocessor]` Section
 

--- a/docs/user/configuration.lex
+++ b/docs/user/configuration.lex
@@ -138,12 +138,12 @@ Configuration
 
     `install` is list-only: even a single install script must be written as a TOML array (`install = ["install.sh"]`). The older single-string form (`install = "install.sh"`) no longer parses — update any older configs that use it.
 
-    Two of the keys do not run a handler — they tell the pipeline to drop a file:
+    Two of the keys map to _filter handlers_ — real handlers that claim a match but produce no executable intent. Their job is to keep matching files away from the deploying handlers (precise mappings, catchall symlink):
 
-    - `ignore` — matching files are silently dropped, mirroring `.gitignore`. Nothing surfaces in `dodot status`.
-    - `skip` — matching files appear in `dodot status` as `skipped` but no handler runs on them. Defaults cover the documentation/legal files (`README`, `LICENSE`, `CHANGELOG`, `CONTRIBUTING`, `AUTHORS`, `NOTICE`, `COPYING` and their `.*` variants), matched case-insensitively. Override per-pack with `skip = []` to deploy a README intentionally.
+    - `ignore` — the `ignore` filter handler claims matches and drops them silently, mirroring `.gitignore`. Nothing surfaces in `dodot status`.
+    - `skip` — the `skip` filter handler claims matches and surfaces them in `dodot status` as `skipped`, but does not deploy them. Defaults cover the documentation/legal files (`README`, `LICENSE`, `CHANGELOG`, `CONTRIBUTING`, `AUTHORS`, `NOTICE`, `COPYING` and their `.*` variants), matched case-insensitively. Override per-pack with `skip = []` to deploy a README intentionally.
 
-    `ignore` wins over `skip` when both match, and both win over precise mappings (`shell`, `install`, …) and the catchall symlink — so a file the user said to drop is dropped, full stop.
+    When both could match, `ignore` wins over `skip`; both win over precise mappings (`shell`, `install`, …) and the catchall symlink — so a file the user said to drop is dropped, full stop.
 
     Distinct from `[pack] ignore`: `[mappings] ignore`/`skip` apply only to handler dispatch within a known pack, while `[pack] ignore` affects pack discovery and scanning. To skip an entire pack, drop a `.dodotignore` marker file (the "pack-ignore" mechanism).
 

--- a/docs/user/getting-started.lex
+++ b/docs/user/getting-started.lex
@@ -60,7 +60,8 @@ dodot: Up and Running in 5 Minutes
         # install = "install.sh"
         # shell = ["aliases.sh", "profile.sh", "login.sh"]
         # homebrew = "Brewfile"
-        # skip = []
+        # ignore = []                                 # silent drop
+        # skip   = ["README.*", "LICENSE.*", ...]    # listed in status as `skipped`
 
         # Preview what will happen without making changes
         $ dodot up nvim --dry-run


### PR DESCRIPTION
## Summary

Stacked on top of #65. Collapses three exclusion mechanisms into one uniform handler model.

**Before:** Pack-level `.dodotignore` (file marker) + `mappings.skip` (silent, `!`-prefix exclusion in matcher, priority 100) + `mappings.exclude` (visible, synthetic `"excluded"` handler with no registry entry, hard-coded case-insensitivity at `rules/mod.rs:156`).

**After:** Pack-level `.dodotignore` (unchanged) + `mappings.ignore` (silent, real `IgnoreHandler`) + `mappings.skip` (visible, real `SkipHandler`). Both new handlers live in a new `ExecutionPhase::Filter` slot that sorts before every other phase.

The naming inversion is deliberate and matches user intuition: `ignore` = hide (mirrors `.gitignore`); `skip` = listed-but-not-acted-on (mirrors a test marked skipped).

## Cleanup this enables

- `Rule::is_exclusion` and the `!`-prefix exclusion phase in `match_file` — gone. Filter handlers win via ordinary descending priority (100 > 50 > 10 > 0).
- Synthetic `"excluded"` handler-name dispatch — gone. Both handlers are real registered handlers.
- Hard-coded `handler == "excluded"` case-insensitivity check — gone. `case_insensitive` is now a per-rule property on `Rule`.

The pack-level `.dodotignore` marker file is unchanged on disk; only its concept name in user-facing docs becomes "pack-ignore" to disambiguate from the intra-pack `mappings.ignore`/`skip` keys.

## Test plan

- [x] `cargo test --workspace` — 520 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --release` — clean
- [x] Smoke-tested against a real fixture: `README.md`, `license`, `CHANGELOG` render with `skipped` label and `·` symbol; `[mappings] ignore = ["*.tmp"]` silently drops the file from status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)