### PR TITLE
feat(probe): per-source stderr capture, drill-down filter, --errors-only

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -37,6 +37,35 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
   a banner names both timestamps and prompts the user to open a new
   shell. Closes #59.
 
+- **Per-source stderr capture and drill-down view for shell-init.**
+  Until now, when a sourced shell file emitted to stderr or exited
+  non-zero, dodot showed only an exit-code count in `--history` — the
+  actual error message was on the user's terminal at startup time and
+  gone. The shell wrapper now redirects each `. file` stderr to a
+  per-shell scratch, re-emits live to the TTY (preserving the existing
+  breadcrumb), and on non-empty stderr appends a record to a sibling
+  `profile-<id>.errors.log` next to the TSV. Empty-stderr sources stay
+  on the fast path — one `[ -s ]` test of overhead. Two new views read
+  the sidecar:
+  - `dodot probe shell-init <pack>[/<file>]` drills into one target's
+    history across recent runs, inlining captured stderr under each
+    failed run.
+  - `dodot probe shell-init --errors-only` lists every target with a
+    non-zero exit somewhere in the window, sorted by failure count desc.
+
+  The `dodot status` runtime-failure footnote was also upgraded to
+  inline a stderr excerpt from the most recent failing run (when
+  captured) and to point users at the per-file probe view instead of
+  `--history` (which only shows aggregate counts).
+
+### Changed
+
+- **`probe shell-init --history` lists newest first.** Previously the
+  history table was reversed to put the latest run nearest the prompt;
+  in practice this was confusing because every other dated listing in
+  the tool reads newest-first. Now `--history` matches that
+  convention.
+
 ### Fixed
 
 - **`dodot up` reconciles deleted source files.** `up` was additive only:

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -249,19 +249,28 @@ pub fn probe_show_data_dir_handler(
 
 /// `dodot probe shell-init` — most recent shell-startup profile.
 ///
-/// Three views, switched by mutually-exclusive flags:
-/// - default: single-run detail (most recent profile)
+/// Four views, picked by argument shape:
+/// - `<pack>[/<file>]` positional: drill-down across recent runs with
+///   captured stderr (wins over flags — the user is asking a specific
+///   question)
 /// - `--runs N`: per-target percentile aggregate over the last N runs
 /// - `--history`: one-row-per-run trend, oldest first
+/// - default: single-run detail (most recent profile)
 pub fn probe_shell_init_handler(
     matches: &clap::ArgMatches,
     _ctx: &CommandContext,
 ) -> HandlerResult<commands::probe::ProbeResult> {
     let ctx = build_readonly_ctx(matches)?;
+    let filter = matches.get_one::<String>("filter").cloned();
     let runs = matches.get_one::<usize>("runs").copied();
     let history = flag_or_false(matches, "history");
+    let errors_only = flag_or_false(matches, "errors-only");
 
-    let result = if let Some(n) = runs {
+    let result = if errors_only {
+        commands::probe::shell_init_errors(&ctx, commands::probe::DEFAULT_FILTER_RUNS)?
+    } else if let Some(f) = filter {
+        commands::probe::shell_init_filter(&ctx, &f, commands::probe::DEFAULT_FILTER_RUNS)?
+    } else if let Some(n) = runs {
         commands::probe::shell_init_aggregate(&ctx, n)?
     } else if history {
         commands::probe::shell_init_history(&ctx, commands::probe::DEFAULT_HISTORY_LIMIT)?

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -249,12 +249,13 @@ pub fn probe_show_data_dir_handler(
 
 /// `dodot probe shell-init` — most recent shell-startup profile.
 ///
-/// Four views, picked by argument shape:
+/// Five views, picked by argument shape:
 /// - `<pack>[/<file>]` positional: drill-down across recent runs with
 ///   captured stderr (wins over flags — the user is asking a specific
 ///   question)
+/// - `--errors-only`: cross-history list of failing targets
 /// - `--runs N`: per-target percentile aggregate over the last N runs
-/// - `--history`: one-row-per-run trend, oldest first
+/// - `--history`: one-row-per-run trend, newest first
 /// - default: single-run detail (most recent profile)
 pub fn probe_shell_init_handler(
     matches: &clap::ArgMatches,

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -400,6 +400,16 @@ fn build_clap_command() -> ClapCommand {
                     ClapCommand::new("shell-init")
                         .about("Per-source timings for the most recent shell startup")
                         .arg(
+                            Arg::new("filter")
+                                .help(
+                                    "Drill into one pack or file (e.g. `gpg` or `gpg/env.sh`) — shows per-run exit codes and captured stderr across recent runs",
+                                )
+                                .value_name("PACK[/FILE]")
+                                .num_args(0..=1)
+                                .conflicts_with("runs")
+                                .conflicts_with("history"),
+                        )
+                        .arg(
                             Arg::new("runs")
                                 .long("runs")
                                 .help(
@@ -417,6 +427,17 @@ fn build_clap_command() -> ClapCommand {
                                 .long("history")
                                 .help("Show one summary row per recent run, oldest first")
                                 .action(ArgAction::SetTrue),
+                        )
+                        .arg(
+                            Arg::new("errors-only")
+                                .long("errors-only")
+                                .help(
+                                    "List every target with a non-zero exit across recent runs, sorted by failure count",
+                                )
+                                .action(ArgAction::SetTrue)
+                                .conflicts_with("runs")
+                                .conflicts_with("history")
+                                .conflicts_with("filter"),
                         ),
                 ),
         )

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -425,7 +425,7 @@ fn build_clap_command() -> ClapCommand {
                         .arg(
                             Arg::new("history")
                                 .long("history")
-                                .help("Show one summary row per recent run, oldest first")
+                                .help("Show one summary row per recent run, newest first")
                                 .action(ArgAction::SetTrue),
                         )
                         .arg(

--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -94,6 +94,15 @@ pub enum ProbeResult {
     /// run, oldest run first (so the latest is closest to the eye in a
     /// terminal where output scrolls down).
     ShellInitHistory(ShellInitHistoryView),
+    /// `dodot probe shell-init <pack>[/<file>]` — drill-down view of
+    /// one target (or one pack) across recent runs. Emits per-run
+    /// duration, exit status, and captured stderr (when any) so the
+    /// user can pinpoint *what* a failing source file printed.
+    ShellInitFilter(ShellInitFilterView),
+    /// `dodot probe shell-init --errors-only` — every target with at
+    /// least one non-zero exit across the examined window, grouped by
+    /// target and sorted by failure count (most-broken first).
+    ShellInitErrors(ShellInitErrorsView),
 }
 
 /// Display payload for `--runs N`.
@@ -237,6 +246,90 @@ pub struct ShellInitGroup {
     pub rows: Vec<ShellInitRow>,
     pub group_total_us: u64,
     pub group_total_label: String,
+}
+
+/// Display payload for the filtered drill-down view.
+///
+/// Renders per-run history of one target (when the filter narrows to a
+/// single file) or every target in a pack across recent runs. Emits the
+/// captured stderr inline so the user can see exactly what each failing
+/// source printed without leaving the terminal.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitFilterView {
+    pub profiling_enabled: bool,
+    pub profiles_dir: String,
+    /// Filter as the user typed it — echoed in the header.
+    pub filter: String,
+    /// Pack portion of the filter (always set).
+    pub filter_pack: String,
+    /// Filename portion of the filter, if any (the part after `/`).
+    pub filter_filename: Option<String>,
+    /// Number of profiles examined.
+    pub runs_examined: usize,
+    /// One block per matching target. When the filter is a specific
+    /// file, this contains at most one block. When it's a pack-only
+    /// filter, one block per target seen in the pack across the
+    /// examined runs.
+    pub targets: Vec<ShellInitFilterTarget>,
+    pub stale: bool,
+    pub latest_profile_when: String,
+    pub last_up_when: String,
+}
+
+/// One target's runs across the examined window.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitFilterTarget {
+    /// Full source path as recorded in the profile.
+    pub target: String,
+    /// Basename for header display.
+    pub display_target: String,
+    /// Pack the target belongs to.
+    pub pack: String,
+    /// Handler (`shell` for sourced files, `path` for PATH exports).
+    pub handler: String,
+    /// Per-run rows, newest first.
+    pub runs: Vec<ShellInitFilterRun>,
+    /// How many of `runs` had a non-zero exit status.
+    pub failure_count: usize,
+}
+
+/// Display payload for `--errors-only`. Same shape as the filter view
+/// minus the user-typed filter string — the implicit filter is "non-
+/// zero exit, any pack, any target".
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitErrorsView {
+    pub profiling_enabled: bool,
+    pub profiles_dir: String,
+    pub runs_examined: usize,
+    /// Targets with at least one failed run in the window, sorted by
+    /// failure count desc (then by pack/target asc as a tiebreaker so
+    /// the order is stable across runs with the same counts).
+    pub targets: Vec<ShellInitFilterTarget>,
+    pub stale: bool,
+    pub latest_profile_when: String,
+    pub last_up_when: String,
+}
+
+/// One per-run row inside a target block.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellInitFilterRun {
+    /// `YYYY-MM-DD HH:MM` of the run.
+    pub when: String,
+    /// Pre-humanised duration label (e.g. `"83 µs"`).
+    pub duration_label: String,
+    pub duration_us: u64,
+    pub exit_status: i32,
+    /// `"deployed"` (success) or `"error"` (non-zero exit) — maps to
+    /// the same theme styles used by the unfiltered view.
+    pub status_class: &'static str,
+    /// Captured stderr split into individual lines. Empty when the
+    /// source printed nothing to stderr in this run. Pre-split because
+    /// the template engine doesn't expose a `.split()` filter, and
+    /// rendering each line with its own indent is cleaner than fighting
+    /// the template language.
+    pub stderr_lines: Vec<String>,
+    /// Source TSV filename, for cross-reference.
+    pub profile_filename: String,
 }
 
 /// One entry in the `probe` summary listing.
@@ -458,21 +551,241 @@ fn into_aggregate_row(t: AggregatedTarget) -> ShellInitAggregateRow {
 /// terminal.
 pub const DEFAULT_HISTORY_LIMIT: usize = 50;
 
-/// Render the per-run history view (one summary line per profile).
-pub fn shell_init_history(ctx: &ExecutionContext, limit: usize) -> Result<ProbeResult> {
+/// Default window for the filtered drill-down view. Wider than
+/// `RUNTIME_FAILURE_WINDOW` (used by `status`) so a user looking at
+/// `dodot probe shell-init <file>` gets enough history to see whether
+/// the failure is recurring or one-off, but bounded so the rendered
+/// output stays readable.
+pub const DEFAULT_FILTER_RUNS: usize = 20;
+
+/// Render the filtered drill-down view for a `<pack>[/<file>]` filter.
+///
+/// `runs` controls how many recent profiles are examined; the caller
+/// passes [`DEFAULT_FILTER_RUNS`] unless it has a specific reason to
+/// look further or fewer.
+pub fn shell_init_filter(ctx: &ExecutionContext, filter: &str, runs: usize) -> Result<ProbeResult> {
     let root_config = ctx.config_manager.root_config()?;
     let profiling_enabled = root_config.profiling.enabled;
-    let mut profiles = read_recent_profiles(ctx.fs.as_ref(), ctx.paths.as_ref(), limit)?;
-    // Capture the newest ts before we reverse for display (the freshness
-    // check looks at the most recent run, not the bottom row).
+    let profiles_dir = ctx.paths.probes_shell_init_dir().display().to_string();
+    let last_up_ts = read_last_up_marker(ctx.fs.as_ref(), ctx.paths.as_ref());
+    let last_up_when = last_up_ts.map(format_unix_ts).unwrap_or_default();
+
+    // Filter parsing: `pack` or `pack/file`. Trim a leading `./` and a
+    // trailing `/` defensively so users can paste tab-completed paths.
+    let trimmed = filter.trim().trim_start_matches("./").trim_end_matches('/');
+    let (filter_pack, filter_filename) = match trimmed.split_once('/') {
+        Some((p, f)) if !p.is_empty() && !f.is_empty() => (p.to_string(), Some(f.to_string())),
+        _ => (trimmed.to_string(), None),
+    };
+
+    let profiles = read_recent_profiles(ctx.fs.as_ref(), ctx.paths.as_ref(), runs)?;
     let latest_profile_ts = profiles
         .first()
         .map(|p| parse_unix_ts_from_filename(&p.filename))
         .unwrap_or(0);
-    // read_recent_profiles returns newest-first; reverse so output reads
-    // chronologically (oldest at top, latest at the bottom near the
-    // user's prompt).
-    profiles.reverse();
+
+    // Bucket per `(pack, handler, target)`. Order: targets sorted by
+    // path so output is stable; runs within each target stay newest-
+    // first (matching the input slice order).
+    use std::collections::BTreeMap;
+    let mut buckets: BTreeMap<(String, String, String), Vec<ShellInitFilterRun>> = BTreeMap::new();
+
+    for profile in &profiles {
+        let when = format_unix_ts(parse_unix_ts_from_filename(&profile.filename));
+        for entry in &profile.entries {
+            if entry.pack != filter_pack {
+                continue;
+            }
+            if let Some(name) = &filter_filename {
+                let basename = std::path::Path::new(&entry.target)
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                if &basename != name {
+                    continue;
+                }
+            }
+            let stderr_lines: Vec<String> = profile
+                .errors
+                .iter()
+                .find(|er| er.target == entry.target)
+                .map(|er| {
+                    er.message
+                        .trim_end()
+                        .lines()
+                        .map(|s| s.to_string())
+                        .collect()
+                })
+                .unwrap_or_default();
+            buckets
+                .entry((
+                    entry.pack.clone(),
+                    entry.handler.clone(),
+                    entry.target.clone(),
+                ))
+                .or_default()
+                .push(ShellInitFilterRun {
+                    when: when.clone(),
+                    duration_us: entry.duration_us,
+                    duration_label: humanize_us(entry.duration_us),
+                    exit_status: entry.exit_status,
+                    status_class: if entry.exit_status == 0 {
+                        "deployed"
+                    } else {
+                        "error"
+                    },
+                    stderr_lines,
+                    profile_filename: profile.filename.clone(),
+                });
+        }
+    }
+
+    let targets: Vec<ShellInitFilterTarget> = buckets
+        .into_iter()
+        .map(|((pack, handler, target), runs_vec)| {
+            let display_target = std::path::Path::new(&target)
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|| target.clone());
+            let failure_count = runs_vec.iter().filter(|r| r.exit_status != 0).count();
+            ShellInitFilterTarget {
+                target,
+                display_target,
+                pack,
+                handler,
+                runs: runs_vec,
+                failure_count,
+            }
+        })
+        .collect();
+
+    Ok(ProbeResult::ShellInitFilter(ShellInitFilterView {
+        profiling_enabled,
+        profiles_dir,
+        filter: filter.trim().to_string(),
+        filter_pack,
+        filter_filename,
+        runs_examined: profiles.len(),
+        targets,
+        stale: is_stale(latest_profile_ts, last_up_ts),
+        latest_profile_when: format_unix_ts(latest_profile_ts),
+        last_up_when,
+    }))
+}
+
+/// Render the cross-history errors view.
+///
+/// Scans the last `runs` profiles, keeps only entries with non-zero
+/// exit status, groups them by target, and orders by failure count
+/// (most-broken first). The `runs` parameter follows the same window
+/// convention as [`shell_init_filter`].
+pub fn shell_init_errors(ctx: &ExecutionContext, runs: usize) -> Result<ProbeResult> {
+    let root_config = ctx.config_manager.root_config()?;
+    let profiling_enabled = root_config.profiling.enabled;
+    let profiles_dir = ctx.paths.probes_shell_init_dir().display().to_string();
+    let last_up_ts = read_last_up_marker(ctx.fs.as_ref(), ctx.paths.as_ref());
+    let last_up_when = last_up_ts.map(format_unix_ts).unwrap_or_default();
+
+    let profiles = read_recent_profiles(ctx.fs.as_ref(), ctx.paths.as_ref(), runs)?;
+    let latest_profile_ts = profiles
+        .first()
+        .map(|p| parse_unix_ts_from_filename(&p.filename))
+        .unwrap_or(0);
+
+    use std::collections::BTreeMap;
+    let mut buckets: BTreeMap<(String, String, String), Vec<ShellInitFilterRun>> = BTreeMap::new();
+
+    for profile in &profiles {
+        let when = format_unix_ts(parse_unix_ts_from_filename(&profile.filename));
+        for entry in &profile.entries {
+            // Errors-only: skip clean runs entirely.
+            if entry.exit_status == 0 {
+                continue;
+            }
+            let stderr_lines: Vec<String> = profile
+                .errors
+                .iter()
+                .find(|er| er.target == entry.target)
+                .map(|er| {
+                    er.message
+                        .trim_end()
+                        .lines()
+                        .map(|s| s.to_string())
+                        .collect()
+                })
+                .unwrap_or_default();
+            buckets
+                .entry((
+                    entry.pack.clone(),
+                    entry.handler.clone(),
+                    entry.target.clone(),
+                ))
+                .or_default()
+                .push(ShellInitFilterRun {
+                    when: when.clone(),
+                    duration_us: entry.duration_us,
+                    duration_label: humanize_us(entry.duration_us),
+                    exit_status: entry.exit_status,
+                    status_class: "error",
+                    stderr_lines,
+                    profile_filename: profile.filename.clone(),
+                });
+        }
+    }
+
+    let mut targets: Vec<ShellInitFilterTarget> = buckets
+        .into_iter()
+        .map(|((pack, handler, target), runs_vec)| {
+            let display_target = std::path::Path::new(&target)
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|| target.clone());
+            let failure_count = runs_vec.len();
+            ShellInitFilterTarget {
+                target,
+                display_target,
+                pack,
+                handler,
+                runs: runs_vec,
+                failure_count,
+            }
+        })
+        .collect();
+
+    // Sort: most-broken first, with a stable (pack, handler, target)
+    // tiebreaker so two targets with the same failure count don't swap
+    // positions across runs.
+    targets.sort_by(|a, b| {
+        b.failure_count
+            .cmp(&a.failure_count)
+            .then_with(|| a.pack.cmp(&b.pack))
+            .then_with(|| a.handler.cmp(&b.handler))
+            .then_with(|| a.target.cmp(&b.target))
+    });
+
+    Ok(ProbeResult::ShellInitErrors(ShellInitErrorsView {
+        profiling_enabled,
+        profiles_dir,
+        runs_examined: profiles.len(),
+        targets,
+        stale: is_stale(latest_profile_ts, last_up_ts),
+        latest_profile_when: format_unix_ts(latest_profile_ts),
+        last_up_when,
+    }))
+}
+
+/// Render the per-run history view (one summary line per profile).
+pub fn shell_init_history(ctx: &ExecutionContext, limit: usize) -> Result<ProbeResult> {
+    let root_config = ctx.config_manager.root_config()?;
+    let profiling_enabled = root_config.profiling.enabled;
+    let profiles = read_recent_profiles(ctx.fs.as_ref(), ctx.paths.as_ref(), limit)?;
+    // `read_recent_profiles` already returns newest-first, which is the
+    // order users expect for a history listing (most recent at the top
+    // of the table). Don't reverse.
+    let latest_profile_ts = profiles
+        .first()
+        .map(|p| parse_unix_ts_from_filename(&p.filename))
+        .unwrap_or(0);
     let history = summarize_history(&profiles);
     let profiles_dir = ctx.paths.probes_shell_init_dir().display().to_string();
     let last_up_ts = read_last_up_marker(ctx.fs.as_ref(), ctx.paths.as_ref());

--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -91,8 +91,8 @@ pub enum ProbeResult {
     /// across the last N runs.
     ShellInitAggregate(ShellInitAggregateView),
     /// `dodot probe shell-init --history` — one summary line per recent
-    /// run, oldest run first (so the latest is closest to the eye in a
-    /// terminal where output scrolls down).
+    /// run, newest first (matches every other dated listing in the tool;
+    /// the user can pipe through `tac` if they want the inverse).
     ShellInitHistory(ShellInitHistoryView),
     /// `dodot probe shell-init <pack>[/<file>]` — drill-down view of
     /// one target (or one pack) across recent runs. Emits per-run

--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -558,6 +558,28 @@ pub const DEFAULT_HISTORY_LIMIT: usize = 50;
 /// output stays readable.
 pub const DEFAULT_FILTER_RUNS: usize = 20;
 
+/// Match a profile target path against a filename-or-subpath filter.
+///
+/// Returns true when:
+/// - the filter is a bare basename (`env.sh`) and `target`'s last path
+///   component equals it, or
+/// - the filter is a subpath (`subdir/env.sh`) and `target` ends with
+///   that subpath at a path boundary.
+///
+/// The boundary check (`/{filter}` suffix) prevents `env.sh` from
+/// matching `nvenv.sh` or other filenames that happen to end with the
+/// same characters.
+fn target_matches_filter(target: &str, filter: &str) -> bool {
+    if !filter.contains('/') {
+        return std::path::Path::new(target)
+            .file_name()
+            .is_some_and(|s| s == std::ffi::OsStr::new(filter));
+    }
+    // Subpath form: must end at a path boundary so `dir/env.sh` doesn't
+    // accidentally match `otherdir/env.sh`.
+    target.ends_with(&format!("/{filter}")) || target == filter
+}
+
 /// Render the filtered drill-down view for a `<pack>[/<file>]` filter.
 ///
 /// `runs` controls how many recent profiles are examined; the caller
@@ -597,11 +619,7 @@ pub fn shell_init_filter(ctx: &ExecutionContext, filter: &str, runs: usize) -> R
                 continue;
             }
             if let Some(name) = &filter_filename {
-                let basename = std::path::Path::new(&entry.target)
-                    .file_name()
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .unwrap_or_default();
-                if &basename != name {
+                if !target_matches_filter(&entry.target, name) {
                     continue;
                 }
             }

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -283,7 +283,7 @@ fn verify_staged(
         //     if any has been collected. Returns None when profiling is
         //     off, when no profiles exist yet, or when this source has
         //     run cleanly in every recent shell.
-        if let Some((label, reason)) = recent_runtime_failures(source, ctx) {
+        if let Some((label, reason)) = recent_runtime_failures(source, pack, &filename_str, ctx) {
             return Health::DeployedWithError { label, reason };
         }
     }
@@ -297,12 +297,26 @@ fn verify_staged(
 /// `dodot probe shell-init --history`.
 const RUNTIME_FAILURE_WINDOW: usize = 5;
 
+/// Maximum number of stderr characters to inline into the status
+/// footnote. Long stderr (stack traces, dumps) is truncated with an
+/// ellipsis; the user can run `dodot probe shell-init <pack>/<file>`
+/// for the full text.
+const STATUS_STDERR_BUDGET: usize = 240;
+
 /// Look at the last few shell-init profiles for any non-zero exit
 /// status from `source`. Returns `Some((short_label, footnote_body))`
 /// if at least one failure was seen; `None` otherwise (including when
 /// profiling is off, so no profiles exist).
+///
+/// When the most recent failing run also has stderr captured (in its
+/// sibling `errors.log`), the footnote inlines a trimmed excerpt so
+/// the user sees the actual error message without having to chase
+/// down a separate command. The pointer at the bottom of the footnote
+/// directs them to the per-file probe view for the full picture.
 fn recent_runtime_failures(
     source: &std::path::Path,
+    pack: &str,
+    filename: &str,
     ctx: &ExecutionContext,
 ) -> Option<(String, String)> {
     let profiles = crate::probe::shell_init::read_recent_profiles(
@@ -323,6 +337,7 @@ fn recent_runtime_failures(
     let mut runs_seen = 0;
     let mut runs_failed = 0;
     let mut last_failure_exit: Option<i32> = None;
+    let mut last_failure_stderr: Option<String> = None;
     for profile in &profiles {
         if let Some(entry) = profile
             .entries
@@ -334,6 +349,15 @@ fn recent_runtime_failures(
                 runs_failed += 1;
                 if last_failure_exit.is_none() {
                     last_failure_exit = Some(entry.exit_status);
+                    // Pull the matching stderr record, if the run has
+                    // an errors.log sibling. Pre-stderr-capture profiles
+                    // and clean-stderr failures both yield None here.
+                    last_failure_stderr = profile
+                        .errors
+                        .iter()
+                        .find(|er| er.target == target_str)
+                        .map(|er| er.message.trim_end().to_string())
+                        .filter(|s| !s.is_empty());
                 }
             }
         }
@@ -344,11 +368,29 @@ fn recent_runtime_failures(
     }
 
     let label = format!("exited {last_exit} ({runs_failed}/{runs_seen})");
-    let reason = format!(
-        "non-zero exit in {runs_failed} of {runs_seen} recent shell startups (last failure: exit {last_exit}). \
-         See `dodot probe shell-init --history` for details."
+    let mut reason = format!(
+        "non-zero exit in {runs_failed} of {runs_seen} recent shell startups (last failure: exit {last_exit})."
     );
+    if let Some(stderr) = last_failure_stderr {
+        reason.push_str(" stderr: ");
+        reason.push_str(&truncate_for_footnote(&stderr, STATUS_STDERR_BUDGET));
+    }
+    reason.push_str(&format!(
+        " Run `dodot probe shell-init {pack}/{filename}` for per-run history and full stderr."
+    ));
     Some((label, reason))
+}
+
+/// Trim multi-line stderr to a single-line excerpt that fits the
+/// footnote budget. Newlines become `↵` so the user sees a hint that
+/// more lines exist; over-long messages get an ellipsis.
+fn truncate_for_footnote(stderr: &str, budget: usize) -> String {
+    let one_line = stderr.replace('\n', " ↵ ");
+    if one_line.chars().count() <= budget {
+        return one_line;
+    }
+    let truncated: String = one_line.chars().take(budget).collect();
+    format!("{truncated}…")
 }
 
 /// Run the `status` command: scan packs and verify deployment chain per file.

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -4165,6 +4165,75 @@ fn probe_shell_init_filter_renders_with_template() {
 }
 
 #[test]
+fn probe_shell_init_filter_supports_nested_subpaths() {
+    // A target deployed under a subdirectory (e.g. `pack/sub/dir/x.sh`)
+    // should be matchable both by basename (`x.sh`) and by subpath
+    // (`sub/dir/x.sh`). The latter is the disambiguator when two files
+    // share a basename.
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &[
+            "source\tgpg\tshell\t/p/gpg/sub/dir/env.sh\t1.0\t1.001\t1",
+            "source\tgpg\tshell\t/p/gpg/other/env.sh\t1.0\t1.001\t0",
+        ],
+    );
+
+    // Subpath filter narrows to the matching nested file only.
+    let result = commands::probe::shell_init_filter(
+        &ctx,
+        "gpg/sub/dir/env.sh",
+        commands::probe::DEFAULT_FILTER_RUNS,
+    )
+    .unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::ShellInitFilter(v) => v,
+        other => panic!("expected ShellInitFilter, got {other:?}"),
+    };
+    assert_eq!(view.targets.len(), 1);
+    assert_eq!(view.targets[0].target, "/p/gpg/sub/dir/env.sh");
+
+    // Bare basename still matches both nested files.
+    let result_basename = commands::probe::shell_init_filter(
+        &ctx,
+        "gpg/env.sh",
+        commands::probe::DEFAULT_FILTER_RUNS,
+    )
+    .unwrap();
+    let view_basename = match result_basename {
+        commands::probe::ProbeResult::ShellInitFilter(v) => v,
+        other => panic!("expected ShellInitFilter, got {other:?}"),
+    };
+    assert_eq!(view_basename.targets.len(), 2);
+}
+
+#[test]
+fn probe_shell_init_filter_basename_does_not_partial_match() {
+    // Boundary check: `env.sh` filter must not match `nvenv.sh`.
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &[
+            "source\tnv\tshell\t/p/nv/nvenv.sh\t1.0\t1.001\t0",
+            "source\tnv\tshell\t/p/nv/env.sh\t1.0\t1.001\t0",
+        ],
+    );
+    let result =
+        commands::probe::shell_init_filter(&ctx, "nv/env.sh", commands::probe::DEFAULT_FILTER_RUNS)
+            .unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::ShellInitFilter(v) => v,
+        other => panic!("expected ShellInitFilter, got {other:?}"),
+    };
+    assert_eq!(view.targets.len(), 1);
+    assert_eq!(view.targets[0].target, "/p/nv/env.sh");
+}
+
+#[test]
 fn probe_shell_init_filter_empty_when_no_match() {
     let env = TempEnvironment::builder().build();
     let ctx = make_ctx(&env);

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -501,6 +501,76 @@ fn status_surfaces_runtime_failures_from_recent_profiles() {
         "note should mention most recent failure exit code: {}",
         note.body
     );
+    // The footnote should point users at the per-file probe view (not
+    // `--history`, which only shows aggregate counts).
+    assert!(
+        note.body.contains("dodot probe shell-init vim/aliases.sh"),
+        "note should point at the filtered probe view: {}",
+        note.body
+    );
+}
+
+#[test]
+fn status_inlines_captured_stderr_into_runtime_failure_footnote() {
+    // When a recent failing run also has a sibling errors.log entry,
+    // the status footnote should inline a snippet of the stderr so the
+    // user sees the actual error inline, not just the exit code.
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("aliases.sh", "alias vi=vim")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    let source_path = env.dotfiles_root.join("vim/aliases.sh");
+    let target = source_path.display().to_string();
+    let probes_dir = env.paths.probes_shell_init_dir();
+    env.fs.mkdir_all(&probes_dir).unwrap();
+    let prof_name = "profile-1714000003-100-1.tsv";
+    let body = format!(
+        "# dodot shell-init profile v1\n\
+         # shell\tbash 5.0\n\
+         # start_t\t1714000003.000000\n\
+         source\tvim\tshell\t{target}\t1714000003.000100\t1714000003.000900\t1\n\
+         # end_t\t1714000003.001000\n",
+    );
+    env.fs
+        .write_file(&probes_dir.join(prof_name), body.as_bytes())
+        .unwrap();
+    let err_log = format!(
+        "# dodot shell-init errors v1\n@@\t{target}\t1\nzsh: command not found: gpg-agent\n"
+    );
+    env.fs
+        .write_file(
+            &probes_dir.join("profile-1714000003-100-1.errors.log"),
+            err_log.as_bytes(),
+        )
+        .unwrap();
+
+    let result = commands::status::status(None, &ctx).unwrap();
+    let row = result.packs[0]
+        .files
+        .iter()
+        .find(|f| f.name == "aliases.sh")
+        .expect("aliases.sh row missing");
+    let note_idx = row.note_ref.expect("expected note ref") as usize;
+    let note = &result.notes[note_idx - 1];
+    assert!(
+        note.body.contains("stderr:"),
+        "footnote should label the stderr excerpt: {}",
+        note.body
+    );
+    assert!(
+        note.body.contains("zsh: command not found: gpg-agent"),
+        "footnote should inline the captured stderr: {}",
+        note.body
+    );
+    assert!(
+        note.body.contains("dodot probe shell-init vim/aliases.sh"),
+        "footnote should point at the per-file probe view: {}",
+        note.body
+    );
 }
 
 #[test]
@@ -3653,7 +3723,7 @@ fn probe_shell_init_aggregate_empty_state_shows_hint() {
 }
 
 #[test]
-fn probe_shell_init_history_renders_one_row_per_run_oldest_first() {
+fn probe_shell_init_history_renders_one_row_per_run_newest_first() {
     let env = TempEnvironment::builder().build();
     let ctx = make_ctx(&env);
     // Three profiles with distinct timestamps in their filenames.
@@ -3686,12 +3756,12 @@ fn probe_shell_init_history_renders_one_row_per_run_oldest_first() {
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
     let rows = parsed["rows"].as_array().unwrap();
     assert_eq!(rows.len(), 3);
-    // Oldest unix_ts first, newest last.
+    // Newest unix_ts first, oldest last (descending).
     let timestamps: Vec<u64> = rows
         .iter()
         .map(|r| r["unix_ts"].as_u64().unwrap_or(0))
         .collect();
-    assert_eq!(timestamps, vec![1714000000, 1714003600, 1714007200]);
+    assert_eq!(timestamps, vec![1714007200, 1714003600, 1714000000]);
     // Middle row had a non-zero exit_status.
     assert_eq!(rows[1]["failed_entries"].as_u64().unwrap(), 1);
     assert_eq!(rows[0]["failed_entries"].as_u64().unwrap(), 0);
@@ -3731,6 +3801,29 @@ fn probe_shell_init_history_json_is_kind_tagged() {
     let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
     assert_eq!(parsed["kind"], "shell-init-history");
     assert!(parsed["rows"].is_array());
+}
+
+#[test]
+fn probe_shell_init_filter_json_is_kind_tagged() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    let result = commands::probe::shell_init_filter(&ctx, "vim", 5).unwrap();
+    let output = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["kind"], "shell-init-filter");
+    assert!(parsed["targets"].is_array());
+    assert_eq!(parsed["filter_pack"], "vim");
+}
+
+#[test]
+fn probe_shell_init_errors_json_is_kind_tagged() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    let result = commands::probe::shell_init_errors(&ctx, 5).unwrap();
+    let output = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["kind"], "shell-init-errors");
+    assert!(parsed["targets"].is_array());
 }
 
 // ── probe shell-init: staleness banner (#59) ────────────────
@@ -3902,6 +3995,284 @@ fn probe_shell_init_history_banner_when_newest_predates_last_up() {
         "history view should show banner, got:\n{text}"
     );
 }
+
+// ── shell-init filter (positional pack[/file] drill-down) ──
+
+fn write_fake_errors_log(env: &TempEnvironment, profile_name: &str, body: &str) {
+    let dir = env.paths.probes_shell_init_dir();
+    env.fs.mkdir_all(&dir).unwrap();
+    let stem = profile_name.trim_end_matches(".tsv");
+    let path = dir.join(format!("{stem}.errors.log"));
+    let mut content = String::from("# dodot shell-init errors v1\n");
+    content.push_str(body);
+    env.fs.write_file(&path, content.as_bytes()).unwrap();
+}
+
+#[test]
+fn probe_shell_init_filter_pack_only_lists_each_target_in_pack() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &[
+            "source\tgpg\tshell\t/p/gpg/env.sh\t1.0\t1.001\t1",
+            "source\tgpg\tshell\t/p/gpg/aliases.sh\t1.0\t1.001\t0",
+            "source\tvim\tshell\t/p/vim/aliases.sh\t1.0\t1.001\t0",
+        ],
+    );
+    let result =
+        commands::probe::shell_init_filter(&ctx, "gpg", commands::probe::DEFAULT_FILTER_RUNS)
+            .unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::ShellInitFilter(v) => v,
+        other => panic!("expected ShellInitFilter, got {other:?}"),
+    };
+    assert_eq!(view.filter_pack, "gpg");
+    assert!(view.filter_filename.is_none());
+    assert_eq!(view.targets.len(), 2, "expected both gpg targets");
+    let names: Vec<&str> = view
+        .targets
+        .iter()
+        .map(|t| t.display_target.as_str())
+        .collect();
+    assert!(names.contains(&"env.sh"));
+    assert!(names.contains(&"aliases.sh"));
+}
+
+#[test]
+fn probe_shell_init_filter_with_filename_narrows_to_single_target() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &[
+            "source\tgpg\tshell\t/p/gpg/env.sh\t1.0\t1.001\t1",
+            "source\tgpg\tshell\t/p/gpg/aliases.sh\t1.0\t1.001\t0",
+        ],
+    );
+    let result = commands::probe::shell_init_filter(
+        &ctx,
+        "gpg/env.sh",
+        commands::probe::DEFAULT_FILTER_RUNS,
+    )
+    .unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::ShellInitFilter(v) => v,
+        other => panic!("expected ShellInitFilter, got {other:?}"),
+    };
+    assert_eq!(view.filter_pack, "gpg");
+    assert_eq!(view.filter_filename.as_deref(), Some("env.sh"));
+    assert_eq!(view.targets.len(), 1);
+    assert_eq!(view.targets[0].display_target, "env.sh");
+    assert_eq!(view.targets[0].failure_count, 1);
+}
+
+#[test]
+fn probe_shell_init_filter_attaches_captured_stderr_to_matching_run() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &["source\tgpg\tshell\t/p/gpg/env.sh\t1.0\t1.001\t1"],
+    );
+    write_fake_errors_log(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        "@@\t/p/gpg/env.sh\t1\nfirst error line\nsecond error line\n",
+    );
+    let result = commands::probe::shell_init_filter(
+        &ctx,
+        "gpg/env.sh",
+        commands::probe::DEFAULT_FILTER_RUNS,
+    )
+    .unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::ShellInitFilter(v) => v,
+        other => panic!("expected ShellInitFilter, got {other:?}"),
+    };
+    assert_eq!(view.targets.len(), 1);
+    assert_eq!(view.targets[0].runs.len(), 1);
+    assert_eq!(
+        view.targets[0].runs[0].stderr_lines,
+        vec!["first error line", "second error line"]
+    );
+}
+
+#[test]
+fn probe_shell_init_filter_runs_are_newest_first() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    // Three runs with monotonically increasing timestamps in the
+    // filename — the filter view should display them newest first
+    // (most recent run at the top of the per-target block).
+    for ts in [1714000001u64, 1714000002, 1714000003] {
+        write_fake_profile(
+            &env,
+            &format!("profile-{ts}-1-1.tsv"),
+            &["source\tgpg\tshell\t/p/gpg/env.sh\t1.0\t1.001\t0"],
+        );
+    }
+    let result = commands::probe::shell_init_filter(
+        &ctx,
+        "gpg/env.sh",
+        commands::probe::DEFAULT_FILTER_RUNS,
+    )
+    .unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::ShellInitFilter(v) => v,
+        other => panic!("expected ShellInitFilter, got {other:?}"),
+    };
+    let runs = &view.targets[0].runs;
+    assert_eq!(runs.len(), 3);
+    assert_eq!(runs[0].profile_filename, "profile-1714000003-1-1.tsv");
+    assert_eq!(runs[2].profile_filename, "profile-1714000001-1-1.tsv");
+}
+
+#[test]
+fn probe_shell_init_filter_renders_with_template() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &["source\tgpg\tshell\t/p/gpg/env.sh\t1.0\t1.001\t1"],
+    );
+    write_fake_errors_log(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        "@@\t/p/gpg/env.sh\t1\nboom\n",
+    );
+    let result = commands::probe::shell_init_filter(
+        &ctx,
+        "gpg/env.sh",
+        commands::probe::DEFAULT_FILTER_RUNS,
+    )
+    .unwrap();
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        output.contains("Shell-init filter"),
+        "header missing:\n{output}"
+    );
+    assert!(output.contains("env.sh"), "target missing:\n{output}");
+    assert!(output.contains("exit 1"), "exit code missing:\n{output}");
+    assert!(
+        output.contains("boom"),
+        "captured stderr missing:\n{output}"
+    );
+}
+
+#[test]
+fn probe_shell_init_filter_empty_when_no_match() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &["source\tvim\tshell\t/p/vim/aliases.sh\t1.0\t1.001\t0"],
+    );
+    let result =
+        commands::probe::shell_init_filter(&ctx, "missing", commands::probe::DEFAULT_FILTER_RUNS)
+            .unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::ShellInitFilter(v) => v,
+        other => panic!("expected ShellInitFilter, got {other:?}"),
+    };
+    assert!(view.targets.is_empty());
+    assert_eq!(view.runs_examined, 1);
+}
+
+// ── shell-init --errors-only ─────────────────────────────────────
+
+#[test]
+fn probe_shell_init_errors_only_keeps_only_failed_runs() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &[
+            "source\tgpg\tshell\t/p/gpg/env.sh\t1.0\t1.001\t1",
+            "source\tvim\tshell\t/p/vim/aliases.sh\t1.0\t1.001\t0",
+        ],
+    );
+    let result =
+        commands::probe::shell_init_errors(&ctx, commands::probe::DEFAULT_FILTER_RUNS).unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::ShellInitErrors(v) => v,
+        other => panic!("expected ShellInitErrors, got {other:?}"),
+    };
+    // vim/aliases.sh succeeded — must not appear. Only gpg/env.sh.
+    assert_eq!(view.targets.len(), 1);
+    assert_eq!(view.targets[0].display_target, "env.sh");
+    assert_eq!(view.targets[0].failure_count, 1);
+}
+
+#[test]
+fn probe_shell_init_errors_only_sorts_by_failure_count_desc() {
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    // Three profiles: target A fails twice, B fails once.
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &[
+            "source\ta\tshell\t/p/a.sh\t1.0\t1.001\t1",
+            "source\tb\tshell\t/p/b.sh\t1.0\t1.001\t1",
+        ],
+    );
+    write_fake_profile(
+        &env,
+        "profile-1714000002-1-1.tsv",
+        &["source\ta\tshell\t/p/a.sh\t1.0\t1.001\t1"],
+    );
+    let result =
+        commands::probe::shell_init_errors(&ctx, commands::probe::DEFAULT_FILTER_RUNS).unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::ShellInitErrors(v) => v,
+        other => panic!("expected ShellInitErrors, got {other:?}"),
+    };
+    assert_eq!(view.targets.len(), 2);
+    assert_eq!(
+        view.targets[0].pack, "a",
+        "most-broken target must come first"
+    );
+    assert_eq!(view.targets[0].failure_count, 2);
+    assert_eq!(view.targets[1].pack, "b");
+    assert_eq!(view.targets[1].failure_count, 1);
+}
+
+#[test]
+fn probe_shell_init_errors_only_clean_window_says_so() {
+    // Only successful runs in the window — view shows 0 targets and
+    // the renderer surfaces a cheerful "no failed sources" line.
+    let env = TempEnvironment::builder().build();
+    let ctx = make_ctx(&env);
+    write_fake_profile(
+        &env,
+        "profile-1714000001-1-1.tsv",
+        &["source\tvim\tshell\t/p/aliases.sh\t1.0\t1.001\t0"],
+    );
+    let result =
+        commands::probe::shell_init_errors(&ctx, commands::probe::DEFAULT_FILTER_RUNS).unwrap();
+    match &result {
+        commands::probe::ProbeResult::ShellInitErrors(v) => {
+            assert!(v.targets.is_empty());
+            assert_eq!(v.runs_examined, 1);
+        }
+        other => panic!("expected ShellInitErrors, got {other:?}"),
+    }
+
+    let output = render::render("probe", &result, OutputMode::Text).unwrap();
+    assert!(
+        output.contains("no failed sources"),
+        "clean-window message missing:\n{output}"
+    );
+}
+
+// ── up command misc ─────────────────────────────────────────────
 
 #[test]
 fn up_writes_last_up_marker() {

--- a/crates/dodot-lib/src/probe/shell_init.rs
+++ b/crates/dodot-lib/src/probe/shell_init.rs
@@ -43,6 +43,19 @@ pub struct ProfileEntry {
     pub exit_status: i32,
 }
 
+/// One captured stderr record from a sourced shell file. The shell
+/// wrapper writes one record per source whose stderr was non-empty,
+/// regardless of exit status (warnings emitted on a successful source
+/// are surfaced too).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ProfileErrorRecord {
+    pub target: String,
+    pub exit_status: i32,
+    /// Captured stderr verbatim, with trailing newline preserved if
+    /// present in the original. May be multiple lines.
+    pub message: String,
+}
+
 /// A whole profile file, post-parse.
 #[derive(Debug, Clone, Serialize)]
 pub struct Profile {
@@ -55,6 +68,12 @@ pub struct Profile {
     /// `# end_t`. `0` if either marker is missing (e.g. crashed shell).
     pub total_duration_us: u64,
     pub entries: Vec<ProfileEntry>,
+    /// Stderr records loaded from the sibling `*.errors.log` file, if
+    /// any. Empty when no errors were captured for this run, when the
+    /// log is missing, or when running with an older profile that
+    /// pre-dates the errors-log feature.
+    #[serde(default)]
+    pub errors: Vec<ProfileErrorRecord>,
 }
 
 impl Profile {
@@ -108,9 +127,100 @@ pub fn read_recent_profiles(fs: &dyn Fs, paths: &dyn Pather, limit: usize) -> Re
     let mut profiles = Vec::with_capacity(entries.len());
     for entry in entries {
         let content = fs.read_to_string(&entry.path)?;
-        profiles.push(parse_profile(&entry.name, &content));
+        let mut profile = parse_profile(&entry.name, &content);
+        // Sibling errors log: same path with `.tsv` swapped for
+        // `.errors.log`. Missing file is normal (no errors captured),
+        // so we silently treat it as empty.
+        let errors_path = errors_log_path_for(&entry.path);
+        if fs.exists(&errors_path) {
+            if let Ok(err_content) = fs.read_to_string(&errors_path) {
+                profile.errors = parse_errors_log(&err_content);
+            }
+        }
+        profiles.push(profile);
     }
     Ok(profiles)
+}
+
+/// Sibling errors-log path for a profile TSV.
+///
+/// Mirrors the shell wrapper: `${prof_file%.tsv}.errors.log`. Falls back
+/// to appending `.errors.log` if the input doesn't end in `.tsv` (a
+/// belt-and-braces guard for filenames the wrapper would never emit).
+fn errors_log_path_for(profile_path: &std::path::Path) -> std::path::PathBuf {
+    let s = profile_path.to_string_lossy();
+    if let Some(stem) = s.strip_suffix(".tsv") {
+        std::path::PathBuf::from(format!("{stem}.errors.log"))
+    } else {
+        std::path::PathBuf::from(format!("{s}.errors.log"))
+    }
+}
+
+/// Parse the textual content of an errors log. Format:
+///
+/// ```text
+/// # dodot shell-init errors v1
+/// @@\t<target>\t<exit_status>
+/// <stderr line 1>
+/// <stderr line 2>
+/// @@\t<target>\t<exit_status>
+/// <stderr line 1>
+/// ```
+///
+/// Lines starting with `# ` are headers (ignored). A line beginning with
+/// `@@\t` opens a new record; subsequent lines until the next `@@\t`
+/// (or EOF) are the captured stderr. Records with malformed headers are
+/// skipped. The trailing newline written after each record by the
+/// shell wrapper appears as a blank line; we strip exactly one trailing
+/// newline from each record's `message` to keep round-tripping clean.
+pub fn parse_errors_log(content: &str) -> Vec<ProfileErrorRecord> {
+    let mut out: Vec<ProfileErrorRecord> = Vec::new();
+    let mut current: Option<(String, i32, String)> = None;
+
+    let flush = |slot: &mut Option<(String, i32, String)>, out: &mut Vec<ProfileErrorRecord>| {
+        if let Some((target, exit_status, mut message)) = slot.take() {
+            // Drop exactly one trailing newline (the wrapper's record
+            // terminator). Preserve any extra blank lines inside.
+            if message.ends_with('\n') {
+                message.pop();
+            }
+            out.push(ProfileErrorRecord {
+                target,
+                exit_status,
+                message,
+            });
+        }
+    };
+
+    for raw_line in content.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        if let Some(rest) = line.strip_prefix("@@\t") {
+            // New record header. Flush any in-progress record first.
+            flush(&mut current, &mut out);
+            let mut parts = rest.splitn(2, '\t');
+            let Some(target) = parts.next() else { continue };
+            let Some(exit_str) = parts.next() else {
+                continue;
+            };
+            let Ok(exit_status) = exit_str.parse::<i32>() else {
+                continue;
+            };
+            current = Some((target.to_string(), exit_status, String::new()));
+            continue;
+        }
+        if line.starts_with('#') && current.is_none() {
+            // Top-of-file version banner; ignore.
+            continue;
+        }
+        if let Some((_, _, ref mut message)) = current {
+            message.push_str(line);
+            message.push('\n');
+        }
+        // Lines outside any record (e.g. trailing junk before the first
+        // `@@`) are silently dropped.
+    }
+    flush(&mut current, &mut out);
+    out
 }
 
 /// Parse the textual content of a profile file. Tolerates missing
