### PR TITLE
feat(probe): warn when shell-init profile predates last `up`

### DIFF
--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -14,8 +14,9 @@ use serde::Serialize;
 use crate::packs::orchestration::ExecutionContext;
 use crate::probe::{
     aggregate_profiles, collect_data_dir_tree, collect_deployment_map, group_profile,
-    read_latest_profile, read_recent_profiles, summarize_history, AggregatedTarget,
-    DeploymentMapEntry, GroupedProfile, HistoryEntry, TreeNode,
+    parse_unix_ts_from_filename, read_last_up_marker, read_latest_profile, read_recent_profiles,
+    summarize_history, AggregatedTarget, DeploymentMapEntry, GroupedProfile, HistoryEntry,
+    TreeNode,
 };
 use crate::Result;
 
@@ -107,6 +108,16 @@ pub struct ShellInitAggregateView {
     pub profiling_enabled: bool,
     pub profiles_dir: String,
     pub rows: Vec<ShellInitAggregateRow>,
+    /// True when the newest aggregated profile was captured before the
+    /// most recent `dodot up`. The renderer prints a freshness banner
+    /// in that case so the user knows to open a new shell.
+    pub stale: bool,
+    /// `YYYY-MM-DD HH:MM` capture time of the newest aggregated
+    /// profile; empty when no profiles were loaded.
+    pub latest_profile_when: String,
+    /// `YYYY-MM-DD HH:MM` of the most recent `dodot up`; empty when
+    /// `up` has never run on this machine.
+    pub last_up_when: String,
 }
 
 /// One per-target aggregate row, durations pre-humanised for the
@@ -135,6 +146,16 @@ pub struct ShellInitHistoryView {
     pub profiling_enabled: bool,
     pub profiles_dir: String,
     pub rows: Vec<ShellInitHistoryRow>,
+    /// True when the newest row was captured before the most recent
+    /// `dodot up`. Older rows in the history are obviously older —
+    /// they're not flagged individually.
+    pub stale: bool,
+    /// `YYYY-MM-DD HH:MM` capture time of the newest history row;
+    /// empty when no profiles exist.
+    pub latest_profile_when: String,
+    /// `YYYY-MM-DD HH:MM` of the most recent `dodot up`; empty when
+    /// `up` has never run on this machine.
+    pub last_up_when: String,
 }
 
 /// One per-run row in `--history`.
@@ -182,6 +203,16 @@ pub struct ShellInitView {
     pub total_us: u64,
     /// Where the profiles live on disk (so the user can `ls` it).
     pub profiles_dir: String,
+    /// True when the displayed profile was captured before the most
+    /// recent `dodot up`. The renderer prints a freshness banner so
+    /// the user knows the timings reflect a pre-up shell.
+    pub stale: bool,
+    /// `YYYY-MM-DD HH:MM` capture time of the displayed profile;
+    /// empty when no profile is available.
+    pub profile_when: String,
+    /// `YYYY-MM-DD HH:MM` of the most recent `dodot up`; empty when
+    /// `up` has never run on this machine.
+    pub last_up_when: String,
 }
 
 /// Display row for one entry in a shell-init group.
