### PR TITLE
ci: sync .github/ policy with canonical templates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,6 @@ This is a Rust project (CLI, library crate, or workspace).
 - Style nits in code that already follows the project's style.
 - Defensive error handling for invariants the type system already enforces.
 - Comments that restate what the code does.
-- Pinning org-internal reusable workflows (e.g. `arthur-debert/dagentic`) to
-  SHA — the reusable pattern is "fix once, propagate", and same-owner
+- Pinning org-internal reusable workflows (e.g. `arthur-debert/gh-dagentic`)
+  to SHA — the reusable pattern is "fix once, propagate", and same-owner
   supply-chain risk is negligible.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,14 +1,19 @@
-# Copilot Instructions — dodot
+# Copilot Instructions
 
-dodot is a Rust CLI dotfile manager. Cargo workspace; binary crate at
-`crates/dodot-cli`; library crates at `crates/dodot-*`.
+This is a Rust project (CLI, library crate, or workspace).
 
 ## Before suggesting a fix
 
-- Run `scripts/check` (umbrella for fmt + clippy + nextest). CI runs the same
-  script; suggestions that don't pass it won't merge.
+- Run the project's umbrella check script if one exists (in `scripts/`,
+  commonly named `check`, `pre-commit`, `rust-pre-commit`, or `ci.sh` — run
+  `ls scripts/` to see which); otherwise `cargo fmt --check && cargo clippy
+  -- -D warnings && cargo test` (some projects use `cargo nextest run`
+  instead of `cargo test`). CI runs the same; if your suggestion doesn't
+  pass, it won't merge — check `.github/workflows/` for the source of truth.
 - Never propose changes that leave tests failing.
-- Update `CHANGELOG_UNRELEASED.md` for user-visible changes.
+- Update the changelog's `Unreleased` section for user-visible changes
+  (`CHANGELOG_UNRELEASED.md` if the project has one, otherwise the
+  `## [Unreleased]` section of `CHANGELOG.md`).
 
 ## Style and scope
 
@@ -29,3 +34,6 @@ dodot is a Rust CLI dotfile manager. Cargo workspace; binary crate at
 - Style nits in code that already follows the project's style.
 - Defensive error handling for invariants the type system already enforces.
 - Comments that restate what the code does.
+- Pinning org-internal reusable workflows (e.g. `arthur-debert/dagentic`) to
+  SHA — the reusable pattern is "fix once, propagate", and same-owner
+  supply-chain risk is negligible.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@
 
 ## Checklist
 
-- [ ] `CHANGELOG_UNRELEASED.md` updated (or chore/docs-only)
-- [ ] `scripts/check` passes locally
+- [ ] Changelog `Unreleased` section updated (or chore/docs-only)
+- [ ] Project umbrella check passes locally — `scripts/{check,pre-commit,rust-pre-commit,ci.sh}` or `cargo fmt --check && cargo clippy -- -D warnings && cargo test` (or `cargo nextest run`)
 - [ ] Tests added or updated for behavior changes
 
 ## Notes for reviewers

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -10,6 +10,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: arthur-debert/dagentic/.github/workflows/copilot-review.yml@main
+    uses: arthur-debert/gh-dagentic/.github/workflows/copilot-review.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -8,6 +8,7 @@ jobs:
   request:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
     permissions:
+      contents: read
       pull-requests: write
     uses: arthur-debert/dagentic/.github/workflows/copilot-review.yml@main
     with:


### PR DESCRIPTION
## Summary

Aligns dodot's `.github/` policy files with the canonical templates after the multi-repo sweep surfaced improvements:

- **copilot-instructions.md**: generic Rust intro (was dodot-specific), full umbrella-script list, nextest noted, plus the "no SHA-pinning of org-internal reusables" rule we learned from PR #74.
- **pull_request_template.md**: matching umbrella-script list.
- **copilot-review.yml**: add `contents: read` permission (suggested by Copilot on padz #113 — specifying any permission removes defaults).

This should be dodot's first PR to **auto-trigger** Copilot review, since `copilot-review.yml` is now on `main`.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only) — chore (CI tooling, no behavior change)
- [x] Project umbrella check passes locally — N/A (config-only)
- [x] Tests added or updated for behavior changes (N/A — config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)