@@ -156,6 +266,7 @@ pub fn parse_profile(filename: &str, content: &str) -> Profile {
         shell,
         total_duration_us,
         entries,
+        errors: Vec::new(),
     }
 }
 
@@ -222,6 +333,10 @@ pub fn rotate_profiles(fs: &dyn Fs, paths: &dyn Pather, keep: usize) -> Result<u
         if fs.remove_file(&entry.path).is_ok() {
             removed += 1;
         }
+        // Best-effort: remove the sibling errors log too, so a long-
+        // running install doesn't accumulate orphan `.errors.log` files.
+        let sidecar = errors_log_path_for(&entry.path);
+        let _ = fs.remove_file(&sidecar);
     }
     Ok(removed)
 }
@@ -592,6 +707,7 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             filename: "x".into(),
             shell: "bash".into(),
             total_duration_us: 10_000,
+            errors: Vec::new(),
             entries: vec![
                 ProfileEntry {
                     phase: "source".into(),
@@ -641,6 +757,7 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             filename: "x".into(),
             shell: "bash".into(),
             total_duration_us: 0,
+            errors: Vec::new(),
             entries: vec![
                 entry("vim", "shell", "/a", 1),
                 entry("git", "symlink", "/b", 1),
@@ -684,6 +801,7 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             filename: "x".into(),
             shell: "".into(),
             total_duration_us: 0,
+            errors: Vec::new(),
             entries: vec![ProfileEntry {
                 phase: "source".into(),
                 pack: "vim".into(),
@@ -761,6 +879,7 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             filename: "profile-1-1-1.tsv".into(),
             shell: "bash".into(),
             total_duration_us: 0,
+            errors: Vec::new(),
             entries: vec![
                 entry("vim", "shell", "/a", 100),
                 entry("vim", "shell", "/b", 200),
@@ -770,6 +889,7 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             filename: "profile-2-1-1.tsv".into(),
             shell: "bash".into(),
             total_duration_us: 0,
+            errors: Vec::new(),
             entries: vec![
                 entry("vim", "shell", "/a", 110),
                 entry("vim", "shell", "/b", 250),
@@ -779,6 +899,7 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             filename: "profile-3-1-1.tsv".into(),
             shell: "bash".into(),
             total_duration_us: 0,
+            errors: Vec::new(),
             entries: vec![entry("vim", "shell", "/a", 120)],
             // /b absent in this run (sparse target presence).
         };
@@ -810,6 +931,7 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             filename: "p".into(),
             shell: "".into(),
             total_duration_us: 0,
+            errors: Vec::new(),
             entries: vec![
                 entry("vim", "shell", "/z", 1),
                 entry("git", "shell", "/a", 1),
@@ -842,6 +964,7 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             filename: "profile-1714000000-12-34.tsv".into(),
             shell: "bash 5.3".into(),
             total_duration_us: 500,
+            errors: Vec::new(),
             entries: vec![
                 entry("vim", "shell", "/a", 100),
                 ProfileEntry {
@@ -874,5 +997,105 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
         );
         assert_eq!(parse_unix_ts_from_filename("garbage.txt"), 0);
         assert_eq!(parse_unix_ts_from_filename("profile-notanum-1-1.tsv"), 0);
+    }
+
+    // ── errors log parsing ────────────────────────────────────────
+
+    #[test]
+    fn parse_errors_log_handles_single_record() {
+        let content = "# dodot shell-init errors v1\n\
+@@\t/p/aliases.sh\t1\n\
+zsh: parse error near unexpected token\n\
+";
+        let recs = parse_errors_log(content);
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].target, "/p/aliases.sh");
+        assert_eq!(recs[0].exit_status, 1);
+        assert_eq!(recs[0].message, "zsh: parse error near unexpected token");
+    }
+
+    #[test]
+    fn parse_errors_log_handles_multiple_records_with_multiline_stderr() {
+        let content = "# dodot shell-init errors v1\n\
+@@\t/p/a.sh\t2\n\
+line one\n\
+line two\n\
+\n\
+@@\t/p/b.sh\t0\n\
+warning: deprecated\n\
+";
+        let recs = parse_errors_log(content);
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[0].target, "/p/a.sh");
+        assert_eq!(recs[0].exit_status, 2);
+        assert_eq!(recs[0].message, "line one\nline two\n");
+        assert_eq!(recs[1].target, "/p/b.sh");
+        assert_eq!(recs[1].exit_status, 0); // success with warnings
+        assert_eq!(recs[1].message, "warning: deprecated");
+    }
+
+    #[test]
+    fn parse_errors_log_skips_malformed_headers() {
+        // A header missing the exit status, and one with non-integer exit.
+        let content = "@@\t/p/a.sh\n\
+some line\n\
+@@\t/p/b.sh\tnotanint\n\
+some line\n\
+@@\t/p/c.sh\t3\n\
+real error\n\
+";
+        let recs = parse_errors_log(content);
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].target, "/p/c.sh");
+        assert_eq!(recs[0].exit_status, 3);
+    }
+
+    #[test]
+    fn parse_errors_log_returns_empty_for_empty_or_header_only() {
+        assert!(parse_errors_log("").is_empty());
+        assert!(parse_errors_log("# dodot shell-init errors v1\n").is_empty());
+    }
+
+    #[test]
+    fn read_recent_loads_sibling_errors_log_when_present() {
+        let env = TempEnvironment::builder().build();
+        // A profile with one source entry...
+        write_profile(
+            &env,
+            "profile-1000-1-1.tsv",
+            "# shell\tbash\n\
+# start_t\t1.0\n\
+source\tvim\tshell\t/p/aliases.sh\t1.0\t1.001\t1\n\
+# end_t\t1.002\n",
+        );
+        // ...and a sibling errors log containing one record.
+        let dir = env.paths.probes_shell_init_dir();
+        env.fs
+            .write_file(
+                &dir.join("profile-1000-1-1.errors.log"),
+                b"# dodot shell-init errors v1\n@@\t/p/aliases.sh\t1\nboom\n",
+            )
+            .unwrap();
+
+        let profiles = read_recent_profiles(env.fs.as_ref(), env.paths.as_ref(), 5).unwrap();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].errors.len(), 1);
+        assert_eq!(profiles[0].errors[0].target, "/p/aliases.sh");
+        assert_eq!(profiles[0].errors[0].message, "boom");
+    }
+
+    #[test]
+    fn read_recent_with_no_sibling_errors_log_yields_empty_errors() {
+        // Older profiles (pre-feature) and clean runs both have no
+        // sibling log; we treat both as "no errors captured".
+        let env = TempEnvironment::builder().build();
+        write_profile(
+            &env,
+            "profile-1000-1-1.tsv",
+            "# shell\tbash\n# start_t\t1.0\n# end_t\t1.001\n",
+        );
+        let profiles = read_recent_profiles(env.fs.as_ref(), env.paths.as_ref(), 5).unwrap();
+        assert_eq!(profiles.len(), 1);
+        assert!(profiles[0].errors.is_empty());
     }
 }

