### PR TITLE
feat(release): support semver pre-release versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g. 0.18.0)'
+        description: 'Version to release (e.g. 0.18.0 or 1.0.0-rc.1)'
         required: true
         type: string
 
@@ -21,6 +21,7 @@ jobs:
     outputs:
       version: ${{ steps.bump.outputs.version }}
       release-sha: ${{ steps.bump.outputs.sha }}
+      prerelease: ${{ steps.bump.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,10 +39,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::version must be MAJOR.MINOR.PATCH (got: $NEW_VERSION)"
+          if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::version must be MAJOR.MINOR.PATCH[-PRERELEASE] (got: $NEW_VERSION)"
             exit 1
           fi
+
+          IS_PRERELEASE=false
+          if [[ "$NEW_VERSION" == *-* ]]; then
+            IS_PRERELEASE=true
+          fi
+          echo "prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
           TAG="v$NEW_VERSION"
           CLI_TOML="crates/dodot-cli/Cargo.toml"
@@ -88,24 +95,35 @@ jobs:
           sed -i -E "s/^dodot-lib = \\{ version = \"$OLD_VERSION\"/dodot-lib = { version = \"$NEW_VERSION\"/" "$CLI_TOML"
           cargo update -p dodot -p dodot-lib
 
-          TODAY=$(date -u +%Y-%m-%d)
-          SECTION=$(mktemp)
-          {
-            printf '## [%s] - %s\n\n' "$NEW_VERSION" "$TODAY"
-            printf '%s\n\n' "$BODY"
-          } > "$SECTION"
-          awk -v section_file="$SECTION" '
-              !inserted && /^## \[/ {
-                  while ((getline line < section_file) > 0) print line
-                  close(section_file)
-                  inserted=1
-              }
-              { print }
-          ' CHANGELOG.md > CHANGELOG.md.tmp
-          mv CHANGELOG.md.tmp CHANGELOG.md
-          rm -f "$SECTION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          cat > CHANGELOG_UNRELEASED.md <<'EOF'
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            # Pre-releases share the unreleased entries with the final they
+            # lead up to: don't roll into CHANGELOG.md and don't clear
+            # CHANGELOG_UNRELEASED.md. Subsequent rc.N / the final release
+            # will see the same entries.
+            git add "$CLI_TOML" "$LIB_TOML" Cargo.lock
+            git commit -m "chore: Release $TAG"
+          else
+            TODAY=$(date -u +%Y-%m-%d)
+            SECTION=$(mktemp)
+            {
+              printf '## [%s] - %s\n\n' "$NEW_VERSION" "$TODAY"
+              printf '%s\n\n' "$BODY"
+            } > "$SECTION"
+            awk -v section_file="$SECTION" '
+                !inserted && /^## \[/ {
+                    while ((getline line < section_file) > 0) print line
+                    close(section_file)
+                    inserted=1
+                }
+                { print }
+            ' CHANGELOG.md > CHANGELOG.md.tmp
+            mv CHANGELOG.md.tmp CHANGELOG.md
+            rm -f "$SECTION"
+
+            cat > CHANGELOG_UNRELEASED.md <<'EOF'
           # Unreleased Changes
 
           Add entries here as changes are made. On release, copy this content into
@@ -117,10 +135,9 @@ jobs:
           `## [version]` heading the release workflow inserts.
           EOF
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "$CLI_TOML" "$LIB_TOML" Cargo.lock CHANGELOG.md CHANGELOG_UNRELEASED.md
-          git commit -m "chore: Release $TAG"
+            git add "$CLI_TOML" "$LIB_TOML" Cargo.lock CHANGELOG.md CHANGELOG_UNRELEASED.md
+            git commit -m "chore: Release $TAG"
+          fi
           git tag -a "$TAG" -m "Release $TAG"
           git push origin main
           git push origin "$TAG"
@@ -139,8 +156,15 @@ jobs:
       - name: Extract release notes from CHANGELOG
         env:
           VERSION: ${{ needs.prepare-release.outputs.version }}
+          PRERELEASE: ${{ needs.prepare-release.outputs.prerelease }}
         run: |
-          awk '/^## \['"$VERSION"'\]/{found=1; next} /^## \[/{if(found) exit} found{print}' CHANGELOG.md > release-notes.md
+          if [ "$PRERELEASE" = "true" ]; then
+            # Pre-releases haven't rolled into CHANGELOG.md — read the
+            # still-uncleared unreleased entries instead.
+            awk '/^### /{found=1} found{print}' CHANGELOG_UNRELEASED.md > release-notes.md
+          else
+            awk '/^## \['"$VERSION"'\]/{found=1; next} /^## \[/{if(found) exit} found{print}' CHANGELOG.md > release-notes.md
+          fi
           if [ ! -s release-notes.md ]; then
             echo "Release v$VERSION" > release-notes.md
           fi
@@ -153,6 +177,7 @@ jobs:
           name: v${{ needs.prepare-release.outputs.version }}
           body_path: release-notes.md
           draft: false