@@ -274,10 +305,14 @@ pub fn shell_init(ctx: &ExecutionContext) -> Result<ProbeResult> {
 
     let profile_opt = read_latest_profile(ctx.fs.as_ref(), ctx.paths.as_ref())?;
     let profiles_dir = ctx.paths.probes_shell_init_dir().display().to_string();
+    let last_up_ts = read_last_up_marker(ctx.fs.as_ref(), ctx.paths.as_ref());
+    let last_up_when = last_up_ts.map(format_unix_ts).unwrap_or_default();
 
     let view = match profile_opt {
         Some(profile) => {
             let grouped = group_profile(&profile);
+            let profile_ts = parse_unix_ts_from_filename(&profile.filename);
+            let stale = is_stale(profile_ts, last_up_ts);
             ShellInitView {
                 filename: profile.filename.clone(),
                 shell: profile.shell.clone(),
@@ -288,6 +323,9 @@ pub fn shell_init(ctx: &ExecutionContext) -> Result<ProbeResult> {
                 framing_us: grouped.framing_us,
                 total_us: grouped.total_us,
                 profiles_dir,
+                stale,
+                profile_when: format_unix_ts(profile_ts),
+                last_up_when,
             }
         }
         None => ShellInitView {
@@ -300,10 +338,20 @@ pub fn shell_init(ctx: &ExecutionContext) -> Result<ProbeResult> {
             framing_us: 0,
             total_us: 0,
             profiles_dir,
+            stale: false,
+            profile_when: String::new(),
+            last_up_when,
         },
     };
 
     Ok(ProbeResult::ShellInit(view))
+}
+
+/// Decide whether a profile timestamp predates the last `dodot up`.
+/// Returns false when either timestamp is unknown — we never warn on
+/// guesswork, only when we have both reference points.
+fn is_stale(profile_ts: u64, last_up_ts: Option<u64>) -> bool {
+    matches!(last_up_ts, Some(last) if profile_ts > 0 && profile_ts < last)
 }
 
 fn shell_init_groups(grouped: &GroupedProfile) -> Vec<ShellInitGroup> {
@@ -366,8 +414,15 @@ pub fn shell_init_aggregate(ctx: &ExecutionContext, runs: usize) -> Result<Probe
     let root_config = ctx.config_manager.root_config()?;
     let profiling_enabled = root_config.profiling.enabled;
     let profiles = read_recent_profiles(ctx.fs.as_ref(), ctx.paths.as_ref(), runs)?;
+    // read_recent_profiles returns newest-first, so the first entry's
+    // filename is the most recent capture.
+    let latest_profile_ts = profiles
+        .first()
+        .map(|p| parse_unix_ts_from_filename(&p.filename))
+        .unwrap_or(0);
     let view = aggregate_profiles(&profiles);
     let profiles_dir = ctx.paths.probes_shell_init_dir().display().to_string();
+    let last_up_ts = read_last_up_marker(ctx.fs.as_ref(), ctx.paths.as_ref());
 
     Ok(ProbeResult::ShellInitAggregate(ShellInitAggregateView {
         runs: view.runs,
@@ -375,6 +430,9 @@ pub fn shell_init_aggregate(ctx: &ExecutionContext, runs: usize) -> Result<Probe
         profiling_enabled,
         profiles_dir,
         rows: view.targets.into_iter().map(into_aggregate_row).collect(),
+        stale: is_stale(latest_profile_ts, last_up_ts),
+        latest_profile_when: format_unix_ts(latest_profile_ts),
+        last_up_when: last_up_ts.map(format_unix_ts).unwrap_or_default(),
     }))
 }
 
@@ -405,17 +463,27 @@ pub fn shell_init_history(ctx: &ExecutionContext, limit: usize) -> Result<ProbeR
     let root_config = ctx.config_manager.root_config()?;
     let profiling_enabled = root_config.profiling.enabled;
     let mut profiles = read_recent_profiles(ctx.fs.as_ref(), ctx.paths.as_ref(), limit)?;
+    // Capture the newest ts before we reverse for display (the freshness
+    // check looks at the most recent run, not the bottom row).
+    let latest_profile_ts = profiles
+        .first()
+        .map(|p| parse_unix_ts_from_filename(&p.filename))
+        .unwrap_or(0);
     // read_recent_profiles returns newest-first; reverse so output reads
     // chronologically (oldest at top, latest at the bottom near the
     // user's prompt).
     profiles.reverse();
     let history = summarize_history(&profiles);
     let profiles_dir = ctx.paths.probes_shell_init_dir().display().to_string();
+    let last_up_ts = read_last_up_marker(ctx.fs.as_ref(), ctx.paths.as_ref());
 
     Ok(ProbeResult::ShellInitHistory(ShellInitHistoryView {
         profiling_enabled,
         profiles_dir,
         rows: history.into_iter().map(into_history_row).collect(),
+        stale: is_stale(latest_profile_ts, last_up_ts),
+        latest_profile_when: format_unix_ts(latest_profile_ts),
+        last_up_when: last_up_ts.map(format_unix_ts).unwrap_or_default(),
     }))
 }
 

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -3550,6 +3550,203 @@ fn probe_shell_init_history_json_is_kind_tagged() {
     assert!(parsed["rows"].is_array());
 }
 
+// ── probe shell-init: staleness banner (#59) ────────────────
+
+/// Plant a `last-up-at` marker at the given unix timestamp so tests
+/// don't depend on real wall-clock writes.
+fn write_last_up_marker_at(env: &TempEnvironment, ts: u64) {
+    env.fs.mkdir_all(env.paths.data_dir()).unwrap();
+    env.fs
+        .write_file(&env.paths.last_up_path(), ts.to_string().as_bytes())
+        .unwrap();
+}
+
+/// Profile filenames encode the unix timestamp. Profile pre-dates the
+/// last `up`, so the staleness banner must fire.
+#[test]
+fn probe_shell_init_banner_when_profile_predates_last_up() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+
+    write_fake_profile(
+        &env,
+        "profile-1714000000-1-1.tsv",
+        &["source\tvim\tshell\t/x/aliases.sh\t1.000000\t1.000100\t0"],
+    );
+    // Up happened one hour after the profile.
+    write_last_up_marker_at(&env, 1714003600);
+
+    let result = commands::probe::shell_init(&ctx).unwrap();
+    let json = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["stale"], true);
+
+    let text = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        text.contains("warning:"),
+        "expected staleness banner, got:\n{text}"
+    );
+    // Banner mentions both timestamps so the user can verify the comparison.
+    assert!(
+        text.contains("2024-04-24") && text.contains("2024-04-25"),
+        "banner should reference both capture and up timestamps, got:\n{text}"
+    );
+    assert!(
+        text.contains("capture a fresh profile"),
+        "banner should explain the remediation, got:\n{text}"
+    );
+}
+
+#[test]
+fn probe_shell_init_no_banner_when_profile_postdates_last_up() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+
+    // Up first, profile after — the user already opened a shell, so
+    // the displayed profile reflects the post-up state. No banner.
+    write_last_up_marker_at(&env, 1714000000);
+    write_fake_profile(
+        &env,
+        "profile-1714003600-1-1.tsv",
+        &["source\tvim\tshell\t/x/aliases.sh\t1.000000\t1.000100\t0"],
+    );
+
+    let result = commands::probe::shell_init(&ctx).unwrap();
+    let json = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["stale"], false);
+
+    let text = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        !text.contains("warning:"),
+        "no banner expected when profile is fresh, got:\n{text}"
+    );
+}
+
+#[test]
+fn probe_shell_init_no_banner_when_no_last_up_marker() {
+    // Profile exists but `up` has never run on this machine — we have
+    // nothing to compare against, so the safe default is "no banner".
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+
+    write_fake_profile(
+        &env,
+        "profile-1714000000-1-1.tsv",
+        &["source\tvim\tshell\t/x/aliases.sh\t1.000000\t1.000100\t0"],
+    );
+
+    let result = commands::probe::shell_init(&ctx).unwrap();
+    let text = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        !text.contains("warning:"),
+        "no banner without an up marker, got:\n{text}"
+    );
+}
+
+#[test]
+fn probe_shell_init_no_banner_when_no_profile() {
+    // Marker exists, but there's no profile yet (e.g. user just ran
+    // first `up`). The empty-state hint is enough; no warning.
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_last_up_marker_at(&env, 1714000000);
+
+    let result = commands::probe::shell_init(&ctx).unwrap();
+    let text = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        !text.contains("warning:"),
+        "no banner when there's no profile to flag, got:\n{text}"
+    );
+}
+
+#[test]
+fn probe_shell_init_aggregate_banner_when_newest_predates_last_up() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &["source\tvim\tshell\t/x.sh\t1.000000\t1.000100\t0"],
+    );
+    write_fake_profile(
+        &env,
+        "profile-1714000002-1-1.tsv",
+        &["source\tvim\tshell\t/x.sh\t1.000000\t1.000200\t0"],
+    );
+    // Up happened after the newest profile.
+    write_last_up_marker_at(&env, 1714000003);
+
+    let result = commands::probe::shell_init_aggregate(&ctx, 5).unwrap();
+    let json = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["stale"], true);
+
+    let text = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        text.contains("warning:"),
+        "aggregate view should show banner, got:\n{text}"
+    );
+}
+
+#[test]
+fn probe_shell_init_history_banner_when_newest_predates_last_up() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+
+    write_fake_profile(
+        &env,
+        "profile-1714000000-1-1.tsv",
+        &["source\tvim\tshell\t/x.sh\t1.000000\t1.000100\t0"],
+    );
+    write_fake_profile(
+        &env,
+        "profile-1714003600-1-1.tsv",
+        &["source\tvim\tshell\t/x.sh\t1.000000\t1.000200\t0"],
+    );
+    // Up after the newest history row.
+    write_last_up_marker_at(&env, 1714007200);
+
+    let result = commands::probe::shell_init_history(&ctx, 50).unwrap();
+    let json = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["stale"], true);
+
+    let text = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        text.contains("warning:"),
+        "history view should show banner, got:\n{text}"
+    );
+}
+
+#[test]
+fn up_writes_last_up_marker() {
+    // The marker is what the staleness check compares against, so the
+    // up command must always leave one behind on a successful run.
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "x")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+
+    assert!(
+        !env.fs.exists(&env.paths.last_up_path()),
+        "marker should not exist before first up"
+    );
+    commands::up::up(None, &ctx).unwrap();
+    assert!(
+        env.fs.exists(&env.paths.last_up_path()),
+        "marker should be written by up"
+    );
+
+    let raw = env.fs.read_to_string(&env.paths.last_up_path()).unwrap();
+    let parsed: u64 = raw.trim().parse().expect("marker should be a unix ts");
+    // Sanity: post-2023.
+    assert!(parsed > 1_700_000_000, "ts should look recent: {parsed}");
+}
+
 // ── deployment map (written on up/down alongside the init script) ──
 
 #[test]

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -121,6 +121,13 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         )?;
         info!("writing deployment map");
         probe::write_deployment_map(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+        // Record the unix timestamp of this up so `dodot probe shell-init`
+        // can flag profiles captured before it as stale. Best effort —
+        // a clock skip would only affect the staleness banner, never the
+        // deployment itself, so we don't fail the run on a write error.
+        if let Err(e) = probe::write_last_up_marker(ctx.fs.as_ref(), ctx.paths.as_ref()) {
+            debug!(error = %e, "failed to write last-up marker");
+        }
         // Prune old shell-init profile reports. Cheap (one read_dir +
         // a few unlinks at most) and runs in dodot's process, not the
         // user's shell.

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -65,6 +65,14 @@ pub trait Pather: Send + Sync {
         self.data_dir().join("deployment-map.tsv")
     }
 
+    /// Path to a single-line file recording the unix timestamp of the
+    /// most recent successful `dodot up`. Used by `dodot probe
+    /// shell-init` to flag profiles captured before that `up` as stale.
+    /// Absent until the first `up` runs.
+    fn last_up_path(&self) -> PathBuf {
+        self.data_dir().join("last-up-at")
+    }
+
     /// Directory where shell-init profile reports are written, one TSV
     /// per shell start. See `docs/proposals/profiling.lex` §3.1.
     fn probes_shell_init_dir(&self) -> PathBuf {

--- a/crates/dodot-lib/src/probe/last_up.rs
+++ b/crates/dodot-lib/src/probe/last_up.rs
@@ -1,0 +1,87 @@
+//! Last-up marker — records the unix timestamp of the most recent
+//! successful `dodot up` to `<data_dir>/last-up-at`.
+//!
+//! Used by `dodot probe shell-init` to flag profiles captured before
+//! that timestamp as stale: a profile only gets written when a new
+//! shell sources `dodot-init.sh`, so running `dodot up` followed by
+//! `dodot probe shell-init` from the same shell otherwise displays
+//! pre-up timings without any indication that they no longer reflect
+//! reality.
+//!
+//! Format: a single line of ASCII decimal — no trailing newline
+//! required, but the reader tolerates it. Anything that fails to parse
+//! is treated as "no marker", same as a missing file.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::fs::Fs;
+use crate::paths::Pather;
+use crate::Result;
+
+/// Write the current unix timestamp to `<data_dir>/last-up-at`.
+pub fn write_last_up_marker(fs: &dyn Fs, paths: &dyn Pather) -> Result<()> {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    fs.mkdir_all(paths.data_dir())?;
+    fs.write_file(&paths.last_up_path(), ts.to_string().as_bytes())
+}
+
+/// Read the unix timestamp of the most recent `dodot up`. Returns
+/// `None` if the marker is missing or unparseable — callers should
+/// treat that as "no last-up known" (e.g., a fresh install that never
+/// ran `up`) rather than as zero, which would make every profile look
+/// fresh.
+pub fn read_last_up_marker(fs: &dyn Fs, paths: &dyn Pather) -> Option<u64> {
+    let path = paths.last_up_path();
+    if !fs.exists(&path) {
+        return None;
+    }
+    fs.read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TempEnvironment;
+
+    #[test]
+    fn missing_marker_reads_as_none() {
+        let env = TempEnvironment::builder().build();
+        assert_eq!(
+            read_last_up_marker(env.fs.as_ref(), env.paths.as_ref()),
+            None
+        );
+    }
+
+    #[test]
+    fn write_then_read_round_trip() {
+        let env = TempEnvironment::builder().build();
+        write_last_up_marker(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        let ts = read_last_up_marker(env.fs.as_ref(), env.paths.as_ref())
+            .expect("marker should exist after write");
+        // Rough sanity check: the timestamp should be after a fixed
+        // historical instant. We can't pin the exact value in a
+        // deterministic test without injecting a clock.
+        assert!(
+            ts > 1_700_000_000,
+            "timestamp should look like a recent unix ts, got {ts}"
+        );
+    }
+
+    #[test]
+    fn unparseable_marker_reads_as_none() {
+        let env = TempEnvironment::builder().build();
+        env.fs.mkdir_all(env.paths.data_dir()).unwrap();
+        env.fs
+            .write_file(&env.paths.last_up_path(), b"not a number")
+            .unwrap();
+        assert_eq!(
+            read_last_up_marker(env.fs.as_ref(), env.paths.as_ref()),
+            None
+        );
+    }
+}

--- a/crates/dodot-lib/src/probe/mod.rs
+++ b/crates/dodot-lib/src/probe/mod.rs
@@ -26,8 +26,10 @@ pub use deployment_map::{
 };
 pub use last_up::{read_last_up_marker, write_last_up_marker};
 pub use shell_init::{
-    aggregate_profiles, group_profile, parse_profile, parse_unix_ts_from_filename,
-    read_latest_profile, read_recent_profiles, rotate_profiles, summarize_history,
-    AggregatedTarget, AggregatedView, GroupedProfile, HistoryEntry, Profile, ProfileEntry,
-    ProfileGroup,
+    aggregate_profiles, group_profile, parse_profile, read_latest_profile, read_recent_profiles,
+    rotate_profiles, summarize_history, AggregatedTarget, AggregatedView, GroupedProfile,
+    HistoryEntry, Profile, ProfileEntry, ProfileGroup,
 };
+// Internal helper, exposed only within dodot-lib so `commands::probe`
+// can compute staleness without re-implementing filename parsing.
+pub(crate) use shell_init::parse_unix_ts_from_filename;

--- a/crates/dodot-lib/src/probe/mod.rs
+++ b/crates/dodot-lib/src/probe/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod data_dir_tree;
 pub mod deployment_map;
+pub mod last_up;
 pub mod shell_init;
 
 pub use data_dir_tree::{collect_data_dir_tree, TreeNode};
@@ -23,8 +24,10 @@ pub use deployment_map::{
     collect_deployment_map, read_deployment_map, write_deployment_map, DeploymentKind,
     DeploymentMapEntry,
 };
+pub use last_up::{read_last_up_marker, write_last_up_marker};
 pub use shell_init::{
-    aggregate_profiles, group_profile, parse_profile, read_latest_profile, read_recent_profiles,
-    rotate_profiles, summarize_history, AggregatedTarget, AggregatedView, GroupedProfile,
-    HistoryEntry, Profile, ProfileEntry, ProfileGroup,
+    aggregate_profiles, group_profile, parse_profile, parse_unix_ts_from_filename,
+    read_latest_profile, read_recent_profiles, rotate_profiles, summarize_history,
+    AggregatedTarget, AggregatedView, GroupedProfile, HistoryEntry, Profile, ProfileEntry,
+    ProfileGroup,
 };

--- a/crates/dodot-lib/src/probe/shell_init.rs
+++ b/crates/dodot-lib/src/probe/shell_init.rs
@@ -415,7 +415,7 @@ fn history_entry_from(profile: &Profile) -> HistoryEntry {
 /// Extract the leading `<unix_ts>` from `profile-<unix_ts>-<pid>-<rand>.tsv`,
 /// returning `0` for any unparseable filename. The renderer formats this
 /// into a date string; storing it as an integer keeps JSON output stable.
-fn parse_unix_ts_from_filename(filename: &str) -> u64 {
+pub fn parse_unix_ts_from_filename(filename: &str) -> u64 {
     filename
         .strip_prefix("profile-")
         .and_then(|rest| rest.split('-').next())

--- a/crates/dodot-lib/src/probe/shell_init.rs
+++ b/crates/dodot-lib/src/probe/shell_init.rs
@@ -415,7 +415,7 @@ fn history_entry_from(profile: &Profile) -> HistoryEntry {
 /// Extract the leading `<unix_ts>` from `profile-<unix_ts>-<pid>-<rand>.tsv`,
 /// returning `0` for any unparseable filename. The renderer formats this
 /// into a date string; storing it as an integer keeps JSON output stable.
-pub fn parse_unix_ts_from_filename(filename: &str) -> u64 {
+pub(crate) fn parse_unix_ts_from_filename(filename: &str) -> u64 {
     filename
         .strip_prefix("profile-")
         .and_then(|rest| rest.split('-').next())

--- a/crates/dodot-lib/src/templates/probe.jinja
+++ b/crates/dodot-lib/src/templates/probe.jinja
@@ -22,7 +22,11 @@
 {% endfor %}
 {%- elif kind == "shell-init" -%}
 [header]Shell-init profile[/header]
-{% if has_profile %}  [dim]run:[/dim] {{ filename }}
+{% if stale %}  [warning]warning:[/warning] this profile was captured at {{ profile_when }} — before
+           your most recent `dodot up` at {{ last_up_when }}. Open a new
+           shell to capture a fresh profile.
+
+{% endif %}{% if has_profile %}  [dim]run:[/dim] {{ filename }}
   [dim]shell:[/dim] {{ shell }}
 
 {% for g in groups %}  [pack-name]{{ g.pack }}[/pack-name] [description]/[/description] [handler-symbol]{{ g.handler }}[/handler-symbol] [dim]({{ g.group_total_label }})[/dim]
@@ -41,7 +45,11 @@
   [dim]for intra-file profiling, see `zprof` (zsh) or PS4 tracing (bash).[/dim]
 {%- elif kind == "shell-init-aggregate" -%}
 [header]Shell-init aggregate[/header]
-  [dim]runs:[/dim] {{ runs }}{% if runs != requested_runs %} [warning](requested {{ requested_runs }})[/warning]{% endif %}
+{% if stale %}  [warning]warning:[/warning] the most recent run was captured at {{ latest_profile_when }} —
+           before your most recent `dodot up` at {{ last_up_when }}. Open
+           a new shell to capture a fresh profile.
+
+{% endif %}  [dim]runs:[/dim] {{ runs }}{% if runs != requested_runs %} [warning](requested {{ requested_runs }})[/warning]{% endif %}
 
 {% if rows %}  [dim]{{ "pack" | col(14) }} {{ "handler" | col(8) }} {{ "target" | col(28) }} {{ "p50" | col(10) }} {{ "p95" | col(10) }} {{ "max" | col(10) }} runs[/dim]
 {% for r in rows %}  [pack-name]{{ r.pack | col(14) }}[/pack-name] [handler-symbol]{{ r.handler | col(8) }}[/handler-symbol] {{ r.target | col(28) }} [deployed]{{ r.p50_label | col(10) }}[/deployed] {{ r.p95_label | col(10) }} {{ r.max_label | col(10) }} [dim]{{ r.seen_label }}[/dim]
@@ -53,7 +61,11 @@
   [dim]profiles dir:[/dim] {{ profiles_dir }}
 {%- elif kind == "shell-init-history" -%}
 [header]Shell-init history[/header]
+{% if stale %}  [warning]warning:[/warning] the most recent run was captured at {{ latest_profile_when }} —
+           before your most recent `dodot up` at {{ last_up_when }}. Open
+           a new shell to capture a fresh profile.
 
+{% endif %}
 {% if rows %}  [dim]{{ "when (UTC)" | col(18) }} {{ "shell" | col(20) }} {{ "total" | col(10) }} {{ "user" | col(10) }} {{ "entries" | col(8) }} fail[/dim]
 {% for r in rows %}  {{ r.when | col(18) }} {{ r.shell | col(20) }} [deployed]{{ r.total_label | col(10) }}[/deployed] {{ r.user_total_label | col(10) }} {{ r.entry_count | string | col(8) }} {% if r.failed_entries > 0 %}[error]{{ r.failed_entries }}[/error]{% else %}[dim]0[/dim]{% endif %}
 {% endfor %}{% else %}{% if profiling_enabled %}  [dim](no profiles yet — open a shell that sources `dodot-init.sh`)[/dim]


### PR DESCRIPTION
## Summary

- Profiles are written by `dodot-init.sh` only when a new shell starts. Running `dodot probe shell-init` after `dodot up` from the **same shell** displays a pre-up profile with no indication that it's stale, leading the user to misread timings/sources.
- Record the unix timestamp of every successful `dodot up` to `<data_dir>/last-up-at`. In each `probe shell-init` view (single, `--runs`, `--history`), compare the most recent profile's filename timestamp against that marker; if the profile predates the up, render a banner naming both timestamps.
- Banner only fires when both reference points exist (no banner on fresh installs that never ran `up`, or when there's no profile yet).

Closes #59.

## Test plan

- [x] `cargo test` (529 tests pass)
- [x] `cargo clippy --all-targets`
- [x] New tests:
  - profile predates last-up → banner fires (single, aggregate, history views)
  - profile post-dates last-up → no banner
  - no last-up marker → no banner (avoid noisy guesswork)
  - no profile → no banner (empty-state hint is enough)
  - `up` writes the marker on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)