--- a/crates/dodot-lib/src/probe/shell_init.rs
+++ b/crates/dodot-lib/src/probe/shell_init.rs
@@ -22,6 +22,7 @@
 //! probe shell-init` working, just with a short report.
 
 use serde::Serialize;
+use tracing::warn;
 
 use crate::fs::Fs;
 use crate::paths::Pather;
@@ -129,12 +130,21 @@ pub fn read_recent_profiles(fs: &dyn Fs, paths: &dyn Pather, limit: usize) -> Re
         let content = fs.read_to_string(&entry.path)?;
         let mut profile = parse_profile(&entry.name, &content);
         // Sibling errors log: same path with `.tsv` swapped for
-        // `.errors.log`. Missing file is normal (no errors captured),
-        // so we silently treat it as empty.
+        // `.errors.log`. Missing file is normal (no errors captured)
+        // and is silently treated as empty. A read failure on a file
+        // that does exist is suspicious — likely permissions or
+        // corruption — so we log it instead of dropping silently. We
+        // still don't fail the whole call: callers want as much profile
+        // data as possible even with one bad sidecar.
         let errors_path = errors_log_path_for(&entry.path);
         if fs.exists(&errors_path) {
-            if let Ok(err_content) = fs.read_to_string(&errors_path) {
-                profile.errors = parse_errors_log(&err_content);
+            match fs.read_to_string(&errors_path) {
+                Ok(err_content) => profile.errors = parse_errors_log(&err_content),
+                Err(e) => warn!(
+                    path = %errors_path.display(),
+                    error = %e,
+                    "errors-log sidecar exists but could not be read; treating as empty"
+                ),
             }
         }
         profiles.push(profile);

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -254,8 +254,9 @@ fn emit_profiling_preamble(script: &mut String, profiles_dir: &Path, init_script
     .unwrap();
     // Sibling errors log: one record per source whose stderr was non-empty.
     // Format: `@@\t<target>\t<exit_status>` header line, followed by the
-    // captured stderr verbatim, followed by a trailing newline. Read by
-    // `probe::shell_init::read_profile_errors`.
+    // captured stderr verbatim, followed by a trailing newline. Loaded
+    // alongside the profile by `probe::shell_init::read_recent_profiles`
+    // and parsed by `probe::shell_init::parse_errors_log`.
     writeln!(
         script,
         "    _dodot_err_file=\"${{_dodot_prof_file%.tsv}}.errors.log\""
@@ -297,14 +298,11 @@ fn emit_profiling_preamble(script: &mut String, profiles_dir: &Path, init_script
         "      }} > \"$_dodot_prof_file\" 2>/dev/null && _dodot_prof=1"
     )
     .unwrap();
-    // Seed the errors log with its version header. The file is created
-    // empty here; per-source stderr records are appended only when a
-    // sourced file actually emits to stderr.
-    writeln!(
-        script,
-        "      [ \"$_dodot_prof\" = \"1\" ] && printf '# dodot shell-init errors v1\\n' > \"$_dodot_err_file\" 2>/dev/null"
-    )
-    .unwrap();
+    // Errors log is created lazily — see `emit_timed_source`. Most shell
+    // startups have no stderr from any source, and writing an empty
+    // header file for each one would defeat the "fast path is free"
+    // claim. The first source that actually emits stderr seeds the
+    // header before appending its record.
     writeln!(script, "    fi").unwrap();
     writeln!(script, "  fi").unwrap();
     writeln!(script, "fi").unwrap();
@@ -364,11 +362,19 @@ fn emit_timed_source(script: &mut String, pack: &str, target: &Path) {
     .unwrap();
     // Stderr-handling block. Skipped entirely when the sourced file was
     // silent (the common case). When non-empty, we print to the user's
-    // stderr and append a record to the errors log. The trailing `\n`
-    // guarantees the next record's `@@` header starts on its own line
-    // even if the captured stderr didn't end with a newline.
+    // stderr and append a record to the errors log. The errors log is
+    // seeded with its `v1` header on first use — keeping creation lazy
+    // means a clean shell startup leaves no orphan `*.errors.log` on
+    // disk. The trailing `\n` after each record guarantees the next
+    // record's `@@` header starts on its own line even if the captured
+    // stderr didn't end with a newline.
     writeln!(script, "  if [ -s \"$_dodot_err_tmp\" ]; then").unwrap();
     writeln!(script, "    cat \"$_dodot_err_tmp\" >&2").unwrap();
+    writeln!(
+        script,
+        "    [ -f \"$_dodot_err_file\" ] || printf '# dodot shell-init errors v1\\n' > \"$_dodot_err_file\" 2>/dev/null"
+    )
+    .unwrap();
     writeln!(script, "    {{").unwrap();
     writeln!(
         script,
@@ -762,10 +768,12 @@ mod tests {
             script.contains("_dodot_err_file=\"${_dodot_prof_file%.tsv}.errors.log\""),
             "errors-log path must be a sibling of the profile TSV:\n{script}"
         );
-        // Versioned header is seeded once per shell.
+        // Versioned header is seeded lazily — only on first stderr from
+        // a sourced file, guarded by `[ -f "$_dodot_err_file" ]` so an
+        // all-silent shell startup leaves no sidecar on disk.
         assert!(
-            script.contains("# dodot shell-init errors v1"),
-            "errors-log must carry a version header:\n{script}"
+            script.contains("[ -f \"$_dodot_err_file\" ] || printf '# dodot shell-init errors v1"),
+            "errors-log header must be seeded lazily on first stderr:\n{script}"
         );
         // Stderr is redirected to the per-shell scratch file during the source.
         assert!(

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -252,6 +252,18 @@ fn emit_profiling_preamble(script: &mut String, profiles_dir: &Path, init_script
         "    _dodot_prof_file=\"$_dodot_prof_dir/profile-${{EPOCHSECONDS:-0}}-$$-${{RANDOM}}.tsv\""
     )
     .unwrap();
+    // Sibling errors log: one record per source whose stderr was non-empty.
+    // Format: `@@\t<target>\t<exit_status>` header line, followed by the
+    // captured stderr verbatim, followed by a trailing newline. Read by
+    // `probe::shell_init::read_profile_errors`.
+    writeln!(
+        script,
+        "    _dodot_err_file=\"${{_dodot_prof_file%.tsv}}.errors.log\""
+    )
+    .unwrap();
+    // Per-shell scratch file for capturing each source's stderr. Reused
+    // across every source in this shell startup; truncated each time.
+    writeln!(script, "    _dodot_err_tmp=\"$_dodot_prof_dir/.errtmp-$$\"").unwrap();
     writeln!(
         script,
         "    if mkdir -p \"$_dodot_prof_dir\" 2>/dev/null; then"
@@ -285,6 +297,14 @@ fn emit_profiling_preamble(script: &mut String, profiles_dir: &Path, init_script
         "      }} > \"$_dodot_prof_file\" 2>/dev/null && _dodot_prof=1"
     )
     .unwrap();
+    // Seed the errors log with its version header. The file is created
+    // empty here; per-source stderr records are appended only when a
+    // sourced file actually emits to stderr.
+    writeln!(
+        script,
+        "      [ \"$_dodot_prof\" = \"1\" ] && printf '# dodot shell-init errors v1\\n' > \"$_dodot_err_file\" 2>/dev/null"
+    )
+    .unwrap();
     writeln!(script, "    fi").unwrap();
     writeln!(script, "  fi").unwrap();
     writeln!(script, "fi").unwrap();
@@ -313,7 +333,9 @@ fn emit_timed_path(script: &mut String, pack: &str, target: &Path) {
 }
 
 /// One inline-timed `[ -f X ] && . X` row, capturing the source's
-/// exit status. Same overhead profile as the PATH variant.
+/// exit status and stderr. Same overhead profile as the PATH variant
+/// when the sourced file is silent; one extra `[ -s ]` test plus an
+/// append when stderr is non-empty.
 ///
 /// Both branches (profiling-active and unprofiled fallback) emit the
 /// loud-failure message on a non-zero source exit, so users see the
@@ -326,10 +348,13 @@ fn emit_timed_source(script: &mut String, pack: &str, target: &Path) {
     // `_dodot_rc` is initialised to 0 *before* the source attempt so a
     // missing file (the `[ -f … ]` test failing) does not get reported
     // as "exited 1". The compound `&& { … }` only sets `_dodot_rc` from
-    // the actual `.` invocation; otherwise it stays 0.
+    // the actual `.` invocation; otherwise it stays 0. Stderr from the
+    // source is redirected to `_dodot_err_tmp`; if non-empty, we
+    // re-emit it to the user's stderr (preserving the shell's own
+    // error display) and append it to the per-shell errors log.
     writeln!(
         script,
-        "  _dodot_rc=0; _dodot_t0=$EPOCHREALTIME; [ -f \"{target_str}\" ] && {{ . \"{target_str}\"; _dodot_rc=$?; }}; _dodot_t1=$EPOCHREALTIME"
+        "  _dodot_rc=0; : > \"$_dodot_err_tmp\" 2>/dev/null; _dodot_t0=$EPOCHREALTIME; [ -f \"{target_str}\" ] && {{ . \"{target_str}\" 2>\"$_dodot_err_tmp\"; _dodot_rc=$?; }}; _dodot_t1=$EPOCHREALTIME"
     )
     .unwrap();
     writeln!(
@@ -337,11 +362,31 @@ fn emit_timed_source(script: &mut String, pack: &str, target: &Path) {
         "  printf 'source\\t{pack}\\tshell\\t%s\\t%s\\t%s\\t%s\\n' {target_q} \"$_dodot_t0\" \"$_dodot_t1\" \"$_dodot_rc\" >> \"$_dodot_prof_file\" 2>/dev/null"
     )
     .unwrap();
+    // Stderr-handling block. Skipped entirely when the sourced file was
+    // silent (the common case). When non-empty, we print to the user's
+    // stderr and append a record to the errors log. The trailing `\n`
+    // guarantees the next record's `@@` header starts on its own line
+    // even if the captured stderr didn't end with a newline.
+    writeln!(script, "  if [ -s \"$_dodot_err_tmp\" ]; then").unwrap();
+    writeln!(script, "    cat \"$_dodot_err_tmp\" >&2").unwrap();
+    writeln!(script, "    {{").unwrap();
     writeln!(
         script,
-        "  [ \"$_dodot_rc\" -ne 0 ] && echo \"dodot: shell source exited $_dodot_rc: {target_str}\" >&2"
+        "      printf '@@\\t%s\\t%s\\n' {target_q} \"$_dodot_rc\""
     )
     .unwrap();
+    writeln!(script, "      cat \"$_dodot_err_tmp\"").unwrap();
+    writeln!(script, "      printf '\\n'").unwrap();
+    writeln!(script, "    }} >> \"$_dodot_err_file\" 2>/dev/null").unwrap();
+    writeln!(script, "  elif [ \"$_dodot_rc\" -ne 0 ]; then").unwrap();
+    // Non-zero exit with empty stderr — still emit the loud breadcrumb
+    // so the user knows dodot saw a failure (matches prior behaviour).
+    writeln!(
+        script,
+        "    echo \"dodot: shell source exited $_dodot_rc: {target_str}\" >&2"
+    )
+    .unwrap();
+    writeln!(script, "  fi").unwrap();
     writeln!(script, "else").unwrap();
     writeln!(
         script,
@@ -362,10 +407,17 @@ fn emit_profiling_epilogue(script: &mut String) {
         "  printf '# end_t\\t%s\\n' \"$EPOCHREALTIME\" >> \"$_dodot_prof_file\" 2>/dev/null"
     )
     .unwrap();
+    // Remove the per-shell stderr scratch file. It's reused across
+    // sources within one shell startup; here at exit we tidy up.
+    writeln!(
+        script,
+        "  [ -n \"${{_dodot_err_tmp:-}}\" ] && rm -f \"$_dodot_err_tmp\" 2>/dev/null"
+    )
+    .unwrap();
     writeln!(script, "fi").unwrap();
     writeln!(
         script,
-        "unset _dodot_prof _dodot_prof_dir _dodot_prof_file _dodot_prof_t0 _dodot_t0 _dodot_t1 _dodot_rc 2>/dev/null"
+        "unset _dodot_prof _dodot_prof_dir _dodot_prof_file _dodot_err_file _dodot_err_tmp _dodot_prof_t0 _dodot_t0 _dodot_t1 _dodot_rc 2>/dev/null"
     )
     .unwrap();
 }
@@ -690,6 +742,50 @@ mod tests {
     }
 
     #[test]
+    fn profiling_captures_source_stderr_into_errors_log() {
+        // The wrapper must redirect each source's stderr to the per-shell
+        // scratch file and append a versioned record (`@@\ttarget\texit`)
+        // to the errors.log sibling whenever stderr is non-empty.
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "")
+            .done()
+            .build();
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+
+        let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
+
+        // Errors-log sibling is derived from the profile-file path.
+        assert!(
+            script.contains("_dodot_err_file=\"${_dodot_prof_file%.tsv}.errors.log\""),
+            "errors-log path must be a sibling of the profile TSV:\n{script}"
+        );
+        // Versioned header is seeded once per shell.
+        assert!(
+            script.contains("# dodot shell-init errors v1"),
+            "errors-log must carry a version header:\n{script}"
+        );
+        // Stderr is redirected to the per-shell scratch file during the source.
+        assert!(
+            script.contains("2>\"$_dodot_err_tmp\""),
+            "source must redirect stderr to scratch file:\n{script}"
+        );
+        // Truncation before each source so a previous source's stderr
+        // doesn't leak into the next record.
+        assert!(
+            script.contains(": > \"$_dodot_err_tmp\""),
+            "scratch file must be truncated before each source:\n{script}"
+        );
+        // The record header uses the @@ sentinel + tab-separated target/exit.
+        assert!(
+            script.contains("printf '@@\\t%s\\t%s\\n'"),
+            "errors-log records must use @@ header format:\n{script}"
+        );
+    }
+
+    #[test]
     fn profiling_epilogue_writes_end_marker_and_unsets_state() {
         let env = TempEnvironment::builder()
             .pack("vim")
@@ -775,19 +871,24 @@ mod tests {
             "plain script missing loud-failure echo:\n{plain}"
         );
 
-        // Profiling on: timed branch echoes after the printf when
-        // _dodot_rc != 0; unprofiled fallback uses the same OR-echo
-        // form as the plain path.
+        // Profiling on: timed branch echoes from the elif-empty-stderr
+        // arm (silent failure case); the with-stderr arm relies on
+        // re-emitting the captured stderr to the user's TTY. Unprofiled
+        // fallback uses the OR-echo form like the plain path.
         let timed = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
         assert!(
-            timed.contains(
-                "[ \"$_dodot_rc\" -ne 0 ] && echo \"dodot: shell source exited $_dodot_rc:"
-            ),
-            "timed script missing profiled-branch echo:\n{timed}"
+            timed.contains("echo \"dodot: shell source exited $_dodot_rc:"),
+            "timed script missing silent-failure echo:\n{timed}"
         );
         assert!(
             timed.contains("dodot: shell source exited $?:"),
             "timed script missing fallback-branch echo:\n{timed}"
+        );
+        // Captured stderr is re-emitted to the user's TTY before being
+        // appended to the errors log, so they still see it live.
+        assert!(
+            timed.contains("cat \"$_dodot_err_tmp\" >&2"),
+            "timed script must echo captured stderr to user's TTY:\n{timed}"
         );
     }
 

--- a/crates/dodot-lib/src/templates/probe.jinja
+++ b/crates/dodot-lib/src/templates/probe.jinja
@@ -59,6 +59,36 @@
   [dim] run `dodot up`, then start a new shell)[/dim]
 {% endif %}{% endif %}
   [dim]profiles dir:[/dim] {{ profiles_dir }}
+{%- elif kind == "shell-init-errors" -%}
+[header]Shell-init errors[/header]
+{% if stale %}  [warning]warning:[/warning] the most recent run was captured at {{ latest_profile_when }} —
+           before your most recent `dodot up` at {{ last_up_when }}. Open
+           a new shell to capture a fresh profile.
+
+{% endif %}  [dim]examined:[/dim] {{ runs_examined }} run{% if runs_examined != 1 %}s{% endif %}
+
+{% if targets %}{% for t in targets %}  [pack-name]{{ t.pack }}[/pack-name] [description]/[/description] [handler-symbol]{{ t.handler }}[/handler-symbol] [dim]/[/dim] {{ t.display_target }} [error]({{ t.failure_count }} failed)[/error]
+  [dim]{{ t.target }}[/dim]
+{% for r in t.runs %}    {{ r.when | col(18) }} [error]{{ r.duration_label | col(10) }}[/error] [error]exit {{ r.exit_status }}[/error]
+{% for line in r.stderr_lines %}      [dim]>[/dim] [error]{{ line }}[/error]
+{% endfor %}{% endfor %}
+{% endfor %}{% else %}  [deployed](no failed sources in the last {{ runs_examined }} run{% if runs_examined != 1 %}s{% endif %})[/deployed]
+{% endif %}  [dim]profiles dir:[/dim] {{ profiles_dir }}
+{%- elif kind == "shell-init-filter" -%}
+[header]Shell-init filter[/header] [pack-name]{{ filter }}[/pack-name]
+{% if stale %}  [warning]warning:[/warning] the most recent run was captured at {{ latest_profile_when }} —
+           before your most recent `dodot up` at {{ last_up_when }}. Open
+           a new shell to capture a fresh profile.
+
+{% endif %}  [dim]examined:[/dim] {{ runs_examined }} run{% if runs_examined != 1 %}s{% endif %}
+
+{% if targets %}{% for t in targets %}  [pack-name]{{ t.pack }}[/pack-name] [description]/[/description] [handler-symbol]{{ t.handler }}[/handler-symbol] [dim]/[/dim] {{ t.display_target }}{% if t.failure_count > 0 %} [error]({{ t.failure_count }} failed)[/error]{% endif %}
+  [dim]{{ t.target }}[/dim]
+{% for r in t.runs %}    {{ r.when | col(18) }} [{{ r.status_class }}]{{ r.duration_label | col(10) }}[/{{ r.status_class }}]{% if r.exit_status != 0 %} [error]exit {{ r.exit_status }}[/error]{% else %} [dim]exit 0[/dim]{% endif %}
+{% for line in r.stderr_lines %}      [dim]>[/dim] [error]{{ line }}[/error]
+{% endfor %}{% endfor %}
+{% endfor %}{% else %}  [dim](no entries matched `{{ filter }}` in the last {{ runs_examined }} run{% if runs_examined != 1 %}s{% endif %})[/dim]
+{% endif %}  [dim]profiles dir:[/dim] {{ profiles_dir }}
 {%- elif kind == "shell-init-history" -%}
 [header]Shell-init history[/header]
 {% if stale %}  [warning]warning:[/warning] the most recent run was captured at {{ latest_profile_when }} —

--- a/docs/proposals/profiling.lex
+++ b/docs/proposals/profiling.lex
@@ -64,6 +64,23 @@ Design Specification: Profiling and the Probe Command
 
         A realistic file on a well-groomed dotfiles install runs 20–40 rows and lands under 4 KB.
 
+        Alongside the TSV, when a sourced file emits anything to stderr the wrapper writes a sibling errors log:
+
+            profile-<unix-ts>-<pid>-<rand>.errors.log
+
+        :: text ::
+
+        Format follows the same plain-text discipline as the TSV — a `# dodot shell-init errors v1` banner, then one record per source-with-stderr in this shape:
+
+            @@<TAB><target><TAB><exit_status>
+            <captured stderr line 1>
+            <captured stderr line 2>
+            ...
+
+        :: text ::
+
+        The `@@` sentinel marks the start of a record; subsequent lines until the next `@@` (or EOF) are the captured stderr verbatim. The wrapper appends a trailing newline after each record so the next header lands on its own line. The file is created lazily — when nothing prints to stderr (the common case), no errors log exists for that run, and the cost on the hot path is one `[ -s ]` test per source. The reader (`probe shell-init <pack>/<file>`, `--errors-only`) loads the sibling automatically when present and silently treats absence as "no errors captured".
+
     3.2. Deployment Map
 
         At the end of every `dodot up` and `dodot down`, dodot also writes `<data_dir>/deployment-map.tsv` with one row per deployed artifact:
@@ -102,12 +119,15 @@ Design Specification: Profiling and the Probe Command
 
         `probe` is registered as a standout command group following the pattern of the existing `status`/`up`/`down` commands [../crates/dodot-cli/src/main.rs]:
 
-            dodot probe                        # help + summary of last run
-            dodot probe shell-init             # detailed timings, last run
-            dodot probe shell-init --runs N    # aggregate over last N runs
-            dodot probe shell-init --history   # one-line trend across runs
-            dodot probe show-data-dir          # tree of <data_dir>
-            dodot probe deployment-map         # source -> deployed table
+            dodot probe                          # help + summary of last run
+            dodot probe shell-init               # detailed timings, last run
+            dodot probe shell-init --runs N      # aggregate over last N runs
+            dodot probe shell-init --history     # one-row-per-run trend, newest first
+            dodot probe shell-init <pack>        # all targets in <pack> across recent runs
+            dodot probe shell-init <pack>/<file> # one target's per-run history + stderr
+            dodot probe shell-init --errors-only # every failing target, ranked by frequency
+            dodot probe show-data-dir            # tree of <data_dir>
+            dodot probe deployment-map           # source -> deployed table
 
         :: text ::
 
@@ -129,7 +149,9 @@ Design Specification: Profiling and the Probe Command
 
         :: text ::
 
-        The `--runs N` flag aggregates across the most recent N reports and shows p50 / p95 / max per target. This is the view for spotting regressions: the eye catches a `p95` that is much worse than `p50`. `--history` is the same data collapsed to one row per run, dated, for a trend glance.
+        The `--runs N` flag aggregates across the most recent N reports and shows p50 / p95 / max per target. This is the view for spotting regressions: the eye catches a `p95` that is much worse than `p50`. `--history` is the same data collapsed to one row per run, dated, newest first, for a trend glance.
+
+        The positional `<pack>[/<file>]` filter is the drill-down view. Pack-only (`gpg`) lists every target in that pack across the last 20 runs; `<pack>/<file>` (`gpg/env.sh`) narrows to one target. Per-run rows show duration, exit status, and — when the run captured any — the stderr inlined under each row. This is the view that answers "*why* did this fail?" instead of just "did it fail?". The `--errors-only` flag is the inverse query: every target with a non-zero exit somewhere in the window, sorted by failure count desc, so the most-broken file is at the top. Both views read the same `*.errors.log` sidecar described in §3.1.
 
         A footer always prints "for intra-file profiling, see `zprof` (zsh) or `PS4` tracing (bash)" — this keeps us honest about our scope (§3.3).
 
@@ -170,9 +192,18 @@ Design Specification: Profiling and the Probe Command
         Extend `shell::generate_init_script` to emit the per-file timing wrapper and the preamble writer. Wire `probe shell-init` reader and the default (single-run) view. Add the `profiling` config section. Rotation also lands here (cheaper to ship together than to defer): the writer side has no rotation logic, but `dodot up` prunes `<data_dir>/probes/shell-init/` to `keep_last_runs` at the end of every run.
 
     Phase 3: aggregation. **(Shipped.)**
-        `--runs N` and `--history` flags on `probe shell-init` for cross-run views — p50/p95/max per target (nearest-rank, no interpolation) and a per-run trend table. Rotation already ran in Phase 2, so this phase was purely additive on the reader side. The history row's `failed_entries` column also subsumes part of what regression-hints (phase 4) would have done: silent source failures across runs are visible at a glance.
+        `--runs N` and `--history` flags on `probe shell-init` for cross-run views — p50/p95/max per target (nearest-rank, no interpolation) and a per-run trend table. Rotation already ran in Phase 2, so this phase was purely additive on the reader side. The history row's `failed_entries` column also subsumes part of what regression-hints (now phase 5) would have done: silent source failures across runs are visible at a glance.
 
-    Phase 4: regression hints (optional, deferred).
+    Phase 4: error visibility. **(Shipped.)**
+        The exit-status column from Phase 2 turned silent failures into a visible counter, but a count without context still leaves the user reaching for a separate tool. This phase closes that loop:
+
+        - The shell wrapper now redirects each `. file` stderr into a per-shell scratch, re-emits live to the user's TTY (preserving the existing breadcrumb), and on non-empty stderr appends a record to a sibling `*.errors.log` next to the TSV (§3.1). Empty-stderr sources still take the fast path — one `[ -s ]` test of overhead.
+        - `dodot probe shell-init <pack>[/<file>]` is the drill-down view: per-run rows with duration, exit, and inlined stderr for one target across recent runs. `--errors-only` is the cross-history "what's broken" listing, sorted by failure count.
+        - `dodot status` was already surfacing recent-run failures via `recent_runtime_failures`. The footnote was upgraded to inline a stderr excerpt from the most recent failing run (when captured) and to point at `dodot probe shell-init <pack>/<file>` for the full picture, not at `--history` (which only shows aggregate counts).
+
+        Rotation was extended to remove the sibling errors log alongside its profile so long-running installs don't accumulate orphan sidecars. The `--history` view's row order was also corrected to newest-first, matching every other dated-listing in the tool.
+
+    Phase 5: regression hints (optional, deferred).
         Would highlight targets whose current-run duration is above their historical p95. Pure presentation; same data. Skipped for now — phase 3's tabular view of p95 next to current run already tells the story for users who care to look, and adding automatic flagging is the kind of thing that's better implemented after observing real usage.
 
 

--- a/docs/proposals/profiling.lex
+++ b/docs/proposals/profiling.lex
@@ -79,7 +79,7 @@ Design Specification: Profiling and the Probe Command
 
         :: text ::
 
-        The `@@` sentinel marks the start of a record; subsequent lines until the next `@@` (or EOF) are the captured stderr verbatim. The wrapper appends a trailing newline after each record so the next header lands on its own line. The file is created lazily — when nothing prints to stderr (the common case), no errors log exists for that run, and the cost on the hot path is one `[ -s ]` test per source. The reader (`probe shell-init <pack>/<file>`, `--errors-only`) loads the sibling automatically when present and silently treats absence as "no errors captured".
+        The `@@` sentinel marks the start of a record; subsequent lines until the next `@@` (or EOF) are the captured stderr verbatim. The wrapper appends a trailing newline after each record so the next header lands on its own line. The file is created lazily — the version-banner header is written by the *first* source whose stderr is non-empty, so a clean shell startup leaves no errors log on disk and the cost on the hot path is one `[ -s ]` test per source. The reader (`probe shell-init <pack>/<file>`, `--errors-only`) loads the sibling automatically when present and silently treats absence as "no errors captured".
 
     3.2. Deployment Map
 


### PR DESCRIPTION
## Summary

- `probe shell-init --history` showed only an aggregate fail counter; the actual stderr from a failing source was on the user's terminal at startup time and gone afterwards.
- The shell wrapper now captures each `. file` stderr to a sibling `*.errors.log` (lazy — empty stderr stays on the fast path, ~one `[ -s ]` test of overhead).
- Two new views read the sidecar: `dodot probe shell-init <pack>[/<file>]` (per-target drill-down with inlined stderr) and `dodot probe shell-init --errors-only` (cross-history listing of failing targets, ranked by frequency).
- The `dodot status` runtime-failure footnote was upgraded to inline a stderr excerpt and to point at the per-file probe view (was pointing at `--history`, which only shows counts).
- `--history` row order corrected to newest-first (matches every other dated listing).

`docs/proposals/profiling.lex` is updated to document the errors.log format (§3.1), the new views (§5.2), and the work as Phase 4 (§7).

## Test plan

- [x] `cargo test -p dodot-lib` — 570 passing (was 554)
- [x] `cargo clippy --all-targets` — clean
- [x] Manual: `dodot probe shell-init gpg/env.sh` against a real install with historical fails (showed per-run history; stderr empty for pre-feature runs as expected)
- [x] Manual: `dodot probe shell-init --errors-only` against same install (showed gpg/env.sh ranked first, 4 historical failures)
- [x] Manual: `dodot up gpg` footnote now reads `Run \`dodot probe shell-init gpg/env.sh\` for per-run history and full stderr.`
- [x] Manual: synthesized errors.log alongside a profile, confirmed stderr renders inline under the matching run
- [ ] Open a fresh shell after merge to confirm wrapper captures stderr in the wild (existing pre-feature profiles have no sidecars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)