### PR TITLE
fix(up): reconcile non-provisioning state on every run

### DIFF
--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -686,6 +686,188 @@ fn up_force_overwrites_existing_files() {
     assert_eq!(content, "[user]\n  name = new");
 }
 
+// ── up: reconcile non-provisioning state (#58) ─────────────
+
+/// `dodot up` was additive only: a deleted source file would leave its
+/// datastore entry behind, so the regenerated init script kept sourcing
+/// a now-missing path. The fix wipes configuration-handler state per
+/// pack at the start of `up` and re-applies from current source.
+#[test]
+fn up_reconciles_deleted_shell_source() {
+    let env = TempEnvironment::builder()
+        .pack("gh")
+        .file("aliases.sh", "alias g=git")
+        .file("profile.sh", "export GH=true")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    let shell_dir = env.paths.handler_data_dir("gh", "shell");
+    let mut before = env.list_dir_names(&shell_dir);
+    before.sort();
+    assert_eq!(before, vec!["aliases.sh", "profile.sh"]);
+
+    // Delete one source from the pack and re-run up.
+    env.fs
+        .remove_file(&env.dotfiles_root.join("gh/profile.sh"))
+        .unwrap();
+    commands::up::up(None, &ctx).unwrap();
+
+    let after = env.list_dir_names(&shell_dir);
+    assert_eq!(
+        after,
+        vec!["aliases.sh"],
+        "orphan datastore entry persisted after re-up"
+    );
+
+    let init = env
+        .fs
+        .read_to_string(&env.paths.init_script_path())
+        .unwrap();
+    assert!(
+        !init.contains("profile.sh"),
+        "regenerated init still references deleted file:\n{init}"
+    );
+    assert!(init.contains("aliases.sh"), "init: {init}");
+}
+
+#[test]
+fn up_reconciles_deleted_symlink_source() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .file("gvimrc", "set guifont=Mono")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    let symlink_dir = env.paths.handler_data_dir("vim", "symlink");
+    let mut before = env.list_dir_names(&symlink_dir);
+    before.sort();
+    assert_eq!(before, vec!["gvimrc", "vimrc"]);
+
+    env.fs
+        .remove_file(&env.dotfiles_root.join("vim/gvimrc"))
+        .unwrap();
+    commands::up::up(None, &ctx).unwrap();
+
+    let after = env.list_dir_names(&symlink_dir);
+    assert_eq!(
+        after,
+        vec!["vimrc"],
+        "orphan datastore symlink persisted after re-up"
+    );
+}
+
+#[test]
+fn up_reconciles_deleted_path_dir() {
+    let env = TempEnvironment::builder()
+        .pack("tools")
+        .file("bin/foo", "#!/bin/sh\necho foo")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    let path_dir = env.paths.handler_data_dir("tools", "path");
+    assert_eq!(env.list_dir_names(&path_dir), vec!["bin"]);
+
+    // Drop the bin/ directory entirely.
+    env.fs
+        .remove_dir_all(&env.dotfiles_root.join("tools/bin"))
+        .unwrap();
+    commands::up::up(None, &ctx).unwrap();
+
+    let after = env.list_dir_names(&path_dir);
+    assert!(
+        after.is_empty(),
+        "path datastore should be empty after source dir removed, got: {after:?}"
+    );
+
+    let init = env
+        .fs
+        .read_to_string(&env.paths.init_script_path())
+        .unwrap();
+    assert!(
+        !init.contains("tools/bin"),
+        "init script still exports deleted PATH entry:\n{init}"
+    );
+}
+
+/// Provisioning handlers (install, homebrew) must NOT be wiped — their
+/// sentinels record "did this run with this content?" and re-running
+/// would defeat the point of sentinels (reinstall on every up).
+#[test]
+fn up_preserves_install_sentinel_when_source_persists() {
+    let env = TempEnvironment::builder()
+        .pack("setup")
+        .file("install.sh", "#!/bin/sh\necho hi")
+        .done()
+        .build();
+
+    let mut ctx = make_ctx(&env);
+    ctx.no_provision = false;
+
+    commands::up::up(None, &ctx).unwrap();
+
+    let install_dir = env.paths.handler_data_dir("setup", "install");
+    let sentinels_before = env.list_dir_names(&install_dir);
+    assert_eq!(
+        sentinels_before.len(),
+        1,
+        "expected one sentinel, got {sentinels_before:?}"
+    );
+    let original = sentinels_before.into_iter().next().unwrap();
+
+    // Re-run up with no source change. The sentinel must persist —
+    // wiping it would force the script to re-execute every time.
+    commands::up::up(None, &ctx).unwrap();
+    let sentinels_after = env.list_dir_names(&install_dir);
+    assert_eq!(
+        sentinels_after,
+        vec![original],
+        "install sentinel should persist across re-up"
+    );
+}
+
+#[test]
+fn up_preserves_install_sentinel_when_source_deleted() {
+    let env = TempEnvironment::builder()
+        .pack("setup")
+        .file("install.sh", "#!/bin/sh\necho hi")
+        .done()
+        .build();
+
+    let mut ctx = make_ctx(&env);
+    ctx.no_provision = false;
+
+    commands::up::up(None, &ctx).unwrap();
+    let install_dir = env.paths.handler_data_dir("setup", "install");
+    let sentinels_before = env.list_dir_names(&install_dir);
+    assert_eq!(sentinels_before.len(), 1);
+
+    // Source vanishes — but the sentinel still records that *some*
+    // version of this script has run, and we don't want the wipe to
+    // erase that history just because the source is no longer in the
+    // pack right now.
+    env.fs
+        .remove_file(&env.dotfiles_root.join("setup/install.sh"))
+        .unwrap();
+    commands::up::up(None, &ctx).unwrap();
+
+    let sentinels_after = env.list_dir_names(&install_dir);
+    assert_eq!(
+        sentinels_after, sentinels_before,
+        "deleting an install source must not wipe its sentinel"
+    );
+}
+
 // ── down ────────────────────────────────────────────────────
 
 #[test]

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -27,8 +27,10 @@ use crate::commands::{
 };
 use crate::conflicts;
 use crate::datastore::format_command_for_display;
