### PR TITLE
chore(homebrew): pass brew style at render-time

### DIFF
--- a/.github/homebrew-formula.rb.tmpl
+++ b/.github/homebrew-formula.rb.tmpl
@@ -45,6 +45,7 @@ class {{CLASS_NAME}} < Formula
       Dir["*/{{BIN_NAME}}"].find { |path| File.file?(path) }
     end
     raise "Could not find {{BIN_NAME}} in extracted archive" unless executable
+
     bin.install executable
   end
 

--- a/.github/render-homebrew-formula.py
+++ b/.github/render-homebrew-formula.py
@@ -75,6 +75,31 @@ def ruby_double_quoted_escape(s: str) -> str:
     return "".join(out)
 
 
+def normalize_brew_desc(s: str) -> str:
+    """Normalize a description for Homebrew's FormulaAudit/Desc rules.
+
+    `brew style` enforces three rules that often clash with natural English /
+    Cargo.toml descriptions: must not start with an article ("A ", "An ",
+    "The "), must not end with a period, must be ≤79 characters. Normalize
+    at render time rather than bending Cargo.toml's `description`, which is
+    the canonical project description that reaches crates.io and other
+    consumers untouched.
+    """
+    s = s.strip()
+    for article in ("A ", "An ", "The "):
+        if s.startswith(article):
+            s = s[len(article):]
+            if s and s[0].islower():
+                s = s[0].upper() + s[1:]
+            break
+    if s.endswith("."):
+        s = s[:-1].rstrip()
+    if len(s) > 79:
+        cut = s.rfind(" ", 0, 80)
+        s = (s[:cut] if cut > 60 else s[:79]).rstrip()
+    return s
+
+
 def build_replacements() -> dict[str, str]:
     replacements: dict[str, str] = {}
     for key in PASSTHROUGH_KEYS:
@@ -84,6 +109,8 @@ def build_replacements() -> dict[str, str]:
     for key in RUBY_STRING_KEYS:
         raw = os.environ.get(key)
         if raw is not None:
+            if key == "DESC":
+                raw = normalize_brew_desc(raw)
             replacements[key] = ruby_double_quoted_escape(raw)
     return replacements
 


### PR DESCRIPTION
## Summary

Two-part fix that lets the homebrew-tools tap's `brew test-bot` go green without hand-editing every formula it receives. **The tap is a receiver — formula style is the source repo's concern.** Fix once at generation, propagate per release.

- **Template** (`.github/homebrew-formula.rb.tmpl`): add a blank line after the `raise ... unless executable` guard clause to satisfy `Layout/EmptyLineAfterGuardClause`.
- **Render script** (`.github/render-homebrew-formula.py`): add `normalize_brew_desc()` to satisfy three FormulaAudit/Desc rules — must not start with an article (`A `/`An `/`The `), must not end with a period, must be ≤79 characters. `Cargo.toml`'s `description` field stays the canonical project description (reaches crates.io and other consumers untouched); only the embedded brew formula gets the brew-specific normalization.

Same fix landing simultaneously in dodot, padz, burgertocow, rustloc, lightable/simple-gal, lex-fmt/lex (the 6 source repos that generate formulas pushed to `arthur-debert/homebrew-tools`). Picks up on the next release of each project — no tap edit needed.

See `~/h/repo-all/tooling.lex` §11.3 for the full architectural reasoning.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only) — chore (CI tooling, no behavior change)
- [x] Project umbrella check passes locally — N/A (release-time scripts only)
- [x] Tests added or updated for behavior changes — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)