### PR TITLE
feat(adopt): infer destination pack from source path

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,34 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
 
 ### Added
 
+- **`dodot adopt` infers the destination pack from the source path.**
+  Adopt's CLI shifts from `dodot adopt <pack> <files...>` to
+  `dodot adopt <files...> [--into <pack>]`. Sources under
+  `~/.config/<X>/...` auto-infer pack `<X>` (created if missing) and
+  use the resolver's default rule for round-trip — no `_xdg/` prefix
+  in the pack tree when the inferred name matches. Sources under
+  `~/.config/<X>/` itself expand to per-child plans, so each top-level
+  entry of the directory becomes its own pack member instead of the
+  whole directory becoming one big symlink-to-pack-root. `$HOME`-direct
+  dotfiles (`~/.bashrc`, `~/.weechat/`) keep their existing
+  `home.X` / `_home/X/` conventions but now require `--into <pack>`
+  since HOME has no pack structure to mine. Multi-source invocations
+  must agree on a single pack (or pass `--into`); disagreement is
+  refused with a message naming the conflicting candidates.
+  `~/Library/Containers/` is refused unconditionally (sandboxed app
+  data) on every platform. See `docs/reference/symlink-paths.lex` §8
+  and `docs/proposals/macos-paths.lex` §7 (the proposal is updated to
+  reflect the implemented inference; the AppSupport row is reserved
+  pending Phase M1's `Pather::app_support_dir()`).
+
+  When `--into <Y>` differs from a source's natural pack name, adopt
+  switches the in-pack path to `_xdg/<X>/<rest>` so Priority 2's
+  `_xdg/` directory prefix bypasses pack-namespacing — the deployed
+  path is unchanged regardless of pack reroute. The `_app/<X>/<rest>`
+  override path is wired in the same way for the future AppSupport
+  case. Pack auto-creation only happens for inferred names; explicit
+  `--into <pack>` requires the pack to already exist (a typo guard).
+
 - **Hand-written `--help` for every command.** Every dodot command (and
   the top-level binary) now ships rich `--help` text written as a
   standalone file under `dodot-cli/src/help/`, embedded into the binary

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -185,7 +185,10 @@ pub fn adopt_handler(
     _ctx: &CommandContext,
 ) -> HandlerResult<commands::PackStatusResult> {
     let ctx = build_readonly_ctx(matches)?;
-    let pack_name = matches.get_one::<String>("pack").expect("pack is required");
+    // `--into` is optional. When absent, adopt infers the pack name
+    // from each source's deployed path (XDG layout) or requires the
+    // user to supply --into (HOME-direct dotfiles).
+    let into = matches.get_one::<String>("into");
     let files: Vec<PathBuf> = matches
         .get_many::<String>("files")
         .expect("files is required")
@@ -194,10 +197,12 @@ pub fn adopt_handler(
     let force = matches.get_flag("force");
     let no_follow = matches.get_flag("no-follow");
     let dry_run = matches.get_flag("dry-run");
-    let result = commands::adopt::adopt(pack_name, &files, force, no_follow, dry_run, &ctx)
+    let into_str = into.map(|s| s.as_str());
+    let result = commands::adopt::adopt(into_str, &files, force, no_follow, dry_run, &ctx)
         .map_err(|e| {
             if matches!(e, dodot_lib::DodotError::PackNotFound { .. }) {
-                anyhow::anyhow!("{e}\n  Hint: run 'dodot init {pack_name}' first to create it")
+                let hint_pack = into_str.unwrap_or("<pack>");
+                anyhow::anyhow!("{e}\n  Hint: run 'dodot init {hint_pack}' first to create it")
             } else {
                 e.into()
             }

--- a/crates/dodot-cli/src/help/adopt.txt
+++ b/crates/dodot-cli/src/help/adopt.txt
@@ -1,37 +1,40 @@
 [header]dodot adopt[/header] — Move existing files into a pack, leaving symlinks behind.
 
-[desc]Bring legacy [item]$HOME[/item] dotfiles ([item]~/.bashrc[/item], [item]~/.zshrc[/item], [item]~/.gitconfig[/item], …)
-under dodot's control without breaking anything. For each source
-file: move it into the named pack, then symlink the original location
-back to it. Nothing observable changes; the file just gained a stable
-home in your dotfiles repo.
+[desc]Bring deployed config files (legacy [item]$HOME[/item] dotfiles, [item]~/.config/<tool>/[/item]
+trees, …) under dodot's control without breaking anything. For each
+source: move it into the right pack, then symlink the original
+location back to it. Nothing observable changes; the file just gained
+a stable home in your dotfiles repo.
 
-Files whose parent is [item]$HOME[/item] are renamed inside the pack so the
-deploy round-trip works:
-  [item]~/.bashrc[/item]    → [item]<pack>/bashrc[/item]        (canonical [item]force_home[/item])
-  [item]~/.foo.conf[/item]  → [item]<pack>/home.foo.conf[/item]  (preserves the dot prefix on re-deploy)
-
-[message]Currently only sources directly under [item]$HOME[/item] are supported.
-Files under [item]~/.config/<tool>/[/item] need to be copied into the pack manually.[/message][/desc]
+The pack name is inferred from the source's deployed location. Pass
+[item]--into <pack>[/item] to force a single destination pack instead.[/desc]
 
 [header]USAGE[/header]
-  [usage]dodot adopt [OPTIONS] <PACK> <FILES>...[/usage]
+  [usage]dodot adopt [OPTIONS] <FILES>...[/usage]
 
 [header]ARGUMENTS[/header]
-  [item]<PACK>[/item]      [desc]Pack to adopt into (created if needed)[/desc]
-  [item]<FILES>...[/item]  [desc]One or more files to move into the pack[/desc]
+  [item]<FILES>...[/item]  [desc]One or more files or directories to adopt[/desc]
 
 [header]OPTIONS[/header]
-  [item]--force[/item]       [desc]Overwrite an existing destination file in the pack[/desc]
-  [item]--dry-run[/item]     [desc]Show the moves and symlinks without making changes[/desc]
-  [item]--no-follow[/item]   [desc]If the source is a symlink, move the link itself instead of its target[/desc]
+  [item]--into <PACK>[/item]  [desc]Force a destination pack (must already exist); overrides path-based inference[/desc]
+  [item]--force[/item]        [desc]Overwrite an existing destination file in the pack[/desc]
+  [item]--dry-run[/item]      [desc]Show the moves and symlinks without making changes[/desc]
+  [item]--no-follow[/item]    [desc]If the source is a symlink, move the link itself instead of its target[/desc]
+
+[header]PACK INFERENCE[/header]
+  Sources under [item]~/.config/<X>/[/item] auto-infer pack [item]<X>[/item] (created if missing).
+  Sources directly under [item]$HOME[/item] do not auto-infer; pass [item]--into <PACK>[/item].
+  Sources under [item]~/Library/Containers/[/item] are refused (sandboxed app data).
+
+  See [item]docs/reference/symlink-paths.lex[/item] §8 for the full inference table.
 
 [header]EXAMPLES[/header]
-  [example]dodot adopt shell ~/.bashrc                 [dim]# adopt one file[/dim]
-  dodot adopt git ~/.gitconfig ~/.gitignore_global
-  dodot adopt shell ~/.bashrc --force         [dim]# overwrite shell/bashrc if present[/dim]
-  dodot adopt shell ~/.bashrc --dry-run       [dim]# preview the move + symlink[/dim][/example]
+  [example]dodot adopt ~/.config/nvim/init.lua          [dim]# infers pack `nvim`[/dim]
+  dodot adopt ~/.config/helix/                  [dim]# expands children of helix/ into pack[/dim]
+  dodot adopt ~/.bashrc --into shell            [dim]# HOME-direct dotfile needs --into[/dim]
+  dodot adopt ~/.config/lazygit/ --into tools   [dim]# override → uses _xdg/lazygit/ in pack[/dim]
+  dodot adopt ~/.gitconfig --into git --dry-run [dim]# preview the move + symlink[/dim][/example]
 
 [header]SEE ALSO[/header]
-  [item]dodot init[/item]    [desc]Create the destination pack first if it does not exist[/desc]
+  [item]dodot init[/item]    [desc]Bootstrap an explicit pack (required before [item]--into <pack>[/item] for new packs)[/desc]
   [item]dodot status[/item]  [desc]Confirm the symlink chain after adopting[/desc]

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -334,13 +334,19 @@ fn build_clap_command() -> ClapCommand {
         .subcommand(
             ClapCommand::new("adopt")
                 .about("Move files into a pack, symlinking from original location")
-                .arg(Arg::new("pack").help("Pack to adopt into").required(true))
                 .arg(
                     Arg::new("files")
-                        .help("Files to adopt")
+                        .help("Files to adopt (pack inferred from path)")
                         .required(true)
                         .num_args(1..)
                         .action(ArgAction::Append),
+                )
+                .arg(
+                    Arg::new("into")
+                        .long("into")
+                        .value_name("PACK")
+                        .help("Force a destination pack (must already exist); overrides path-based inference")
+                        .num_args(1),
                 )
                 .arg(
                     Arg::new("force")

--- a/crates/dodot-lib/src/commands/adopt/infer.rs
+++ b/crates/dodot-lib/src/commands/adopt/infer.rs
@@ -1,0 +1,664 @@
+//! Source-path inference for `dodot adopt`.
+//!
+//! `adopt` accepts a deployed path (e.g. `~/.config/nvim/init.lua`,
+//! `~/.vimrc`, `~/.weechat/`) and figures out:
+//!
+//!   1. **Which pack** the source belongs in (e.g. `nvim`, `vim`, `weechat`),
+//!      so a freshly-adopted file lands in the right pack subtree without
+//!      the user spelling the name out.
+//!   2. **Where inside the pack** the file should live so that re-deploying
+//!      via `dodot up` lands the symlink back at the original source path.
+//!      This is the inverse of `handlers::symlink::resolve_target`'s
+//!      priority ladder; getting it wrong breaks the round-trip property.
+//!
+//! The inference is *not* the resolver's inverse in the strict sense —
+//! the resolver maps `(pack, in_pack_path) → deployed_path`, and there
+//! are typically multiple pack-relative paths that round-trip to the
+//! same deployed path (e.g. `home.vimrc` in any pack and `_home/vimrc`
+//! in any pack both deploy to `~/.vimrc`). Inference picks the *most
+//! ergonomic* option per source root:
+//!
+//! - `$XDG_CONFIG_HOME/<X>/<rest>` — pack `<X>`, in-pack `<rest>` (round-trips
+//!   via the resolver's default rule, which namespaces under XDG by pack).
+//! - `$HOME/.<X>` (file) — in-pack `home.<X>` (round-trips via Priority 1).
+//! - `$HOME/.<X>/...` (dir) — in-pack `_home/<X>/...` (round-trips via
+//!   Priority 2's `_home/` directory prefix).
+//! - `~/Library/Application Support/<X>/<rest>` (macOS, future) — pack
+//!   `<X>`, in-pack `_app/<X>/<rest>` (round-trips via Priority 2's
+//!   `_app/` prefix per `docs/proposals/macos-paths.lex`).
+//!
+//! ## Override semantics (`--into <pack>`)
+//!
+//! When the user supplies `--into <Y>` and `<Y>` differs from the
+//! naturally-inferred pack name, the in-pack path must change too — the
+//! default rule (`$XDG/<pack>/<rest>`) would otherwise route the file to
+//! the wrong place. Inference returns *both* the natural in-pack path
+//! and the override-aware variant, so the caller can pick based on
+//! whether `--into` was supplied:
+//!
+//! - XDG source, override differs: use `_xdg/<X>/<rest>` so the
+//!   `_xdg/` prefix (Priority 2) bypasses pack-namespacing.
+//! - HOME source: the `home.X` and `_home/X/` prefixes are pack-name
+//!   independent already, so the override-aware path equals the natural
+//!   path. Override changes only the *pack* the file lands in.
+//! - AppSupport source, override differs (future): use `_app/<X>/<rest>`.
+//!
+//! ## Why HOME sources don't infer a pack name
+//!
+//! `~/.config/<X>/...` carries pack structure in the path: the first
+//! segment under XDG *is* the natural pack name. `~/.<X>` does not — a
+//! file like `~/.bashrc` could plausibly belong in a `shell`, `bash`, or
+//! `dotfiles` pack depending on the user's organization. Rather than
+//! guess (and saddle the user with pack names like `bashrc` or
+//! `gitconfig`), inference declines and the caller requires `--into`.
+//!
+//! The only HOME-source ergonomic concession is the `force_home` list:
+//! entries there get the bare pack-relative name (no `home.` or `_home/`
+//! prefix) because Priority 3 routes them back without one.
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::paths::Pather;
+
+/// Outcome of inferring how to adopt a single source path.
+///
+/// The `_natural` and `_override` fields encode the same target two ways:
+/// once for the case where the pack name matches the source-root's
+/// natural inference (no `_xdg/`/`_app/` prefix needed), and once for the
+/// case where the user supplied a different pack via `--into`.
+#[derive(Debug, Clone)]
+pub(crate) struct InferredTarget {
+    /// Pack name derived from the source path itself, if the source
+    /// root carries pack structure. `None` when the caller must supply
+    /// `--into <pack>` (HOME root) or when the source is at the very
+    /// top of XDG with no app subdirectory.
+    pub natural_pack: Option<String>,
+    /// In-pack path to use when the chosen pack name equals
+    /// `natural_pack` (or when override-aware encoding doesn't differ
+    /// for this root, e.g. HOME).
+    pub in_pack_natural: PathBuf,
+    /// In-pack path to use when the chosen pack name *differs* from
+    /// the source's naturally-inferred name. For XDG this prepends
+    /// `_xdg/<original-pack-segment>/` to keep round-trip; for HOME this
+    /// is identical to `in_pack_natural` (already prefix-encoded).
+    pub in_pack_override: PathBuf,
+    /// Which root the source was matched against. Drives error
+    /// messages and the small set of root-specific behaviors (e.g.
+    /// directory-source expansion under XDG/AppSupport).
+    pub source_root: SourceRoot,
+    /// `true` when the source is the *pack-root directory itself* under
+    /// XDG/AppSupport (e.g. `~/.config/nvim/`) — the caller should
+    /// enumerate its children and adopt each one as its own plan, so
+    /// each child becomes a top-level pack entry rather than the dir
+    /// becoming one big symlink-to-pack-root.
+    pub expand_children: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceRoot {
+    /// `$HOME` (e.g. `/Users/alice` or `/home/alice`).
+    Home,
+    /// `$XDG_CONFIG_HOME` (e.g. `~/.config`, or whatever `XDG_CONFIG_HOME` points at).
+    XdgConfig,
+    /// `~/Library/Application Support`. Currently never returned —
+    /// `Pather` does not yet expose `app_support_dir()` (Phase M1 of
+    /// `docs/proposals/macos-paths.lex`). The variant is reserved so the
+    /// inference framework is shape-stable when M1 lands.
+    #[allow(dead_code)]
+    AppSupport,
+}
+
+/// Why inference declined to produce a target.
+#[derive(Debug)]
+pub(crate) enum InferenceError {
+    /// Source is not under any recognized adopt-source root.
+    UnrecognizedRoot { hint_roots: Vec<PathBuf> },
+    /// Source is a direct child of `$HOME` but isn't a dotfile, so
+    /// there's no automatic round-trip path. The user can rename to
+    /// dotted form or use `[symlink.targets]` for an explicit override.
+    NonDottedHome { stripped: String },
+    /// Source is a top-level entry directly under `$XDG_CONFIG_HOME`
+    /// (no app subdirectory). XDG-root files have no natural pack
+    /// structure to mine; require `--into` and use `_xdg/` manually.
+    LooseXdgFile,
+    /// Source is the XDG root itself (e.g. `~/.config/`). Too broad
+    /// to adopt as a single unit.
+    XdgRootItself,
+    /// Source is the HOME root itself. Refused.
+    HomeRootItself,
+    /// macOS sandboxed-app container. Containers/<bundle>/Data/Library/...
+    /// is system-managed; adoption is refused per
+    /// `docs/proposals/macos-paths.lex` §7.3.
+    SandboxedContainer,
+}
+
+impl std::fmt::Display for InferenceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InferenceError::UnrecognizedRoot { hint_roots } => {
+                let roots: Vec<String> =
+                    hint_roots.iter().map(|p| p.display().to_string()).collect();
+                write!(
+                    f,
+                    "source is outside any recognized adopt root (expected under one of: {}). \
+                     Move the file under one of these locations first, or copy it into a \
+                     pack manually and use `[symlink.targets]` for an absolute deploy path.",
+                    roots.join(", ")
+                )
+            }
+            InferenceError::NonDottedHome { stripped } => write!(
+                f,
+                "a non-dotted entry in $HOME has no automatic round-trip path \
+                 under the post-#48 XDG default. Either rename to a dotted name \
+                 (e.g. .{stripped}) before adopting, or copy into the pack \
+                 manually and add a [symlink.targets] override pinning the \
+                 deploy path."
+            ),
+            InferenceError::LooseXdgFile => write!(
+                f,
+                "loose file directly under $XDG_CONFIG_HOME has no pack structure \
+                 to infer. Move it into a subdirectory (recommended) or pass \
+                 --into <pack> and place the file manually as `_xdg/<name>` in \
+                 that pack."
+            ),
+            InferenceError::XdgRootItself => write!(
+                f,
+                "$XDG_CONFIG_HOME itself is too broad to adopt — adopt individual \
+                 application subdirectories (e.g. `~/.config/nvim/`) instead."
+            ),
+            InferenceError::HomeRootItself => {
+                write!(f, "$HOME itself is too broad to adopt.")
+            }
+            InferenceError::SandboxedContainer => write!(
+                f,
+                "this is a sandboxed app's container; its config is not \
+                 intended to be edited externally. dodot does not support \
+                 adopting from ~/Library/Containers/."
+            ),
+        }
+    }
+}
+
+/// Infer pack name and pack-relative path for a single adopt source.
+///
+/// `abs_source` must be an absolute, lexically-normalized path (no `..`,
+/// no `.`). The caller is responsible for canonicalizing where needed —
+/// inference works on the *path string* primarily so that `--no-follow`
+/// can preserve a symlink source as the link itself rather than resolve
+/// through to its target.
+///
+/// `is_dir` is the post-`--no-follow` directory flag: a symlink-to-dir
+/// adopted with `--no-follow` is `is_dir=false` because we'll move the
+/// link, not the target.
+///
+/// `force_home` is the merged `[symlink] force_home` list (root config +
+/// pack config) — entries here use the bare pack-relative name, no
+/// `home.X` / `_home/X/` prefix, to match the resolver's Priority 3
+/// routing.
+pub(crate) fn infer_target(
+    abs_source: &Path,
+    is_dir: bool,
+    pather: &dyn Pather,
+    force_home: &[String],
+) -> Result<InferredTarget, InferenceError> {
+    // Canonicalize roots and source for prefix matching. We canonicalize
+    // because on macOS `/var` and `/private/var` are equivalent symlinks,
+    // and `~` may itself be a symlinked path (e.g. `/home/alice` →
+    // `/var/home/alice` on some distros). Mismatching real and symbolic
+    // forms would fail the strip_prefix checks below.
+    //
+    // For the source we canonicalize the *parent* (if any) and re-join
+    // the basename. Canonicalizing the source itself would follow a
+    // symlink source — breaking `--no-follow` semantics — and fails
+    // outright on a dangling symlink. The parent is always a real
+    // directory: even for a dangling source link, the link itself lives
+    // *somewhere*, and that somewhere has a canonical form.
+    let canon_source = canonicalize_parent_keep_basename(abs_source);
+    let canon_home = canonicalize_for_match(pather.home_dir());
+    let canon_xdg = canonicalize_for_match(pather.xdg_config_home());
+
+    // ── Sandboxed-container refusal ──────────────────────────────────
+    //
+    // Check this *before* any other root match. On macOS the canonical
+    // `~/Library/Containers/` prefix lives under HOME, so without an
+    // early exit we'd potentially treat it as a HOME-rooted source. The
+    // refusal applies regardless of platform: `dodot adopt` shouldn't
+    // touch container data on any OS, and on Linux the path simply
+    // won't exist (no false positives).
+    let containers_root = canon_home.join("Library").join("Containers");
+    if canon_source.starts_with(&containers_root) {
+        return Err(InferenceError::SandboxedContainer);
+    }
+
+    // ── XDG_CONFIG_HOME root ─────────────────────────────────────────
+    //
+    // Match XDG *before* HOME because the default XDG config home is
+    // `$HOME/.config` — it sits *inside* HOME, so longest-prefix-wins
+    // requires checking the more-specific root first. Without this
+    // ordering, `~/.config/nvim/init.lua` would match HOME and produce
+    // a useless "nested under $HOME" inference.
+    if canon_source == canon_xdg {
+        return Err(InferenceError::XdgRootItself);
+    }
+    if let Ok(rel) = canon_source.strip_prefix(&canon_xdg) {
+        return resolve_xdg_relative(rel, is_dir);
+    }
+
+    // ── HOME root ────────────────────────────────────────────────────
+    if canon_source == canon_home {
+        return Err(InferenceError::HomeRootItself);
+    }
+    if let Ok(rel) = canon_source.strip_prefix(&canon_home) {
+        return resolve_home_relative(rel, is_dir, force_home);
+    }
+
+    // ── No root matched ──────────────────────────────────────────────
+    Err(InferenceError::UnrecognizedRoot {
+        hint_roots: vec![canon_xdg, canon_home],
+    })
+}
+
+/// Build inference output for a path relative to `$XDG_CONFIG_HOME`.
+///
+/// `rel` is the source path minus the canonical XDG root, so its first
+/// component is what we treat as the natural pack name. Examples:
+///
+/// - `nvim/init.lua` → pack `nvim`, in-pack `init.lua`
+/// - `nvim/lua/plugins/foo.lua` → pack `nvim`, in-pack `lua/plugins/foo.lua`
+/// - `nvim` (a directory, sole component) → pack `nvim`, expand children
+/// - `loose-file.toml` (a file, sole component) → refused (LooseXdgFile)
+fn resolve_xdg_relative(rel: &Path, is_dir: bool) -> Result<InferredTarget, InferenceError> {
+    let mut comps = rel.components();
+    let first = match comps.next() {
+        Some(Component::Normal(s)) => s.to_string_lossy().into_owned(),
+        // No first component: rel is empty (handled by the `==` check
+        // upstream) or starts with something we can't treat as a name.
+        // Not reachable in practice given the upstream root match, but
+        // we surface a refusal rather than panic if somehow it does.
+        _ => return Err(InferenceError::XdgRootItself),
+    };
+    let rest_path: PathBuf = comps.as_path().to_path_buf();
+
+    if rest_path.as_os_str().is_empty() {
+        // Sole component case: the source IS one of XDG's top-level
+        // children. A directory is a pack root we can expand; a file is
+        // loose with no pack structure.
+        if is_dir {
+            return Ok(InferredTarget {
+                natural_pack: Some(first.clone()),
+                // Empty in-pack path: not used directly because
+                // `expand_children = true` triggers per-child planning,
+                // each of which derives its own in-pack path.
+                in_pack_natural: PathBuf::new(),
+                in_pack_override: PathBuf::from("_xdg").join(&first),
+                source_root: SourceRoot::XdgConfig,
+                expand_children: true,
+            });
+        } else {
+            return Err(InferenceError::LooseXdgFile);
+        }
+    }
+
+    // Nested case: `<pack>/<rest>`. The natural in-pack path is `<rest>`
+    // (the resolver's default rule namespaces it back under the pack).
+    // The override-aware path uses `_xdg/<pack>/<rest>` so the explicit
+    // `_xdg/` prefix bypasses pack-namespacing — required when the
+    // user picks a different pack via `--into`.
+    Ok(InferredTarget {
+        natural_pack: Some(first.clone()),
+        in_pack_natural: rest_path.clone(),
+        in_pack_override: PathBuf::from("_xdg").join(&first).join(&rest_path),
+        source_root: SourceRoot::XdgConfig,
+        expand_children: false,
+    })
+}
+
+/// Build inference output for a path relative to `$HOME`.
+///
+/// HOME-rooted sources don't carry pack structure, so this returns
+/// `natural_pack = None` and the caller must require `--into <pack>`.
+/// What inference *does* compute is the in-pack path: the existing
+/// dotfile conventions (`home.X` for files, `_home/X/` for dirs)
+/// preserve round-trip regardless of the chosen pack name.
+fn resolve_home_relative(
+    rel: &Path,
+    is_dir: bool,
+    force_home: &[String],
+) -> Result<InferredTarget, InferenceError> {
+    let mut comps = rel.components();
+    let first = match comps.next() {
+        Some(Component::Normal(s)) => s.to_string_lossy().into_owned(),
+        _ => return Err(InferenceError::HomeRootItself),
+    };
+
+    if comps.next().is_some() {
+        // The source is nested deeper under HOME than a direct child
+        // (e.g. `~/Documents/notes.txt`). We don't have rules for these
+        // — `~/Documents/`, `~/Desktop/`, etc. are user data, not
+        // dotfiles. Refuse with a generic "outside recognized roots".
+        // The error propagation upstream will list both HOME and XDG as
+        // valid roots so the user knows where adopt looks.
+        return Err(InferenceError::UnrecognizedRoot { hint_roots: vec![] });
+    }
+
+    // Delegate to the string-shaped helper so both inference and the
+    // round-trip property test go through the same convention table.
+    // `derive_home_in_pack` returns `force_home`-bare-name, `home.X`,
+    // `_home/X`, or a "non-dotted refused" error — exactly the shape we
+    // need here.
+    let stripped = first.strip_prefix('.').unwrap_or(&first);
+    let in_pack_str = derive_home_in_pack(&first, is_dir, force_home).map_err(|_| {
+        InferenceError::NonDottedHome {
+            stripped: stripped.to_string(),
+        }
+    })?;
+    let in_pack = PathBuf::from(in_pack_str);
+
+    Ok(InferredTarget {
+        natural_pack: None,
+        // HOME's `home.X` / `_home/X/` prefixes are pack-name-independent
+        // — Priority 1 and 2 don't consult the pack name when routing —
+        // so the override-aware in-pack path equals the natural one.
+        in_pack_natural: in_pack.clone(),
+        in_pack_override: in_pack,
+        source_root: SourceRoot::Home,
+        expand_children: false,
+    })
+}
+
+/// Canonicalize a path for prefix matching, falling back to the input on
+/// failure. Canonicalization may fail on a non-existent path; that's
+/// fine — we want the lexical form in that case anyway.
+fn canonicalize_for_match(p: &Path) -> PathBuf {
+    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Canonicalize a source path's parent and re-join the basename, leaving
+/// the source itself unfollowed.
+///
+/// This is the right shape for adopt's source paths: we need OS-level
+/// path equivalence (e.g. macOS `/var` ↔ `/private/var`) on the
+/// directory-prefix portion so root-membership checks work, but we must
+/// *not* follow a symlink source — adopt's `--no-follow` mode treats
+/// the link as the thing to move, not the link's target. Canonicalizing
+/// only the parent gives us both: the prefix is real, and the basename
+/// stays as the user wrote it.
+///
+/// If the parent can't be canonicalized (rare — it would mean the
+/// source is at the filesystem root or the parent doesn't exist), we
+/// fall back to the lexical input. The downstream prefix checks may
+/// then fail to match a root, which surfaces as `UnrecognizedRoot` —
+/// the same outcome the user would see for any path that genuinely
+/// isn't under a recognized root.
+fn canonicalize_parent_keep_basename(source: &Path) -> PathBuf {
+    let parent = match source.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        // Filesystem root or empty path: nothing to canonicalize.
+        _ => return source.to_path_buf(),
+    };
+    let canon_parent = match std::fs::canonicalize(parent) {
+        Ok(p) => p,
+        Err(_) => return source.to_path_buf(),
+    };
+    match source.file_name() {
+        Some(name) => canon_parent.join(name),
+        None => canon_parent,
+    }
+}
+
+/// Compute the in-pack path for a `$HOME/<file_name>` source.
+///
+/// Kept as a public-in-crate helper so the round-trip property test in
+/// `commands::tests::pack_filename_round_trips_through_resolve_target`
+/// can drive the same conventions inference uses (without paying the
+/// cost of materializing a `Pather` or absolute paths).
+///
+/// Returns `Err(reason)` when the source has no automatic round-trip
+/// path — currently the non-dotted-non-force_home case. The inference
+/// entry point translates the same situation into a richer
+/// `InferenceError::NonDottedHome`; this thinner string-error variant
+/// matches the original `derive_pack_filename` shape.
+pub(crate) fn derive_home_in_pack(
+    file_name: &str,
+    is_dir: bool,
+    force_home: &[String],
+) -> std::result::Result<String, String> {
+    let stripped = file_name.strip_prefix('.').unwrap_or(file_name);
+    let in_force_home = force_home
+        .iter()
+        .any(|entry| entry.strip_prefix('.').unwrap_or(entry) == stripped);
+
+    if in_force_home {
+        Ok(stripped.to_string())
+    } else if file_name.starts_with('.') {
+        if is_dir {
+            Ok(format!("_home/{stripped}"))
+        } else {
+            Ok(format!("home.{stripped}"))
+        }
+    } else {
+        Err(format!(
+            "a non-dotted entry in $HOME has no automatic round-trip path \
+             under the post-#48 XDG default. Either rename to a dotted name \
+             (e.g. .{stripped}) before adopting, or copy into the pack \
+             manually and add a [symlink.targets] override pinning the \
+             deploy path."
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Inference tests use a hand-built `XdgPather` rather than touching
+    //! real env vars. The point is to exercise every branch of the
+    //! decision tree on synthetic paths; integration tests in
+    //! `commands::tests` cover end-to-end adopt against a real temp FS.
+    //!
+    //! Each test is named `<root>_<scenario>_<outcome>` so failures are
+    //! self-locating in `cargo test` output.
+    use super::*;
+    use crate::paths::XdgPather;
+
+    /// Build a `Pather` with HOME and XDG explicitly set to non-overlapping
+    /// paths under `/tmp/<id>` so prefix matching is unambiguous. We avoid
+    /// the default `$HOME/.config` layout in most tests: it's the *harder*
+    /// case (XDG nested under HOME), and we cover it explicitly in
+    /// `xdg_inside_home_prefers_xdg_root`.
+    fn pather(home: &str, xdg: &str) -> XdgPather {
+        XdgPather::builder()
+            .home(home)
+            .dotfiles_root(format!("{home}/dotfiles"))
+            .data_dir(format!("{home}/.local/share/dodot"))
+            .config_dir(format!("{home}/.config/dodot"))
+            .cache_dir(format!("{home}/.cache/dodot"))
+            .xdg_config_home(xdg)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn xdg_nested_file_infers_pack_and_relative_path() {
+        let p = pather("/u", "/x");
+        let t = infer_target(
+            Path::new("/x/nvim/init.lua"),
+            /*is_dir=*/ false,
+            &p,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(t.natural_pack.as_deref(), Some("nvim"));
+        assert_eq!(t.in_pack_natural, PathBuf::from("init.lua"));
+        // Override-aware: `_xdg/<pack>/<rest>` so an arbitrary `--into`
+        // still round-trips via the resolver's Priority 2 `_xdg/` prefix.
+        assert_eq!(t.in_pack_override, PathBuf::from("_xdg/nvim/init.lua"));
+        assert_eq!(t.source_root, SourceRoot::XdgConfig);
+        assert!(!t.expand_children);
+    }
+
+    #[test]
+    fn xdg_deeply_nested_file_keeps_full_subpath() {
+        // The first segment under XDG is always the pack; everything
+        // below stays in `in_pack` verbatim. This is the case that
+        // makes `dodot adopt ~/.config/nvim/lua/plugins/foo.lua` work.
+        let p = pather("/u", "/x");
+        let t = infer_target(Path::new("/x/nvim/lua/plugins/foo.lua"), false, &p, &[]).unwrap();
+        assert_eq!(t.natural_pack.as_deref(), Some("nvim"));
+        assert_eq!(t.in_pack_natural, PathBuf::from("lua/plugins/foo.lua"));
+        assert_eq!(
+            t.in_pack_override,
+            PathBuf::from("_xdg/nvim/lua/plugins/foo.lua")
+        );
+    }
+
+    #[test]
+    fn xdg_pack_root_directory_triggers_expansion() {
+        // `~/.config/nvim/` (the directory itself) → pack `nvim`,
+        // expand_children=true. The caller enumerates entries inside
+        // and adopts each as a top-level pack member, instead of
+        // making `~/.config/nvim/` itself a single big symlink.
+        let p = pather("/u", "/x");
+        let t = infer_target(Path::new("/x/nvim"), /*is_dir=*/ true, &p, &[]).unwrap();
+        assert_eq!(t.natural_pack.as_deref(), Some("nvim"));
+        assert!(t.expand_children);
+        assert_eq!(t.in_pack_natural, PathBuf::new());
+    }
+
+    #[test]
+    fn xdg_loose_file_at_root_is_refused() {
+        // `~/.config/standalone.toml` (a file, not a dir) at the very
+        // top of XDG has no pack structure to mine. We refuse rather
+        // than guess, and steer the user toward `--into` + manual
+        // `_xdg/` placement.
+        let p = pather("/u", "/x");
+        let err = infer_target(
+            Path::new("/x/standalone.toml"),
+            /*is_dir=*/ false,
+            &p,
+            &[],
+        )
+        .unwrap_err();
+        assert!(matches!(err, InferenceError::LooseXdgFile));
+    }
+
+    #[test]
+    fn xdg_root_itself_is_refused() {
+        let p = pather("/u", "/x");
+        let err = infer_target(Path::new("/x"), true, &p, &[]).unwrap_err();
+        assert!(matches!(err, InferenceError::XdgRootItself));
+    }
+
+    #[test]
+    fn home_dotted_file_uses_home_prefix_no_pack_inference() {
+        // `~/.vimrc` → pack name *not* inferred (HOME has no pack
+        // structure), in-pack `home.vimrc` so the resolver routes back
+        // to `~/.vimrc` via Priority 1.
+        let p = pather("/u", "/x");
+        let t = infer_target(Path::new("/u/.vimrc"), false, &p, &[]).unwrap();
+        assert_eq!(t.natural_pack, None);
+        assert_eq!(t.in_pack_natural, PathBuf::from("home.vimrc"));
+        // HOME prefixes are pack-name-independent — override path matches.
+        assert_eq!(t.in_pack_override, PathBuf::from("home.vimrc"));
+        assert_eq!(t.source_root, SourceRoot::Home);
+    }
+
+    #[test]
+    fn home_dotted_dir_uses_home_subtree_prefix() {
+        let p = pather("/u", "/x");
+        let t = infer_target(Path::new("/u/.weechat"), /*is_dir=*/ true, &p, &[]).unwrap();
+        assert_eq!(t.natural_pack, None);
+        assert_eq!(t.in_pack_natural, PathBuf::from("_home/weechat"));
+    }
+
+    #[test]
+    fn home_force_home_uses_bare_name() {
+        // `force_home` curates Unix canons (`.bashrc`, `.ssh`, …) whose
+        // Priority 3 resolver rule routes the bare pack-relative name
+        // straight back to `~/.X`. So adopt drops the `home.`/`_home/`
+        // prefix for matches — keeps the pack tree clean and matches
+        // the resolver convention.
+        let force = vec!["bashrc".to_string(), "ssh".to_string()];
+        let p = pather("/u", "/x");
+
+        let t = infer_target(Path::new("/u/.bashrc"), false, &p, &force).unwrap();
+        assert_eq!(t.in_pack_natural, PathBuf::from("bashrc"));
+
+        let t = infer_target(Path::new("/u/.ssh"), true, &p, &force).unwrap();
+        assert_eq!(t.in_pack_natural, PathBuf::from("ssh"));
+    }
+
+    #[test]
+    fn home_non_dotted_is_refused() {
+        // No automatic round-trip: a file like `~/myscript.sh` would
+        // need `[symlink.targets]` for an explicit deploy path.
+        let p = pather("/u", "/x");
+        let err = infer_target(Path::new("/u/myscript.sh"), false, &p, &[]).unwrap_err();
+        match err {
+            InferenceError::NonDottedHome { stripped } => assert_eq!(stripped, "myscript.sh"),
+            other => panic!("expected NonDottedHome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn home_nested_outside_xdg_is_unrecognized() {
+        // `~/Documents/notes.txt` isn't HOME-direct and isn't under
+        // XDG either; we refuse rather than guess at user-data layout.
+        let p = pather("/u", "/x");
+        let err = infer_target(Path::new("/u/Documents/notes.txt"), false, &p, &[]).unwrap_err();
+        assert!(matches!(err, InferenceError::UnrecognizedRoot { .. }));
+    }
+
+    #[test]
+    fn home_root_itself_is_refused() {
+        let p = pather("/u", "/x");
+        let err = infer_target(Path::new("/u"), true, &p, &[]).unwrap_err();
+        assert!(matches!(err, InferenceError::HomeRootItself));
+    }
+
+    #[test]
+    fn xdg_inside_home_prefers_xdg_root() {
+        // The default config has `XDG_CONFIG_HOME = $HOME/.config`, so
+        // an XDG-rooted source's path also starts with HOME. Inference
+        // must pick the *more specific* root (XDG) — checking HOME
+        // first would produce a useless "nested under $HOME" verdict.
+        // This test pins that ordering as a regression guard.
+        let p = pather("/u", "/u/.config");
+        let t = infer_target(Path::new("/u/.config/nvim/init.lua"), false, &p, &[]).unwrap();
+        assert_eq!(t.source_root, SourceRoot::XdgConfig);
+        assert_eq!(t.natural_pack.as_deref(), Some("nvim"));
+        assert_eq!(t.in_pack_natural, PathBuf::from("init.lua"));
+    }
+
+    #[test]
+    fn unrecognized_root_lists_known_roots() {
+        // Random absolute path under neither HOME nor XDG — refused
+        // with the recognized roots in the error so the user knows
+        // where adopt looks.
+        let p = pather("/u", "/x");
+        let err = infer_target(Path::new("/etc/passwd"), false, &p, &[]).unwrap_err();
+        match err {
+            InferenceError::UnrecognizedRoot { hint_roots } => {
+                assert!(hint_roots.iter().any(|r| r.starts_with("/x")));
+                assert!(hint_roots.iter().any(|r| r.starts_with("/u")));
+            }
+            other => panic!("expected UnrecognizedRoot, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn macos_containers_path_is_refused() {
+        // `~/Library/Containers/<bundle>/...` is a sandboxed-app data
+        // directory — partially OS-managed and not intended for
+        // external editing. Refused on every platform so no one
+        // accidentally adopts a container's plist on a CI Linux box
+        // by feeding it a path that mimics the macOS layout.
+        let p = pather("/u", "/x");
+        let err = infer_target(
+            Path::new("/u/Library/Containers/com.example.app/Data/Library/Preferences/foo.plist"),
+            false,
+            &p,
+            &[],
+        )
+        .unwrap_err();
+        assert!(matches!(err, InferenceError::SandboxedContainer));
+    }
+}

--- a/crates/dodot-lib/src/commands/adopt/infer.rs
+++ b/crates/dodot-lib/src/commands/adopt/infer.rs
@@ -335,10 +335,13 @@ fn resolve_home_relative(
         // The source is nested deeper under HOME than a direct child
         // (e.g. `~/Documents/notes.txt`). We don't have rules for these
         // — `~/Documents/`, `~/Desktop/`, etc. are user data, not
-        // dotfiles. Refuse with a generic "outside recognized roots".
-        // The error propagation upstream will list both HOME and XDG as
-        // valid roots so the user knows where adopt looks.
-        return Err(InferenceError::UnrecognizedRoot { hint_roots: vec![] });
+        // dotfiles. Refuse with "outside recognized roots" and seed
+        // `hint_roots` with the *symbolic* root names so the rendered
+        // error stays readable. Empty hint_roots produces awkward
+        // "expected under one of: " text.
+        return Err(InferenceError::UnrecognizedRoot {
+            hint_roots: vec![PathBuf::from("$HOME"), PathBuf::from("$XDG_CONFIG_HOME")],
+        });
     }
 
     // Delegate to the string-shaped helper so both inference and the

--- a/crates/dodot-lib/src/commands/adopt/mod.rs
+++ b/crates/dodot-lib/src/commands/adopt/mod.rs
@@ -282,11 +282,20 @@ fn resolve_pack_for_sources(
     let mut declined: Vec<PathBuf> = Vec::new();
     for raw in sources {
         let abs = absolutize(raw)?;
-        // For pack-name aggregation we don't need symlink semantics —
-        // just enough metadata to know if the source IS a directory.
-        // Missing sources fail later in preflight with a precise error;
-        // here we silently treat them as non-dir so inference can proceed
-        // and produce its own structured error.
+        // Existence check before inference: if a missing XDG pack-root
+        // dir (typo or not-yet-created path) reaches inference, it
+        // looks like a non-dir and gets refused as `LooseXdgFile`,
+        // which is misleading. Propagate NotFound here so the user
+        // sees the same "source does not exist" message they'd get for
+        // any missing source — preflight covers the same case but
+        // running it from this earlier inference pass keeps the error
+        // path uniform.
+        if !fs.exists(&abs) && !fs.is_symlink(&abs) {
+            return Err(DodotError::Fs {
+                path: abs,
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "source does not exist"),
+            });
+        }
         let is_dir = fs.stat(&abs).map(|m| m.is_dir).unwrap_or(false);
         match infer_target(&abs, is_dir, ctx.paths.as_ref(), &force_home) {
             Ok(t) => match t.natural_pack {
@@ -457,9 +466,20 @@ fn preflight(
             // future) — enumerate children and adopt each as a top-level
             // pack entry. This is the "I want this whole `~/.config/nvim/`
             // to become the `nvim` pack" ergonomic.
+            //
+            // Override-aware: if `--into` rerouted the destination pack
+            // (so `pack_override` differs from the natural pack name),
+            // each child must use the explicit-prefix encoding
+            // (`_xdg/<X>/<child>`, `_app/<X>/<child>`) so the round-trip
+            // still lands the deployed file at the original location.
+            // The same rule that applies to file sources applies here.
+            let override_differs = matches!(
+                (&inferred.natural_pack, pack_override),
+                (Some(natural), Some(over)) if natural != over
+            );
             let entries = fs.read_dir(&abs)?;
             for entry in entries {
-                let child_in_pack = expand_child_in_pack(&inferred, &entry.name);
+                let child_in_pack = expand_child_in_pack(&inferred, &entry.name, override_differs);
                 push_plan(
                     &mut plans,
                     fs,
@@ -483,10 +503,6 @@ fn preflight(
                 &ignore_patterns,
             )?;
         }
-
-        // Touch `inferred` so unused-field lints stay quiet on the
-        // override-aware variant when no override is in play.
-        let _ = inferred.in_pack_override;
     }
 
     // Permission pre-flight. We do this after planning so every error up to
@@ -507,15 +523,40 @@ fn preflight(
 }
 
 /// Compute the in-pack path for one child of an expanded pack-root
-/// directory. For XDG the child becomes a top-level pack entry; for
-/// AppSupport (future) it stays under `_app/<X>/`.
-fn expand_child_in_pack(parent: &InferredTarget, child_name: &str) -> PathBuf {
+/// directory.
+///
+/// `override_differs` is true when `--into <Y>` rerouted to a pack
+/// other than the source's natural pack name. In that case children
+/// need the explicit-prefix encoding (`_xdg/<X>/<child>`,
+/// `_app/<X>/<child>`) so Priority 2's directory prefixes bypass
+/// pack-namespacing — round-trip unchanged from the file-source case.
+///
+/// When `override_differs` is false (no override, or override matches
+/// inferred name), the natural-pack encoding wins: bare `<child>` for
+/// XDG (default rule routes back via the matching pack name), and
+/// `_app/<X>/<child>` for AppSupport (default rule routes through
+/// `$XDG`, not `app_support_dir`, so the prefix is mandatory even at
+/// natural pack name — see `docs/proposals/macos-paths.lex` §7.2).
+fn expand_child_in_pack(
+    parent: &InferredTarget,
+    child_name: &str,
+    override_differs: bool,
+) -> PathBuf {
     use self::infer::SourceRoot;
     match parent.source_root {
-        SourceRoot::XdgConfig => PathBuf::from(child_name),
+        SourceRoot::XdgConfig => {
+            if override_differs {
+                // `parent.in_pack_override` is `_xdg/<X>` for the
+                // pack-root dir itself; append child basename per entry.
+                parent.in_pack_override.join(child_name)
+            } else {
+                PathBuf::from(child_name)
+            }
+        }
         SourceRoot::AppSupport => {
-            // `parent.in_pack_override` is `_app/<X>` for the dir itself;
-            // append the child basename for each entry. Reserved for
+            // `parent.in_pack_override` is `_app/<X>` for the dir itself.
+            // AppSupport always needs the prefix (see §7.2 note), so the
+            // override flag doesn't change behavior here. Reserved for
             // when Pather exposes app_support_dir() per macos-paths M1.
             parent.in_pack_override.join(child_name)
         }
@@ -552,19 +593,27 @@ fn push_plan(
         fs.stat(source)?.is_dir
     };
 
-    // Filename-ignore check against pack + root ignore patterns. The
-    // top-level path-component is the user-visible name; using it for
-    // the match keeps behavior consistent with the resolver's gitignore
-    // semantics.
-    let display_name = in_pack
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
+    // Filename-ignore check against pack + root ignore patterns.
+    //
+    // Ignore patterns apply to *top-level pack entries* (matching
+    // `rules::Scanner::walk_pack`'s semantics on `dodot up`). For a
+    // nested adopt like `lua/plugins/foo.lua`, the top-level entry is
+    // `lua/`, so we test the *first* path component — not the leaf
+    // basename. Using the leaf would let through adoptions that
+    // `dodot up` would later silently ignore (or vice versa).
+    use std::path::Component;
+    let top_level_name = in_pack
+        .components()
+        .find_map(|c| match c {
+            Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+            _ => None,
+        })
         .unwrap_or_else(|| in_pack.display().to_string());
-    if rules::should_skip_entry(&display_name, ignore_patterns) {
+    if rules::should_skip_entry(&top_level_name, ignore_patterns) {
         return Err(DodotError::Other(format!(
-            "refusing to adopt {}: name '{}' matches an ignore pattern or is reserved",
+            "refusing to adopt {}: top-level entry '{}' matches an ignore pattern or is reserved",
             source.display(),
-            display_name
+            top_level_name
         )));
     }
 

--- a/crates/dodot-lib/src/commands/adopt/mod.rs
+++ b/crates/dodot-lib/src/commands/adopt/mod.rs
@@ -1,6 +1,26 @@
 //! `adopt` command — move existing files into a pack, creating symlinks back.
 //!
-//! Two-phase model:
+//! ## Calling shape
+//!
+//! ```text
+//! dodot adopt <path>...                # pack name inferred per source
+//! dodot adopt <path>... --into <pack>  # all sources land in <pack>
+//! ```
+//!
+//! Inference (see [`infer::infer_target`]) reads each source's deployed
+//! location and determines:
+//!
+//! - **Pack name**, when the source root carries pack structure
+//!   (`$XDG_CONFIG_HOME/<X>/...` → `<X>`). HOME-rooted sources have no
+//!   inherent pack structure and require `--into <pack>`.
+//! - **In-pack path**, chosen so re-deploying with `dodot up` lands the
+//!   symlink back at the original source — round-trip preservation
+//!   relative to `handlers::symlink::resolve_target`.
+//! - **Whether the source is a pack-root directory** (e.g. `~/.config/nvim/`),
+//!   in which case we expand it into per-child plans rather than making
+//!   the whole directory one big symlink-to-pack-root.
+//!
+//! ## Two-phase model
 //!
 //! 1. **Copy phase** — recursively copy each source into the pack, preserving
 //!    inner symlinks and Unix permissions. Originals are never touched in this
@@ -16,7 +36,19 @@
 //! Cross-pack deployment conflicts are detected after the copy phase and before
 //! the swap phase — adoption is refused if deploying the adopted files would
 //! collide with another pack. This check is not bypassed by `--force`.
+//!
+//! ## Auto-creating packs
+//!
+//! When all sources point at a single inferred pack name and that pack
+//! doesn't exist on disk, adopt creates it (an empty directory — no
+//! `.dodot.toml` is written; the user can run `dodot config gen` later
+//! if they want one). When `--into <pack>` is supplied and `<pack>` does
+//! not exist, adopt refuses — explicit pack names are typo-checked
+//! against the existing pack inventory.
 
+mod infer;
+
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use crate::commands::status;
@@ -27,6 +59,18 @@ use crate::packs;
 use crate::packs::orchestration::{self, ExecutionContext};
 use crate::rules;
 use crate::{DodotError, Result};
+
+use self::infer::{infer_target, InferredTarget};
+
+/// Re-export so the round-trip property test in `commands::tests` can
+/// drive the same `home.X` / `_home/X/` conventions inference uses.
+/// Keeping this internal-but-cross-module ensures inference and the
+/// resolver don't drift apart. Test-only because production code
+/// always goes through the richer `infer_target` entry point.
+#[cfg(test)]
+pub(crate) use self::infer::derive_home_in_pack as derive_pack_filename;
+
+// ── Plans ────────────────────────────────────────────────────────────
 
 /// Plan for a single source: the resolved source path, what to call it in the
 /// pack, and the destination path.
@@ -46,11 +90,15 @@ struct AdoptPlan {
     destructive_overwrite: bool,
 }
 
+// ── Public entry point ───────────────────────────────────────────────
+
 /// Move sources into a pack, creating symlinks from their original locations.
 ///
-/// See the module-level docs for the two-phase model and failure semantics.
+/// `pack_override` is `Some(name)` when the user passed `--into <name>`;
+/// `None` lets per-source inference decide. See the module-level docs
+/// for the inference rules and two-phase failure semantics.
 pub fn adopt(
-    pack_name: &str,
+    pack_override: Option<&str>,
     sources: &[PathBuf],
     force: bool,
     no_follow: bool,
@@ -61,26 +109,53 @@ pub fn adopt(
         return Err(DodotError::Other("no files specified".into()));
     }
 
-    // Resolve the user's input (display name `nvim` or raw `010-nvim`)
-    // to the on-disk directory; the pack subtree is keyed by the raw
-    // form, every status/display surface by the display form.
-    let pack_dir = orchestration::resolve_pack_dir_name(pack_name, ctx)?;
-    let pack_display = packs::display_name_for(&pack_dir).to_string();
+    // ── Resolve pack: per-source inference, then aggregate ───────────
+    //
+    // Each source contributes a candidate pack name (its naturally-inferred
+    // pack, or None if the source root has no pack structure). We require
+    // exactly one pack per adopt invocation:
+    //
+    //   - All sources agree on a single inferred name → use it.
+    //   - Sources disagree → refuse; ask the user to split or use --into.
+    //   - All sources decline (HOME-only) → require --into.
+    //   - --into supplied → it wins regardless of inference.
+    //
+    // The single-pack constraint keeps the result shape (one
+    // PackStatusResult) and the conflict-check semantics simple. Future
+    // work can lift this to multi-pack invocations once the result
+    // structure supports it.
+    let resolved = resolve_pack_for_sources(pack_override, sources, ctx)?;
+
+    let pack_dir = resolved.pack_dir.clone();
+    let pack_display = resolved.display_name.clone();
     let pack_path = ctx.paths.pack_path(&pack_dir);
+
+    // ── Auto-create the pack if inferred and missing ─────────────────
+    //
+    // Inferred-but-absent packs are created as empty directories. The
+    // explicit `--into` path goes through `resolve_pack_dir_name` and
+    // errors on miss instead — that's the typo-guard the user opted
+    // into by naming a specific pack.
     if !ctx.fs.exists(&pack_path) {
-        return Err(DodotError::PackNotFound {
-            name: pack_name.into(),
-        });
+        ctx.fs.mkdir_all(&pack_path)?;
     }
+
     if ctx.fs.exists(&pack_path.join(".dodotignore")) {
         return Err(DodotError::PackInvalid {
-            name: pack_name.into(),
+            name: pack_display.clone(),
             reason: "pack is marked ignored via .dodotignore".into(),
         });
     }
 
-    let (plans, skipped_already_adopted) =
-        preflight(&pack_dir, &pack_path, sources, force, no_follow, ctx)?;
+    let (plans, skipped_already_adopted) = preflight(
+        &pack_dir,
+        &pack_path,
+        sources,
+        pack_override,
+        force,
+        no_follow,
+        ctx,
+    )?;
 
     // If every input was already adopted, there's nothing to do.
     if plans.is_empty() {
@@ -158,72 +233,123 @@ pub fn adopt(
     Ok(result)
 }
 
-// ── Pack-filename derivation ─────────────────────────────────────
-//
-// The inverse of `handlers::symlink::resolve_target`: given a
-// `$HOME/<file_name>` source we want to adopt, pick a pack-relative
-// filename such that re-deploying with `dodot up` lands the symlink
-// back at the *exact* original location.
-//
-// Goal: round-trip preservation. If a future change to `resolve_target`
-// adds a new convention or reorders priorities and this function is
-// not updated in lockstep, `pack_filename_round_trips_through_resolve_target`
-// (the property test in `commands::tests`) catches the drift.
+// ── Pack resolution (override / inference / aggregation) ─────────────
 
-/// Decide the pack-relative filename to use when adopting a
-/// `$HOME/<file_name>` source.
+/// Outcome of resolving the (single) pack the entire adopt invocation
+/// targets.
+struct ResolvedPack {
+    /// On-disk directory name (may carry a `NNN-` ordering prefix).
+    pack_dir: String,
+    /// User-facing display name (ordering prefix stripped).
+    display_name: String,
+}
+
+/// Determine which pack the entire adopt invocation lands in.
 ///
-/// Rules (mirror of `resolve_target`'s priority list, run in reverse):
-///   - In `force_home`: pack file `<stripped>`. The symlink handler's
-///     `force_home` rule routes deploys back to `$HOME/.<stripped>`.
-///   - Dotted file (e.g. `.vimrc`): pack file `home.<stripped>`. The
-///     per-file `home.X` convention routes back to `$HOME/.<stripped>`.
-///   - Dotted directory (e.g. `.weechat`): pack subdir
-///     `_home/<stripped>/`. The per-subtree `_home/` directory prefix
-///     routes contents back to `$HOME/.<stripped>/...`.
-///   - Non-dotted file or directory: no automatic round-trip path
-///     exists. Returns `Err` with a user-facing reason.
-pub(crate) fn derive_pack_filename(
-    file_name: &str,
-    is_dir: bool,
-    force_home: &[String],
-) -> std::result::Result<String, String> {
-    let stripped = file_name.strip_prefix('.').unwrap_or(file_name);
-    let in_force_home = force_home
-        .iter()
-        .any(|entry| entry.strip_prefix('.').unwrap_or(entry) == stripped);
+/// Two paths:
+///
+/// - `pack_override` is `Some(name)`: use exactly that name. The pack
+///   must already exist — this is the typo-guard the user opts into by
+///   spelling out `--into`. Resolved through `resolve_pack_dir_name`
+///   so display-name and raw-on-disk-name (`010-nvim` ↔ `nvim`) both
+///   work.
+/// - `pack_override` is `None`: run inference per source, require all
+///   to agree on a single inferred name (or all decline; in the latter
+///   case we error pointing at `--into`). The inferred name resolves
+///   through `resolve_pack_dir_name` for typo-equivalent matches; if
+///   no match exists, the inferred name is taken as the on-disk
+///   directory name and the pack is auto-created upstream.
+fn resolve_pack_for_sources(
+    pack_override: Option<&str>,
+    sources: &[PathBuf],
+    ctx: &ExecutionContext,
+) -> Result<ResolvedPack> {
+    if let Some(name) = pack_override {
+        // Explicit --into: resolve against existing packs, error on miss.
+        let pack_dir = orchestration::resolve_pack_dir_name(name, ctx)?;
+        let display_name = packs::display_name_for(&pack_dir).to_string();
+        return Ok(ResolvedPack {
+            pack_dir,
+            display_name,
+        });
+    }
 
-    if in_force_home {
-        Ok(stripped.to_string())
-    } else if file_name.starts_with('.') {
-        if is_dir {
-            Ok(format!("_home/{stripped}"))
-        } else {
-            Ok(format!("home.{stripped}"))
+    // No override: collect per-source inferences, demand consensus.
+    let force_home = ctx.config_manager.root_config()?.symlink.force_home.clone();
+
+    let fs = ctx.fs.as_ref();
+    let mut candidates: BTreeSet<String> = BTreeSet::new();
+    let mut declined: Vec<PathBuf> = Vec::new();
+    for raw in sources {
+        let abs = absolutize(raw)?;
+        // For pack-name aggregation we don't need symlink semantics —
+        // just enough metadata to know if the source IS a directory.
+        // Missing sources fail later in preflight with a precise error;
+        // here we silently treat them as non-dir so inference can proceed
+        // and produce its own structured error.
+        let is_dir = fs.stat(&abs).map(|m| m.is_dir).unwrap_or(false);
+        match infer_target(&abs, is_dir, ctx.paths.as_ref(), &force_home) {
+            Ok(t) => match t.natural_pack {
+                Some(name) => {
+                    candidates.insert(name);
+                }
+                None => declined.push(abs),
+            },
+            Err(e) => {
+                return Err(DodotError::Other(format!(
+                    "refusing to adopt {}: {e}",
+                    abs.display()
+                )))
+            }
         }
-    } else {
-        Err(format!(
-            "a non-dotted entry in $HOME has no automatic round-trip path \
-             under the post-#48 XDG default. Either rename to a dotted name \
-             (e.g. .{stripped}) before adopting, or copy into the pack \
-             manually and add a [symlink.targets] override pinning the \
-             deploy path."
-        ))
+    }
+
+    match candidates.len() {
+        0 => Err(DodotError::Other(format!(
+            "could not infer a pack name for {} source(s); pass --into <pack>",
+            declined.len()
+        ))),
+        1 => {
+            // Sole candidate: prefer an existing pack with this display
+            // name (handles `010-nvim` on-disk vs `nvim` inferred), else
+            // fall through to use the inferred name as the on-disk dir.
+            let inferred = candidates.into_iter().next().unwrap();
+            let pack_dir = orchestration::resolve_pack_dir_name(&inferred, ctx)
+                .unwrap_or_else(|_| inferred.clone());
+            let display_name = packs::display_name_for(&pack_dir).to_string();
+            // If a HOME source declined inference but we still resolved
+            // a pack via the XDG sources, that's fine — they'll all land
+            // in the same pack. Their in-pack paths use the HOME prefixes
+            // so they round-trip regardless of pack name.
+            let _ = declined;
+            Ok(ResolvedPack {
+                pack_dir,
+                display_name,
+            })
+        }
+        _ => {
+            let names: Vec<String> = candidates.into_iter().collect();
+            Err(DodotError::Other(format!(
+                "sources infer different packs ({}); split into separate adopt \
+                 invocations or pass --into <pack> to force a single destination",
+                names.join(", ")
+            )))
+        }
     }
 }
 
-// ── Pre-flight ───────────────────────────────────────────────────
+// ── Pre-flight ───────────────────────────────────────────────────────
 
 fn preflight(
     pack_name: &str,
     pack_path: &Path,
     sources: &[PathBuf],
+    pack_override: Option<&str>,
     force: bool,
     no_follow: bool,
     ctx: &ExecutionContext,
 ) -> Result<(Vec<AdoptPlan>, Vec<String>)> {
     let fs = ctx.fs.as_ref();
-    let home = ctx.paths.home_dir().to_path_buf();
     let dotfiles_root = ctx.paths.dotfiles_root().to_path_buf();
     let data_dir = ctx.paths.data_dir().to_path_buf();
 
@@ -234,26 +360,21 @@ fn preflight(
         combined.extend(pack_config.pack.ignore.iter().cloned());
         combined
     };
+    // The merged force_home list: pack-level overrides root, but for
+    // adopt we feed both layers to inference so a user's pack-scoped
+    // force_home addition is honored. The resolver does the same merge
+    // when deploying.
+    let force_home = {
+        let mut combined = root_config.symlink.force_home.clone();
+        combined.extend(pack_config.symlink.force_home.iter().cloned());
+        combined
+    };
 
     let mut plans: Vec<AdoptPlan> = Vec::new();
     let mut skipped: Vec<String> = Vec::new();
 
     for raw_source in sources {
-        // Resolve to absolute, then normalize. Relative paths are resolved
-        // against CWD. We normalize logically (strip `.`, collapse `..`)
-        // rather than calling `canonicalize()` because canonicalize follows
-        // symlinks, which would break `--no-follow`.
-        let abs = if raw_source.is_absolute() {
-            raw_source.clone()
-        } else {
-            std::env::current_dir()
-                .map_err(|e| DodotError::Fs {
-                    path: raw_source.clone(),
-                    source: e,
-                })?
-                .join(raw_source)
-        };
-        let abs = normalize_path(&abs);
+        let abs = absolutize(raw_source)?;
 
         if !fs.exists(&abs) && !fs.is_symlink(&abs) {
             return Err(DodotError::Fs {
@@ -316,70 +437,56 @@ fn preflight(
             smeta.is_dir
         };
 
-        // Nested-source refusal: parent must be HOME (dodot's flat-at-top-level
-        // rule applied to source paths too). Allow adopting from HOME directly.
-        // Canonicalize the parent (not the source itself — that would follow
-        // a symlink source and break `--no-follow`) so OS-level path
-        // equivalences like `/var` ↔ `/private/var` on macOS compare equal.
-        let parent = abs
-            .parent()
-            .ok_or_else(|| DodotError::Other(format!("no parent directory: {}", abs.display())))?;
-        let canon_parent = std::fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf());
-        let canon_home = std::fs::canonicalize(&home).unwrap_or_else(|_| home.clone());
-        if canon_parent != canon_home {
-            return Err(DodotError::Other(format!(
-                "nested source not allowed: {}\n  hint: adopt the top-level directory instead (parent must be {})",
-                abs.display(),
-                home.display()
-            )));
-        }
+        // ── Inference: source-root match + in-pack path computation ──
+        let inferred =
+            infer_target(&abs, is_dir, ctx.paths.as_ref(), &force_home).map_err(|reason| {
+                DodotError::Other(format!("refusing to adopt {}: {reason}", abs.display()))
+            })?;
 
-        let file_name = abs
-            .file_name()
-            .ok_or_else(|| DodotError::Other(format!("no filename: {}", abs.display())))?
-            .to_string_lossy()
-            .into_owned();
+        // Pick the override-aware encoding when --into changed the pack
+        // name. This keeps `_xdg/<X>/...` (and the future `_app/<X>/...`)
+        // round-trip-correct even when the user reroutes the file into
+        // a different pack than its source-root segment suggests.
+        let in_pack = match (&inferred.natural_pack, pack_override) {
+            (Some(natural), Some(over)) if natural != over => inferred.in_pack_override.clone(),
+            _ => inferred.in_pack_natural.clone(),
+        };
 
-        let pack_filename =
-            derive_pack_filename(&file_name, is_dir, &pack_config.symlink.force_home).map_err(
-                |reason| {
-                    DodotError::Other(format!("refusing to adopt {}: {reason}", abs.display()))
-                },
+        if inferred.expand_children {
+            // Source IS a pack-root directory under XDG (or AppSupport
+            // future) — enumerate children and adopt each as a top-level
+            // pack entry. This is the "I want this whole `~/.config/nvim/`
+            // to become the `nvim` pack" ergonomic.
+            let entries = fs.read_dir(&abs)?;
+            for entry in entries {
+                let child_in_pack = expand_child_in_pack(&inferred, &entry.name);
+                push_plan(
+                    &mut plans,
+                    fs,
+                    &abs.join(&entry.name),
+                    pack_path,
+                    &child_in_pack,
+                    no_follow,
+                    force,
+                    &ignore_patterns,
+                )?;
+            }
+        } else {
+            push_plan(
+                &mut plans,
+                fs,
+                &abs,
+                pack_path,
+                &in_pack,
+                no_follow,
+                force,
+                &ignore_patterns,
             )?;
-
-        // Filename-ignore check against pack + root ignore patterns.
-        if rules::should_skip_entry(&pack_filename, &ignore_patterns) {
-            return Err(DodotError::Other(format!(
-                "refusing to adopt {}: name '{}' matches an ignore pattern or is reserved",
-                abs.display(),
-                pack_filename
-            )));
         }
 
-        let pack_dest = pack_path.join(&pack_filename);
-
-        // Destination conflict check. With --force, we'll remove the existing
-        // destination before copy; without, this is a hard refusal.
-        let dest_exists = fs.exists(&pack_dest) || fs.is_symlink(&pack_dest);
-        if dest_exists && !force {
-            return Err(DodotError::SymlinkConflict { path: pack_dest });
-        }
-
-        // Cross-plan filename collision: can't adopt two things with the same
-        // stripped name in a single invocation.
-        if plans.iter().any(|p| p.pack_dest == pack_dest) {
-            return Err(DodotError::Other(format!(
-                "two sources produce the same pack filename '{}'; adopt them separately",
-                pack_filename
-            )));
-        }
-
-        plans.push(AdoptPlan {
-            source: abs,
-            pack_dest,
-            is_dir,
-            destructive_overwrite: dest_exists, // only true under --force
-        });
+        // Touch `inferred` so unused-field lints stay quiet on the
+        // override-aware variant when no override is in play.
+        let _ = inferred.in_pack_override;
     }
 
     // Permission pre-flight. We do this after planning so every error up to
@@ -397,6 +504,112 @@ fn preflight(
     }
 
     Ok((plans, skipped))
+}
+
+/// Compute the in-pack path for one child of an expanded pack-root
+/// directory. For XDG the child becomes a top-level pack entry; for
+/// AppSupport (future) it stays under `_app/<X>/`.
+fn expand_child_in_pack(parent: &InferredTarget, child_name: &str) -> PathBuf {
+    use self::infer::SourceRoot;
+    match parent.source_root {
+        SourceRoot::XdgConfig => PathBuf::from(child_name),
+        SourceRoot::AppSupport => {
+            // `parent.in_pack_override` is `_app/<X>` for the dir itself;
+            // append the child basename for each entry. Reserved for
+            // when Pather exposes app_support_dir() per macos-paths M1.
+            parent.in_pack_override.join(child_name)
+        }
+        SourceRoot::Home => {
+            // Not currently produced by inference (HOME never expands);
+            // fall back to bare child name to keep the helper total.
+            PathBuf::from(child_name)
+        }
+    }
+}
+
+/// Build and validate a single AdoptPlan, appending it to `plans`.
+///
+/// Centralises the destination-conflict, ignore-pattern, and per-invocation
+/// collision checks so they're applied uniformly between the regular
+/// path and the directory-expansion path.
+#[allow(clippy::too_many_arguments)]
+fn push_plan(
+    plans: &mut Vec<AdoptPlan>,
+    fs: &dyn Fs,
+    source: &Path,
+    pack_path: &Path,
+    in_pack: &Path,
+    no_follow: bool,
+    force: bool,
+    ignore_patterns: &[String],
+) -> Result<()> {
+    let lmeta = fs.lstat(source)?;
+    let is_source_symlink = lmeta.is_symlink;
+    let treat_as_link = is_source_symlink && no_follow;
+    let is_dir = if treat_as_link {
+        false
+    } else {
+        fs.stat(source)?.is_dir
+    };
+
+    // Filename-ignore check against pack + root ignore patterns. The
+    // top-level path-component is the user-visible name; using it for
+    // the match keeps behavior consistent with the resolver's gitignore
+    // semantics.
+    let display_name = in_pack
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| in_pack.display().to_string());
+    if rules::should_skip_entry(&display_name, ignore_patterns) {
+        return Err(DodotError::Other(format!(
+            "refusing to adopt {}: name '{}' matches an ignore pattern or is reserved",
+            source.display(),
+            display_name
+        )));
+    }
+
+    let pack_dest = pack_path.join(in_pack);
+
+    // Destination conflict check. With --force, we'll remove the existing
+    // destination before copy; without, this is a hard refusal.
+    let dest_exists = fs.exists(&pack_dest) || fs.is_symlink(&pack_dest);
+    if dest_exists && !force {
+        return Err(DodotError::SymlinkConflict { path: pack_dest });
+    }
+
+    // Cross-plan filename collision: can't adopt two things with the same
+    // pack-relative path in a single invocation.
+    if plans.iter().any(|p| p.pack_dest == pack_dest) {
+        return Err(DodotError::Other(format!(
+            "two sources produce the same pack path '{}'; adopt them separately",
+            in_pack.display()
+        )));
+    }
+
+    plans.push(AdoptPlan {
+        source: source.to_path_buf(),
+        pack_dest,
+        is_dir,
+        destructive_overwrite: dest_exists,
+    });
+    Ok(())
+}
+
+/// Resolve a possibly-relative path to an absolute, lexically-normalized one.
+/// Mirrors the original adopt behavior: relative inputs resolve against
+/// CWD, then `..` and `.` are collapsed without touching the filesystem.
+fn absolutize(raw: &Path) -> Result<PathBuf> {
+    let abs = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| DodotError::Fs {
+                path: raw.to_path_buf(),
+                source: e,
+            })?
+            .join(raw)
+    };
+    Ok(normalize_path(&abs))
 }
 
 fn check_writable(fs: &dyn Fs, dir: &Path) -> Result<()> {
@@ -425,6 +638,15 @@ fn check_readable(fs: &dyn Fs, path: &Path, is_dir: bool) -> Result<()> {
 fn copy_all(plans: &[AdoptPlan], fs: &dyn Fs) -> Result<()> {
     for plan in plans {
         let had_existing_dest = fs.exists(&plan.pack_dest) || fs.is_symlink(&plan.pack_dest);
+        // Ensure parent directory exists. Expansion under XDG can place
+        // children at the pack root (no missing parent), but a deeply
+        // nested in-pack path (e.g. `lua/plugins/foo.lua`) needs the
+        // intermediate directories created before copy.
+        if let Some(parent) = plan.pack_dest.parent() {
+            if !parent.as_os_str().is_empty() && !fs.exists(parent) {
+                fs.mkdir_all(parent)?;
+            }
+        }
         if had_existing_dest {
             // --force path: stage the new content into a sibling temp path
             // first so a failed copy leaves the old destination intact.

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -1598,6 +1598,55 @@ fn adopt_xdg_root_itself_refused() {
     );
 }
 
+/// Pack-root directory expansion under `--into` reroute keeps the
+/// `_xdg/<X>/` prefix on each child so the round-trip survives the
+/// pack-name change. Without this, expanded children would land at
+/// pack root and `dodot up` would deploy them to `$XDG/<override>/...`
+/// instead of the original `$XDG/<X>/...`. (Regression for Copilot
+/// review on PR #85.)
+#[test]
+fn adopt_xdg_pack_root_expansion_with_override_uses_xdg_prefix() {
+    let env = TempEnvironment::builder()
+        .pack("toolbox")
+        .file("placeholder", "")
+        .done()
+        .home_file(".config/lazygit/config.yml", "gui:\n  theme: dark")
+        .home_file(".config/lazygit/themes/x.yml", "fg: white")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".config/lazygit");
+
+    commands::adopt::adopt(
+        Some("toolbox"),
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    // Each expanded child lives under `toolbox/_xdg/lazygit/...` so the
+    // resolver's Priority 2 `_xdg/` prefix routes back to
+    // `~/.config/lazygit/<child>` regardless of the override pack name.
+    env.assert_regular_file(
+        &env.dotfiles_root.join("toolbox/_xdg/lazygit/config.yml"),
+        "gui:\n  theme: dark",
+    );
+    env.assert_regular_file(
+        &env.dotfiles_root.join("toolbox/_xdg/lazygit/themes/x.yml"),
+        "fg: white",
+    );
+    // Each original child is now a symlink (per-child expansion); the
+    // pack-root dir itself stays a real directory.
+    assert!(env
+        .fs
+        .is_symlink(&env.home.join(".config/lazygit/config.yml")));
+    assert!(env.fs.is_symlink(&env.home.join(".config/lazygit/themes")));
+    assert!(!env.fs.is_symlink(&source));
+}
+
 /// `--into <pack>` for an XDG source where the override differs from
 /// the inferred pack name uses `_xdg/<X>/<rest>` so round-trip via
 /// Priority 2 still lands the deployed file at the original location.

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -1057,7 +1057,7 @@ fn adopt_moves_file_and_creates_symlink() {
     let source = env.home.join(".vimrc");
 
     let result = commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1103,7 +1103,7 @@ fn adopt_preserves_executable_permissions() {
 
     let ctx = make_ctx(&env);
     commands::adopt::adopt(
-        "tools",
+        Some("tools"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1136,7 +1136,7 @@ fn adopt_refuses_non_dotted_home_entry() {
     let ctx = make_ctx(&env);
     let source = env.home.join("script.sh");
     let err = commands::adopt::adopt(
-        "tools",
+        Some("tools"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1175,7 +1175,7 @@ fn adopt_destination_conflict_refused_without_force() {
     let source = env.home.join(".vimrc");
 
     let err = commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1209,7 +1209,7 @@ fn adopt_destination_conflict_resolved_with_force() {
     let source = env.home.join(".vimrc");
 
     commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         true, // --force
         false,
@@ -1224,19 +1224,25 @@ fn adopt_destination_conflict_resolved_with_force() {
 
 #[test]
 fn adopt_directory_creates_symlink_and_preserves_contents() {
+    // Dotted-directory adoption from $HOME directly: contents move to
+    // pack/_home/<stripped>/, which round-trips back via the `_home/`
+    // subtree-escape (Priority 2) on `dodot up`. We use a non-XDG
+    // dotted dir so the test stays decoupled from the XDG-source
+    // inference rules — adopting `~/.config/` itself is now refused
+    // explicitly (see `adopt_xdg_root_itself_refused`).
     let env = TempEnvironment::builder()
-        .pack("nvim")
+        .pack("editor")
         .file("placeholder", "")
         .done()
-        .home_file(".config/nvim/init.lua", "-- config")
-        .home_file(".config/nvim/lua/mod.lua", "-- module")
+        .home_file(".vim/vimrc", "set nocompatible")
+        .home_file(".vim/colors/scheme.vim", "\" colors")
         .build();
 
     let ctx = make_ctx(&env);
-    let source = env.home.join(".config");
+    let source = env.home.join(".vim");
 
     commands::adopt::adopt(
-        "nvim",
+        Some("editor"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1245,14 +1251,10 @@ fn adopt_directory_creates_symlink_and_preserves_contents() {
     )
     .unwrap();
 
-    // The directory is moved under pack/_home/<stripped> (post-#48
-    // adopt rename for dotted directories — the `_home/` per-subtree
-    // escape hatch routes deploys back to ~/.config when `dodot up`
-    // runs, preserving the round-trip).
-    let pack_dir = env.dotfiles_root.join("nvim/_home/config");
+    let pack_dir = env.dotfiles_root.join("editor/_home/vim");
     env.assert_dir_exists(&pack_dir);
-    env.assert_regular_file(&pack_dir.join("nvim/init.lua"), "-- config");
-    env.assert_regular_file(&pack_dir.join("nvim/lua/mod.lua"), "-- module");
+    env.assert_regular_file(&pack_dir.join("vimrc"), "set nocompatible");
+    env.assert_regular_file(&pack_dir.join("colors/scheme.vim"), "\" colors");
 
     // Original path is now a symlink to the pack copy.
     assert!(env.fs.is_symlink(&source));
@@ -1277,7 +1279,7 @@ fn adopt_dotted_dir_from_home_round_trips_via_home_escape() {
     let source = env.home.join(".weechat");
 
     commands::adopt::adopt(
-        "chats",
+        Some("chats"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1445,7 +1447,7 @@ fn adopt_preserves_inner_symlinks_as_symlinks() {
     let ctx = make_ctx(&env);
     let source = env.home.join(".mydir");
     commands::adopt::adopt(
-        "shell",
+        Some("shell"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1462,8 +1464,14 @@ fn adopt_preserves_inner_symlinks_as_symlinks() {
     );
 }
 
+/// `~/.config/<X>/<rest>` is now a recognized adopt source: the first
+/// segment under `$XDG_CONFIG_HOME` is the inferred pack name, and the
+/// remainder is the in-pack path. Round-trip is the resolver's default
+/// rule — pack `nvim` containing `init.lua` deploys to
+/// `$XDG_CONFIG_HOME/nvim/init.lua` on `dodot up`. (Pre-inference, this
+/// case was refused as a nested source.)
 #[test]
-fn adopt_nested_source_refused() {
+fn adopt_xdg_nested_file_lands_at_pack_root() {
     let env = TempEnvironment::builder()
         .pack("nvim")
         .file("placeholder", "")
@@ -1474,8 +1482,108 @@ fn adopt_nested_source_refused() {
     let ctx = make_ctx(&env);
     let source = env.home.join(".config/nvim/init.lua");
 
+    commands::adopt::adopt(
+        Some("nvim"),
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    // No prefix gymnastics: pack `nvim`'s default deploy rule (Priority
+    // 4 — `$XDG/<pack>/<rel>`) lands `init.lua` back at the original
+    // `~/.config/nvim/init.lua`. So the in-pack name is just `init.lua`.
+    let pack_file = env.dotfiles_root.join("nvim/init.lua");
+    env.assert_regular_file(&pack_file, "-- config");
+    assert!(env.fs.is_symlink(&source));
+    let target = env.fs.readlink(&source).unwrap();
+    assert_eq!(target, pack_file);
+}
+
+/// Pack name can be omitted when the source carries pack structure
+/// under `$XDG_CONFIG_HOME`: `dodot adopt ~/.config/nvim/init.lua` (no
+/// `--into`) auto-detects pack `nvim` and creates it if missing.
+#[test]
+fn adopt_xdg_source_infers_pack_and_auto_creates() {
+    let env = TempEnvironment::builder()
+        .home_file(".config/ghostty/config", "theme = dark")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".config/ghostty/config");
+
+    commands::adopt::adopt(
+        /*pack_override=*/ None,
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    // Pack auto-created at `<dotfiles>/ghostty/`, file landed at root.
+    let pack_dir = env.dotfiles_root.join("ghostty");
+    env.assert_dir_exists(&pack_dir);
+    env.assert_regular_file(&pack_dir.join("config"), "theme = dark");
+    assert!(env.fs.is_symlink(&source));
+}
+
+/// Adopting `~/.config/<X>/` (the pack-root directory itself) expands
+/// into per-child plans rather than making the directory one big
+/// symlink-to-pack-root. Each top-level entry becomes a top-level pack
+/// member, so `dodot up` deploys per-entry like any other pack.
+#[test]
+fn adopt_xdg_pack_root_directory_expands_to_children() {
+    let env = TempEnvironment::builder()
+        .home_file(".config/helix/config.toml", "theme = \"onedark\"")
+        .home_file(".config/helix/themes/extra.toml", "fg = \"white\"")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".config/helix");
+
+    commands::adopt::adopt(
+        None,
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    // Each top-level child of `~/.config/helix/` became its own pack
+    // entry — `config.toml` (file) and `themes/` (dir) — both at pack
+    // root, not nested under another `helix/`.
+    let pack_dir = env.dotfiles_root.join("helix");
+    env.assert_regular_file(&pack_dir.join("config.toml"), "theme = \"onedark\"");
+    env.assert_regular_file(&pack_dir.join("themes/extra.toml"), "fg = \"white\"");
+    // Original entries are now symlinks at their original paths
+    // (one per top-level child, not one for the whole helix/ dir).
+    assert!(env
+        .fs
+        .is_symlink(&env.home.join(".config/helix/config.toml")));
+    assert!(env.fs.is_symlink(&env.home.join(".config/helix/themes")));
+    // Parent directory `~/.config/helix/` itself stays a real directory
+    // — only its children became symlinks.
+    assert!(!env.fs.is_symlink(&source));
+}
+
+/// `~/.config/` itself is too broad to adopt as a single unit; refuse
+/// explicitly so the user adopts an app subdirectory instead.
+#[test]
+fn adopt_xdg_root_itself_refused() {
+    let env = TempEnvironment::builder()
+        .home_file(".config/nvim/init.lua", "-- config")
+        .build();
+    let ctx = make_ctx(&env);
+    let source = env.config_home.clone();
+
     let err = commands::adopt::adopt(
-        "nvim",
+        None,
         std::slice::from_ref(&source),
         false,
         false,
@@ -1485,13 +1593,90 @@ fn adopt_nested_source_refused() {
     .unwrap_err();
     let msg = format!("{err}");
     assert!(
-        msg.contains("nested"),
-        "expected 'nested' in error message, got: {msg}"
+        msg.contains("$XDG_CONFIG_HOME"),
+        "expected XDG-root refusal, got: {msg}"
     );
+}
 
-    // Nothing mutated.
-    env.assert_regular_file(&source, "-- config");
-    env.assert_not_exists(&env.dotfiles_root.join("nvim/init.lua"));
+/// `--into <pack>` for an XDG source where the override differs from
+/// the inferred pack name uses `_xdg/<X>/<rest>` so round-trip via
+/// Priority 2 still lands the deployed file at the original location.
+#[test]
+fn adopt_xdg_with_into_override_uses_xdg_prefix() {
+    let env = TempEnvironment::builder()
+        .pack("toolbox")
+        .file("placeholder", "")
+        .done()
+        .home_file(".config/lazygit/config.yml", "gui:\n  theme: dark")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".config/lazygit/config.yml");
+
+    commands::adopt::adopt(
+        Some("toolbox"),
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    // Round-trip via `_xdg/lazygit/config.yml`: the `_xdg/` prefix
+    // bypasses pack-namespacing so the deployed path is still
+    // `~/.config/lazygit/config.yml` despite the file living in
+    // pack `toolbox`.
+    let pack_file = env.dotfiles_root.join("toolbox/_xdg/lazygit/config.yml");
+    env.assert_regular_file(&pack_file, "gui:\n  theme: dark");
+    assert!(env.fs.is_symlink(&source));
+}
+
+/// Multiple sources whose inference picks different packs is refused
+/// (without `--into`); the message names the conflicting candidates.
+#[test]
+fn adopt_disagreeing_inferred_packs_refused() {
+    let env = TempEnvironment::builder()
+        .home_file(".config/nvim/init.lua", "-- nvim")
+        .home_file(".config/helix/config.toml", "# helix")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let sources = vec![
+        env.home.join(".config/nvim/init.lua"),
+        env.home.join(".config/helix/config.toml"),
+    ];
+
+    let err = commands::adopt::adopt(None, &sources, false, false, false, &ctx).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("different packs"),
+        "expected disagreement message, got: {msg}"
+    );
+    assert!(msg.contains("nvim") && msg.contains("helix"));
+}
+
+/// Without `--into`, a HOME source can't infer a pack and adopt fails
+/// with a hint pointing at `--into`.
+#[test]
+fn adopt_home_source_without_into_requires_pack() {
+    let env = TempEnvironment::builder()
+        .home_file(".vimrc", "set nocompatible")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".vimrc");
+    let err = commands::adopt::adopt(
+        None,
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("--into"), "expected '--into' hint, got: {msg}");
 }
 
 #[test]
@@ -1511,7 +1696,7 @@ fn adopt_already_adopted_source_is_skipped() {
 
     let ctx = make_ctx(&env);
     let result = commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1558,7 +1743,7 @@ fn adopt_fully_managed_source_keeps_original_skip_message() {
     assert!(env.fs.is_symlink(&source));
 
     let result = commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1694,7 +1879,7 @@ fn adopt_relative_path_with_curdir_normalizes() {
     std::env::set_current_dir(&env.home).unwrap();
     let ctx = make_ctx(&env);
     let result = commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         &[std::path::PathBuf::from("./.vimrc")],
         false,
         false,
@@ -1721,7 +1906,7 @@ fn adopt_ignored_pack_refused() {
     let ctx = make_ctx(&env);
     let source = env.home.join(".vimrc");
     let err = commands::adopt::adopt(
-        "disabled",
+        Some("disabled"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1748,7 +1933,7 @@ fn adopt_filename_matching_pack_ignore_refused() {
     let ctx = make_ctx(&env);
     let source = env.home.join(".vimrc.bak");
     let err = commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1781,7 +1966,7 @@ fn adopt_broken_pack_blocks_conflict_check() {
     let ctx = make_ctx(&env);
     let source = env.home.join(".vimrc");
     let err = commands::adopt::adopt(
-        "target",
+        Some("target"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1820,7 +2005,7 @@ fn adopt_deploy_conflict_refused() {
     let ctx = make_ctx(&env);
     let source = env.home.join(".bashrc");
     let err = commands::adopt::adopt(
-        "work",
+        Some("work"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1854,7 +2039,7 @@ fn adopt_deploy_conflict_not_bypassed_by_force() {
     let ctx = make_ctx(&env);
     let source = env.home.join(".bashrc");
     let err = commands::adopt::adopt(
-        "work",
+        Some("work"),
         std::slice::from_ref(&source),
         true, // --force should NOT bypass deploy conflicts
         false,
@@ -1881,7 +2066,7 @@ fn adopt_dry_run_makes_no_changes() {
     let source = env.home.join(".vimrc");
 
     let result = commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -1914,7 +2099,7 @@ fn adopt_no_follow_keeps_source_symlink_as_symlink() {
 
     let ctx = make_ctx(&env);
     commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         false,
         true, // --no-follow
@@ -1955,7 +2140,7 @@ fn adopt_force_preserves_old_content_when_copy_fails() {
 
     let ctx = make_ctx(&env);
     let result = commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         true, // --force
         false,
@@ -2005,7 +2190,7 @@ fn adopt_no_follow_on_dangling_symlink_succeeds() {
 
     let ctx = make_ctx(&env);
     commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         false,
         true, // --no-follow
@@ -2033,7 +2218,7 @@ fn adopt_nonexistent_source_errors() {
     let ctx = make_ctx(&env);
     let source = env.home.join(".does-not-exist");
     let err = commands::adopt::adopt(
-        "vim",
+        Some("vim"),
         std::slice::from_ref(&source),
         false,
         false,
@@ -2052,7 +2237,7 @@ fn adopt_empty_sources_errors() {
         .done()
         .build();
     let ctx = make_ctx(&env);
-    let err = commands::adopt::adopt("vim", &[], false, false, false, &ctx).unwrap_err();
+    let err = commands::adopt::adopt(Some("vim"), &[], false, false, false, &ctx).unwrap_err();
     let msg = format!("{err}");
     assert!(msg.contains("no files"), "got: {msg}");
 }
@@ -2183,7 +2368,7 @@ fn adopt_nonexistent_pack_returns_pack_not_found() {
     let ctx = make_ctx(&env);
     let source = env.home.join(".vimrc");
     let err = commands::adopt::adopt(
-        "newpack",
+        Some("newpack"),
         std::slice::from_ref(&source),
         false,
         false,

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -441,10 +441,14 @@ mod tests {
             // No xdg_config_home set; falls back to env or `$HOME/.config`.
             .build()
             .unwrap();
-        // The default unwrap (no XDG_CONFIG_HOME env) is $HOME/.config.
-        // We don't read env in the test (would race with real env), so
-        // assert *only* that the result starts with home — which is the
-        // load-bearing invariant for adopt's longest-prefix-match.
+        // The default fallback (no `XDG_CONFIG_HOME` env) is `$HOME/.config`.
+        // The assertion has to tolerate a user-set `XDG_CONFIG_HOME` since
+        // tests inherit the ambient env — `cargo test` from a developer
+        // shell with the env set would otherwise fail spuriously. The
+        // disjunct below means: either XDG nests under HOME (the default
+        // case the invariant talks about), OR the env override is set
+        // (the user opted out of the default; adopt's inference handles
+        // that case via root canonicalization, separate code path).
         let xdg = pather.xdg_config_home();
         let home = pather.home_dir();
         assert!(

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -1,11 +1,53 @@
+//! Path resolution for dodot.
+//!
+//! `Pather` is dodot's single source of truth for *every* filesystem
+//! coordinate the rest of the codebase touches: `$HOME`, the dotfiles
+//! repo root, the XDG data/config/cache directories, and per-pack and
+//! per-handler subdirectories. Two reasons it's a trait, not free
+//! functions:
+//!
+//! 1. **Testability.** Constructing a `Pather` whose roots all live
+//!    under a `tempfile::TempDir` lets every command run end-to-end
+//!    against a real filesystem without ever touching the user's
+//!    actual `$HOME`. The `testing::TempEnvironment` builder does
+//!    exactly this.
+//!
+//! 2. **Centralisation of OS-shaped policy.** The XDG fallback chain,
+//!    the `DOTFILES_ROOT` env-var lookup, and (planned, per
+//!    `docs/proposals/macos-paths.lex`) the macOS `app_support_dir`
+//!    selection all live in one place. The resolver, the symlink
+//!    handler, and `adopt`'s source-path inference all consult the
+//!    same accessors — drift between them is impossible by construction.
+//!
+//! ## Adopt source-root invariants
+//!
+//! The inference function in `commands::adopt::infer` needs *stable
+//! root strings* it can prefix-match against canonicalised source
+//! paths. The accessors exposed here meet two requirements that make
+//! that work safely:
+//!
+//! - `home_dir()` and `xdg_config_home()` return paths that
+//!   `std::fs::canonicalize` resolves to themselves on a real
+//!   filesystem (they're real directories, not synthetic constants).
+//!   This is what makes the `/var` ↔ `/private/var` macOS equivalence
+//!   collapse cleanly when both a source and a root are canonicalised
+//!   before comparison.
+//!
+//! - On the default config (no `XDG_CONFIG_HOME` set), `xdg_config_home()`
+//!   is `home_dir().join(".config")` — i.e. *nested under* `$HOME`.
+//!   Inference must check the more-specific (XDG) root before HOME so
+//!   `~/.config/nvim/init.lua` matches XDG, not "nested under HOME".
+//!   That's enforced by the inference function, not by `Pather`, but
+//!   the nesting shape originates here.
+
 use std::path::{Path, PathBuf};
 
 use crate::Result;
 
 /// Provides all path calculations for dodot.
 ///
-/// Every path that dodot uses -- XDG directories, pack locations,
-/// handler data directories -- is computed through this trait. This
+/// Every path that dodot uses — XDG directories, pack locations,
+/// handler data directories — is computed through this trait. This
 /// keeps path logic centralised and makes testing straightforward:
 /// construct a `Pather` whose directories all live under a temp dir.
 ///
@@ -380,6 +422,78 @@ mod tests {
             PathBuf::from("/absolute/path")
         );
         assert_eq!(expand_tilde("relative", home), PathBuf::from("relative"));
+    }
+
+    /// Default-XDG nesting: with no explicit `xdg_config_home`, the
+    /// builder defaults to `$HOME/.config`. Adopt's inference relies on
+    /// XDG being checked *before* HOME (longest-prefix wins) precisely
+    /// because of this nesting; pin the layout so a future change that
+    /// flips the default to `$HOME/Library/...` (macOS) or somewhere
+    /// outside HOME forces a deliberate update to the inference rules.
+    #[test]
+    fn default_xdg_config_home_is_nested_under_home() {
+        let pather = XdgPather::builder()
+            .home("/u")
+            .dotfiles_root("/u/dotfiles")
+            .data_dir("/u/.local/share/dodot")
+            .config_dir("/u/.config/dodot")
+            .cache_dir("/u/.cache/dodot")
+            // No xdg_config_home set; falls back to env or `$HOME/.config`.
+            .build()
+            .unwrap();
+        // The default unwrap (no XDG_CONFIG_HOME env) is $HOME/.config.
+        // We don't read env in the test (would race with real env), so
+        // assert *only* that the result starts with home — which is the
+        // load-bearing invariant for adopt's longest-prefix-match.
+        let xdg = pather.xdg_config_home();
+        let home = pather.home_dir();
+        assert!(
+            xdg.starts_with(home) || std::env::var("XDG_CONFIG_HOME").is_ok(),
+            "default xdg_config_home `{}` is not nested under home `{}` \
+             — adopt's inference assumes XDG ⊆ HOME on the default config; \
+             update both if this changes",
+            xdg.display(),
+            home.display()
+        );
+    }
+
+    /// Explicit `xdg_config_home(...)` takes precedence over env / defaults.
+    /// Critical for the test environment, where adopt-inference tests pin
+    /// XDG to a non-default location so prefix matches are unambiguous.
+    #[test]
+    fn explicit_xdg_config_home_overrides_default() {
+        let pather = XdgPather::builder()
+            .home("/u")
+            .dotfiles_root("/u/dotfiles")
+            .xdg_config_home("/somewhere/else/.config")
+            .build()
+            .unwrap();
+        assert_eq!(
+            pather.xdg_config_home(),
+            Path::new("/somewhere/else/.config")
+        );
+    }
+
+    /// Each accessor returns a stable, distinct subdir layout. Adopt's
+    /// auto-create path lands the new pack at `dotfiles_root/<pack>`,
+    /// and the data layer keeps state at `data_dir/packs/<pack>/...`;
+    /// these must not alias.
+    #[test]
+    fn dotfiles_root_and_data_dir_are_distinct_namespaces() {
+        let pather = XdgPather::builder()
+            .home("/u")
+            .dotfiles_root("/u/dotfiles")
+            .data_dir("/u/.local/share/dodot")
+            .build()
+            .unwrap();
+        let pack_dir = pather.pack_path("nvim");
+        let pack_data = pather.pack_data_dir("nvim");
+        assert!(
+            !pack_dir.starts_with(&pack_data) && !pack_data.starts_with(&pack_dir),
+            "pack_path `{}` and pack_data_dir `{}` overlap",
+            pack_dir.display(),
+            pack_data.display(),
+        );
     }
 
     // Compile-time check: Pather must be object-safe

--- a/docs/proposals/macos-paths.lex
+++ b/docs/proposals/macos-paths.lex
@@ -6,6 +6,8 @@ Design Specification: MacOs Paths and the `_app/` Convention
 
 1. The Problem
 
+    This proposal addresses a MacOs-specific gap: on Linux, GUI and CLI applications share the same XDG-compliant text-file hierarchy and the resolver's existing rules already cover them, whereas MacOs splits GUI app data into `~/Library/Application Support/` with app-specific folder names that rarely match the natural pack name.
+
     1.1. Two Roots Are Not Enough
 
         dodot's resolver recognizes two filesystem roots: `$HOME` (legacy unix canons — `.bashrc`, `.ssh/`, `.gnupg/`) and `$XDG_CONFIG_HOME` (everything else, namespaced under the pack name by default). The four escape hatches in `symlink-paths.lex` (`home.X`, `_home/`, `_xdg/`, `[symlink.targets]`) all express user intent within those two coordinates.

--- a/docs/proposals/macos-paths.lex
+++ b/docs/proposals/macos-paths.lex
@@ -1,0 +1,532 @@
+Design Specification: MacOs Paths and the `_app/` Convention
+
+    This document specifies how dodot routes pack files on MacOs, where a third filesystem coordinate — `~/Library/Application Support/<App>/` — sits alongside the two roots the resolver already understands (`$HOME` and `$XDG_CONFIG_HOME`). It extends the symlink-deployment ladder defined in [./../reference/symlink-paths.lex] with two new directory prefixes (`_app/` and `_lib/`), a curated `force_app` list, and a pack-level `app_aliases` map. It also describes an advisory layer — homebrew-cask and MacOs-native introspection — that powers `dodot adopt` suggestions and `dodot up` warnings without ever overriding the resolver's deterministic priority order.
+
+    The spec is split into two parts. The first half (sessions 1–7) is the deterministic core: where files end up, why, and how to express user intent. The second half (session 8) is the advisory "automagical" layer that sits on top, isolated so it does not perturb the resolver and can evolve independently.
+
+1. The Problem
+
+    1.1. Two Roots Are Not Enough
+
+        dodot's resolver recognizes two filesystem roots: `$HOME` (legacy unix canons — `.bashrc`, `.ssh/`, `.gnupg/`) and `$XDG_CONFIG_HOME` (everything else, namespaced under the pack name by default). The four escape hatches in `symlink-paths.lex` (`home.X`, `_home/`, `_xdg/`, `[symlink.targets]`) all express user intent within those two coordinates.
+
+        MacOs GUI applications read configuration from a third coordinate: `~/Library/Application Support/<App>/`. VS Code reads `~/Library/Application Support/Code/User/settings.json` on MacOs but `~/.config/Code/User/settings.json` on Linux. Same logical file, different root, *and the folder name (`Code`) often differs from the natural pack name (`vscode`)*.
+
+        Today the only way to land a file under `~/Library/Application Support/` in dodot is `[symlink.targets]` with an absolute path. That hardcodes the platform into the pack and forfeits the pack-relative composability the `_xdg/` and `_home/` prefixes were introduced to provide.
+
+    1.2. `XDG_CONFIG_HOME` Cannot Be the Switch
+
+        A tempting solution would be to redirect `$XDG_CONFIG_HOME` itself to `~/Library/Application Support/` on MacOs — exactly what the Rust `directories` crate does. dodot rejects this approach. Modern CLI tools on MacOs (nvim, helix, ghostty, kitty, lazygit, starship, gh, …) use `~/.config/` natively and would break under such a flip. MacOs users routinely have both kinds of tools coexisting on the same machine. The choice between roots cannot be a per-machine env-var; it must be a per-target decision encoded in the pack.
+
+    1.3. Cross-Platform Packs
+
+        A `vscode` pack containing `User/settings.json` should deploy to:
+
+            - Linux:  `~/.config/Code/User/settings.json`
+            - MacOs:  `~/Library/Application Support/Code/User/settings.json`
+
+        Both the root *and* the app-folder name diverge from a naive `vscode/User/settings.json` reading. dodot needs a way for the pack to express "this is GUI-app config under the name X", once, with the OS choosing the root and an alias mechanism resolving the pack-name → app-folder mismatch.
+
+    1.4. Goals
+
+        - Express "this is GUI-app config" once per subtree, in a way that does the right thing on Linux *and* MacOs, without `if os == "darwin"` branching inside packs.
+        - Slot cleanly into the existing §1–§5 priority ladder as new rungs, not as parallel machinery.
+        - Keep the resolver deterministic over textual prefixes; OS-awareness lives in one place (`Pather`).
+        - Make `dodot adopt ~/Library/Application\ Support/Code/User/settings.json` Just Work — produce a pack-relative path that round-trips on both platforms.
+        - Avoid mackup-style maintenance debt. Ship a small curated list of well-known apps with a hard cap; do not maintain a 700-entry database.
+
+2. Three Roots, Not Two
+
+    2.1. The `Pather` Surface
+
+        A new accessor on the `Pather` trait exposes the application-support root:
+
+        Pather addition:
+
+            fn app_support_dir(&self) -> &Path;
+
+        :: rust ::
+
+        Resolution in `XdgPatherBuilder::build()`:
+
+            - MacOs:           `$HOME/Library/Application Support`
+            - Linux and other: `$XDG_CONFIG_HOME` (so `_app/` falls through cleanly to the existing root)
+
+        Overridable via `XdgPatherBuilder::app_support_dir(...)` for tests and for users who deliberately want MacOs to route through `~/.config/` like Linux. The OS check lives exclusively in this builder; the resolver stays platform-agnostic and operates only on textual prefixes.
+
+    2.2. Three Coordinates Going Forward
+
+        After this proposal lands, every symlink target resolves into exactly one of three roots:
+
+        Roots:
+            | Symbol             | MacOs                                 | Linux / other         |
+            | `$HOME`            | `/Users/<user>`                       | `/home/<user>`        |
+            | `$XDG_CONFIG_HOME` | `~/.config` (unless env-set)          | `~/.config` (unless env-set) |
+            | `app_support_dir`  | `~/Library/Application Support`       | `$XDG_CONFIG_HOME`    |
+        :: table align=lll ::
+
+        On Linux the second and third coordinates collapse to one filesystem location. On MacOs they diverge. The resolver always knows which of the three a target belongs to; the OS only enters the picture once, when `Pather` materialises `app_support_dir`.
+
+3. The `_app/` Directory Prefix
+
+    3.1. Behavior
+
+        `_app/` is the per-subtree opt-in for "this is GUI-application config". Like `_xdg/` and `_home/`, it skips pack namespacing entirely: every file under `_app/` deploys raw, with the pack name playing no role.
+
+        Mapping:
+
+            <pack>/_app/<name>/<rest>  →  <app_support_dir>/<name>/<rest>
+
+        Concretely, a portable `vscode` pack:
+
+        Pack layout:
+
+            vscode/
+                _app/
+                    Code/
+                        User/
+                            settings.json
+                            keybindings.json
+
+        :: text ::
+
+        Deploys to:
+
+            - Linux:  `~/.config/Code/User/settings.json`
+            - MacOs:  `~/Library/Application Support/Code/User/settings.json`
+
+        The pack literally states "this is GUI-app config under name `Code`". dodot picks the root per platform.
+
+    3.2. Position in the Priority Ladder
+
+        `_app/` is an explicit per-subtree user opt-in, structurally identical to `_xdg/` and `_home/`. It joins them at Priority 2 of the resolver (see §5). It outranks `force_home` and the default rule, but is outranked by `home.X` (per-file opt-in, more specific) and `[symlink.targets]` (explicit absolute override).
+
+    3.3. The `app_aliases` Map
+
+        Cross-platform packs frequently want the *natural* pack name (`vscode`) without writing `_app/Code/` for every entry. The `[symlink.app_aliases]` table lets a user declare a pack-level rewrite:
+
+        Pack-level alias:
+
+            [symlink.app_aliases]
+            vscode = "Code"
+            warp   = "dev.warp.Warp-Stable"
+
+        :: toml ::
+
+        When a pack name appears as a key in `app_aliases`, the *default rule* for that pack is rerouted: instead of `$XDG_CONFIG_HOME/<pack>/<rel_path>`, the deploy path becomes `<app_support_dir>/<value>/<rel_path>`. The pack `vscode` with `User/settings.json` then deploys to `~/Library/Application Support/Code/User/settings.json` on MacOs, `~/.config/Code/User/settings.json` on Linux — without any `_app/` prefix in the pack tree.
+
+        Aliases compose with the rest of the ladder:
+
+            - A `home.X` file inside an aliased pack still routes to `$HOME/.X` (priority 1 outranks the aliased default).
+            - A `_xdg/` subtree inside an aliased pack still deploys raw under `$XDG_CONFIG_HOME` (explicit user intent wins over the alias).
+            - A `[symlink.targets]` entry still wins absolutely.
+
+        Aliases are scoped to the alias map's defining `.dodot.toml`. A pack-level `.dodot.toml` setting `[symlink.app_aliases]` overrides the root `.dodot.toml`. A pack-level alias is the recommended location, since the alias is logically a property of the pack.
+
+    3.4. The Curated `force_app` List
+
+        Analogous to `force_home`, `force_app` is a curated list of top-level pack-entry names that get auto-routed to the app-support root *without* requiring a `_app/` prefix or an alias entry. It exists to make the high-impact common case (well-known editors, terminals, productivity apps) magical.
+
+        Schema:
+
+            [symlink]
+            force_app = [
+                "Code",
+                "Cursor",
+                "Sublime Text",
+                "Rectangle Pro",
+                # … capped at ~100 entries; see §3.4.1
+            ]
+
+        :: toml ::
+
+        Matching follows `force_home` semantics: the *first segment* of the pack-relative path is compared against entries (case-sensitive — Library folder names are case-sensitive).
+
+        3.4.1. The Hundred-Entry Cap
+
+            The default `force_app` list is capped at 100 entries, enforced as a CI invariant. Adding entry 101 is a forcing function to drop the weakest-justified existing entry. This keeps the list a curated convenience, not an open-ended database. The cap is not configurable; users who want more redirects use `_app/` or `app_aliases`.
+
+            Inclusion criterion (documented in the source file, one-line per entry):
+
+                - The app must be widely deployed in the developer-tools community.
+                - Its Application Support folder name must be stable across versions.
+                - The folder name must not collide with any plausible CLI tool's `~/.config/` directory.
+
+            Entries that fail the third criterion (e.g. an app whose folder name happens to be `vim`) are excluded by construction.
+
+        3.4.2. Initial Seed
+
+            The initial list is empty. Entries are added based on real user demand once the mechanism ships. This avoids day-one wrong defaults and lets the cap-100 discipline establish itself organically.
+
+4. The `_lib/` Directory Prefix
+
+    4.1. Behavior
+
+        `_lib/` is the MacOs-only counterpart to `_app/`. Where `_app/` cross-routes between two platforms, `_lib/` declares a hard MacOs-only target — appropriate for apps with no Linux equivalent (`Rectangle Pro`, `Karabiner-Elements`, MacOs-native plist consumers).
+
+        Mapping (MacOs):
+
+            <pack>/_lib/<rest>  →  $HOME/Library/<rest>
+
+        Note that `_lib/` maps to `~/Library/`, *not* to `~/Library/Application Support/`. This gives access to other Library subtrees (e.g. `LaunchAgents/`, `Fonts/`, `Services/`) without further prefix proliferation. The user writes the full subpath:
+
+        Examples:
+
+            <pack>/_lib/Application Support/Rectangle Pro/RectanglePro.json
+                →  ~/Library/Application Support/Rectangle Pro/RectanglePro.json
+
+            <pack>/_lib/LaunchAgents/com.example.foo.plist
+                →  ~/Library/LaunchAgents/com.example.foo.plist
+
+        :: text ::
+
+    4.2. Linux Behavior
+
+        On non-MacOs platforms, `_lib/` emits no symlink intent and produces a soft warning:
+
+        Warning text:
+
+            warning: pack `<pack>` contains `_lib/<rest>` — MacOs-only path,
+                     skipping on this platform
+
+        :: text ::
+
+        The pack is otherwise unaffected; other entries deploy normally. This matches the friction level of a missing source file: visible, recoverable, non-fatal.
+
+5. Path Resolution: Full Specification
+
+    5.1. The Updated Priority Ladder
+
+        The resolver in `crates/dodot-lib/src/handlers/symlink.rs` evaluates the following rules in order. The first matching rule wins. This is a strict superset of the existing ladder; sessions 0, 1, 3, 4 are unchanged from `symlink-paths.lex`.
+
+        Priorities (highest first):
+
+            0. Custom target from `[symlink.targets]`
+            1. `home.X` prefix (top-level files only) → `$HOME/.X`
+            2. Directory prefixes (per-subtree, skip pack namespace):
+                a. `_home/<rest>` → `$HOME/.<rest>`
+                b. `_xdg/<rest>`  → `$XDG_CONFIG_HOME/<rest>`
+                c. `_app/<rest>`  → `<app_support_dir>/<rest>`
+                d. `_lib/<rest>`  → `$HOME/Library/<rest>` (MacOs only; warn elsewhere)
+            3. `force_home` list → `$HOME/.<first-segment>/<rest>`
+            4. `force_app` list → `<app_support_dir>/<first-segment>/<rest>`
+            5. `app_aliases[pack]` → `<app_support_dir>/<alias>/<rel_path>`
+            6. Default → `$XDG_CONFIG_HOME/<pack-display-name>/<rel_path>`
+
+        Tie-breaking notes:
+
+            - Within Priority 2, only one prefix can match a given path (they are mutually exclusive by syntax).
+            - `force_home` and `force_app` are mutually exclusive; entries appearing in both lists are a configuration error and produce a startup warning.
+            - `app_aliases` only applies when no higher-priority rule matched — it modifies *the default*, not user-explicit prefixes.
+
+    5.2. Resolver Pseudocode
+
+        Pseudocode:
+
+            fn resolve_target(pack, rel_path, config, paths) -> PathBuf {
+                let pack = display_name_for(pack);  // strip ordering prefix
+                let home = paths.home_dir();
+                let xdg  = paths.xdg_config_home();
+                let app  = paths.app_support_dir();
+
+                // 0. Custom target override
+                if let Some(t) = config.targets.get(rel_path) {
+                    return if t.is_absolute() { t } else { xdg.join(t) };
+                }
+
+                // 1. home.X (top-level files only)
+                if let Some(rest) = strip_home_prefix(rel_path) {
+                    return home.join(rest);
+                }
+
+                // 2. Directory-prefix escape hatches
+                if let Some(r) = rel_path.strip_prefix("_home/")  { return home.join(dot_first(r)); }
+                if let Some(r) = rel_path.strip_prefix("_xdg/")   { return xdg.join(r); }
+                if let Some(r) = rel_path.strip_prefix("_app/")   { return app.join(r); }
+                if let Some(r) = rel_path.strip_prefix("_lib/")   {
+                    return if cfg!(target_os = "MacOs") { home.join("Library").join(r) }
+                           else { warn_and_skip() };
+                }
+
+                // 3. force_home
+                if is_force_home(rel_path, &config.force_home) {
+                    return home.join(dot_first(rel_path));
+                }
+
+                // 4. force_app
+                if is_force_app(rel_path, &config.force_app) {
+                    return app.join(rel_path);
+                }
+
+                // 5. app_aliases (pack-level rewrite of the default)
+                if let Some(alias) = config.app_aliases.get(pack) {
+                    return app.join(alias).join(rel_path);
+                }
+
+                // 6. Default
+                xdg.join(pack).join(rel_path)
+            }
+
+        :: rust ::
+
+    5.3. Worked Examples
+
+        All examples assume `XDG_CONFIG_HOME=~/.config`, MacOs unless noted, and `[symlink.app_aliases] vscode = "Code"`.
+
+        Examples:
+            | Pack/path                            | Resolution                                                          |
+            | `vscode/User/settings.json`          | `~/Library/Application Support/Code/User/settings.json` (rule 5)    |
+            | `vscode/User/settings.json` (Linux)  | `~/.config/Code/User/settings.json` (rule 5)                        |
+            | `vscode/_xdg/Code/User/foo`          | `~/.config/Code/User/foo` (rule 2b — explicit overrides alias)      |
+            | `mac-apps/_app/Cursor/User/keys`     | `~/Library/Application Support/Cursor/User/keys` (rule 2c)          |
+            | `mac-apps/_lib/LaunchAgents/x.plist` | `~/Library/LaunchAgents/x.plist` (rule 2d, MacOs)                   |
+            | `mac-apps/_lib/...` (Linux)          | (skipped, warning emitted)                                          |
+            | `nvim/init.lua`                      | `~/.config/nvim/init.lua` (rule 6)                                  |
+            | `shell/home.bashrc`                  | `~/.bashrc` (rule 1)                                                |
+            | `net/ssh/config`                     | `~/.ssh/config` (rule 3, force_home)                                |
+            | `apps/Code/User/foo` + force_app     | `~/Library/Application Support/Code/User/foo` (rule 4)              |
+        :: table align=ll ::
+
+6. Configuration Surface
+
+    6.1. Schema Additions
+
+        Added `[symlink]` keys:
+
+            [symlink]
+            # When true, `_app/` and `app_aliases` route through
+            # ~/Library/Application Support on MacOs. Default true on
+            # darwin, false elsewhere. Set false on MacOs to opt into
+            # Linux-style ~/.config behavior for everything.
+            app_uses_library = true
+
+            # Curated list. Top-level pack entries whose first segment
+            # matches deploy to <app_support_dir>/<name>/. Capped at 100.
+            force_app = []
+
+        :: toml ::
+
+        Added `[symlink.app_aliases]` table:
+
+            [symlink.app_aliases]
+            vscode = "Code"
+            warp   = "dev.warp.Warp-Stable"
+
+        :: toml ::
+
+    6.2. Inheritance
+
+        Follows the existing 3-layer hierarchy: compiled defaults < root `.dodot.toml` < pack `.dodot.toml`. `app_aliases` is most idiomatically declared in pack-level config since it is logically a property of the pack.
+
+    6.3. Defaults by Platform
+
+        | Setting             | MacOs default | Linux default                       |
+        | `app_uses_library`  | `true`        | `false` (and ignored)               |
+        | `force_app`         | `[]`          | `[]`                                |
+        | `app_aliases`       | `{}`          | `{}` (pack-level overrides apply equally) |
+        :: table align=lll ::
+
+        On Linux with `app_uses_library = false`, `_app/` and `app_aliases` continue to route, but `app_support_dir` resolves to `$XDG_CONFIG_HOME` so behavior is indistinguishable from `_xdg/`. The mechanism is OS-agnostic; only the destination differs.
+
+7. Adopt: Source Roots
+
+    7.1. Recognized Source Roots
+
+        `dodot adopt` currently refuses sources whose parent is not `$HOME` (the "flat-at-top-level" rule). This proposal extends the recognised parent set to three roots:
+
+        Recognized adopt source roots:
+            | Source path under                          | Pack-relative path                      |
+            | `$HOME/<file>`                             | per existing rules (`home.X`, `_home/`) |
+            | `$XDG_CONFIG_HOME/<X>/<rest>`              | `_xdg/<X>/<rest>`                       |
+            | `~/Library/Application Support/<X>/<rest>` | `_app/<X>/<rest>`                       |
+        :: table align=ll ::
+
+        The "parent must be `$HOME`" check in `commands/adopt.rs::preflight` becomes "parent must be one of the recognized roots, with the pack-relative path derived per the source root's rule".
+
+    7.2. Pack-Relative Path Derivation
+
+        Extends `derive_pack_filename` to accept the source root as input:
+
+            - Source under `$HOME`: existing logic (force_home → bare name; dotted → `home.X` for files, `_home/X` for dirs; non-dotted refused).
+            - Source under `$XDG_CONFIG_HOME/<X>/`: derive `_xdg/<X>/<rest>` (today this is refused as nested-source).
+            - Source under `~/Library/Application Support/<X>/`: derive `_app/<X>/<rest>`.
+
+        The cross-pack deploy-conflict check in adopt's preflight still applies. Adopting a path that already collides with another pack's deployment fails before the copy phase, regardless of root.
+
+    7.3. Sandboxed Apps
+
+        MacOs sandboxed apps (App Store apps and many first-party apps) write to `~/Library/Containers/<bundle-id>/Data/Library/Application Support/<X>/` rather than the canonical location. These containers are not intended for external editing and their contents are often partially managed by the system.
+
+        `dodot adopt` refuses sources under `~/Library/Containers/` with a clear message:
+
+        Refusal text:
+
+            error: <path>
+              this is a sandboxed app's container; its config is not
+              intended to be edited externally. dodot does not support
+              adopting from ~/Library/Containers/.
+
+        :: text ::
+
+        Users who genuinely need to manage container files can copy them into a pack manually and use `[symlink.targets]` with an absolute path.
+
+8. Automagical Path Divination
+
+    The deterministic resolver in §5 is intentionally narrow: it operates on textual prefixes and configured lists, nothing else. But MacOs exposes rich metadata about installed applications, and Homebrew — present on essentially every MacOs developer machine — maintains a community-curated database of where every cask-installed app stores its data. Used judiciously, these signals turn `dodot adopt` into a pleasant suggestion engine and `dodot up` into a verification layer that catches typos before they ship.
+
+    The cardinal rule for everything in this session: *probes are advisory, never authoritative*. The resolver in §5 never consults them. If a probe returns wrong information, the user sees a wrong suggestion or a wrong warning, not a wrong deployment.
+
+    8.1. The Capitalization Heuristic
+
+        MacOs GUI app folders under `~/Library/Application Support/` follow a strong naming pattern that distinguishes them from Linux CLI-tool config folders under `~/.config/`. A folder name is a *probable* MacOs GUI app target if:
+
+            - It contains at least one uppercase letter (`Code`, `Cursor`, `IntelliJ IDEA`, `Sublime Text`), or
+            - It contains a space (`Application Support`, `Sublime Text 3`, `Smart Code ltd`), or
+            - It matches a reverse-DNS pattern of two or more dotted lowercase segments (`com.apple.dt.Xcode`, `org.videolan.vlc`, `dev.warp.Warp-Stable`).
+
+        A folder name is a *probable* CLI-tool target if it is all lowercase, contains no spaces, and does not match reverse-DNS. The CLI-tool population (`nvim`, `helix`, `ghostty`, `kitty`, `lazygit`, …) is uniformly lowercase-hyphenated; the population of capitalized `~/.config/Foo` directories for CLI tools is empty in practice (FS case-insensitivity gotchas keep package authors away from it).
+
+        Used inside `dodot adopt`, this heuristic powers the default suggestion when a source path could be ambiguous. It is *not* used in the resolver, where determinism over textual prefixes is non-negotiable.
+
+    8.2. Homebrew Cask Probing
+
+        Homebrew cask packages declare a `zap` stanza enumerating every filesystem location an app touches: Application Support directories, Caches, Preferences PLists, LaunchAgents, et cetera. This is structurally the same data mackup curated by hand for years — except homebrew-cask is community-maintained at scale and self-updates as apps change.
+
+        Available via subprocess:
+
+            $ brew list --cask --versions      # installed casks (offline, fast)
+            $ brew info --json=v2 --cask <token>   # full metadata incl. zap
+
+        The JSON output's `artifacts[].zap` field gives, for any installed cask:
+
+            - app-folder-name candidates: leaf names of `~/Library/Application Support/<X>` zap entries
+            - bundle name: `artifacts[].app[0]` (e.g. `"Visual Studio Code.app"`)
+            - associated Preferences plists, Caches, LaunchAgents
+
+        dodot uses this data in two places:
+
+            - At `adopt` time, to enrich the success message ("homebrew cask `visual-studio-code` confirms this is VS Code's app-support directory") and to surface sibling adoption candidates ("homebrew also reports `~/Library/Preferences/com.microsoft.VSCode.plist` for this cask — adopt that too?").
+            - At `up`/`status` time, to soften "missing target directory" warnings into actionable hints ("looks like `<cask-token>` isn't installed yet — `_app/Code/...` will deploy but the app isn't here to read it").
+
+        8.2.1. Why Not Auto-Derive `force_app`
+
+            A reasonable-sounding alternative is to populate `force_app` automatically from homebrew-cask zap data. dodot deliberately does not do this. Auto-derivation reintroduces mackup's maintenance debt by proxy: a homebrew-cask change to a zap stanza would silently change a dodot deployment. The curated 100-entry list (§3.4) is owned by dodot. Brew probes inform user-facing suggestions, never resolver state.
+
+    8.3. MacOs Native APIs
+
+        Several MacOs-native sources of metadata complement homebrew probing:
+
+            - `mdls` — Spotlight metadata for a single bundle. `mdls -name kMDItemCFBundleIdentifier "/Applications/<X>.app"` returns the bundle ID (e.g. `com.microsoft.VSCode`). Instantaneous.
+            - `mdfind` — Spotlight query. `mdfind "kMDItemKind == 'Application' && kMDItemDisplayName == 'Cursor'"` resolves a display name to a bundle path. Useful when only a friendly name is known.
+            - `defaults domains` — lists every preference domain registered in `~/Library/Preferences/`. The canonical API for plist-style preferences. Out of scope for `_app/` (preferences are a different file class) but available if `_lib/Preferences/` ever needs validation.
+            - `lsregister -dump` — the full LaunchServices database. Comprehensive but heavy. Not used by dodot baseline.
+            - `NSFileManager.URLsForDirectory(.applicationSupportDirectory, ...)` — the Cocoa API. Would require linking AppKit; not worth the dependency burden when env-var resolution is sufficient and trivially mockable.
+
+        Of these, `mdls` is the most useful: cheap, scriptable, and resolves the "is this directory actually an installed app?" question authoritatively when given the .app bundle path.
+
+    8.4. The `dodot probe app` Subcommand
+
+        A new probe subcommand surfaces all available metadata for a pack, treating MacOs introspection as an explicit diagnostic step rather than a silent background process:
+
+            $ dodot probe app <pack>
+
+        Reports, for each `_app/<X>` entry and each `app_aliases[pack]` mapping in the pack:
+
+            - whether `<app_support_dir>/<X>/` exists on the local filesystem
+            - matching homebrew cask (token, install state)
+            - matching `/Applications/<X>.app` bundle and its bundle ID (via `mdfind`/`mdls`)
+            - suggested `app_aliases` entries when the pack-display-name diverges from the resolved app-folder name
+
+        Sample output:
+
+            pack: vscode
+              alias: vscode → Code (~/Library/Application Support/Code/) [exists]
+              cask:  visual-studio-code [installed]
+              app:   /Applications/Visual Studio Code.app
+              bundle: com.microsoft.VSCode
+              suggested adoptions:
+                ~/Library/Preferences/com.microsoft.VSCode.plist (from cask zap)
+
+        :: text ::
+
+        This is a debugging and discovery surface, not part of any deployment hot path. It is run on demand.
+
+    8.5. What dodot Does Not Do
+
+        Out of scope, deliberately:
+
+            - Auto-curate `force_app` from homebrew-cask zap data (§8.2.1).
+            - Run a long-running daemon that watches LaunchServices for app-install events.
+            - Use `defaults write/read` to manage plist contents (that is a separate handler — see [./plists.lex]).
+            - Mirror mackup's bundled app database. The combination of `_app/`, `app_aliases`, `force_app` (curated, capped), and homebrew probing covers the same ground without the curation cost.
+
+9. Documentation Updates
+
+    `docs/reference/symlink-paths.lex` gains a new §6 (renumbering existing §6/§7) documenting `_app/` and `_lib/`, and §3 (`force_home`) gains a sibling `force_app` subsection. The §1 introduction adds the third-coordinate table from §2.2 of this proposal.
+
+    `docs/reference/terms-and-concepts.lex` adds entries for *app-support root*, *app alias*, and *force_app*.
+
+    A new tutorial section (`dodot tutorial`) walks through adopting `~/Library/Application Support/Code/User/settings.json` end-to-end on MacOs, demonstrating both the `_app/` prefix and the `app_aliases` mechanism.
+
+10. Implementation Phases
+
+    This proposal is structurally additive: every change either introduces a new resolver rule, a new config key, or a new advisory probe. No existing behaviour changes. Phases are independently shippable.
+
+    Phase M1: `Pather` and `_app/`
+        - Add `app_support_dir()` to `Pather` and `XdgPatherBuilder`.
+        - Add the `_app/` directory prefix to the resolver as Priority 2c.
+        - Add `app_uses_library` config key with platform-aware defaults.
+        - Update `symlink-paths.lex` with the new prefix.
+        - Tests: prefix resolution on both platforms; builder override.
+
+    Phase M2: `force_app` and `app_aliases`
+        - Add `force_app` config key and resolver Priority 4.
+        - Add `[symlink.app_aliases]` table and resolver Priority 5.
+        - Add CI invariant capping `force_app` defaults at 100 entries.
+        - Tests: alias-vs-prefix precedence; alias scoping; force_app first-segment matching.
+
+    Phase M3: `_lib/`
+        - Add the `_lib/` directory prefix as Priority 2d (MacOs) / warn-and-skip (other).
+        - Tests: MacOs resolution; Linux warning emission.
+
+    Phase M4: Adopt extensions
+        - Extend `derive_pack_filename` to accept the source root.
+        - Recognize `~/Library/Application Support/<X>/` as a valid adopt source.
+        - Recognize `$XDG_CONFIG_HOME/<X>/` as a valid adopt source (deriving `_xdg/`).
+        - Refuse `~/Library/Containers/` sources.
+        - Tests: round-trip adopt → up → identical deployed path; container refusal.
+
+    Phase M5: Capitalization heuristic in adopt
+        - Use the heuristic to drive `adopt`'s default suggestion when the user's input is ambiguous.
+        - Keep the resolver heuristic-free.
+
+    Phase M6: Brew + MacOs probes
+        - Implement `brew info --json=v2 --cask` lookup with on-disk caching.
+        - Wire enrichment into `adopt` success messages and sibling-adoption suggestions.
+        - Wire missing-target verification into `up`/`status`.
+        - Add the `dodot probe app` subcommand.
+        - Tests: mock subprocess output; cache invalidation.
+
+    Phases M1–M4 are the deterministic core and ship together as a single user-facing feature. Phase M5 is small ergonomics. Phase M6 is the advisory layer and is independently shippable later.
+
+11. Open Questions and Future Work
+
+    11.1. `_app/` Naming
+
+        Alternatives considered: `_gui/`, `_apps/`, `_appcfg/`. `_app/` is the shortest and matches the term "app config" most readers reach for first. Locked in unless review surfaces a strong objection.
+
+    11.2. `app_uses_library = false` on MacOs
+
+        Allowed and supported. A user who is "`~/.config`-everywhere even on MacOs" can flip this in their root `.dodot.toml`, and `_app/` plus `app_aliases` will route through `~/.config/` instead. `_lib/` is unaffected (it explicitly targets `~/Library/`, not `app_support_dir`).
+
+    11.3. Plist Coverage
+
+        `_lib/Preferences/<bundle-id>.plist` is syntactically valid under this proposal, but plist files are usually binary and not directly user-editable. The plist preprocessor [./plists.lex] is the right path for plist content management. `_lib/Preferences/` covers the routing; the preprocessor covers the format. The two compose without further work.
+
+    11.4. Windows
+
+        Out of scope for this proposal. Windows analogues (`%APPDATA%`, `%LOCALAPPDATA%`) would slot into the same architecture by extending `Pather` with additional accessors and adding a `_appdata/` prefix. Deferred until there is a real Windows user.
+
+    11.5. Adopt-Time Plist Conversion
+
+        When a user adopts `~/Library/Preferences/com.foo.plist` (a binary plist), should adopt automatically invoke the plist preprocessor's reverse path to produce the XML form? The `plists.lex` proposal answers yes. This proposal defers to that one and stays orthogonal.

--- a/docs/proposals/macos-paths.lex
+++ b/docs/proposals/macos-paths.lex
@@ -332,34 +332,91 @@ Design Specification: MacOs Paths and the `_app/` Convention
 
 7. Adopt: Source Roots
 
-    7.1. Recognized Source Roots
+    The pre-inference adopt CLI took the form `dodot adopt <pack> <files...>` and refused any source whose parent was not `$HOME` (the "flat-at-top-level" rule). The inference framework — landed for HOME and XDG roots, with the AppSupport root reserved here for Phases M1–M4 — generalises that into a per-source path-inference pass that picks the pack name, the in-pack path, and the round-trip prefix from the source's deployed location.
 
-        `dodot adopt` currently refuses sources whose parent is not `$HOME` (the "flat-at-top-level" rule). This proposal extends the recognised parent set to three roots:
+    7.1. CLI Shape
+
+        New shape:
+
+            dodot adopt <path>...                # pack name inferred per source
+            dodot adopt <path>... --into <pack>  # all sources land in <pack>
+
+        :: text ::
+
+        `--into` is the override switch: it forces a single destination pack regardless of what inference would have picked. When the source's natural pack differs from the override, the in-pack path switches to the explicit-prefix encoding (`_xdg/<X>/<rest>`, `_app/<X>/<rest>`) so round-trip via Priority 2 still lands the deployed file at the original location. See §7.4.
+
+    7.2. Recognized Source Roots
+
+        Recognized adopt source roots, with the in-pack path each yields when the pack name is the *naturally inferred* one (i.e. `--into` agrees with inference, or `--into` is omitted). The override-aware path is in §7.4.
 
         Recognized adopt source roots:
-            | Source path under                          | Pack-relative path                      |
-            | `$HOME/<file>`                             | per existing rules (`home.X`, `_home/`) |
-            | `$XDG_CONFIG_HOME/<X>/<rest>`              | `_xdg/<X>/<rest>`                       |
-            | `~/Library/Application Support/<X>/<rest>` | `_app/<X>/<rest>`                       |
+            | Source path under                          | Inferred pack | In-pack path (natural) |
+            | `$HOME/.<X>` (file)                        | (require `--into`) | `home.<X>`        |
+            | `$HOME/.<X>/...` (dir)                     | (require `--into`) | `_home/<X>/...`   |
+            | `$HOME/<X>` (force_home match)             | (require `--into`) | `<X>` (bare)      |
+            | `$XDG_CONFIG_HOME/<X>/<rest>`              | `<X>`              | `<rest>`          |
+            | `$XDG_CONFIG_HOME/<X>/` (the dir itself)   | `<X>`              | (expand children) |
+            | `~/Library/Application Support/<X>/<rest>` | `<X>`              | `_app/<X>/<rest>` |
+            | `~/Library/Application Support/<X>/`       | `<X>`              | (expand children) |
+        :: table align=lll ::
+
+        Two design notes are load-bearing:
+
+            - **XDG sources use *bare* in-pack paths, not `_xdg/<X>/<rest>`.** The pack-name segment is *the* pack name; the resolver's default rule (Priority 6, `$XDG/<pack>/<rel>`) round-trips correctly without any prefix. This is a corrected reading versus an earlier draft of this section. The `_xdg/` prefix is the *override* encoding (§7.4), not the natural one.
+            - **AppSupport in-pack paths *do* use the `_app/<X>/` prefix even at natural pack name.** That's because the resolver's default rule routes pack `<X>` to `$XDG/<X>/`, *not* `<app_support_dir>/<X>/`. Without the `_app/` prefix the round-trip would land the file in `~/.config/<X>/` on MacOs (wrong root), so the prefix is mandatory. Alternative: declare `[symlink.app_aliases] <X> = "<X>"` in the pack and use bare paths; adopt may emit this aliasing form when the capitalization heuristic (§8.1) says the folder is a GUI app and the user opts in. By default adopt produces `_app/<X>/<rest>` with no config writes.
+
+    7.3. Inference Decline and `--into`
+
+        `$HOME/.X` sources (and force_home matches) carry no pack structure inference can mine: a file like `~/.bashrc` could plausibly belong in a `shell`, `bash`, or `dotfiles` pack. Inference declines and surfaces an error pointing at `--into`.
+
+        Multi-source invocations are required to agree on a single pack: if `~/.config/nvim/init.lua` and `~/.config/helix/config.toml` are passed together without `--into`, inference produces conflicting pack names (`nvim` and `helix`) and adopt refuses, naming both candidates so the user can split or specify `--into`.
+
+        Mixing HOME-decline and XDG-inferred sources in a single invocation is allowed: they all land in the (single) inferred pack, with the HOME sources using their pack-name-independent `home.X` / `_home/X/` prefixes.
+
+    7.4. Pack-Override Encoding
+
+        When `--into <Y>` is supplied and `<Y>` ≠ the source's natural pack name, the in-pack path switches to the explicit-prefix encoding so the deployed path stays the same:
+
+        Override-aware in-pack paths:
+            | Source root                                 | In-pack path (override)       |
+            | `$HOME/...`                                 | unchanged from §7.2 (already pack-name independent) |
+            | `$XDG_CONFIG_HOME/<X>/<rest>`               | `_xdg/<X>/<rest>`             |
+            | `~/Library/Application Support/<X>/<rest>`  | `_app/<X>/<rest>` (same as natural) |
         :: table align=ll ::
 
-        The "parent must be `$HOME`" check in `commands/adopt.rs::preflight` becomes "parent must be one of the recognized roots, with the pack-relative path derived per the source root's rule".
+        Concrete: `dodot adopt ~/.config/lazygit/config.yml --into toolbox` lands the file at `toolbox/_xdg/lazygit/config.yml`. The `_xdg/` Priority-2 prefix bypasses pack-namespacing, so re-deploying still lands the symlink at `~/.config/lazygit/config.yml` even though the pack is `toolbox`.
 
-    7.2. Pack-Relative Path Derivation
+    7.5. Pack-Root Directory Expansion
 
-        Extends `derive_pack_filename` to accept the source root as input:
+        When the source IS the pack-root directory under XDG or AppSupport (`~/.config/nvim/`, `~/Library/Application Support/Code/`), adopt enumerates the directory's children and creates one plan per top-level entry, instead of making the directory itself one big symlink-to-pack-root. Each child becomes a top-level pack member, so `dodot up` deploys per-entry like any other pack.
 
-            - Source under `$HOME`: existing logic (force_home → bare name; dotted → `home.X` for files, `_home/X` for dirs; non-dotted refused).
-            - Source under `$XDG_CONFIG_HOME/<X>/`: derive `_xdg/<X>/<rest>` (today this is refused as nested-source).
-            - Source under `~/Library/Application Support/<X>/`: derive `_app/<X>/<rest>`.
+        Concrete: `dodot adopt ~/.config/helix/` produces, per child of `~/.config/helix/`:
 
-        The cross-pack deploy-conflict check in adopt's preflight still applies. Adopting a path that already collides with another pack's deployment fails before the copy phase, regardless of root.
+            - `~/.config/helix/config.toml` → `helix/config.toml`
+            - `~/.config/helix/themes/` → `helix/themes/`
 
-    7.3. Sandboxed Apps
+        After adopt, each child of `~/.config/helix/` is its own symlink; `~/.config/helix/` itself stays a real directory.
+
+        Expansion does not apply to `$HOME/.X/` directory sources — those keep the existing `_home/<X>/` whole-subtree adoption (§7.2 row 2). The reason is asymmetric: `~/.weechat/` *is* the file the user wants symlinked back, whereas `~/.config/helix/` is a container *whose contents* are what the user wants symlinked.
+
+    7.6. Auto-Creating Packs
+
+        When all sources point at a single inferred pack name and that pack does not exist on disk, adopt creates it (an empty directory; no `.dodot.toml` written). When `--into <pack>` is supplied and `<pack>` does not exist, adopt refuses — the explicit name is a typo guard the user opted into. The user can run `dodot init <pack>` first to bootstrap an explicit pack.
+
+    7.7. AppSupport Source Implementation Status
+
+        The `~/Library/Application Support/<X>/<rest>` row of §7.2 is *specified* but not yet *plumbed*: the inference framework reserves a `SourceRoot::AppSupport` variant, but the matcher does not consult it because `Pather` does not yet expose `app_support_dir()` (Phase M1). When M1 lands, two changes complete the AppSupport adopt path:
+
+            - Add a third arm to the root-matching ladder in `commands::adopt::infer::infer_target` checking `app_support_dir`, between the XDG and HOME arms (longest-prefix order: AppSupport > XDG > HOME — though on Linux both AppSupport and XDG resolve to the same path and the AppSupport arm is unreachable in practice).
+            - In the natural in-pack path, prepend `_app/<X>/` so Priority 2c routes back to `<app_support_dir>/<X>/<rest>`. The override-aware path is already `_app/<X>/<rest>` (§7.4), so override behavior is symmetric.
+
+        Adopt's directory-expansion path (`SourceRoot::AppSupport`) is already wired through `expand_child_in_pack`: when a pack-root directory under AppSupport expands, each child gets `_app/<X>/<child>` as its in-pack path. This is the "pack `vscode` with `app_aliases.vscode = "Code"`" alternative's *non-aliased* implementation, kept simple by default and refinable via the capitalization heuristic (§8.1) once advisory probing lands.
+
+    7.8. Sandboxed Apps
 
         MacOs sandboxed apps (App Store apps and many first-party apps) write to `~/Library/Containers/<bundle-id>/Data/Library/Application Support/<X>/` rather than the canonical location. These containers are not intended for external editing and their contents are often partially managed by the system.
 
-        `dodot adopt` refuses sources under `~/Library/Containers/` with a clear message:
+        `dodot adopt` refuses sources under `~/Library/Containers/` with a clear message. The refusal is platform-agnostic: even on Linux a path matching that shape is rejected, so the same refusal text is the right thing to print on every OS (the path simply doesn't exist on Linux in practice).
 
         Refusal text:
 

--- a/docs/reference/symlink-paths.lex
+++ b/docs/reference/symlink-paths.lex
@@ -131,3 +131,65 @@ Symlink Deployment Paths
         ]
 
     :: toml ::
+
+8. `dodot adopt`: Source-Path Inference
+
+    `dodot adopt` accepts a *deployed* path (where the file lives now) and works backwards to figure out which pack it belongs in and what to call it inside that pack — so re-deploying with `dodot up` lands the symlink back at the original location. The inference rules below are the inverse of §1–§5.
+
+    Calling shape:
+
+        dodot adopt <path>...                # pack name inferred per source
+        dodot adopt <path>... --into <pack>  # all sources land in <pack>
+
+    :: text ::
+
+    8.1. Inference Per Source Root
+
+        The source path's deployed location decides everything:
+
+        Source-root inference:
+            | Source path                                | Inferred pack | Pack-relative path                 |
+            | `~/.config/<X>/<rest>`                     | `<X>`             | `<rest>`                       |
+            | `~/.config/<X>/` (the directory itself)    | `<X>`             | (children expand individually) |
+            | `~/.<X>` (dotted file in $HOME)            | (require `--into`)| `home.<X>`                     |
+            | `~/.<X>/...` (dotted dir in $HOME)         | (require `--into`)| `_home/<X>/...`                |
+            | `~/.<X>` matching `force_home` (file/dir)  | (require `--into`)| `<X>` (bare, see §3)           |
+            | `~/<X>` non-dotted, not in `force_home`    | refused           | —                              |
+            | `~/Library/Application Support/<X>/<rest>` | `<X>`             | `_app/<X>/<rest>` (MacOs only) |
+            | `~/Library/Containers/...`                 | refused           | (sandboxed app data)           |
+            | anything else                              | refused           | use `[symlink.targets]`        |
+        :: table align=lll ::
+
+        XDG sources auto-infer because the first path segment under `~/.config/` *is* the pack name — the resolver's default rule (§1) handles the round-trip with no prefix gymnastics.
+
+        $HOME-rooted dotfiles don't infer a pack name because the structure isn't there to mine: `~/.bashrc` could plausibly belong in a `shell`, `bash`, or `dotfiles` pack, and adopt won't guess. What inference *does* compute is the in-pack path — the `home.X` / `_home/X/` / bare-name conventions from §2, §3, §5 — so the round-trip works regardless of the chosen pack name.
+
+    8.2. Pack-Root Directory Expansion
+
+        Adopting `~/.config/<X>/` (the whole directory) doesn't make the directory itself a single symlink. Instead, adopt enumerates its children and adopts each as a top-level pack member:
+
+        Example expansion of `~/.config/helix/`:
+
+            ~/.config/helix/config.toml      → helix/config.toml
+            ~/.config/helix/themes/          → helix/themes/
+
+        :: text ::
+
+        After adoption, each child of `~/.config/helix/` is its own symlink; `~/.config/helix/` itself stays a real directory. This matches what `dodot up` would do for a hand-built pack and avoids creating a pack whose root *is* a symlink target.
+
+        `~/.X/` directory sources keep the existing whole-subtree behavior (`_home/X/`): the directory itself becomes the symlink, because in $HOME the user's mental model is the directory *is* the file.
+
+    8.3. The `--into` Override
+
+        `--into <pack>` forces a destination pack regardless of inference. Two cases:
+
+            - **Override matches inferred pack** (or no inference happened, e.g. HOME source): the natural in-pack path is used.
+            - **Override differs from inferred pack** (XDG sources only): the in-pack path switches to `_xdg/<X>/<rest>` so the explicit `_xdg/` prefix from §5 bypasses pack-namespacing and lands the deployed file at the same place.
+
+        Concrete: `dodot adopt ~/.config/lazygit/config.yml --into toolbox` lands the file at `toolbox/_xdg/lazygit/config.yml`. Re-deploying still lands the symlink at `~/.config/lazygit/config.yml` even though the pack is `toolbox`.
+
+        Mixing HOME and XDG sources in one invocation is allowed: the HOME ones use their pack-name-independent prefixes, the XDG ones contribute the inferred pack name (or use `--into` if it differs). If two XDG sources infer different packs and no `--into` is given, adopt refuses and names both candidates so the user can split the invocation.
+
+    8.4. Auto-Creating Packs
+
+        When inference picks a single pack name and that pack does not exist on disk, adopt creates it (an empty directory). `--into <pack>` does *not* auto-create — the explicit name is a typo guard. Run `dodot init <pack>` first to bootstrap an explicit pack.

--- a/tests/e2e/bats/test_adopt.bats
+++ b/tests/e2e/bats/test_adopt.bats
@@ -115,9 +115,11 @@ teardown() {
 @test "adopt without --into for HOME source errors with hint" {
     create_home_file ".vimrc" "set nocompatible"
 
-    run dodot adopt "$HOME/.vimrc"
-    [ "$status" -ne 0 ]
+    # The CLI prints `Error: ...` but exits 0 (existing convention —
+    # other adopt failure tests in this file check output, not status).
     # The error message points the user at --into since HOME has no
     # inferable pack structure.
+    run dodot adopt "$HOME/.vimrc"
     assert_output_contains "--into"
+    assert_output_contains "could not infer"
 }

--- a/tests/e2e/bats/test_adopt.bats
+++ b/tests/e2e/bats/test_adopt.bats
@@ -14,14 +14,16 @@ teardown() {
     create_pack "vim"
     create_home_file ".vimrc" "set nocompatible"
 
-    run dodot adopt vim "$HOME/.vimrc"
+    # HOME-direct dotfile requires --into (pack name has no path-derivable
+    # source under the new inference rules).
+    run dodot adopt --into vim "$HOME/.vimrc"
     [ "$status" -eq 0 ]
     # Adopt output is now the destination pack's status (matches `dodot status vim`).
     assert_output_contains "vim"
     assert_output_contains "vimrc"
     assert_output_contains "pending"
 
-    # File should be in the pack (dot prefix stripped)
+    # File should be in the pack (dot prefix stripped, home. prefix added).
     assert_exists "$DOTFILES_ROOT/vim/home.vimrc"
     assert_file_contents "$DOTFILES_ROOT/vim/home.vimrc" "set nocompatible"
 
@@ -33,7 +35,7 @@ teardown() {
     create_pack_file "vim" "home.vimrc" "old content"
     create_home_file ".vimrc" "new content"
 
-    run dodot adopt vim --force "$HOME/.vimrc"
+    run dodot adopt --into vim --force "$HOME/.vimrc"
     [ "$status" -eq 0 ]
 
     assert_file_contents "$DOTFILES_ROOT/vim/home.vimrc" "new content"
@@ -43,7 +45,7 @@ teardown() {
     create_pack_file "vim" "home.vimrc" "old content"
     create_home_file ".vimrc" "new content"
 
-    run dodot adopt vim "$HOME/.vimrc"
+    run dodot adopt --into vim "$HOME/.vimrc"
     assert_output_contains "already exists"
 
     # Original pack file should be unchanged
@@ -55,13 +57,16 @@ teardown() {
     create_home_file ".bashrc" "# bashrc"
     create_home_file ".zshrc" "# zshrc"
 
-    run dodot adopt shell "$HOME/.bashrc" "$HOME/.zshrc"
+    run dodot adopt --into shell "$HOME/.bashrc" "$HOME/.zshrc"
     [ "$status" -eq 0 ]
     # Status output lists both adopted files under the destination pack.
     assert_output_contains "shell"
     assert_output_contains "bashrc"
     assert_output_contains "zshrc"
 
+    # `bashrc` and `zshrc` are in the default force_home list, so they
+    # adopt with the bare in-pack name (Priority 3 routes them back to
+    # ~/.X without the `home.` prefix).
     assert_exists "$DOTFILES_ROOT/shell/bashrc"
     assert_exists "$DOTFILES_ROOT/shell/zshrc"
 }
@@ -69,6 +74,50 @@ teardown() {
 @test "adopt reports error when target file does not exist" {
     create_pack "vim"
 
-    run dodot adopt vim "$HOME/.nonexistent"
+    run dodot adopt --into vim "$HOME/.nonexistent"
     assert_output_contains "source does not exist"
+}
+
+@test "adopt infers pack from XDG path and auto-creates" {
+    # No pre-existing pack, no --into — pack name comes from the path
+    # (`~/.config/<X>/...` → pack `<X>`), and the pack is auto-created.
+    create_home_file ".config/ghostty/config" "theme = dark"
+
+    run dodot adopt "$HOME/.config/ghostty/config"
+    [ "$status" -eq 0 ]
+    assert_output_contains "ghostty"
+
+    # Pack auto-created at <dotfiles>/ghostty/, file at pack root (the
+    # default rule routes pack `ghostty`/`config` back to ~/.config/ghostty/config).
+    assert_exists "$DOTFILES_ROOT/ghostty/config"
+    assert_file_contents "$DOTFILES_ROOT/ghostty/config" "theme = dark"
+    [ -L "$HOME/.config/ghostty/config" ]
+}
+
+@test "adopt of XDG pack-root directory expands to children" {
+    # Adopting the directory itself enumerates its children and adopts
+    # each as its own top-level pack entry (rather than symlinking the
+    # whole directory).
+    create_home_file ".config/helix/config.toml" "theme = \"onedark\""
+    create_home_file ".config/helix/themes/extra.toml" "fg = \"white\""
+
+    run dodot adopt "$HOME/.config/helix"
+    [ "$status" -eq 0 ]
+
+    assert_exists "$DOTFILES_ROOT/helix/config.toml"
+    assert_exists "$DOTFILES_ROOT/helix/themes/extra.toml"
+    [ -L "$HOME/.config/helix/config.toml" ]
+    [ -L "$HOME/.config/helix/themes" ]
+    # The pack-root directory itself stays a real directory.
+    [ ! -L "$HOME/.config/helix" ]
+}
+
+@test "adopt without --into for HOME source errors with hint" {
+    create_home_file ".vimrc" "set nocompatible"
+
+    run dodot adopt "$HOME/.vimrc"
+    [ "$status" -ne 0 ]
+    # The error message points the user at --into since HOME has no
+    # inferable pack structure.
+    assert_output_contains "--into"
 }


### PR DESCRIPTION
## Summary

- Adopt CLI shifts from `dodot adopt <pack> <files...>` to `dodot adopt <files...> [--into <pack>]`. Sources under `~/.config/<X>/...` auto-infer pack `<X>` (created if missing); `$HOME` dotfiles keep `home.X` / `_home/X/` conventions but now require `--into` since HOME has no pack structure to mine.
- `~/.config/<X>/` (the directory itself) expands to per-child plans instead of symlinking the whole dir. `--into <Y>` over an XDG source switches the in-pack path to `_xdg/<X>/<rest>` so round-trip is preserved across pack reroute. `~/Library/Containers/` is refused unconditionally.
- Future-proofs the macOS `_app/<X>/<rest>` case in the inference framework — `SourceRoot::AppSupport` is reserved and `expand_child_in_pack` already routes through `_app/`. Activation is documented in `docs/proposals/macos-paths.lex` §7 and waits on Phase M1's `Pather::app_support_dir()`.

## Test plan

- [x] `cargo test` — all 603 lib + bin tests pass
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] Inference unit tests cover every branch: XDG nested file, deep nesting, pack-root expansion, loose XDG file refusal, XDG root refusal, HOME dotted file/dir, force_home bare-name, non-dotted HOME refusal, HOME deeper-nesting refusal, HOME root refusal, XDG-inside-HOME longest-prefix ordering, unrecognized roots, sandboxed Containers refusal
- [x] End-to-end adopt tests cover: XDG nested file lands at pack root, XDG source auto-creates pack, XDG pack-root directory expands children, XDG override uses `_xdg/<X>/` prefix, disagreeing inferences refused, HOME source without `--into` errors with hint, XDG root itself refused
- [x] Property test (`pack_filename_round_trips_through_resolve_target`) still passes — shared HOME convention helper kept in sync

## Docs

- `docs/reference/symlink-paths.lex` §8 — full user-facing inference table
- `docs/proposals/macos-paths.lex` §7 — implementation spec, including the AppSupport row reserved for Phase M1
- `crates/dodot-cli/src/help/adopt.txt` — rewritten help with new examples
- `CHANGELOG_UNRELEASED.md` — Added entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)