+use crate::handlers;
 use crate::operations::HandlerIntent;
 use crate::packs::orchestration::{self, ExecutionContext, PackResult};
+use crate::packs::Pack;
 use crate::probe;
 use crate::shell;
 use crate::Result;
@@ -80,11 +82,45 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     }
     debug!("no cross-pack conflicts");
 
-    // Phase 3: Execute intents for each pack
+    // Phase 3: Reconcile non-provisioning state, then execute intents.
+    //
+    // For configuration handlers (path, shell, symlink), every `up` is
+    // equivalent to "down (those handlers) + up": we wipe the stored
+    // state for each pack before re-applying current source. That way
+    // a file deleted from the pack stops appearing in the regenerated
+    // init script and the deployed user-side links — instead of
+    // lingering as a stale entry that points at a now-missing source.
+    //
+    // Provisioning handlers (install, homebrew) are deliberately left
+    // alone. Their sentinels record "did this run with this content?"
+    // independently of whether the source still exists right now;
+    // wiping them would force install scripts and `brew bundle` to
+    // re-execute on every up, defeating the sentinel mechanism.
     let mut pack_results: Vec<PackResult> = intent_errors;
+    let config_handlers = if ctx.dry_run {
+        Vec::new()
+    } else {
+        handlers::configuration_handler_names(ctx.fs.as_ref())
+    };
 
     for (pack_name, intents) in pack_intents {
         info!(pack = %pack_name, intents = intents.len(), "executing pack");
+
+        if !ctx.dry_run {
+            if let Some(pack) = packs.iter().find(|p| p.display_name == pack_name) {
+                if let Err(e) = wipe_configuration_state(pack, &config_handlers, ctx) {
+                    info!(pack = %pack_name, error = %e, "reconcile failed");
+                    pack_results.push(PackResult {
+                        pack_name,
+                        success: false,
+                        operations: Vec::new(),
+                        error: Some(format!("reconcile error: {e}")),
+                    });
+                    continue;
+                }
+            }
+        }
+
         match orchestration::execute_intents(intents, ctx) {
             Ok(operations) => {
                 let success = operations.iter().all(|r| r.success);
@@ -247,6 +283,20 @@ pub fn up_or_status_for_conflict(
         }
         Err(e) => Err(e),
     }
+}
+
+/// Remove datastore state for a pack across the given configuration
+/// handlers. Datastore is keyed by on-disk directory name (e.g.
+/// `010-nvim`), not the display name (`nvim`).
+fn wipe_configuration_state(
+    pack: &Pack,
+    config_handlers: &[String],
+    ctx: &ExecutionContext,
+) -> Result<()> {
+    for handler in config_handlers {
+        ctx.datastore.remove_state(&pack.name, handler)?;
+    }
+    Ok(())
 }
 
 /// Render operations directly from pack_results — used for dry-run, where

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -19,6 +19,8 @@
 //! Dry-run keeps the per-intent rendering since there's no
 //! post-execution state to verify.
 
+use std::collections::HashMap;
+
 use tracing::{debug, info};
 
 use crate::commands::{
@@ -102,22 +104,29 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     } else {
         handlers::configuration_handler_names(ctx.fs.as_ref())
     };
+    // pack_intents was built from `packs`, so every display_name maps
+    // to exactly one Pack. Keying by &str avoids cloning and makes the
+    // missing-pack case a bug rather than silent skip.
+    let pack_by_display: HashMap<&str, &Pack> =
+        packs.iter().map(|p| (p.display_name.as_str(), p)).collect();
 
     for (pack_name, intents) in pack_intents {
         info!(pack = %pack_name, intents = intents.len(), "executing pack");
 
         if !ctx.dry_run {
-            if let Some(pack) = packs.iter().find(|p| p.display_name == pack_name) {
-                if let Err(e) = wipe_configuration_state(pack, &config_handlers, ctx) {
-                    info!(pack = %pack_name, error = %e, "reconcile failed");
-                    pack_results.push(PackResult {
-                        pack_name,
-                        success: false,
-                        operations: Vec::new(),
-                        error: Some(format!("reconcile error: {e}")),
-                    });
-                    continue;
-                }
+            let pack = pack_by_display
+                .get(pack_name.as_str())
+                .copied()
+                .expect("pack_intents was built from packs; lookup must succeed");
+            if let Err(e) = wipe_configuration_state(pack, &config_handlers, ctx) {
+                info!(pack = %pack_name, error = %e, "reconcile failed");
+                pack_results.push(PackResult {
+                    pack_name,
+                    success: false,
+                    operations: Vec::new(),
+                    error: Some(format!("reconcile error: {e}")),
+                });
+                continue;
             }
         }
 

--- a/crates/dodot-lib/src/handlers/mod.rs
+++ b/crates/dodot-lib/src/handlers/mod.rs
@@ -239,6 +239,25 @@ pub const HANDLER_PATH: &str = "path";
 pub const HANDLER_INSTALL: &str = "install";
 pub const HANDLER_HOMEBREW: &str = "homebrew";
 
+/// Names of all configuration-category handlers in the registry.
+///
+/// Returned in no particular order. Used by `dodot up` to wipe stale
+/// per-pack state before re-applying current source: every successful
+/// `up` for these handlers is equivalent to "down (these handlers) +
+/// up", so a deleted source file no longer leaves an orphan entry.
+///
+/// Code-execution handlers (install, homebrew) are excluded — their
+/// sentinels record "did this run with this content?" and must persist
+/// across re-runs of `up` so install scripts and `brew bundle` aren't
+/// re-executed every time.
+pub fn configuration_handler_names(fs: &dyn Fs) -> Vec<String> {
+    create_registry(fs)
+        .iter()
+        .filter(|(_, h)| h.category() == HandlerCategory::Configuration)
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
 /// Create the default handler registry.
 ///
 /// Returns a map from handler name to handler instance. The `fs`


### PR DESCRIPTION
## Summary

- `dodot up` was additive only — handler `to_intents()` only emits intents from current source, and nothing in the up flow scanned the datastore for orphans. A file deleted from a pack left its data link behind, so the regenerated init script kept sourcing a now-missing path.
- Wipe each pack's datastore state for every configuration-category handler (path, shell, symlink) at the start of `up`, then re-apply from current source.
- Provisioning handlers (install, homebrew) are deliberately excluded — their sentinels track "did this run with this content?" independent of whether the source still exists right now; wiping would force install scripts and `brew bundle` to re-execute on every up.

Closes #58.

## Test plan

- [x] `cargo test` (524 tests pass)
- [x] `cargo clippy --all-targets`
- [x] New tests exercise:
  - shell: delete `profile.sh` → re-up → datastore entry gone, init script no longer references it
  - symlink: delete `gvimrc` source → re-up → datastore symlink gone
  - path: remove `bin/` dir → re-up → path datastore empty, init script no longer exports it
  - install carve-out: re-up with unchanged source → sentinel persists
  - install carve-out: delete source → re-up → sentinel persists (no re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)