### PR TITLE
ci: add github policy files and copilot review workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @arthur-debert

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@ dodot is a Rust CLI dotfile manager. Cargo workspace; binary crate at
 
 ## What will get pushed back on
 
-- Suggestions that ignore `CLAUDE.md` or content under `docs/`.
+- Suggestions that ignore content under `docs/`.
 - Style nits in code that already follows the project's style.
 - Defensive error handling for invariants the type system already enforces.
 - Comments that restate what the code does.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# Copilot Instructions — dodot
+
+dodot is a Rust CLI dotfile manager. Cargo workspace; binary crate at
+`crates/dodot-cli`; library crates at `crates/dodot-*`.
+
+## Before suggesting a fix
+
+- Run `scripts/check` (umbrella for fmt + clippy + nextest). CI runs the same
+  script; suggestions that don't pass it won't merge.
+- Never propose changes that leave tests failing.
+- Update `CHANGELOG_UNRELEASED.md` for user-visible changes.
+
+## Style and scope
+
+- Keep changes minimal. Don't add features, refactor, or introduce abstractions
+  beyond what the task requires.
+- No backwards-compatibility hacks: no `// removed` comments, no renaming unused
+  vars to `_var`, no shim modules. If something is unused, delete it.
+- No fallbacks, defaults, or feature flags unless the PR explicitly asks for them.
+- Default to no comments. Well-named identifiers carry the *what*. Reserve
+  comments for non-obvious *why* (hidden constraint, workaround, surprising
+  invariant).
+- Trust internal code and framework guarantees. Only validate at system
+  boundaries (user input, external commands, filesystem entry).
+
+## What will get pushed back on
+
+- Suggestions that ignore `CLAUDE.md` or content under `docs/`.
+- Style nits in code that already follows the project's style.
+- Defensive error handling for invariants the type system already enforces.
+- Comments that restate what the code does.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- 1-3 sentences: what changed and why. -->
+
+## Checklist
+
+- [ ] `CHANGELOG_UNRELEASED.md` updated (or chore/docs-only)
+- [ ] `scripts/check` passes locally
+- [ ] Tests added or updated for behavior changes
+
+## Notes for reviewers
+
+<!-- Optional: context to help triage Copilot's review faster. -->

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,14 @@
+name: Copilot Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  request:
+    if: github.event.pull_request.draft == false
+    permissions:
+      pull-requests: write
+    uses: arthur-debert/dagentic/.github/workflows/copilot-review.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   request:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
     permissions:
       pull-requests: write
     uses: arthur-debert/dagentic/.github/workflows/copilot-review.yml@main


### PR DESCRIPTION
## Summary

First-time-on-dodot wiring for the GitHub-side standardization rollout:

- **CODEOWNERS** — single owner
- **dependabot.yml** — weekly cargo + github-actions, 5 PR cap per ecosystem
- **copilot-instructions.md** — project-aware guidance for the AI reviewer (run `scripts/check`, no backwards-compat shims, default to no comments, etc.)
- **pull_request_template.md** — CHANGELOG + `scripts/check` + tests checklist
- **copilot-review.yml** — auto-request Copilot on each PR via the reusable workflow in `arthur-debert/dagentic`

Companion to the new `main-branch-protection` ruleset (PR required, `check` + `e2e` must pass, 0 approvals required, no force-push, no deletion).

## Checklist

- [ ] `CHANGELOG_UNRELEASED.md` updated (or chore/docs-only) — chore (CI tooling)
- [x] `scripts/check` passes locally (no code changes)
- [x] Tests added or updated for behavior changes (N/A — config only)

## Notes for reviewers

This PR is itself the first end-to-end test of:
1. The new ruleset (it forced a PR rather than direct push ✓)
2. The Copilot review workflow (this PR should trigger an auto review request once merged — but on this PR specifically, the workflow doesn't yet exist on main, so no auto-request fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)