+          prerelease: ${{ needs.prepare-release.outputs.prerelease == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "::error::version must be MAJOR.MINOR.PATCH[-PRERELEASE] (got: $NEW_VERSION)"
             exit 1
           fi

--- a/scripts/diff-since-release
+++ b/scripts/diff-since-release
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-latest_tag=$(git tag --list 'v*' --sort=-version:refname | head -n1)
+# Skip pre-release tags (e.g. v1.0.0-rc.1) — we want the diff against the
+# last *final* release, since pre-releases share unreleased changelog entries
+# with the final they lead up to.
+latest_tag=$(git tag --list 'v*' --sort=-version:refname | grep -v -- '-' | head -n1)
 
 if [ -z "$latest_tag" ]; then
     echo "No release tags found"

--- a/scripts/release
+++ b/scripts/release
@@ -7,16 +7,22 @@ set -euo pipefail
 #    or:  scripts/release <bump-level>        e.g. scripts/release minor
 #                                                  (one of: major, minor, patch)
 #
+# Pre-releases: pass a semver pre-release suffix to cut a release candidate
+# or beta, e.g. scripts/release 1.0.0-rc.1. CI marks the GitHub Release as
+# "pre-release" (so it isn't shown as Latest) and skips rolling
+# CHANGELOG_UNRELEASED.md into CHANGELOG.md, so subsequent RCs / the final
+# release can still draw from the same unreleased entries.
+#
 # What CI does (all on GitHub):
 #   1. Bumps version in Cargo.toml files + refreshes Cargo.lock
-#   2. Rolls CHANGELOG_UNRELEASED.md into CHANGELOG.md
+#   2. Rolls CHANGELOG_UNRELEASED.md into CHANGELOG.md (final releases only)
 #   3. Commits "chore: Release vX.Y.Z" on main + creates+pushes tag
-#   4. Creates GitHub Release with notes from CHANGELOG
+#   4. Creates GitHub Release with notes from CHANGELOG / unreleased file
 #   5. Builds binaries (macOS arm64, linux x64+arm64), signs+notarizes macOS
 #   6. Publishes dodot-lib and dodot to crates.io
 #
 # Preconditions (checked by CI before mutating anything):
-#   - version is MAJOR.MINOR.PATCH and does not already exist as a tag
+#   - version is MAJOR.MINOR.PATCH[-PRERELEASE] and does not already exist as a tag
 #   - Cargo.toml version differs from the requested version
 #   - CHANGELOG_UNRELEASED.md has entries
 #
@@ -55,8 +61,8 @@ case "$arg" in
         echo "Bumping ${arg}: ${current} -> ${new_version}"
         ;;
     *)
-        if ! [[ "$arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "version must be MAJOR.MINOR.PATCH or one of: major, minor, patch (got: $arg)" >&2
+        if ! [[ "$arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "version must be MAJOR.MINOR.PATCH[-PRERELEASE] or one of: major, minor, patch (got: $arg)" >&2
             exit 2
         fi
         new_version="$arg"

--- a/scripts/release
+++ b/scripts/release
@@ -50,8 +50,12 @@ case "$arg" in
     major|minor|patch)
         current=$(grep -E '^version' "$repo_root/crates/dodot-lib/Cargo.toml" \
             | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+        # Strip any pre-release suffix before parsing. The bump shortcuts
+        # operate on the core MAJOR.MINOR.PATCH; if you want to step from
+        # 1.0.0-rc.1 to 1.0.0, type the version literally.
+        current_core="${current%%-*}"
         MAJOR=0; MINOR=0; PATCH=0; SPECIAL=""
-        semverParseInto "$current" MAJOR MINOR PATCH SPECIAL
+        semverParseInto "$current_core" MAJOR MINOR PATCH SPECIAL
         case "$arg" in
             major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
             minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
@@ -61,7 +65,7 @@ case "$arg" in
         echo "Bumping ${arg}: ${current} -> ${new_version}"
         ;;
     *)
-        if ! [[ "$arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+        if ! [[ "$arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "version must be MAJOR.MINOR.PATCH[-PRERELEASE] or one of: major, minor, patch (got: $arg)" >&2
             exit 2
         fi


### PR DESCRIPTION
## Summary

Allow `MAJOR.MINOR.PATCH-PRERELEASE` versions (e.g. `1.0.0-rc.1`) through both `scripts/release` and `.github/workflows/release.yml`. Final-release behaviour is unchanged.

## What changes for pre-releases

- **Tag + commit**: workflow still bumps `Cargo.toml`/`Cargo.lock` and creates `chore: Release vX.Y.Z-rc.N` + tag — same as final.
- **GitHub Release**: marked `prerelease: true` so it isn't surfaced as Latest.
- **Changelog**: `CHANGELOG.md` is *not* modified and `CHANGELOG_UNRELEASED.md` is *not* cleared. Subsequent `rc.N` / the final release see the same unreleased entries — they accumulate across the RC cycle and only roll on the final.
- **Release notes**: extracted from `CHANGELOG_UNRELEASED.md` (still uncleared) rather than from a `## [version]` section of `CHANGELOG.md` (which doesn't exist for the RC).
- **`diff-since-release`**: skips pre-release tags so the "last release" baseline is always a final release, matching how unreleased entries accumulate.

## Why this shape

A pre-release in this model is a *trial-balloon build of the same content* the final will ship. Cargo and crates.io accept `-rc.N` natively (and semver requirements like `^1.0` exclude pre-releases automatically, so consumers don't get them by accident), so the RC is a real, installable artifact — but the changelog story stays consistent: one final release, one changelog section.

## Test plan

- [x] `bash -n scripts/release` and `bash -n scripts/diff-since-release` — clean
- [x] Workflow YAML parses via `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] Regex spot-check accepts `1.0.0`, `1.0.0-rc.1`, `1.0.0-beta`, `1.0.0-rc1`; rejects `1.0`, `abc`
- [x] `diff-since-release` filter (`grep -v -- '-'`) correctly skips `v1.0.0-rc.1` and lands on `v0.22.0`
- [ ] End-to-end verified by cutting `v1.0.0-rc.1` after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)