### PR TITLE
feat: macOS paths — _app/, _lib/, force_app, app_aliases (M1-M5)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -7,3 +7,50 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
 `### Removed`, `### Fixed`, `### Security`) so they nest cleanly under the
 `## [version]` heading the release workflow inserts.
+
+### Added
+
+- **MacOs paths: `_app/`, `_lib/`, `force_app`, `app_aliases`.** Dodot
+  now models `~/Library/Application Support/<App>/` as a third
+  filesystem coordinate alongside `$HOME` and `$XDG_CONFIG_HOME`, so
+  cross-platform packs can deploy GUI-app config correctly on both
+  MacOs and Linux without `if os == "darwin"` branching inside packs.
+  The full design lives in `docs/proposals/macos-paths.lex`; user-facing
+  pieces (Phase M1–M5) shipping in this release:
+    - **`_app/<name>/<rest>` directory prefix** — deploys raw under
+      `<app_support_dir>/<name>/<rest>`. On MacOs that's
+      `~/Library/Application Support`; on Linux it collapses to
+      `$XDG_CONFIG_HOME` so the same pack tree works on both. New
+      Priority 2c in the symlink resolver.
+    - **`_lib/<rest>` directory prefix (MacOs only)** — deploys to
+      `$HOME/Library/<rest>` for non-Application-Support Library
+      subtrees (`LaunchAgents/`, `Fonts/`, `Services/`). On
+      non-MacOs platforms emits a soft warning and skips with no
+      symlink. New Priority 2d.
+    - **`[symlink] force_app`** — curated list of GUI-app folder
+      names (case-sensitive, capped at 100) whose first path segment
+      routes to `<app_support_dir>/<name>/<rest>` without a `_app/`
+      prefix. Ships seeded with `Code`, `Cursor`, `Zed`, `Emacs`.
+      New Priority 4.
+    - **`[symlink.app_aliases]` table** — pack-name → app-folder-name
+      rewrites. A pack named `vscode` aliased to `Code` deploys to
+      `<app_support_dir>/Code/...` so the pack name stays
+      lowercase-ergonomic. New Priority 5; modifies the default rule
+      only — explicit prefixes still win.
+    - **`[symlink] app_uses_library`** (default `true` on MacOs,
+      ignored elsewhere) — set to `false` on MacOs to opt the entire
+      pack tree into Linux-style `~/.config` placement.
+    - **`dodot adopt ~/Library/Application Support/<X>/...`** —
+      AppSupport sources now infer pack `<X>` and produce
+      `_app/<X>/<rest>` in-pack paths that round-trip back to the
+      same deployed location. Pack-root directory expansion works
+      the same as for XDG.
+    - **Capitalization heuristic for adopt suggestions** — when an
+      AppSupport adopt's inferred pack name passes the GUI-app
+      heuristic (uppercase / space / reverse-DNS shape), adopt
+      surfaces an advisory tip pointing at the `app_aliases`
+      ergonomic. Purely advisory; the resolver and pack tree are
+      unaffected. See `docs/proposals/macos-paths.lex` §8.1.
+
+  Phase M6 (homebrew-cask probing, `dodot probe app` subcommand) is
+  intentionally deferred to a separate PR.

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,22 +10,22 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
 
 ### Added
 
-- **MacOs paths: `_app/`, `_lib/`, `force_app`, `app_aliases`.** Dodot
+- **macOS paths: `_app/`, `_lib/`, `force_app`, `app_aliases`.** Dodot
   now models `~/Library/Application Support/<App>/` as a third
   filesystem coordinate alongside `$HOME` and `$XDG_CONFIG_HOME`, so
   cross-platform packs can deploy GUI-app config correctly on both
-  MacOs and Linux without `if os == "darwin"` branching inside packs.
+  macOS and Linux without `if os == "darwin"` branching inside packs.
   The full design lives in `docs/proposals/macos-paths.lex`; user-facing
   pieces (Phase M1–M5) shipping in this release:
     - **`_app/<name>/<rest>` directory prefix** — deploys raw under
-      `<app_support_dir>/<name>/<rest>`. On MacOs that's
+      `<app_support_dir>/<name>/<rest>`. On macOS that's
       `~/Library/Application Support`; on Linux it collapses to
       `$XDG_CONFIG_HOME` so the same pack tree works on both. New
       Priority 2c in the symlink resolver.
-    - **`_lib/<rest>` directory prefix (MacOs only)** — deploys to
+    - **`_lib/<rest>` directory prefix (macOS only)** — deploys to
       `$HOME/Library/<rest>` for non-Application-Support Library
       subtrees (`LaunchAgents/`, `Fonts/`, `Services/`). On
-      non-MacOs platforms emits a soft warning and skips with no
+      non-macOS platforms emits a soft warning and skips with no
       symlink. New Priority 2d.
     - **`[symlink] force_app`** — curated list of GUI-app folder
       names (case-sensitive, capped at 100) whose first path segment
@@ -37,8 +37,8 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
       `<app_support_dir>/Code/...` so the pack name stays
       lowercase-ergonomic. New Priority 5; modifies the default rule
       only — explicit prefixes still win.
-    - **`[symlink] app_uses_library`** (default `true` on MacOs,
-      ignored elsewhere) — set to `false` on MacOs to opt the entire
+    - **`[symlink] app_uses_library`** (default `true` on macOS,
+      ignored elsewhere) — set to `false` on macOS to opt the entire
       pack tree into Linux-style `~/.config` placement.
     - **`dodot adopt ~/Library/Application Support/<X>/...`** —
       AppSupport sources now infer pack `<X>` and produce

--- a/crates/dodot-lib/src/commands/adopt/infer.rs
+++ b/crates/dodot-lib/src/commands/adopt/infer.rs
@@ -100,11 +100,11 @@ pub(crate) enum SourceRoot {
     Home,
     /// `$XDG_CONFIG_HOME` (e.g. `~/.config`, or whatever `XDG_CONFIG_HOME` points at).
     XdgConfig,
-    /// `~/Library/Application Support`. Currently never returned —
-    /// `Pather` does not yet expose `app_support_dir()` (Phase M1 of
-    /// `docs/proposals/macos-paths.lex`). The variant is reserved so the
-    /// inference framework is shape-stable when M1 lands.
-    #[allow(dead_code)]
+    /// `~/Library/Application Support` on macOS, or whatever
+    /// `Pather::app_support_dir()` returns. On Linux this collapses to
+    /// `xdg_config_home`, so the AppSupport arm is unreachable in
+    /// practice on non-macOS hosts (XDG matches first via
+    /// longest-prefix order).
     AppSupport,
 }
 
@@ -216,6 +216,7 @@ pub(crate) fn infer_target(
     let canon_source = canonicalize_parent_keep_basename(abs_source);
     let canon_home = canonicalize_for_match(pather.home_dir());
     let canon_xdg = canonicalize_for_match(pather.xdg_config_home());
+    let canon_app = canonicalize_for_match(pather.app_support_dir());
 
     // ── Sandboxed-container refusal ──────────────────────────────────
     //
@@ -228,6 +229,31 @@ pub(crate) fn infer_target(
     let containers_root = canon_home.join("Library").join("Containers");
     if canon_source.starts_with(&containers_root) {
         return Err(InferenceError::SandboxedContainer);
+    }
+
+    // ── AppSupport root (longest-prefix wins) ────────────────────────
+    //
+    // On macOS `app_support_dir` is `~/Library/Application Support` —
+    // strictly more specific than HOME and disjoint from XDG. Match it
+    // *before* XDG and HOME so a path like `~/Library/Application
+    // Support/Code/User/settings.json` produces an AppSupport-rooted
+    // inference instead of falling through to HOME and emitting a
+    // "nested under $HOME" verdict.
+    //
+    // On Linux `app_support_dir` collapses to `xdg_config_home`, so
+    // either: (a) `canon_app == canon_xdg`, in which case any source
+    // under XDG will match here too — but `resolve_xdg_relative`
+    // produces the right answer for that root, so we steer Linux
+    // sources back through the XDG branch by checking equality first;
+    // or (b) the user explicitly set `app_uses_library = false` on
+    // macOS, which similarly collapses the two — same handling.
+    if canon_app != canon_xdg {
+        if canon_source == canon_app {
+            return Err(InferenceError::XdgRootItself);
+        }
+        if let Ok(rel) = canon_source.strip_prefix(&canon_app) {
+            return resolve_app_support_relative(rel, is_dir);
+        }
     }
 
     // ── XDG_CONFIG_HOME root ─────────────────────────────────────────
@@ -253,9 +279,11 @@ pub(crate) fn infer_target(
     }
 
     // ── No root matched ──────────────────────────────────────────────
-    Err(InferenceError::UnrecognizedRoot {
-        hint_roots: vec![canon_xdg, canon_home],
-    })
+    let mut hint_roots = vec![canon_xdg, canon_home];
+    if canon_app != hint_roots[0] && canon_app != hint_roots[1] {
+        hint_roots.push(canon_app);
+    }
+    Err(InferenceError::UnrecognizedRoot { hint_roots })
 }
 
 /// Build inference output for a path relative to `$XDG_CONFIG_HOME`.
@@ -309,6 +337,62 @@ fn resolve_xdg_relative(rel: &Path, is_dir: bool) -> Result<InferredTarget, Infe
         in_pack_natural: rest_path.clone(),
         in_pack_override: PathBuf::from("_xdg").join(&first).join(&rest_path),
         source_root: SourceRoot::XdgConfig,
+        expand_children: false,
+    })
+}
+
+/// Build inference output for a path relative to `app_support_dir`.
+///
+/// `~/Library/Application Support/<X>/<rest>` infers pack `<X>` and
+/// in-pack path `_app/<X>/<rest>`. The `_app/` prefix is *mandatory*
+/// even at natural pack name because the resolver's default rule
+/// (Priority 6) routes `<pack>/<rel>` through `$XDG/<pack>/<rel>`, not
+/// `<app_support_dir>/<pack>/<rel>` — without the prefix the
+/// round-trip would land the file at `~/.config/<X>/...` on macOS,
+/// which is not where `dodot adopt` picked it up. See
+/// `docs/proposals/macos-paths.lex` §7.2.
+///
+/// The `app_aliases` form (declare `[symlink.app_aliases] <X> = "<X>"`
+/// in the pack and use bare paths) is an alternative the user can opt
+/// into manually; adopt's automatic output is the prefix form.
+fn resolve_app_support_relative(
+    rel: &Path,
+    is_dir: bool,
+) -> Result<InferredTarget, InferenceError> {
+    let mut comps = rel.components();
+    let first = match comps.next() {
+        Some(Component::Normal(s)) => s.to_string_lossy().into_owned(),
+        _ => return Err(InferenceError::XdgRootItself),
+    };
+    let rest_path: PathBuf = comps.as_path().to_path_buf();
+
+    if rest_path.as_os_str().is_empty() {
+        // Sole component: source IS the app's top-level Application
+        // Support directory. A directory expands; a loose file is
+        // refused (same shape as XDG's LooseXdgFile case).
+        if is_dir {
+            return Ok(InferredTarget {
+                natural_pack: Some(first.clone()),
+                in_pack_natural: PathBuf::from("_app").join(&first),
+                in_pack_override: PathBuf::from("_app").join(&first),
+                source_root: SourceRoot::AppSupport,
+                expand_children: true,
+            });
+        } else {
+            return Err(InferenceError::LooseXdgFile);
+        }
+    }
+
+    // Nested case: `<X>/<rest>`. Both natural and override encodings
+    // use the explicit `_app/<X>/...` prefix — the override flag
+    // doesn't change anything for AppSupport because the natural
+    // encoding is *already* prefixed (see §7.2 note).
+    let in_pack = PathBuf::from("_app").join(&first).join(&rest_path);
+    Ok(InferredTarget {
+        natural_pack: Some(first.clone()),
+        in_pack_natural: in_pack.clone(),
+        in_pack_override: in_pack,
+        source_root: SourceRoot::AppSupport,
         expand_children: false,
     })
 }
@@ -409,6 +493,45 @@ fn canonicalize_parent_keep_basename(source: &Path) -> PathBuf {
     }
 }
 
+/// Capitalization heuristic — does `name` look like a macOS GUI-app
+/// folder name?
+///
+/// macOS GUI apps under `~/Library/Application Support/` follow a
+/// strong naming pattern (uppercase letters, spaces, or reverse-DNS
+/// segments) that distinguishes them from CLI-tool folders under
+/// `~/.config/` (uniformly lowercase-hyphenated). We use this to drive
+/// adopt's *suggestion* output — never the resolver, which stays
+/// heuristic-free per `docs/proposals/macos-paths.lex` §8.1.
+///
+/// Returns `true` when:
+///
+/// - the name contains at least one uppercase letter (`Code`,
+///   `Cursor`, `IntelliJ IDEA`), or
+/// - the name contains a space (`Sublime Text 3`), or
+/// - the name matches a reverse-DNS pattern: at least two
+///   dot-separated segments where every segment is non-empty and
+///   lowercase (`com.apple.dt.Xcode`, `dev.warp.Warp-Stable` —
+///   the trailing "Warp-Stable" segment makes the latter qualify
+///   under the *uppercase* clause already, but we keep the rDNS
+///   check independent for fully-lowercase rDNS names).
+pub(crate) fn is_gui_app_folder(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    if name.chars().any(|c| c.is_ascii_uppercase()) {
+        return true;
+    }
+    if name.contains(' ') {
+        return true;
+    }
+    // Reverse-DNS: ≥2 dotted segments, every segment non-empty.
+    let segments: Vec<&str> = name.split('.').collect();
+    if segments.len() >= 2 && segments.iter().all(|s| !s.is_empty()) {
+        return true;
+    }
+    false
+}
+
 /// Compute the in-pack path for a `$HOME/<file_name>` source.
 ///
 /// Kept as a public-in-crate helper so the round-trip property test in
@@ -467,6 +590,11 @@ mod tests {
     /// the default `$HOME/.config` layout in most tests: it's the *harder*
     /// case (XDG nested under HOME), and we cover it explicitly in
     /// `xdg_inside_home_prefers_xdg_root`.
+    ///
+    /// `app_support_dir` is pinned to a path under HOME (mirroring the
+    /// real macOS layout). Tests that need to exercise the
+    /// non-macOS / collapsed AppSupport case use [`pather_app_collapsed`]
+    /// instead.
     fn pather(home: &str, xdg: &str) -> XdgPather {
         XdgPather::builder()
             .home(home)
@@ -475,6 +603,23 @@ mod tests {
             .config_dir(format!("{home}/.config/dodot"))
             .cache_dir(format!("{home}/.cache/dodot"))
             .xdg_config_home(xdg)
+            .app_support_dir(format!("{home}/Library/Application Support"))
+            .build()
+            .unwrap()
+    }
+
+    /// Variant of [`pather`] where `app_support_dir` collapses onto
+    /// `xdg_config_home` — the Linux default and the macOS
+    /// `app_uses_library = false` opt-out.
+    fn pather_app_collapsed(home: &str, xdg: &str) -> XdgPather {
+        XdgPather::builder()
+            .home(home)
+            .dotfiles_root(format!("{home}/dotfiles"))
+            .data_dir(format!("{home}/.local/share/dodot"))
+            .config_dir(format!("{home}/.config/dodot"))
+            .cache_dir(format!("{home}/.cache/dodot"))
+            .xdg_config_home(xdg)
+            .app_support_dir(xdg)
             .build()
             .unwrap()
     }
@@ -645,6 +790,150 @@ mod tests {
             }
             other => panic!("expected UnrecognizedRoot, got {other:?}"),
         }
+    }
+
+    // ── AppSupport source root ──────────────────────────────────
+
+    #[test]
+    fn app_support_nested_file_uses_app_prefix() {
+        // `~/Library/Application Support/Code/User/settings.json` →
+        // pack `Code`, in-pack `_app/Code/User/settings.json`. The
+        // `_app/` prefix is mandatory at natural pack name (see
+        // resolver Priority 6 → §7.2).
+        let p = pather("/u", "/x");
+        let t = infer_target(
+            Path::new("/u/Library/Application Support/Code/User/settings.json"),
+            false,
+            &p,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(t.natural_pack.as_deref(), Some("Code"));
+        assert_eq!(
+            t.in_pack_natural,
+            PathBuf::from("_app/Code/User/settings.json")
+        );
+        // The override-aware path is identical for AppSupport — the
+        // explicit prefix is required either way.
+        assert_eq!(
+            t.in_pack_override,
+            PathBuf::from("_app/Code/User/settings.json")
+        );
+        assert_eq!(t.source_root, SourceRoot::AppSupport);
+        assert!(!t.expand_children);
+    }
+
+    #[test]
+    fn app_support_pack_root_directory_triggers_expansion() {
+        // `~/Library/Application Support/Cursor/` (the directory) →
+        // pack `Cursor`, expand_children=true. The caller enumerates
+        // its children and adopts each as a top-level pack member.
+        let p = pather("/u", "/x");
+        let t = infer_target(
+            Path::new("/u/Library/Application Support/Cursor"),
+            /*is_dir=*/ true,
+            &p,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(t.natural_pack.as_deref(), Some("Cursor"));
+        assert!(t.expand_children);
+        // For AppSupport pack-root expansion, in_pack_override carries
+        // `_app/<X>` so per-child plans can join the child basename.
+        assert_eq!(t.in_pack_override, PathBuf::from("_app/Cursor"));
+    }
+
+    #[test]
+    fn app_support_outranks_home_when_distinct_root() {
+        // On a real macOS layout `~/Library/Application Support` lives
+        // under HOME — longest-prefix-wins requires AppSupport be
+        // checked first. `pather()` mirrors that layout.
+        let p = pather("/u", "/x");
+        let t = infer_target(
+            Path::new("/u/Library/Application Support/Zed/settings.json"),
+            false,
+            &p,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(t.source_root, SourceRoot::AppSupport);
+        assert_eq!(t.natural_pack.as_deref(), Some("Zed"));
+    }
+
+    #[test]
+    fn app_support_collapsed_falls_back_to_xdg_or_home() {
+        // When `app_support_dir == xdg_config_home` (Linux, or macOS
+        // with `app_uses_library = false`), the AppSupport arm is
+        // unreachable and a path that *would* have matched it falls
+        // through. A `~/Library/Application Support/...` path on
+        // Linux thus lands in HOME-rooted territory and produces the
+        // "nested under HOME" refusal — exactly what we want when the
+        // user is opting out of macOS-style routing.
+        let p = pather_app_collapsed("/u", "/x");
+        let err = infer_target(
+            Path::new("/u/Library/Application Support/Code/User/settings.json"),
+            false,
+            &p,
+            &[],
+        )
+        .unwrap_err();
+        assert!(matches!(err, InferenceError::UnrecognizedRoot { .. }));
+    }
+
+    // ── Capitalization heuristic ────────────────────────────────
+
+    #[test]
+    fn gui_app_heuristic_uppercase_yes() {
+        // Strong uppercase signal: any non-empty name with at least one
+        // uppercase ASCII letter qualifies. This is the dominant
+        // pattern for `~/Library/Application Support/` folder names.
+        assert!(is_gui_app_folder("Code"));
+        assert!(is_gui_app_folder("Cursor"));
+        assert!(is_gui_app_folder("IntelliJ"));
+        assert!(is_gui_app_folder("Visual Studio Code"));
+    }
+
+    #[test]
+    fn gui_app_heuristic_space_yes() {
+        // Spaces are the second-strongest signal: CLI tools don't put
+        // spaces in `~/.config/<X>/` for portability reasons.
+        assert!(is_gui_app_folder("sublime text"));
+        assert!(is_gui_app_folder("smart code ltd"));
+    }
+
+    #[test]
+    fn gui_app_heuristic_reverse_dns_yes() {
+        // Reverse-DNS is the third signal — captures bundle-ID-shaped
+        // names that some apps use (`dev.warp.Warp-Stable`,
+        // `com.apple.dt.Xcode`).
+        assert!(is_gui_app_folder("dev.warp.warp-stable"));
+        assert!(is_gui_app_folder("com.apple.dt.xcode"));
+        assert!(is_gui_app_folder("org.videolan.vlc"));
+    }
+
+    #[test]
+    fn gui_app_heuristic_lowercase_cli_tool_no() {
+        // The CLI-tool population is uniformly lowercase-hyphenated and
+        // never matches the rDNS shape (single segment, no dots).
+        assert!(!is_gui_app_folder("nvim"));
+        assert!(!is_gui_app_folder("helix"));
+        assert!(!is_gui_app_folder("ghostty"));
+        assert!(!is_gui_app_folder("lazygit"));
+        assert!(!is_gui_app_folder("starship"));
+    }
+
+    #[test]
+    fn gui_app_heuristic_empty_name_no() {
+        assert!(!is_gui_app_folder(""));
+    }
+
+    #[test]
+    fn gui_app_heuristic_dotted_but_empty_segment_no() {
+        // A name like `.bashrc` or `foo..bar` shouldn't slip through
+        // the rDNS branch — rDNS requires every segment non-empty.
+        assert!(!is_gui_app_folder(".bashrc"));
+        assert!(!is_gui_app_folder("foo..bar"));
+        assert!(!is_gui_app_folder("trailing."));
     }
 
     #[test]

--- a/crates/dodot-lib/src/commands/adopt/mod.rs
+++ b/crates/dodot-lib/src/commands/adopt/mod.rs
@@ -198,6 +198,53 @@ pub fn adopt(
     for msg in skipped_already_adopted {
         result.warnings.push(msg);
     }
+
+    // Capitalization-heuristic advisory (M5): when a successfully
+    // adopted source comes from AppSupport and its naturally-inferred
+    // pack name passes the GUI-app heuristic (uppercase / space /
+    // reverse-DNS), suggest the `app_aliases` ergonomic. The hint is
+    // purely advisory — the resolver and the actual pack tree are
+    // unaffected. See `docs/proposals/macos-paths.lex` §8.1.
+    //
+    // We only emit the hint when:
+    //   - `pack_override` is None (user didn't pre-pick a pack name)
+    //   - the pack on disk is named `<X>` matching the heuristic
+    //   - at least one source was AppSupport-rooted in this invocation
+    if pack_override.is_none() && infer::is_gui_app_folder(&pack_display) {
+        let force_home = ctx.config_manager.root_config()?.symlink.force_home.clone();
+        let any_app_support = sources.iter().any(|s| {
+            absolutize(s)
+                .ok()
+                .and_then(|abs| {
+                    let is_dir = ctx.fs.stat(&abs).map(|m| m.is_dir).unwrap_or(false);
+                    infer::infer_target(&abs, is_dir, ctx.paths.as_ref(), &force_home).ok()
+                })
+                .map(|t| t.source_root == infer::SourceRoot::AppSupport)
+                .unwrap_or(false)
+        });
+        if any_app_support {
+            // Pick a sensible lowercase suggestion: strip spaces and
+            // lowercase the first segment. `Visual Studio Code` →
+            // `visualstudiocode`; `Code` → `code`. The exact name is
+            // up to the user — this is a starting point, not a rule.
+            let suggested_alias: String = pack_display
+                .chars()
+                .filter(|c| !c.is_whitespace())
+                .flat_map(char::to_lowercase)
+                .collect();
+            if !suggested_alias.is_empty() && suggested_alias != pack_display {
+                result.warnings.push(format!(
+                    "tip: pack `{}` looks like a macOS GUI-app folder. Consider \
+                     renaming the pack to `{}` and adding\n  \
+                     [symlink.app_aliases]\n  {} = \"{}\"\n\
+                     to your .dodot.toml so future files can use bare paths instead \
+                     of `_app/{}/...`.",
+                    pack_display, suggested_alias, suggested_alias, pack_display, pack_display,
+                ));
+            }
+        }
+    }
+
     // Adopt failures are real errors — surface them in the same
     // command-wide notes list that drives `[N]` markers for status/up.
     // To keep the model consistent ("every note is referenced by a row"),

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -485,9 +485,10 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         // element is the user-facing label that surfaces in any
         // resulting `DisplayConflict.claimants` entry, so it tracks
         // the pack's display name rather than its raw on-disk name.
-        match orchestration::collect_pack_intents(&pack, ctx) {
-            Ok(intents) => {
-                pack_intents.push((pack.display_name.clone(), intents));
+        match orchestration::plan_pack(&pack, ctx) {
+            Ok(plan) => {
+                warnings.extend(plan.warnings);
+                pack_intents.push((pack.display_name.clone(), plan.intents));
             }
             Err(err) => {
                 warnings.push(format!(

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -502,6 +502,26 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         for m in &matches {
             let rel_str = m.relative_path.to_string_lossy().into_owned();
 
+            // Skip rows for symlink entries whose resolver returns
+            // `Resolution::Skip` — currently `_lib/<rest>` on non-macOS.
+            // The planner already drops the intent and `plan_pack`
+            // surfaces a "skipped on this platform" warning; rendering
+            // a "pending" row alongside the warning would contradict
+            // it and mislead users into thinking a deploy is pending.
+            if m.handler == HANDLER_SYMLINK
+                && matches!(
+                    crate::handlers::symlink::resolve_target_full(
+                        &pack.name,
+                        &rel_str,
+                        &pack.config,
+                        ctx.paths.as_ref(),
+                    ),
+                    crate::handlers::symlink::Resolution::Skip { .. }
+                )
+            {
+                continue;
+            }
+
             // Per-file chain verification based on handler type
             let health = match m.handler.as_str() {
                 "symlink" => {

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -502,22 +502,22 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         for m in &matches {
             let rel_str = m.relative_path.to_string_lossy().into_owned();
 
-            // Skip rows for symlink entries whose resolver returns
-            // `Resolution::Skip` — currently `_lib/<rest>` on non-macOS.
-            // The planner already drops the intent and `plan_pack`
-            // surfaces a "skipped on this platform" warning; rendering
-            // a "pending" row alongside the warning would contradict
-            // it and mislead users into thinking a deploy is pending.
+            // Skip rows for `_lib/` entries on non-macOS. Two cases
+            // need to be handled:
+            //
+            // - `_lib/<rest>` files — the resolver returns
+            //   `Resolution::Skip` and the planner drops the intent.
+            // - the top-level `_lib` directory itself — its match
+            //   reaches status but `dir_intents` forces per-file mode
+            //   and every nested file resolves to Skip, so nothing
+            //   under the directory is ever deployed.
+            //
+            // Either way, rendering a "pending symlink" row alongside
+            // the planner's "skipping on this platform" warning would
+            // contradict the warning and mislead users.
             if m.handler == HANDLER_SYMLINK
-                && matches!(
-                    crate::handlers::symlink::resolve_target_full(
-                        &pack.name,
-                        &rel_str,
-                        &pack.config,
-                        ctx.paths.as_ref(),
-                    ),
-                    crate::handlers::symlink::Resolution::Skip { .. }
-                )
+                && !cfg!(target_os = "macos")
+                && (rel_str == "_lib" || rel_str.starts_with("_lib/"))
             {
                 continue;
             }

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -76,6 +76,68 @@ fn status_shows_pending_before_up() {
     }
 }
 
+/// On non-macOS, `_lib/<rest>` entries resolve to `Resolution::Skip`
+/// in the planner. Status must suppress the corresponding row and
+/// only surface the warning — otherwise the user sees a confusing
+/// "pending symlink" row alongside a "skipping on this platform"
+/// warning. Regression for review feedback on PR #90.
+#[test]
+fn status_suppresses_lib_prefix_rows_when_skipped() {
+    let env = TempEnvironment::builder()
+        .pack("macapps")
+        .file("_lib/LaunchAgents/com.example.foo.plist", "x")
+        .file("regular.toml", "y")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    let result = commands::status::status(None, &ctx).unwrap();
+
+    // The pack is present either way; what we're pinning is the
+    // *file rows*: on non-macOS the `_lib/...` row is suppressed,
+    // on macOS it appears like any other pending symlink.
+    let pack = result
+        .packs
+        .iter()
+        .find(|p| p.name == "macapps")
+        .expect("macapps pack must appear");
+
+    let lib_row = pack
+        .files
+        .iter()
+        .find(|f| f.name.starts_with("_lib/") || f.name == "_lib");
+    let regular_row = pack.files.iter().find(|f| f.name == "regular.toml");
+
+    assert!(
+        regular_row.is_some(),
+        "non-_lib entry must always render; got files {:?}",
+        pack.files.iter().map(|f| &f.name).collect::<Vec<_>>()
+    );
+
+    if cfg!(target_os = "macos") {
+        assert!(
+            lib_row.is_some(),
+            "on macOS `_lib/` entries should render normally; got files {:?}",
+            pack.files.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+    } else {
+        assert!(
+            lib_row.is_none(),
+            "on non-macOS `_lib/` rows must be suppressed; got files {:?}",
+            pack.files.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+        // The warning channel still carries the explanation.
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("_lib/") && w.contains("macOS-only")),
+            "expected `_lib/` macOS-only warning; got {:?}",
+            result.warnings
+        );
+    }
+}
+
 #[test]
 fn status_renders_with_standout() {
     let env = TempEnvironment::builder()

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -126,13 +126,17 @@ fn status_suppresses_lib_prefix_rows_when_skipped() {
             "on non-macOS `_lib/` rows must be suppressed; got files {:?}",
             pack.files.iter().map(|f| &f.name).collect::<Vec<_>>()
         );
-        // The warning channel still carries the explanation.
+        // The warning channel still carries the explanation. The
+        // exact form depends on whether the catchall scanner matched
+        // the top-level `_lib` directory or a nested `_lib/<rest>`
+        // file — either way, the warning mentions `_lib` and the
+        // macOS-only constraint.
         assert!(
             result
                 .warnings
                 .iter()
-                .any(|w| w.contains("_lib/") && w.contains("macOS-only")),
-            "expected `_lib/` macOS-only warning; got {:?}",
+                .any(|w| w.contains("_lib") && w.contains("macOS-only")),
+            "expected a `_lib` macOS-only warning; got {:?}",
             result.warnings
         );
     }

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -1681,6 +1681,199 @@ fn adopt_xdg_with_into_override_uses_xdg_prefix() {
     assert!(env.fs.is_symlink(&source));
 }
 
+/// Adopting a file under `~/Library/Application Support/<X>/` infers
+/// pack `<X>`, places the file at `_app/<X>/<rest>` in the pack tree,
+/// and round-trips via the resolver's Priority 2c `_app/` prefix back
+/// to the original AppSupport location. The `TempEnvironment` pins
+/// `app_support_dir` under the temp HOME on every platform so this
+/// test runs identically on Linux and macOS.
+#[test]
+fn adopt_app_support_source_round_trips_through_app_prefix() {
+    let env = TempEnvironment::builder()
+        .home_file(
+            "Library/Application Support/Code/User/settings.json",
+            "{\"editor.fontSize\": 14}",
+        )
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.app_support.join("Code/User/settings.json");
+
+    commands::adopt::adopt(
+        /*pack_override=*/ None,
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    // Pack auto-created at `<dotfiles>/Code/`. The file lives at
+    // `_app/Code/User/settings.json` — the prefix is mandatory at
+    // natural pack name because the default rule routes through XDG,
+    // not app_support_dir.
+    let pack_file = env.dotfiles_root.join("Code/_app/Code/User/settings.json");
+    env.assert_regular_file(&pack_file, "{\"editor.fontSize\": 14}");
+
+    // Original deploy location is now a symlink — and the symlink
+    // chain points (eventually) back at the pack copy. Resolve via
+    // resolve_target_full to confirm round-trip.
+    assert!(env.fs.is_symlink(&source));
+
+    use crate::handlers::symlink::{resolve_target_full, Resolution};
+    let resolution = resolve_target_full(
+        "Code",
+        "_app/Code/User/settings.json",
+        &Default::default(),
+        env.paths.as_ref(),
+    );
+    match resolution {
+        Resolution::Path(p) => assert_eq!(p, source),
+        Resolution::Skip { reason } => panic!("expected Path, got Skip({reason})"),
+    }
+}
+
+/// Adopting `~/Library/Application Support/<X>/` (the directory
+/// itself) expands into per-child plans, mirroring the XDG pack-root
+/// expansion. Each top-level entry under the AppSupport folder
+/// becomes a top-level pack entry, prefixed with `_app/<X>/`.
+#[test]
+fn adopt_app_support_pack_root_directory_expands_to_children() {
+    let env = TempEnvironment::builder()
+        .home_file(
+            "Library/Application Support/Cursor/User/settings.json",
+            "{}",
+        )
+        .home_file(
+            "Library/Application Support/Cursor/User/keybindings.json",
+            "[]",
+        )
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.app_support.join("Cursor");
+
+    commands::adopt::adopt(
+        None,
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    // The pack-root directory expanded: the single child of `Cursor/`
+    // is `User/`, so the pack contains `_app/Cursor/User/` (a
+    // directory whose contents come along).
+    let pack_dir = env.dotfiles_root.join("Cursor");
+    env.assert_dir_exists(&pack_dir);
+    env.assert_regular_file(&pack_dir.join("_app/Cursor/User/settings.json"), "{}");
+    env.assert_regular_file(&pack_dir.join("_app/Cursor/User/keybindings.json"), "[]");
+    // The expanded child (`User/`) at the original AppSupport
+    // location is now a symlink, but the parent `Cursor/` itself
+    // stays a real directory.
+    assert!(env.fs.is_symlink(&env.app_support.join("Cursor/User")));
+    assert!(!env.fs.is_symlink(&source));
+}
+
+/// M5 capitalization-heuristic advisory: when a user adopts an
+/// AppSupport source whose folder name passes the GUI-app heuristic
+/// (`Code`, uppercase), adopt emits a tip pointing at the
+/// `app_aliases` ergonomic. The pack tree itself is unaffected — the
+/// hint is purely advisory.
+#[test]
+fn adopt_app_support_emits_capitalization_hint() {
+    let env = TempEnvironment::builder()
+        .home_file("Library/Application Support/Code/User/settings.json", "{}")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.app_support.join("Code/User/settings.json");
+
+    let result = commands::adopt::adopt(
+        /*pack_override=*/ None,
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.contains("app_aliases") && w.contains("Code")),
+        "expected an `app_aliases` tip in warnings, got: {:?}",
+        result.warnings
+    );
+}
+
+/// The advisory is suppressed when the user passed `--into <pack>`:
+/// they already chose their pack name, so suggesting another one
+/// would be noise. The pack used here (`Code`) only exists to satisfy
+/// `--into`'s typo-guard requirement.
+#[test]
+fn adopt_app_support_into_override_suppresses_hint() {
+    let env = TempEnvironment::builder()
+        .pack("Code")
+        .file("placeholder", "")
+        .done()
+        .home_file("Library/Application Support/Code/User/settings.json", "{}")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.app_support.join("Code/User/settings.json");
+
+    let result = commands::adopt::adopt(
+        Some("Code"),
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    assert!(
+        !result.warnings.iter().any(|w| w.contains("app_aliases")),
+        "expected no app_aliases tip with --into, got: {:?}",
+        result.warnings
+    );
+}
+
+/// Lowercase CLI-tool-style folder names (`nvim`, `helix`, …) don't
+/// trigger the heuristic. An XDG adopt of a typical CLI tool stays
+/// hint-free.
+#[test]
+fn adopt_xdg_lowercase_pack_emits_no_hint() {
+    let env = TempEnvironment::builder()
+        .home_file(".config/nvim/init.lua", "-- nvim")
+        .build();
+
+    let ctx = make_ctx(&env);
+    let source = env.home.join(".config/nvim/init.lua");
+
+    let result = commands::adopt::adopt(
+        None,
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    assert!(
+        !result.warnings.iter().any(|w| w.contains("app_aliases")),
+        "expected no app_aliases tip for plain XDG adopt, got: {:?}",
+        result.warnings
+    );
+}
+
 /// Multiple sources whose inference picks different packs is refused
 /// (without `--into`); the message names the conflicting candidates.
 #[test]

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -57,11 +57,13 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
 
     let mut pack_intents: Vec<(String, Vec<HandlerIntent>)> = Vec::with_capacity(packs.len());
     let mut intent_errors: Vec<PackResult> = Vec::new();
+    let mut planning_warnings: Vec<String> = Vec::new();
 
     for pack in &packs {
-        match orchestration::collect_pack_intents(pack, ctx) {
-            Ok(intents) => {
-                pack_intents.push((pack.display_name.clone(), intents));
+        match orchestration::plan_pack(pack, ctx) {
+            Ok(plan) => {
+                planning_warnings.extend(plan.warnings);
+                pack_intents.push((pack.display_name.clone(), plan.intents));
             }
             Err(e) => {
                 info!(pack = %pack.display_name, error = %e, "intent collection failed");
@@ -257,7 +259,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         message: Some(message),
         dry_run: ctx.dry_run,
         packs: display_packs,
-        warnings: Vec::new(),
+        warnings: planning_warnings,
         notes,
         conflicts: Vec::new(),
         ignored_packs: Vec::new(),

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -66,6 +66,37 @@ pub struct SymlinkSection {
     #[config(default = ["ssh", "aws", "kube", "bashrc", "zshrc", "profile", "bash_profile", "bash_login", "bash_logout", "inputrc"])]
     pub force_home: Vec<String>,
 
+    /// Whether `_app/` and `app_aliases` route through the macOS
+    /// `~/Library/Application Support` root. Defaults to `true` on
+    /// macOS, ignored on other platforms (where `app_support_dir`
+    /// always collapses to `xdg_config_home`).
+    ///
+    /// Setting this to `false` on macOS opts the user into Linux-style
+    /// `~/.config` placement for *every* `_app/` and `app_aliases`
+    /// entry. `_lib/` is unaffected — it explicitly targets
+    /// `~/Library/`.
+    ///
+    /// See `docs/proposals/macos-paths.lex` §11.2.
+    #[config(default = true)]
+    pub app_uses_library: bool,
+
+    /// Curated list of GUI-app folder names whose first path segment
+    /// routes to `<app_support_dir>/<seg>/<rest>` without requiring a
+    /// `_app/` prefix in the pack tree. Capped at 100 entries; see
+    /// `docs/proposals/macos-paths.lex` §3.4.
+    ///
+    /// Matching is case-sensitive (Library folder names are case-sensitive
+    /// on macOS) and on the first path segment only.
+    #[config(default = ["Code", "Cursor", "Zed", "Emacs"])]
+    pub force_app: Vec<String>,
+
+    /// Pack-name → GUI-app folder name rewrites. When the pack name
+    /// matches a key here, the resolver's default rule reroutes to
+    /// `<app_support_dir>/<value>/<rel_path>`. See
+    /// `docs/proposals/macos-paths.lex` §3.3.
+    #[config(default = {})]
+    pub app_aliases: std::collections::HashMap<String, String>,
+
     /// Paths that must not be symlinked for security reasons.
     #[config(default = [
         ".ssh/id_rsa", ".ssh/id_ed25519", ".ssh/id_dsa", ".ssh/id_ecdsa",
@@ -213,6 +244,13 @@ impl DodotConfig {
     pub fn to_handler_config(&self) -> HandlerConfig {
         HandlerConfig {
             force_home: self.symlink.force_home.clone(),
+            // `force_app` and `app_aliases` always pass through to the
+            // resolver. On non-macOS (and on macOS with
+            // `app_uses_library = false`) the `app_support_dir` accessor
+            // already collapses to `xdg_config_home`, so the routing is
+            // mechanically correct without an extra branch here.
+            force_app: self.symlink.force_app.clone(),
+            app_aliases: self.symlink.app_aliases.clone(),
             protected_paths: self.symlink.protected_paths.clone(),
             targets: self.symlink.targets.clone(),
             auto_chmod_exec: self.path.auto_chmod_exec,
@@ -589,6 +627,81 @@ homebrew = "RootBrewfile"
 
         let hcfg = cfg.to_handler_config();
         assert_eq!(hcfg.force_home, cfg.symlink.force_home);
+        assert_eq!(hcfg.force_app, cfg.symlink.force_app);
+        assert_eq!(hcfg.app_aliases, cfg.symlink.app_aliases);
         assert_eq!(hcfg.protected_paths, cfg.symlink.protected_paths);
+    }
+
+    /// Hard cap on the seeded `force_app` defaults — see
+    /// `docs/proposals/macos-paths.lex` §3.4.1. Adding entry 101 is
+    /// supposed to be a forcing function to drop the weakest-justified
+    /// existing entry; this test makes that forcing function *visible*
+    /// rather than relying on review discipline alone.
+    #[test]
+    fn default_force_app_under_hundred_entry_cap() {
+        let env = TempEnvironment::builder().build();
+        let mgr = ConfigManager::new(&env.dotfiles_root).unwrap();
+        let cfg = mgr.root_config().unwrap();
+        assert!(
+            cfg.symlink.force_app.len() <= 100,
+            "force_app default has {} entries; cap is 100. \
+             Drop the weakest-justified entry before adding another. \
+             See docs/proposals/macos-paths.lex §3.4.1.",
+            cfg.symlink.force_app.len()
+        );
+    }
+
+    /// Compile-time sanity on the seeded force_app entries. These ship
+    /// in the default config and must stay correctly capitalized to
+    /// match the actual macOS Application Support folder names.
+    #[test]
+    fn default_force_app_seed_contains_expected_entries() {
+        let env = TempEnvironment::builder().build();
+        let mgr = ConfigManager::new(&env.dotfiles_root).unwrap();
+        let cfg = mgr.root_config().unwrap();
+        for expected in ["Code", "Cursor", "Zed", "Emacs"] {
+            assert!(
+                cfg.symlink.force_app.iter().any(|e| e == expected),
+                "expected default force_app to contain `{expected}`; got {:?}",
+                cfg.symlink.force_app
+            );
+        }
+    }
+
+    #[test]
+    fn app_uses_library_default_is_true() {
+        let env = TempEnvironment::builder().build();
+        let mgr = ConfigManager::new(&env.dotfiles_root).unwrap();
+        let cfg = mgr.root_config().unwrap();
+        assert!(
+            cfg.symlink.app_uses_library,
+            "app_uses_library must default to true; macOS gets the Library \
+             root, Linux already collapses app_support_dir to xdg_config_home"
+        );
+    }
+
+    #[test]
+    fn app_aliases_overridable_in_root_config() {
+        let env = TempEnvironment::builder().build();
+        env.fs
+            .write_file(
+                &env.dotfiles_root.join(".dodot.toml"),
+                br#"
+[symlink.app_aliases]
+vscode = "Code"
+warp = "dev.warp.Warp-Stable"
+"#,
+            )
+            .unwrap();
+        let mgr = ConfigManager::new(&env.dotfiles_root).unwrap();
+        let cfg = mgr.root_config().unwrap();
+        assert_eq!(
+            cfg.symlink.app_aliases.get("vscode").map(String::as_str),
+            Some("Code")
+        );
+        assert_eq!(
+            cfg.symlink.app_aliases.get("warp").map(String::as_str),
+            Some("dev.warp.Warp-Stable")
+        );
     }
 }

--- a/crates/dodot-lib/src/handlers/mod.rs
+++ b/crates/dodot-lib/src/handlers/mod.rs
@@ -187,6 +187,24 @@ pub trait Handler: Send + Sync {
         fs: &dyn Fs,
     ) -> Result<Vec<HandlerIntent>>;
 
+    /// Soft warnings produced for a set of matches — non-fatal,
+    /// human-readable strings the orchestration surfaces in
+    /// `PackStatusResult.warnings`.
+    ///
+    /// Default empty. The symlink handler overrides this to flag
+    /// `_lib/` entries on non-macOS platforms (per
+    /// `docs/proposals/macos-paths.lex` §4.2): the pack is otherwise
+    /// fine, other entries deploy normally, but the user gets a visible
+    /// "skipped on this platform" notice.
+    fn warnings_for_matches(
+        &self,
+        _matches: &[RuleMatch],
+        _config: &HandlerConfig,
+        _paths: &dyn Pather,
+    ) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Check whether a file has been deployed by this handler.
     fn check_status(
         &self,
@@ -204,6 +222,20 @@ pub trait Handler: Send + Sync {
 pub struct HandlerConfig {
     /// Paths that must be forced to `$HOME` (e.g. `["ssh", "bashrc"]`).
     pub force_home: Vec<String>,
+    /// Paths that must be forced to the app-support root (e.g.
+    /// `["Code", "Cursor"]`). Curated GUI-app folder names whose first
+    /// path segment routes to `<app_support_dir>/<seg>/<rest>` without
+    /// requiring a `_app/` prefix in the pack tree. See
+    /// `docs/proposals/macos-paths.lex` §3.4.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub force_app: Vec<String>,
+    /// Pack-name → app-support folder name rewrites. When the pack
+    /// name appears as a key here, the resolver's default rule routes
+    /// through `<app_support_dir>/<alias>/<rel_path>` instead of
+    /// `$XDG_CONFIG_HOME/<pack>/<rel_path>`. See `app_aliases` in
+    /// `docs/proposals/macos-paths.lex` §3.3.
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub app_aliases: std::collections::HashMap<String, String>,
     /// Paths that must not be symlinked (e.g. `[".ssh/id_rsa"]`).
     pub protected_paths: Vec<String>,
     /// Per-file custom symlink target overrides.
@@ -224,6 +256,8 @@ impl Default for HandlerConfig {
     fn default() -> Self {
         Self {
             force_home: Vec::new(),
+            force_app: Vec::new(),
+            app_aliases: std::collections::HashMap::new(),
             protected_paths: Vec::new(),
             targets: std::collections::HashMap::new(),
             auto_chmod_exec: true,

--- a/crates/dodot-lib/src/handlers/symlink.rs
+++ b/crates/dodot-lib/src/handlers/symlink.rs
@@ -108,25 +108,27 @@ impl Handler for SymlinkHandler {
         config: &HandlerConfig,
         paths: &dyn Pather,
     ) -> Vec<String> {
+        if cfg!(target_os = "macos") {
+            return Vec::new();
+        }
         let mut out = Vec::new();
         for m in matches {
             let rel_str = m.relative_path.to_string_lossy();
             if is_protected(&rel_str, &config.protected_paths) {
                 continue;
             }
-            // We only inspect `_lib/` for warnings; other rules return
-            // `Resolution::Path` so they have nothing to surface here.
-            // For directory matches we don't recurse — the resolver only
-            // hits `_lib/` for files (the wholesale dir branch never
-            // returns Skip), so a soft top-level signal is enough.
-            if let Some(stripped) = rel_str.strip_prefix("_lib/") {
-                if !cfg!(target_os = "macos") {
-                    out.push(format!(
-                        "warning: pack `{}` contains `_lib/{stripped}` — \
-                         macOS-only path, skipping on this platform",
-                        m.pack
-                    ));
-                }
+            // Surface a single warning per `_lib/` entry, regardless of
+            // whether the match is the top-level `_lib` directory (the
+            // common case via the catchall scanner) or a nested
+            // `_lib/<rest>` file. The resolver's `_lib/` branch returns
+            // `Resolution::Skip` on every non-macOS host; the warning
+            // explains why no symlink got created.
+            if rel_str == "_lib" || rel_str.starts_with("_lib/") {
+                out.push(format!(
+                    "warning: pack `{}` contains `{rel_str}` — \
+                     macOS-only path, skipping on this platform",
+                    m.pack
+                ));
             }
         }
         let _ = paths; // reserved for future per-warning path enrichment
@@ -242,13 +244,18 @@ fn collect_per_file_intents(
         if is_protected(&rel_str, &config.protected_paths) {
             continue;
         }
-        let user_path = resolve_target(&m.pack, &rel_str, config, paths);
-        out.push(HandlerIntent::Link {
-            pack: m.pack.clone(),
-            handler: HANDLER_SYMLINK.into(),
-            source: entry.path.clone(),
-            user_path,
-        });
+        // Use the full Resolution channel so `_lib/` on non-macOS is
+        // skipped (no Link intent produced); `warnings_for_matches`
+        // surfaces the user-visible warning out-of-band.
+        match resolve_target_full(&m.pack, &rel_str, config, paths) {
+            Resolution::Path(user_path) => out.push(HandlerIntent::Link {
+                pack: m.pack.clone(),
+                handler: HANDLER_SYMLINK.into(),
+                source: entry.path.clone(),
+                user_path,
+            }),
+            Resolution::Skip { .. } => continue,
+        }
     }
     Ok(())
 }

--- a/crates/dodot-lib/src/handlers/symlink.rs
+++ b/crates/dodot-lib/src/handlers/symlink.rs
@@ -5,16 +5,32 @@
 //!
 //! 0. **Custom target** from `[symlink.targets]` config
 //! 1. **`home.X` prefix** (top-level files only) — routes to `$HOME/.X`
-//! 2. **`_home/` or `_xdg/` directory prefix** — raw `$HOME/.<rest>` or
-//!    `$XDG_CONFIG_HOME/<rest>` (escape hatches that skip pack
-//!    namespacing entirely)
+//! 2. **Directory prefixes** (per-subtree, skip pack namespace):
+//!    a. `_home/<rest>` → `$HOME/.<rest>`
+//!    b. `_xdg/<rest>`  → `$XDG_CONFIG_HOME/<rest>`
+//!    c. `_app/<rest>`  → `<app_support_dir>/<rest>` (macOS:
+//!    `~/Library/Application Support`; non-macOS: collapses to
+//!    `xdg_config_home`)
+//!    d. `_lib/<rest>`  → `$HOME/Library/<rest>` (macOS only; emits a
+//!    warning and skips on other platforms)
 //! 3. **`force_home` config list** — canonical `$HOME` tools (ssh, gpg,
 //!    bashrc, etc.)
-//! 4. **Default**: `$XDG_CONFIG_HOME/<pack>/<rel_path>` for every
+//! 4. **`force_app` config list** — curated GUI-app folders that route
+//!    to `<app_support_dir>/<first-segment>/<rest>` without requiring
+//!    a `_app/` prefix in the pack tree.
+//! 5. **`app_aliases[pack]`** — pack-level rewrite that reroutes the
+//!    *default rule* to `<app_support_dir>/<alias>/<rel_path>` so a
+//!    natural pack name (`vscode`) can deploy to a GUI-app folder
+//!    name (`Code`) without `_app/` prefixes everywhere.
+//! 6. **Default**: `$XDG_CONFIG_HOME/<pack>/<rel_path>` for every
 //!    pack-root entry (file or directory) and every nested file. The
 //!    pack name namespaces config under XDG, matching modern tool
 //!    conventions (nvim, helix, ghostty, …) without requiring users
 //!    to write `pack/program/` doubled paths.
+//!
+//! See `docs/proposals/macos-paths.lex` for the full rationale behind
+//! the third coordinate (`app_support_dir`) and the `_app/` / `_lib/`
+//! prefix family.
 
 use std::path::{Path, PathBuf};
 
@@ -67,17 +83,54 @@ impl Handler for SymlinkHandler {
             if m.is_dir {
                 intents.extend(dir_intents(m, config, paths, fs)?);
             } else {
-                let user_path = resolve_target(&m.pack, &rel_str, config, paths);
-                intents.push(HandlerIntent::Link {
-                    pack: m.pack.clone(),
-                    handler: HANDLER_SYMLINK.into(),
-                    source: m.absolute_path.clone(),
-                    user_path,
-                });
+                match resolve_target_full(&m.pack, &rel_str, config, paths) {
+                    Resolution::Path(user_path) => intents.push(HandlerIntent::Link {
+                        pack: m.pack.clone(),
+                        handler: HANDLER_SYMLINK.into(),
+                        source: m.absolute_path.clone(),
+                        user_path,
+                    }),
+                    Resolution::Skip { .. } => {
+                        // `_lib/` on non-macOS — silently skipped here;
+                        // `warnings_for_matches` produces the user-visible
+                        // text in PackStatusResult.warnings.
+                    }
+                }
             }
         }
 
         Ok(intents)
+    }
+
+    fn warnings_for_matches(
+        &self,
+        matches: &[RuleMatch],
+        config: &HandlerConfig,
+        paths: &dyn Pather,
+    ) -> Vec<String> {
+        let mut out = Vec::new();
+        for m in matches {
+            let rel_str = m.relative_path.to_string_lossy();
+            if is_protected(&rel_str, &config.protected_paths) {
+                continue;
+            }
+            // We only inspect `_lib/` for warnings; other rules return
+            // `Resolution::Path` so they have nothing to surface here.
+            // For directory matches we don't recurse — the resolver only
+            // hits `_lib/` for files (the wholesale dir branch never
+            // returns Skip), so a soft top-level signal is enough.
+            if let Some(stripped) = rel_str.strip_prefix("_lib/") {
+                if !cfg!(target_os = "macos") {
+                    out.push(format!(
+                        "warning: pack `{}` contains `_lib/{stripped}` — \
+                         macOS-only path, skipping on this platform",
+                        m.pack
+                    ));
+                }
+            }
+        }
+        let _ = paths; // reserved for future per-warning path enrichment
+        out
     }
 
     fn check_status(
@@ -135,12 +188,12 @@ fn dir_intents(
         .keys()
         .any(|k| k.starts_with(&dir_prefix) || k == rel_str.as_ref());
 
-    // `_home/` and `_xdg/` are per-subtree escape hatches that strip
-    // their prefix during file-level resolution. Wholesale-linking the
-    // top-level `_home` or `_xdg` dir would bake the prefix into the
-    // deploy path (e.g. `~/.config/<pack>/_home`) — clearly not what
-    // the user meant. Force per-file mode for these.
-    let is_escape_prefix_dir = matches!(rel_str.as_ref(), "_home" | "_xdg");
+    // `_home/`, `_xdg/`, `_app/`, and `_lib/` are per-subtree escape
+    // hatches that strip their prefix during file-level resolution.
+    // Wholesale-linking the top-level escape dir would bake the prefix
+    // into the deploy path (e.g. `~/.config/<pack>/_home`) — clearly
+    // not what the user meant. Force per-file mode for these.
+    let is_escape_prefix_dir = matches!(rel_str.as_ref(), "_home" | "_xdg" | "_app" | "_lib");
 
     if !has_override && !is_escape_prefix_dir {
         let user_path = resolve_target(&m.pack, &rel_str, config, paths);
@@ -222,25 +275,64 @@ fn strip_home_prefix(rel_path: &str) -> Option<String> {
     None
 }
 
+/// Outcome of resolving a single symlink target.
+///
+/// Most rules return a concrete path. The `_lib/` prefix on non-macOS
+/// platforms returns `Skip` so the handler emits a soft warning and
+/// drops the intent — the pack stays valid and other entries deploy
+/// normally. See `docs/proposals/macos-paths.lex` §4.2.
+#[derive(Debug, Clone)]
+pub(crate) enum Resolution {
+    /// Deploy at the given path.
+    Path(PathBuf),
+    /// Skip this entry; the caller surfaces a warning out-of-band via
+    /// [`Handler::warnings_for_matches`]. The `reason` field carries a
+    /// human-readable explanation for callers (and future diagnostics)
+    /// that want it inline.
+    Skip {
+        #[allow(dead_code)]
+        reason: String,
+    },
+}
+
 /// Resolve the target path for a symlink.
 ///
 /// `pack` is the pack name; it namespaces the default XDG target so
 /// `pack vim/vimrc` deploys under `$XDG_CONFIG_HOME/vim/vimrc` rather
 /// than `$XDG_CONFIG_HOME/vimrc`.
 ///
-/// Priority (highest first):
-/// 0. Custom target override from config (`[symlink.targets]`)
-/// 1. `home.X` prefix convention (top-level files only) → `$HOME/.X`
-/// 2. Explicit `_home/` or `_xdg/` directory prefix (escape hatches —
-///    skip pack namespacing entirely)
-/// 3. `force_home` config list (ssh, gpg, bashrc, …)
-/// 4. Default: `$XDG_CONFIG_HOME/<pack>/<rel_path>`
+/// See the module-level docs for the full priority ladder. This thin
+/// wrapper unwraps the [`Resolution`] back to a `PathBuf` for callers
+/// that only ever care about deployable rules; sites that need to
+/// honor `Skip` (the `_lib/` non-macOS branch) should call
+/// [`resolve_target_full`] directly.
 pub(crate) fn resolve_target(
     pack: &str,
     rel_path: &str,
     config: &HandlerConfig,
     paths: &dyn Pather,
 ) -> PathBuf {
+    match resolve_target_full(pack, rel_path, config, paths) {
+        Resolution::Path(p) => p,
+        Resolution::Skip { .. } => {
+            // Skip-routed entries still need *some* PathBuf for the few
+            // call sites that ignore the skip channel (mostly tests). A
+            // production caller goes through `resolve_target_full` and
+            // never sees this branch.
+            paths.xdg_config_home().to_path_buf()
+        }
+    }
+}
+
+/// Same as [`resolve_target`] but exposes the full [`Resolution`]
+/// outcome, including the `Skip` variant produced by `_lib/` on
+/// non-macOS platforms.
+pub(crate) fn resolve_target_full(
+    pack: &str,
+    rel_path: &str,
+    config: &HandlerConfig,
+    paths: &dyn Pather,
+) -> Resolution {
     // Strip any `NNN-` ordering prefix from the pack name before
     // computing the deployed path. The pack's *display name* — not its
     // on-disk directory name — is what the user expects in
@@ -250,40 +342,56 @@ pub(crate) fn resolve_target(
     let pack = crate::packs::display_name_for(pack);
     let home = paths.home_dir();
     let xdg_config = paths.xdg_config_home();
+    let app_support = paths.app_support_dir();
 
     // Priority 0: Custom target override from [symlink.targets]
     if let Some(target) = config.targets.get(rel_path) {
         if target.starts_with('/') {
             // Absolute path — use as-is
-            return PathBuf::from(target);
+            return Resolution::Path(PathBuf::from(target));
         }
         // Relative path — resolve from XDG_CONFIG_HOME
-        return xdg_config.join(target);
+        return Resolution::Path(xdg_config.join(target));
     }
 
     // Priority 1: home. prefix convention (per-file opt-in for $HOME placement)
     // home.bashrc → ~/.bashrc, home.vimrc → ~/.vimrc (top-level files only).
     if let Some(dotted) = strip_home_prefix(rel_path) {
-        return home.join(&dotted);
+        return Resolution::Path(home.join(&dotted));
     }
 
     // Priority 2: Explicit directory-prefix escape hatches.
     // _home/<rest> → $HOME/.<rest> (raw, no pack namespace)
     // _xdg/<rest>  → $XDG_CONFIG_HOME/<rest> (raw, no pack namespace)
+    // _app/<rest>  → <app_support_dir>/<rest> (raw, no pack namespace)
+    // _lib/<rest>  → $HOME/Library/<rest> (macOS only; warn elsewhere)
     if let Some(stripped) = rel_path.strip_prefix("_home/") {
         let parts: Vec<&str> = stripped.split('/').collect();
         if let Some(first) = parts.first() {
             if !first.is_empty() && !first.starts_with('.') {
                 let mut new_parts = vec![format!(".{first}")];
                 new_parts.extend(parts[1..].iter().map(|s| s.to_string()));
-                return home.join(new_parts.join("/"));
+                return Resolution::Path(home.join(new_parts.join("/")));
             }
         }
-        return home.join(stripped);
+        return Resolution::Path(home.join(stripped));
     }
 
     if let Some(stripped) = rel_path.strip_prefix("_xdg/") {
-        return xdg_config.join(stripped);
+        return Resolution::Path(xdg_config.join(stripped));
+    }
+
+    if let Some(stripped) = rel_path.strip_prefix("_app/") {
+        return Resolution::Path(app_support.join(stripped));
+    }
+
+    if let Some(stripped) = rel_path.strip_prefix("_lib/") {
+        if cfg!(target_os = "macos") {
+            return Resolution::Path(home.join("Library").join(stripped));
+        }
+        return Resolution::Skip {
+            reason: format!("_lib/{stripped} — macOS-only path, skipping on this platform"),
+        };
     }
 
     // Priority 3: force_home blacklist (ssh, gpg, bashrc, …)
@@ -302,7 +410,7 @@ pub(crate) fn resolve_target(
             for part in rest {
                 result = result.join(part);
             }
-            return result;
+            return Resolution::Path(result);
         }
 
         let filename = Path::new(rel_path)
@@ -314,16 +422,35 @@ pub(crate) fn resolve_target(
         } else {
             format!(".{filename}")
         };
-        return home.join(dotted);
+        return Resolution::Path(home.join(dotted));
     }
 
-    // Priority 4: Default — $XDG_CONFIG_HOME/<pack>/<rel_path>
+    // Priority 4: force_app — curated GUI-app folders that route to
+    // `<app_support_dir>/<first-segment>/<rest>` without a `_app/`
+    // prefix. Mirrors `force_home` semantics: first segment compared
+    // case-sensitively (Library folder names *are* case-sensitive).
+    if is_force_app(rel_path, &config.force_app) {
+        return Resolution::Path(app_support.join(rel_path));
+    }
+
+    // Priority 5: app_aliases — pack-level rewrite of the default rule.
+    // When the pack name appears in the alias map, route the deploy
+    // through `<app_support_dir>/<alias>/<rel_path>` instead of the
+    // XDG default. Aliases compose: higher-priority rules above (for
+    // `home.X`, `_home/`, `_xdg/`, `_app/`, `force_home`, `force_app`)
+    // already returned, so by the time we get here we're in the default
+    // bucket and the alias is the right rewrite to apply.
+    if let Some(alias) = config.app_aliases.get(pack) {
+        return Resolution::Path(app_support.join(alias).join(rel_path));
+    }
+
+    // Priority 6: Default — $XDG_CONFIG_HOME/<pack>/<rel_path>
     //
     // The pack name namespaces every entry by default so common modern
     // tools (nvim, helix, ghostty, …) work out of the box without
     // requiring `pack/program/` doubled paths. The escape hatches above
     // cover legacy `$HOME` tools and any user-specified overrides.
-    xdg_config.join(pack).join(rel_path)
+    Resolution::Path(xdg_config.join(pack).join(rel_path))
 }
 
 /// Check if a path matches any force_home entry.
@@ -335,6 +462,17 @@ fn is_force_home(rel_path: &str, force_home: &[String]) -> bool {
         let entry_without_dot = entry.strip_prefix('.').unwrap_or(entry);
         entry_without_dot == without_dot
     })
+}
+
+/// Check if a path matches any `force_app` entry.
+///
+/// Matching is *case-sensitive* on the first path segment — Library
+/// folder names on macOS are case-sensitive, and `Code` (VS Code) must
+/// not also match a hypothetical `code` CLI tool's `~/.config/code/`
+/// directory. See `docs/proposals/macos-paths.lex` §3.4.
+fn is_force_app(rel_path: &str, force_app: &[String]) -> bool {
+    let first_segment = rel_path.split('/').next().unwrap_or(rel_path);
+    force_app.iter().any(|entry| entry == first_segment)
 }
 
 /// Check if a path is in the protected paths list.
@@ -368,10 +506,14 @@ mod tests {
     use crate::paths::XdgPather;
 
     fn test_pather() -> XdgPather {
+        // Pin app_support_dir explicitly so resolver tests behave
+        // identically on Linux and macOS hosts. Production builds let
+        // the platform default kick in; unit tests need determinism.
         XdgPather::builder()
             .home("/home/alice")
             .dotfiles_root("/home/alice/dotfiles")
             .xdg_config_home("/home/alice/.config")
+            .app_support_dir("/home/alice/Library/Application Support")
             .build()
             .unwrap()
     }
@@ -520,6 +662,208 @@ mod tests {
             &test_pather(),
         );
         assert_eq!(target, PathBuf::from("/home/alice/.config/ghostty/config"));
+    }
+
+    // ── Priority 2c: _app/ prefix ───────────────────────────────
+
+    #[test]
+    fn app_prefix_routes_to_app_support_root() {
+        // _app/<rest> deploys raw under app_support_dir, no pack
+        // namespace. The pack-relative path mirrors the on-disk
+        // Application Support tree exactly.
+        let config = HandlerConfig::default();
+        let target = resolve_target(
+            "macapps",
+            "_app/Code/User/settings.json",
+            &config,
+            &test_pather(),
+        );
+        assert_eq!(
+            target,
+            PathBuf::from("/home/alice/Library/Application Support/Code/User/settings.json")
+        );
+    }
+
+    #[test]
+    fn app_prefix_outranks_default() {
+        // A pack literally named `Code` with `_app/Code/x` is covered by
+        // Priority 2c — the default rule (Priority 6) never sees it.
+        let config = HandlerConfig::default();
+        let target = resolve_target("Code", "_app/Code/x", &config, &test_pather());
+        assert_eq!(
+            target,
+            PathBuf::from("/home/alice/Library/Application Support/Code/x")
+        );
+    }
+
+    // ── Priority 2d: _lib/ prefix (macOS only) ──────────────────
+
+    #[test]
+    fn lib_prefix_resolution_full_returns_skip_on_non_macos() {
+        // The `_lib/` prefix is macOS-only. On every other host the
+        // resolver returns `Resolution::Skip` so the symlink handler
+        // can omit the intent and surface a soft warning. The test is
+        // gated on `cfg!(target_os = "macos")` for the positive case
+        // (the skip branch is the *only* branch on Linux CI).
+        let config = HandlerConfig::default();
+        let resolution = resolve_target_full(
+            "macapps",
+            "_lib/LaunchAgents/com.example.foo.plist",
+            &config,
+            &test_pather(),
+        );
+        if cfg!(target_os = "macos") {
+            match resolution {
+                Resolution::Path(p) => assert_eq!(
+                    p,
+                    PathBuf::from("/home/alice/Library/LaunchAgents/com.example.foo.plist")
+                ),
+                Resolution::Skip { reason } => {
+                    panic!("expected Path on macOS, got Skip({reason})")
+                }
+            }
+        } else {
+            assert!(
+                matches!(resolution, Resolution::Skip { .. }),
+                "_lib/ on non-macOS must skip; got {resolution:?}"
+            );
+        }
+    }
+
+    // ── Priority 4: force_app ───────────────────────────────────
+
+    #[test]
+    fn force_app_routes_first_segment_to_app_support() {
+        // `force_app = ["Code"]` makes a top-level `Code/...` entry
+        // route to <app_support_dir>/Code/... without a `_app/` prefix
+        // in the pack tree.
+        let config = HandlerConfig {
+            force_app: vec!["Code".into()],
+            ..HandlerConfig::default()
+        };
+        let target = resolve_target(
+            "macapps",
+            "Code/User/settings.json",
+            &config,
+            &test_pather(),
+        );
+        assert_eq!(
+            target,
+            PathBuf::from("/home/alice/Library/Application Support/Code/User/settings.json")
+        );
+    }
+
+    #[test]
+    fn force_app_is_case_sensitive() {
+        // `Code` ≠ `code`. Library folder names are case-sensitive on
+        // macOS, and conflating `Code` (VS Code) with `code` (a CLI
+        // tool's `~/.config/code/`) would route the latter wrong.
+        let config = HandlerConfig {
+            force_app: vec!["Code".into()],
+            ..HandlerConfig::default()
+        };
+        let target = resolve_target("misc", "code/foo", &config, &test_pather());
+        assert_eq!(target, PathBuf::from("/home/alice/.config/misc/code/foo"));
+    }
+
+    #[test]
+    fn force_app_loses_to_explicit_app_prefix() {
+        // Priority 2c (`_app/`) outranks Priority 4 (`force_app`). A
+        // pack that mixes both gets the explicit prefix's routing.
+        let config = HandlerConfig {
+            force_app: vec!["Code".into()],
+            ..HandlerConfig::default()
+        };
+        let target = resolve_target("misc", "_app/Code/x", &config, &test_pather());
+        assert_eq!(
+            target,
+            PathBuf::from("/home/alice/Library/Application Support/Code/x")
+        );
+    }
+
+    // ── Priority 5: app_aliases ─────────────────────────────────
+
+    #[test]
+    fn app_alias_reroutes_default_rule() {
+        // Pack `vscode` aliased to `Code` deploys top-level files to
+        // <app_support_dir>/Code/... instead of $XDG/vscode/...
+        let mut aliases = std::collections::HashMap::new();
+        aliases.insert("vscode".into(), "Code".into());
+        let config = HandlerConfig {
+            app_aliases: aliases,
+            ..HandlerConfig::default()
+        };
+        let target = resolve_target("vscode", "User/settings.json", &config, &test_pather());
+        assert_eq!(
+            target,
+            PathBuf::from("/home/alice/Library/Application Support/Code/User/settings.json")
+        );
+    }
+
+    #[test]
+    fn app_alias_loses_to_explicit_xdg_prefix() {
+        // Aliases only modify the default rule (Priority 6). A
+        // `_xdg/...` entry is Priority 2b and routes raw under XDG —
+        // explicit user intent wins over the alias.
+        let mut aliases = std::collections::HashMap::new();
+        aliases.insert("vscode".into(), "Code".into());
+        let config = HandlerConfig {
+            app_aliases: aliases,
+            ..HandlerConfig::default()
+        };
+        let target = resolve_target("vscode", "_xdg/Code/User/foo", &config, &test_pather());
+        assert_eq!(target, PathBuf::from("/home/alice/.config/Code/User/foo"));
+    }
+
+    #[test]
+    fn app_alias_loses_to_home_prefix() {
+        // home.X (Priority 1) outranks alias-driven defaults — a
+        // `home.foo` file in an aliased pack still routes to ~/.foo.
+        let mut aliases = std::collections::HashMap::new();
+        aliases.insert("vscode".into(), "Code".into());
+        let config = HandlerConfig {
+            app_aliases: aliases,
+            ..HandlerConfig::default()
+        };
+        let target = resolve_target("vscode", "home.editorconfig", &config, &test_pather());
+        assert_eq!(target, PathBuf::from("/home/alice/.editorconfig"));
+    }
+
+    #[test]
+    fn app_alias_uses_pack_display_name() {
+        // Pack ordering prefix is stripped before alias lookup, just
+        // like for the default rule. `010-vscode` aliased as `vscode`
+        // → `Code` still routes correctly.
+        let mut aliases = std::collections::HashMap::new();
+        aliases.insert("vscode".into(), "Code".into());
+        let config = HandlerConfig {
+            app_aliases: aliases,
+            ..HandlerConfig::default()
+        };
+        let target = resolve_target("010-vscode", "settings.json", &config, &test_pather());
+        assert_eq!(
+            target,
+            PathBuf::from("/home/alice/Library/Application Support/Code/settings.json")
+        );
+    }
+
+    #[test]
+    fn force_app_outranks_app_alias() {
+        // `force_app` is Priority 4, `app_aliases` is Priority 5. If a
+        // pack has an alias and a top-level entry whose first segment
+        // is in force_app, the force_app routing wins.
+        let mut aliases = std::collections::HashMap::new();
+        aliases.insert("anything".into(), "AliasedFolder".into());
+        let config = HandlerConfig {
+            force_app: vec!["Cursor".into()],
+            app_aliases: aliases,
+            ..HandlerConfig::default()
+        };
+        let target = resolve_target("anything", "Cursor/x", &config, &test_pather());
+        assert_eq!(
+            target,
+            PathBuf::from("/home/alice/Library/Application Support/Cursor/x")
+        );
     }
 
     // ── Protected paths ─────────────────────────────────────────
@@ -778,6 +1122,111 @@ mod tests {
         );
         if let HandlerIntent::Link { source, .. } = &intents[0] {
             assert!(source.ends_with("ssh/config"));
+        }
+    }
+
+    // ── _lib/ warnings emission ─────────────────────────────────
+
+    #[test]
+    fn lib_prefix_emits_warning_on_non_macos() {
+        // The symlink handler's `warnings_for_matches` surfaces the
+        // soft "_lib/<rest> — macOS-only path, skipping" notice on
+        // every non-macOS host. On macOS the rule resolves as a real
+        // path, so the warnings list stays empty.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("macapps")
+            .file("_lib/LaunchAgents/com.example.foo.plist", "# stub plist")
+            .done()
+            .build();
+
+        let m = RuleMatch {
+            relative_path: PathBuf::from("_lib/LaunchAgents/com.example.foo.plist"),
+            absolute_path: env
+                .dotfiles_root
+                .join("macapps/_lib/LaunchAgents/com.example.foo.plist"),
+            pack: "macapps".into(),
+            handler: HANDLER_SYMLINK.into(),
+            is_dir: false,
+            options: std::collections::HashMap::new(),
+            preprocessor_source: None,
+        };
+        let handler = SymlinkHandler;
+        let config = HandlerConfig::default();
+        let warnings =
+            handler.warnings_for_matches(std::slice::from_ref(&m), &config, env.paths.as_ref());
+
+        if cfg!(target_os = "macos") {
+            assert!(
+                warnings.is_empty(),
+                "_lib/ should not warn on macOS; got {warnings:?}"
+            );
+            // And the intent is generated as a real Link.
+            let intents = handler
+                .to_intents(&[m], &config, env.paths.as_ref(), env.fs.as_ref())
+                .unwrap();
+            assert_eq!(intents.len(), 1);
+        } else {
+            assert_eq!(warnings.len(), 1, "expected one warning, got {warnings:?}");
+            assert!(
+                warnings[0].contains("macOS-only path"),
+                "warning text should mention macOS-only: {warnings:?}"
+            );
+            // And the intent is *omitted* — `to_intents` skips it.
+            let intents = handler
+                .to_intents(&[m], &config, env.paths.as_ref(), env.fs.as_ref())
+                .unwrap();
+            assert!(
+                intents.is_empty(),
+                "_lib/ on non-macOS must not emit Link intents: {intents:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn top_level_app_and_lib_dirs_force_per_file_mode() {
+        // Regression: a top-level `_app` or `_lib` directory MUST NOT
+        // be wholesale-linked — that would bake the prefix into the
+        // deploy path (`~/.config/<pack>/_app/...`). Same per-file
+        // forcing as `_home` and `_xdg`. Discovered by the bats e2e
+        // suite for `_app/`.
+        for prefix in ["_app", "_lib"] {
+            let env = crate::testing::TempEnvironment::builder()
+                .pack("macapps")
+                .file(&format!("{prefix}/Code/x.json"), "x")
+                .done()
+                .build();
+            let m = build_dir_match(&env, "macapps", prefix);
+            let handler = SymlinkHandler;
+            let intents = handler
+                .to_intents(
+                    &[m],
+                    &HandlerConfig::default(),
+                    env.paths.as_ref(),
+                    env.fs.as_ref(),
+                )
+                .unwrap();
+            // _lib/ on non-macOS produces no intent (skipped). On
+            // macOS it produces 1 link. _app/ produces 1 link
+            // everywhere (collapses to xdg on Linux but still emits).
+            let expected = match prefix {
+                "_lib" if !cfg!(target_os = "macos") => 0,
+                _ => 1,
+            };
+            assert_eq!(
+                intents.len(),
+                expected,
+                "prefix={prefix}: expected {expected} intents, got {intents:?}"
+            );
+            // The user_path should NOT contain the literal prefix —
+            // the resolver stripped it. (Skip this check when no
+            // intents were produced.)
+            if let Some(HandlerIntent::Link { user_path, .. }) = intents.first() {
+                assert!(
+                    !user_path.to_string_lossy().contains(&format!("/{prefix}/")),
+                    "prefix={prefix} leaked into deploy path: {}",
+                    user_path.display()
+                );
+            }
         }
     }
 

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -73,13 +73,14 @@ impl ExecutionContext {
         // everywhere even on macOS" escape hatch from
         // `docs/proposals/macos-paths.lex` §6.3 / §11.2.
         //
-        // Reading root config here means a malformed root .dodot.toml
-        // surfaces at context construction (the same place
-        // `ConfigManager::new` failures already surface) rather than
-        // later inside a command. Best-effort: if the root config is
-        // unreadable we fall through to platform defaults — that
-        // matches the rest of dodot's "broken config still lets you
-        // see status" posture.
+        // Soft-fail by design: a config-load failure here only blocks
+        // the `app_uses_library = false` override from being applied,
+        // not context construction itself. Real config errors (parse
+        // failures, missing required fields) bubble up the next time a
+        // command calls `config_manager.root_config()` — same surface,
+        // same error path, just without preempting Pather construction.
+        // If the read fails here we leave `app_support_dir` at the
+        // platform default and let the actual command surface the error.
         let mut paths_builder = crate::paths::XdgPather::builder().dotfiles_root(dotfiles_root);
         if let Ok(root_config) = config_manager.root_config() {
             if !root_config.symlink.app_uses_library {

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -66,11 +66,37 @@ impl ExecutionContext {
     /// returned context for any other consumer that cares. Callers
     /// only need to override specific fields (e.g. `dry_run`).
     pub fn production(dotfiles_root: &std::path::Path, verbose: bool) -> crate::Result<Self> {
-        let paths = Arc::new(
-            crate::paths::XdgPather::builder()
-                .dotfiles_root(dotfiles_root)
-                .build()?,
-        );
+        let config_manager = Arc::new(ConfigManager::new(dotfiles_root)?);
+
+        // Honor `app_uses_library = false` by collapsing app_support_dir
+        // onto xdg_config_home — that's the "Linux-style ~/.config
+        // everywhere even on macOS" escape hatch from
+        // `docs/proposals/macos-paths.lex` §6.3 / §11.2.
+        //
+        // Reading root config here means a malformed root .dodot.toml
+        // surfaces at context construction (the same place
+        // `ConfigManager::new` failures already surface) rather than
+        // later inside a command. Best-effort: if the root config is
+        // unreadable we fall through to platform defaults — that
+        // matches the rest of dodot's "broken config still lets you
+        // see status" posture.
+        let mut paths_builder = crate::paths::XdgPather::builder().dotfiles_root(dotfiles_root);
+        if let Ok(root_config) = config_manager.root_config() {
+            if !root_config.symlink.app_uses_library {
+                // Resolve XDG the way XdgPatherBuilder will, then pin
+                // app_support_dir at the same path. We can't read the
+                // builder's resolved xdg back out before build(), so
+                // duplicate the precedence here.
+                let home = std::env::var("HOME")
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|_| std::path::PathBuf::from("/tmp/dodot-unknown-home"));
+                let xdg = std::env::var("XDG_CONFIG_HOME")
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|_| home.join(".config"));
+                paths_builder = paths_builder.app_support_dir(xdg);
+            }
+        }
+        let paths = Arc::new(paths_builder.build()?);
         let fs: Arc<dyn Fs> = Arc::new(crate::fs::OsFs::new());
         let runner: Arc<dyn crate::datastore::CommandRunner> =
             Arc::new(crate::datastore::ShellCommandRunner::new(verbose));
@@ -79,7 +105,6 @@ impl ExecutionContext {
             paths.clone(),
             runner,
         ));
-        let config_manager = Arc::new(ConfigManager::new(dotfiles_root)?);
 
         Ok(Self {
             fs,
@@ -321,6 +346,35 @@ pub fn collect_pack_intents_with_preprocessors(
     collect_pack_intents_inner(pack, ctx, &pack_config, preprocessors)
 }
 
+/// Plan for a single pack — the intents the executor will run plus
+/// any soft warnings the handlers emitted during planning.
+///
+/// Warnings are non-fatal, human-readable strings (currently the
+/// `_lib/` non-macOS skip notice from
+/// `docs/proposals/macos-paths.lex` §4.2). Callers that surface
+/// `PackStatusResult.warnings` should consume them; pure-execution
+/// callers can ignore the field.
+#[derive(Debug, Default, Clone)]
+pub struct PackPlan {
+    pub intents: Vec<crate::operations::HandlerIntent>,
+    pub warnings: Vec<String>,
+}
+
+/// Like [`collect_pack_intents`], but returns both intents and any
+/// soft warnings the handlers produced during planning.
+///
+/// Use this when surfacing per-pack warnings in user-facing output
+/// (e.g. `commands::up` populating `PackStatusResult.warnings`). Pure
+/// execution callers should keep using [`collect_pack_intents`].
+pub fn plan_pack(pack: &Pack, ctx: &ExecutionContext) -> Result<PackPlan> {
+    let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
+    let registry = crate::preprocessing::default_registry(
+        &pack_config.preprocessor.template,
+        ctx.paths.as_ref(),
+    )?;
+    plan_pack_inner(pack, ctx, &pack_config, Some(&registry))
+}
+
 /// Shared implementation that takes a pre-loaded pack config. Both
 /// entrypoints load the config once and pass it through so we don't
 /// re-merge config for every pack (the ConfigManager caches by path,
@@ -331,6 +385,18 @@ fn collect_pack_intents_inner(
     pack_config: &crate::config::DodotConfig,
     preprocessors: Option<&crate::preprocessing::PreprocessorRegistry>,
 ) -> Result<Vec<crate::operations::HandlerIntent>> {
+    plan_pack_inner(pack, ctx, pack_config, preprocessors).map(|p| p.intents)
+}
+
+/// Same scan/preprocess/match/group/intents pipeline as
+/// [`collect_pack_intents_inner`], but additionally collects
+/// per-handler `warnings_for_matches` output.
+fn plan_pack_inner(
+    pack: &Pack,
+    ctx: &ExecutionContext,
+    pack_config: &crate::config::DodotConfig,
+    preprocessors: Option<&crate::preprocessing::PreprocessorRegistry>,
+) -> Result<PackPlan> {
     let rules = crate::config::mappings_to_rules(&pack_config.mappings);
 
     // Phase 1: Walk pack directory
@@ -377,6 +443,7 @@ fn collect_pack_intents_inner(
 
     // Generate intents from each handler
     let mut all_intents = Vec::new();
+    let mut all_warnings = Vec::new();
     for handler_name in &order {
         let handler = match registry.get(handler_name.as_str()) {
             Some(h) => h,
@@ -406,11 +473,26 @@ fn collect_pack_intents_inner(
                 "generated intents"
             );
             all_intents.extend(intents);
+
+            let warnings =
+                handler.warnings_for_matches(handler_matches, &pack.config, ctx.paths.as_ref());
+            for w in &warnings {
+                tracing::warn!(pack = %pack.name, handler = %handler_name, "{w}");
+            }
+            all_warnings.extend(warnings);
         }
     }
 
-    info!(pack = %pack.name, intents = all_intents.len(), "collected intents");
-    Ok(all_intents)
+    info!(
+        pack = %pack.name,
+        intents = all_intents.len(),
+        warnings = all_warnings.len(),
+        "collected intents"
+    );
+    Ok(PackPlan {
+        intents: all_intents,
+        warnings: all_warnings,
+    })
 }
 
 /// Execute a pre-collected set of intents.

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -72,6 +72,21 @@ pub trait Pather: Send + Sync {
     /// for subdirectory target mapping.
     fn xdg_config_home(&self) -> &Path;
 
+    /// Application-support root, the third filesystem coordinate the
+    /// symlink resolver understands.
+    ///
+    /// On macOS this resolves to `$HOME/Library/Application Support` by
+    /// default, the canonical home for GUI app config. On Linux and
+    /// other platforms it resolves to `xdg_config_home()` so the `_app/`
+    /// prefix and `app_aliases` route through `~/.config` —
+    /// indistinguishable from `_xdg/` on those platforms but the
+    /// mechanism stays platform-agnostic.
+    ///
+    /// The OS check lives only in [`XdgPatherBuilder::build`]; the
+    /// resolver operates on textual prefixes alone. See
+    /// `docs/proposals/macos-paths.lex` §2.1.
+    fn app_support_dir(&self) -> &Path;
+
     /// Shell scripts directory (e.g. `~/.local/share/dodot/shell`).
     fn shell_dir(&self) -> &Path;
 
@@ -135,6 +150,7 @@ pub struct XdgPather {
     config_dir: PathBuf,
     cache_dir: PathBuf,
     xdg_config_home: PathBuf,
+    app_support_dir: PathBuf,
     shell_dir: PathBuf,
 }
 
@@ -150,6 +166,7 @@ pub struct XdgPatherBuilder {
     config_dir: Option<PathBuf>,
     cache_dir: Option<PathBuf>,
     xdg_config_home: Option<PathBuf>,
+    app_support_dir: Option<PathBuf>,
 }
 
 impl XdgPatherBuilder {
@@ -180,6 +197,18 @@ impl XdgPatherBuilder {
 
     pub fn xdg_config_home(mut self, path: impl Into<PathBuf>) -> Self {
         self.xdg_config_home = Some(path.into());
+        self
+    }
+
+    /// Override the application-support root.
+    ///
+    /// Tests pin this to a non-default location so prefix matches are
+    /// deterministic across platforms. End users may also flip this
+    /// (typically via the `app_uses_library` config key, which is
+    /// ultimately what wires through here) to opt into Linux-style
+    /// `~/.config` placement on macOS.
+    pub fn app_support_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.app_support_dir = Some(path.into());
         self
     }
 
@@ -216,6 +245,17 @@ impl XdgPatherBuilder {
 
         let shell_dir = data_dir.join("shell");
 
+        // Application-support root: macOS routes to `~/Library/Application Support`,
+        // every other platform falls through to `xdg_config_home`. The OS
+        // branch lives here exclusively; the resolver only sees a path.
+        let app_support_dir = self.app_support_dir.unwrap_or_else(|| {
+            if cfg!(target_os = "macos") {
+                home.join("Library").join("Application Support")
+            } else {
+                xdg_config_home.clone()
+            }
+        });
+
         Ok(XdgPather {
             home,
             dotfiles_root,
@@ -223,6 +263,7 @@ impl XdgPatherBuilder {
             config_dir,
             cache_dir,
             xdg_config_home,
+            app_support_dir,
             shell_dir,
         })
     }
@@ -263,6 +304,10 @@ impl Pather for XdgPather {
 
     fn xdg_config_home(&self) -> &Path {
         &self.xdg_config_home
+    }
+
+    fn app_support_dir(&self) -> &Path {
+        &self.app_support_dir
     }
 
     fn shell_dir(&self) -> &Path {
@@ -498,6 +543,53 @@ mod tests {
             pack_dir.display(),
             pack_data.display(),
         );
+    }
+
+    /// Explicit `app_support_dir(...)` overrides the platform default.
+    /// Tests rely on this to pin the third coordinate at a known
+    /// non-XDG, non-HOME location so the resolver's `_app/` rule has
+    /// somewhere unambiguous to land.
+    #[test]
+    fn explicit_app_support_dir_overrides_default() {
+        let pather = XdgPather::builder()
+            .home("/u")
+            .dotfiles_root("/u/dotfiles")
+            .xdg_config_home("/u/.config")
+            .app_support_dir("/u/Library/Application Support")
+            .build()
+            .unwrap();
+        assert_eq!(
+            pather.app_support_dir(),
+            Path::new("/u/Library/Application Support")
+        );
+    }
+
+    /// Default app_support_dir on Linux/non-macOS collapses to xdg_config_home.
+    /// On macOS it points under `$HOME/Library/Application Support`.
+    /// We don't `cfg!` the assertion here because the explicit-builder
+    /// test above pins the override path; this test exercises the
+    /// implicit default and the platform branch together.
+    #[test]
+    fn default_app_support_dir_is_platform_aware() {
+        let pather = XdgPather::builder()
+            .home("/u")
+            .dotfiles_root("/u/dotfiles")
+            .xdg_config_home("/u/.config")
+            .build()
+            .unwrap();
+        if cfg!(target_os = "macos") {
+            assert_eq!(
+                pather.app_support_dir(),
+                Path::new("/u/Library/Application Support"),
+                "macOS default should route under $HOME/Library/Application Support"
+            );
+        } else {
+            assert_eq!(
+                pather.app_support_dir(),
+                pather.xdg_config_home(),
+                "non-macOS default should collapse to xdg_config_home"
+            );
+        }
     }
 
     // Compile-time check: Pather must be object-safe

--- a/crates/dodot-lib/src/testing/mod.rs
+++ b/crates/dodot-lib/src/testing/mod.rs
@@ -48,6 +48,11 @@ pub struct TempEnvironment {
     /// Simulated XDG config home (e.g. for symlink target mapping).
     pub config_home: PathBuf,
 
+    /// Simulated `~/Library/Application Support` root. Pinned to a
+    /// directory under the temp dir on every platform so `_app/` and
+    /// `app_aliases` tests behave identically on Linux and macOS.
+    pub app_support: PathBuf,
+
     /// Real filesystem handle.
     pub fs: Arc<OsFs>,
 
@@ -284,6 +289,11 @@ impl TempEnvironmentBuilder {
         let cache_dir = home.join(".cache").join("dodot");
         let shell_dir = data_dir.join("shell");
         let packs_data_dir = data_dir.join("packs");
+        // App-support root pinned under the temp dir on every platform.
+        // Real macOS uses `~/Library/Application Support`; tests pin it
+        // here so the `_app/` resolver branch routes somewhere we can
+        // make assertions about regardless of host OS.
+        let app_support = home.join("Library").join("Application Support");
 
         // Create base directories
         for dir in [
@@ -294,6 +304,7 @@ impl TempEnvironmentBuilder {
             &cache_dir,
             &shell_dir,
             &packs_data_dir,
+            &app_support,
         ] {
             fs.mkdir_all(dir)
                 .unwrap_or_else(|e| panic!("failed to create {}: {e}", dir.display()));
@@ -341,6 +352,7 @@ impl TempEnvironmentBuilder {
                 .config_dir(config_home.join("dodot"))
                 .cache_dir(&cache_dir)
                 .xdg_config_home(&config_home)
+                .app_support_dir(&app_support)
                 .build()
                 .expect("failed to build XdgPather for test environment"),
         );
@@ -351,6 +363,7 @@ impl TempEnvironmentBuilder {
             dotfiles_root,
             data_dir,
             config_home,
+            app_support,
             fs,
             paths,
         }
@@ -500,6 +513,7 @@ mod tests {
         assert_eq!(env.paths.dotfiles_root(), env.dotfiles_root);
         assert_eq!(env.paths.data_dir(), env.data_dir);
         assert_eq!(env.paths.xdg_config_home(), env.config_home);
+        assert_eq!(env.paths.app_support_dir(), env.app_support);
     }
 
     #[test]

--- a/docs/reference/symlink-paths.lex
+++ b/docs/reference/symlink-paths.lex
@@ -6,20 +6,19 @@ Symlink Deployment Paths
 
 0. The Scenario
 
-    After decades crowding user's ~ with dotfiles, the XDG spec tackles the issue. It fixes it, and fixes it well. It has actually succeeded, but between the many years it took the ecosystem to react and some compromises on the spirit of interoperability, public perception is often on the contrary.  This matters (hence the inclusion) because it sets the tone right: paths in dodot are XDG paths.
-    This sets the tone better. There are two exceptions to this rule: 
+    After decades of dotfiles crowding `$HOME`, the XDG spec tackled the issue — and it has succeeded. Adoption took years and the ecosystem still has rough edges, so public perception of XDG is more skeptical than the actual state warrants. Calling that out matters because it sets the tone for this document: paths in dodot are XDG paths by default.
 
-        1. The holdouts: some unix old timer's files (.ssh, .zshrc, .gpg ) have decades of deployment *and* tooling is built on top. This will expect the files to be under home. So breaking this would break lots of other things in the ecosystem. Note that there are about 10 of these only. Dodot handles this (more on it bellow). 
-        2. MacOs GUI Apps: a schism has surface, with the xdg paths pointing to the "correct" ~/Library directories (i.g. Application Support) being used by GUI Apps, and most cli software either both or ~/.config. If not on darwin, or not using dodot to handle GUI configs, this is immaterial.
+    There are two exceptions to that rule:
 
+        1. The holdouts: a handful of Unix files (`.ssh`, `.zshrc`, `.gnupg`, …) have decades of tooling that expects them in `$HOME`. Breaking that would cascade into the rest of the ecosystem. There are about ten of these in total; dodot handles them via the `force_home` list (§3).
+        2. macOS GUI apps: a schism exists between modern CLI tools (which use `~/.config`) and GUI apps (which use `~/Library/Application Support`). If you're not on Darwin or don't use dodot to manage GUI app config, this is immaterial — and dodot exposes the macOS-side routing via `_app/`, `_lib/`, `force_app`, and `app_aliases` (§6).
 
-    In a nutshell: 
-        dodot uses XDG fully, except for unix cannons. Additionally, since there are always exceptions this is fully controllable: 
-        - config: resolve to home  (unix cannons)
-        - file/dir names: 
-            - prefixing files with home. (i.e. home.some-config -> ~/.some-config)
-            - enclosing links under a _home directory or _xdg do the expect thing.
-        That is, if a you need to break convention, you get a simple, explicit mechanism for doing so. 
+    In a nutshell:
+        dodot uses XDG by default, except for Unix canons. Where you need to break convention, the mechanism is explicit:
+        - config: resolve to `$HOME` (Unix canons)
+        - file/dir names:
+            - prefix files with `home.` (e.g. `home.some-config` → `~/.some-config`)
+            - place links under a `_home/` or `_xdg/` directory for whole-subtree routing.
 
 
 
@@ -29,7 +28,7 @@ Symlink Deployment Paths
 
 1. The Default Rule
 
-    Dodot respects the `XDG_CONFIG_HOME` specification. If the user has set the `XDG_CONFIG_HOME` environments variable, dodot honors it; otherwise it defaults to `~/.config`. For brevity, this document refers to it as `$XDG_CONFIG_HOME`.
+    Dodot respects the `XDG_CONFIG_HOME` specification. If the user has set the `XDG_CONFIG_HOME` environment variable, dodot honors it; otherwise it defaults to `~/.config`. For brevity, this document refers to it as `$XDG_CONFIG_HOME`.
 
     The default rule for every pack-root entry — file or directory — is:
 
@@ -87,7 +86,7 @@ Symlink Deployment Paths
 
     3.1. Force App for GUI Application Folders
 
-        On MacOs, GUI app config lives at `~/Library/Application Support/<App>/`, a third filesystem coordinate alongside `$HOME` and `$XDG_CONFIG_HOME`. Dodot ships a curated companion to `force_home` — `force_app` — listing common GUI-app folder names whose first path segment routes to `<app_support_dir>/<name>/<rest>` without requiring a `_app/` prefix in the pack tree.
+        On macOS, GUI app config lives at `~/Library/Application Support/<App>/`, a third filesystem coordinate alongside `$HOME` and `$XDG_CONFIG_HOME`. Dodot ships a curated companion to `force_home` — `force_app` — listing common GUI-app folder names whose first path segment routes to `<app_support_dir>/<name>/<rest>` without requiring a `_app/` prefix in the pack tree.
 
         Force app:
 
@@ -101,9 +100,9 @@ Symlink Deployment Paths
 
         :: toml ::
 
-        Matching is case-sensitive and on the first path segment only — Library folder names are case-sensitive on MacOs, and `Code` (VS Code) must not collide with a hypothetical `code` CLI tool's `~/.config/code/` directory.
+        Matching is case-sensitive and on the first path segment only — Library folder names are case-sensitive on macOS, and `Code` (VS Code) must not collide with a hypothetical `code` CLI tool's `~/.config/code/` directory.
 
-        On Linux (or on MacOs with `app_uses_library = false`, see §6) the `app_support_dir` collapses onto `$XDG_CONFIG_HOME` and `force_app` routes through XDG instead — same mechanism, same rules, different destination.
+        On Linux (or on macOS with `app_uses_library = false`, see §6) the `app_support_dir` collapses onto `$XDG_CONFIG_HOME` and `force_app` routes through XDG instead — same mechanism, same rules, different destination.
 
 4. Linking Outside of `XDG_CONFIG_HOME`
 
@@ -130,18 +129,18 @@ Symlink Deployment Paths
 
     `_xdg/` is the escape hatch for when your pack name doesn't match the target program — e.g. a `term-config` pack containing configs for several terminals would put each at `term-config/_xdg/ghostty/config`, `term-config/_xdg/kitty/kitty.conf`, etc., and dodot deploys them straight to `$XDG_CONFIG_HOME/ghostty/config` and `$XDG_CONFIG_HOME/kitty/kitty.conf`. The pack name plays no role inside `_xdg/`.
 
-6. MacOs: `_app/`, `_lib/`, and Application Support
+6. macOS: `_app/`, `_lib/`, and Application Support
 
-    On MacOs, GUI applications read configuration from `~/Library/Application Support/<App>/` — a third filesystem coordinate alongside `$HOME` and `$XDG_CONFIG_HOME`. Dodot models this as `app_support_dir` and exposes two new directory prefixes plus a pack-level alias mechanism so the same pack tree can deploy correctly on both Linux and MacOs without `if os == "darwin"` branching inside packs.
+    On macOS, GUI applications read configuration from `~/Library/Application Support/<App>/` — a third filesystem coordinate alongside `$HOME` and `$XDG_CONFIG_HOME`. Dodot models this as `app_support_dir` and exposes two new directory prefixes plus a pack-level alias mechanism so the same pack tree can deploy correctly on both Linux and macOS without `if os == "darwin"` branching inside packs.
 
     Roots:
-        | Symbol             | MacOs                                 | Linux / other                |
+        | Symbol             | macOS                                 | Linux / other                |
         | `$HOME`            | `/Users/<user>`                       | `/home/<user>`               |
         | `$XDG_CONFIG_HOME` | `~/.config` (unless env-set)          | `~/.config` (unless env-set) |
         | `app_support_dir`  | `~/Library/Application Support`       | `$XDG_CONFIG_HOME`           |
     :: table align=lll ::
 
-    On Linux the second and third coordinates collapse to one location, so `_app/` and `app_aliases` route through `~/.config` — indistinguishable from `_xdg/` in effect, but the same pack tree still works. On MacOs the third coordinate diverges and the routing kicks in.
+    On Linux the second and third coordinates collapse to one location, so `_app/` and `app_aliases` route through `~/.config` — indistinguishable from `_xdg/` in effect, but the same pack tree still works. On macOS the third coordinate diverges and the routing kicks in.
 
     6.1. The `_app/` Directory Prefix
 
@@ -163,17 +162,17 @@ Symlink Deployment Paths
         deploys to:
 
             - Linux:  `~/.config/Code/User/settings.json`
-            - MacOs:  `~/Library/Application Support/Code/User/settings.json`
+            - macOS:  `~/Library/Application Support/Code/User/settings.json`
 
         :: text ::
 
         The pack literally states "this is GUI-app config under name `Code`". Dodot picks the root per platform.
 
-    6.2. The `_lib/` Directory Prefix (MacOs Only)
+    6.2. The `_lib/` Directory Prefix (macOS Only)
 
-        `_lib/` is the MacOs-only counterpart to `_app/`. Where `_app/` cross-routes between platforms, `_lib/` declares a hard MacOs-only target — appropriate for apps with no Linux equivalent:
+        `_lib/` is the macOS-only counterpart to `_app/`. Where `_app/` cross-routes between platforms, `_lib/` declares a hard macOS-only target — appropriate for apps with no Linux equivalent:
 
-            <pack>/_lib/<rest>  →  $HOME/Library/<rest>          # MacOs only
+            <pack>/_lib/<rest>  →  $HOME/Library/<rest>          # macOS only
 
         :: text ::
 
@@ -187,7 +186,7 @@ Symlink Deployment Paths
 
         :: text ::
 
-        On non-MacOs platforms, `_lib/` emits no symlink intent and produces a soft warning:
+        On non-macOS platforms, `_lib/` emits no symlink intent and produces a soft warning:
 
             warning: pack `<pack>` contains `_lib/<rest>` — macOS-only path,
                      skipping on this platform
@@ -208,13 +207,13 @@ Symlink Deployment Paths
 
         :: toml ::
 
-        When a pack name appears as a key in `app_aliases`, the *default rule* for that pack is rerouted: instead of `$XDG_CONFIG_HOME/<pack>/<rel_path>`, the deploy path becomes `<app_support_dir>/<value>/<rel_path>`. The pack `vscode` with `User/settings.json` then deploys to `~/Library/Application Support/Code/User/settings.json` on MacOs and `~/.config/Code/User/settings.json` on Linux — without any `_app/` prefix in the pack tree.
+        When a pack name appears as a key in `app_aliases`, the *default rule* for that pack is rerouted: instead of `$XDG_CONFIG_HOME/<pack>/<rel_path>`, the deploy path becomes `<app_support_dir>/<value>/<rel_path>`. The pack `vscode` with `User/settings.json` then deploys to `~/Library/Application Support/Code/User/settings.json` on macOS and `~/.config/Code/User/settings.json` on Linux — without any `_app/` prefix in the pack tree.
 
         Aliases compose with the rest of the priority ladder: `home.X` (Priority 1) and the directory prefixes (`_home/`, `_xdg/`, `_app/`, `_lib/` — Priority 2) all outrank the alias-driven default. A `[symlink.targets]` entry (Priority 0) still wins absolutely.
 
     6.4. The `app_uses_library` Switch
 
-        On MacOs the `app_support_dir` defaults to `~/Library/Application Support`. To opt the entire pack tree into Linux-style `~/.config` placement on MacOs (e.g. for a user who keeps everything XDG-style), set:
+        On macOS the `app_support_dir` defaults to `~/Library/Application Support`. To opt the entire pack tree into Linux-style `~/.config` placement on macOS (e.g. for a user who keeps everything XDG-style), set:
 
         Override:
 
@@ -227,7 +226,7 @@ Symlink Deployment Paths
 
     6.5. Priority Ladder Summary
 
-        With the MacOs additions, the resolver evaluates the following rules in order. The first matching rule wins:
+        With the macOS additions, the resolver evaluates the following rules in order. The first matching rule wins:
 
         Priorities (highest first):
 
@@ -237,7 +236,7 @@ Symlink Deployment Paths
                 a. `_home/<rest>` → `$HOME/.<rest>`
                 b. `_xdg/<rest>`  → `$XDG_CONFIG_HOME/<rest>`
                 c. `_app/<rest>`  → `<app_support_dir>/<rest>`
-                d. `_lib/<rest>`  → `$HOME/Library/<rest>` (MacOs only; warn elsewhere)
+                d. `_lib/<rest>`  → `$HOME/Library/<rest>` (macOS only; warn elsewhere)
             3. `force_home` list → `$HOME/.<first-segment>/<rest>`
             4. `force_app` list → `<app_support_dir>/<first-segment>/<rest>`
             5. `app_aliases[pack]` → `<app_support_dir>/<alias>/<rel_path>`
@@ -313,7 +312,7 @@ Symlink Deployment Paths
             | `~/.<X>/...` (dotted dir in $HOME)         | (require `--into`)| `_home/<X>/...`                |
             | `~/.<X>` matching `force_home` (file/dir)  | (require `--into`)| `<X>` (bare, see §3)           |
             | `~/<X>` non-dotted, not in `force_home`    | refused           | —                              |
-            | `~/Library/Application Support/<X>/<rest>` | `<X>`             | `_app/<X>/<rest>` (MacOs only) |
+            | `~/Library/Application Support/<X>/<rest>` | `<X>`             | `_app/<X>/<rest>` (macOS only) |
             | `~/Library/Containers/...`                 | refused           | (sandboxed app data)           |
             | anything else                              | refused           | use `[symlink.targets]`        |
         :: table align=lll ::

--- a/docs/reference/symlink-paths.lex
+++ b/docs/reference/symlink-paths.lex
@@ -85,6 +85,26 @@ Symlink Deployment Paths
 
     Overriding this list allows you to change this behavior in case you need to, including adding other paths to force to home.
 
+    3.1. Force App for GUI Application Folders
+
+        On MacOs, GUI app config lives at `~/Library/Application Support/<App>/`, a third filesystem coordinate alongside `$HOME` and `$XDG_CONFIG_HOME`. Dodot ships a curated companion to `force_home` — `force_app` — listing common GUI-app folder names whose first path segment routes to `<app_support_dir>/<name>/<rest>` without requiring a `_app/` prefix in the pack tree.
+
+        Force app:
+
+            [symlink]
+            force_app = [
+                "Code",       # VS Code
+                "Cursor",     # Cursor (AI fork of VS Code)
+                "Zed",        # Zed editor
+                "Emacs"       # Emacs.app
+            ]
+
+        :: toml ::
+
+        Matching is case-sensitive and on the first path segment only — Library folder names are case-sensitive on MacOs, and `Code` (VS Code) must not collide with a hypothetical `code` CLI tool's `~/.config/code/` directory.
+
+        On Linux (or on MacOs with `app_uses_library = false`, see §6) the `app_support_dir` collapses onto `$XDG_CONFIG_HOME` and `force_app` routes through XDG instead — same mechanism, same rules, different destination.
+
 4. Linking Outside of `XDG_CONFIG_HOME`
 
     You can tell dodot to link a file to any arbitrary location by using the `.dodot.toml` config.
@@ -110,7 +130,122 @@ Symlink Deployment Paths
 
     `_xdg/` is the escape hatch for when your pack name doesn't match the target program — e.g. a `term-config` pack containing configs for several terminals would put each at `term-config/_xdg/ghostty/config`, `term-config/_xdg/kitty/kitty.conf`, etc., and dodot deploys them straight to `$XDG_CONFIG_HOME/ghostty/config` and `$XDG_CONFIG_HOME/kitty/kitty.conf`. The pack name plays no role inside `_xdg/`.
 
-6. Security Restricted Symlink File Names
+6. MacOs: `_app/`, `_lib/`, and Application Support
+
+    On MacOs, GUI applications read configuration from `~/Library/Application Support/<App>/` — a third filesystem coordinate alongside `$HOME` and `$XDG_CONFIG_HOME`. Dodot models this as `app_support_dir` and exposes two new directory prefixes plus a pack-level alias mechanism so the same pack tree can deploy correctly on both Linux and MacOs without `if os == "darwin"` branching inside packs.
+
+    Roots:
+        | Symbol             | MacOs                                 | Linux / other                |
+        | `$HOME`            | `/Users/<user>`                       | `/home/<user>`               |
+        | `$XDG_CONFIG_HOME` | `~/.config` (unless env-set)          | `~/.config` (unless env-set) |
+        | `app_support_dir`  | `~/Library/Application Support`       | `$XDG_CONFIG_HOME`           |
+    :: table align=lll ::
+
+    On Linux the second and third coordinates collapse to one location, so `_app/` and `app_aliases` route through `~/.config` — indistinguishable from `_xdg/` in effect, but the same pack tree still works. On MacOs the third coordinate diverges and the routing kicks in.
+
+    6.1. The `_app/` Directory Prefix
+
+        `_app/` is the per-subtree opt-in for "this is GUI-application config". Like `_xdg/` and `_home/`, it skips pack namespacing entirely:
+
+            <pack>/_app/<name>/<rest>  →  <app_support_dir>/<name>/<rest>
+
+        A portable `vscode` pack laid out as:
+
+            vscode/
+                _app/
+                    Code/
+                        User/
+                            settings.json
+                            keybindings.json
+
+        :: text ::
+
+        deploys to:
+
+            - Linux:  `~/.config/Code/User/settings.json`
+            - MacOs:  `~/Library/Application Support/Code/User/settings.json`
+
+        :: text ::
+
+        The pack literally states "this is GUI-app config under name `Code`". Dodot picks the root per platform.
+
+    6.2. The `_lib/` Directory Prefix (MacOs Only)
+
+        `_lib/` is the MacOs-only counterpart to `_app/`. Where `_app/` cross-routes between platforms, `_lib/` declares a hard MacOs-only target — appropriate for apps with no Linux equivalent:
+
+            <pack>/_lib/<rest>  →  $HOME/Library/<rest>          # MacOs only
+
+        :: text ::
+
+        Note that `_lib/` maps to `~/Library/`, *not* to `~/Library/Application Support/`. This gives access to other Library subtrees (`LaunchAgents/`, `Fonts/`, `Services/`) without further prefix proliferation. The user writes the full subpath:
+
+            <pack>/_lib/Application Support/Rectangle Pro/RectanglePro.json
+                →  ~/Library/Application Support/Rectangle Pro/RectanglePro.json
+
+            <pack>/_lib/LaunchAgents/com.example.foo.plist
+                →  ~/Library/LaunchAgents/com.example.foo.plist
+
+        :: text ::
+
+        On non-MacOs platforms, `_lib/` emits no symlink intent and produces a soft warning:
+
+            warning: pack `<pack>` contains `_lib/<rest>` — macOS-only path,
+                     skipping on this platform
+
+        :: text ::
+
+        The pack is otherwise unaffected; other entries deploy normally.
+
+    6.3. The `[symlink.app_aliases]` Map
+
+        Cross-platform packs frequently want a *natural* lowercase pack name (`vscode`) without writing `_app/Code/` for every entry. The `[symlink.app_aliases]` table lets a user declare a pack-level rewrite:
+
+        Pack-level alias:
+
+            [symlink.app_aliases]
+            vscode = "Code"
+            warp   = "dev.warp.Warp-Stable"
+
+        :: toml ::
+
+        When a pack name appears as a key in `app_aliases`, the *default rule* for that pack is rerouted: instead of `$XDG_CONFIG_HOME/<pack>/<rel_path>`, the deploy path becomes `<app_support_dir>/<value>/<rel_path>`. The pack `vscode` with `User/settings.json` then deploys to `~/Library/Application Support/Code/User/settings.json` on MacOs and `~/.config/Code/User/settings.json` on Linux — without any `_app/` prefix in the pack tree.
+
+        Aliases compose with the rest of the priority ladder: `home.X` (Priority 1) and the directory prefixes (`_home/`, `_xdg/`, `_app/`, `_lib/` — Priority 2) all outrank the alias-driven default. A `[symlink.targets]` entry (Priority 0) still wins absolutely.
+
+    6.4. The `app_uses_library` Switch
+
+        On MacOs the `app_support_dir` defaults to `~/Library/Application Support`. To opt the entire pack tree into Linux-style `~/.config` placement on MacOs (e.g. for a user who keeps everything XDG-style), set:
+
+        Override:
+
+            [symlink]
+            app_uses_library = false
+
+        :: toml ::
+
+        With this, `_app/` and `app_aliases` route through `~/.config/...` instead. `_lib/` is unaffected — it explicitly targets `~/Library/`, not `app_support_dir`.
+
+    6.5. Priority Ladder Summary
+
+        With the MacOs additions, the resolver evaluates the following rules in order. The first matching rule wins:
+
+        Priorities (highest first):
+
+            0. `[symlink.targets]` custom target
+            1. `home.X` prefix (top-level files only) → `$HOME/.X`
+            2. Directory prefixes (per-subtree, skip pack namespace):
+                a. `_home/<rest>` → `$HOME/.<rest>`
+                b. `_xdg/<rest>`  → `$XDG_CONFIG_HOME/<rest>`
+                c. `_app/<rest>`  → `<app_support_dir>/<rest>`
+                d. `_lib/<rest>`  → `$HOME/Library/<rest>` (MacOs only; warn elsewhere)
+            3. `force_home` list → `$HOME/.<first-segment>/<rest>`
+            4. `force_app` list → `<app_support_dir>/<first-segment>/<rest>`
+            5. `app_aliases[pack]` → `<app_support_dir>/<alias>/<rel_path>`
+            6. Default → `$XDG_CONFIG_HOME/<pack-display-name>/<rel_path>`
+
+        :: text ::
+
+7. Security Restricted Symlink File Names
 
     To avoid accidental security issues, dodot will not create symlinks for the following files and directories. This can also be configured.
 
@@ -133,7 +268,7 @@ Symlink Deployment Paths
 
     :: toml ::
 
-7. Ignored File Patterns
+8. Ignored File Patterns
 
     These are unlikely to be useful as symlinks, and are often present by accident or auto generated. These will not be linked, something you can override through config.
 
@@ -155,9 +290,9 @@ Symlink Deployment Paths
 
     :: toml ::
 
-8. `dodot adopt`: Source-Path Inference
+9. `dodot adopt`: Source-Path Inference
 
-    `dodot adopt` accepts a *deployed* path (where the file lives now) and works backwards to figure out which pack it belongs in and what to call it inside that pack — so re-deploying with `dodot up` lands the symlink back at the original location. The inference rules below are the inverse of §1–§5.
+    `dodot adopt` accepts a *deployed* path (where the file lives now) and works backwards to figure out which pack it belongs in and what to call it inside that pack — so re-deploying with `dodot up` lands the symlink back at the original location. The inference rules below are the inverse of §1–§6.
 
     Calling shape:
 
@@ -166,7 +301,7 @@ Symlink Deployment Paths
 
     :: text ::
 
-    8.1. Inference Per Source Root
+    9.1. Inference Per Source Root
 
         The source path's deployed location decides everything:
 
@@ -187,7 +322,7 @@ Symlink Deployment Paths
 
         $HOME-rooted dotfiles don't infer a pack name because the structure isn't there to mine: `~/.bashrc` could plausibly belong in a `shell`, `bash`, or `dotfiles` pack, and adopt won't guess. What inference *does* compute is the in-pack path — the `home.X` / `_home/X/` / bare-name conventions from §2, §3, §5 — so the round-trip works regardless of the chosen pack name.
 
-    8.2. Pack-Root Directory Expansion
+    9.2. Pack-Root Directory Expansion
 
         Adopting `~/.config/<X>/` (the whole directory) doesn't make the directory itself a single symlink. Instead, adopt enumerates its children and adopts each as a top-level pack member:
 
@@ -202,7 +337,7 @@ Symlink Deployment Paths
 
         `~/.X/` directory sources keep the existing whole-subtree behavior (`_home/X/`): the directory itself becomes the symlink, because in $HOME the user's mental model is the directory *is* the file.
 
-    8.3. The `--into` Override
+    9.3. The `--into` Override
 
         `--into <pack>` forces a destination pack regardless of inference. Two cases:
 
@@ -213,6 +348,6 @@ Symlink Deployment Paths
 
         Mixing HOME and XDG sources in one invocation is allowed: the HOME ones use their pack-name-independent prefixes, the XDG ones contribute the inferred pack name (or use `--into` if it differs). If two XDG sources infer different packs and no `--into` is given, adopt refuses and names both candidates so the user can split the invocation.
 
-    8.4. Auto-Creating Packs
+    9.4. Auto-Creating Packs
 
         When inference picks a single pack name and that pack does not exist on disk, adopt creates it (an empty directory). `--into <pack>` does *not* auto-create — the explicit name is a typo guard. Run `dodot init <pack>` first to bootstrap an explicit pack.

--- a/docs/reference/symlink-paths.lex
+++ b/docs/reference/symlink-paths.lex
@@ -2,11 +2,34 @@ Symlink Deployment Paths
 
     Symlinking is the core of a dotfile manager, and dodot ships with smart defaults plus overrides for every case where the defaults are wrong. This document is the full reference for where files end up on deploy.
 
+    Dodot makes the extra effort to be simple and predictable, but path handling is anything but, and in the service of being useful, there is some magic behaviour around paths. This document goes over them. 
+
+0. The Scenario
+
+    After decades crowding user's ~ with dotfiles, the XDG spec tackles the issue. It fixes it, and fixes it well. It has actually succeeded, but between the many years it took the ecosystem to react and some compromises on the spirit of interoperability, public perception is often on the contrary.  This matters (hence the inclusion) because it sets the tone right: paths in dodot are XDG paths.
+    This sets the tone better. There are two exceptions to this rule: 
+
+        1. The holdouts: some unix old timer's files (.ssh, .zshrc, .gpg ) have decades of deployment *and* tooling is built on top. This will expect the files to be under home. So breaking this would break lots of other things in the ecosystem. Note that there are about 10 of these only. Dodot handles this (more on it bellow). 
+        2. MacOs GUI Apps: a schism has surface, with the xdg paths pointing to the "correct" ~/Library directories (i.g. Application Support) being used by GUI Apps, and most cli software either both or ~/.config. If not on darwin, or not using dodot to handle GUI configs, this is immaterial.
+
+
+    In a nutshell: 
+        dodot uses XDG fully, except for unix cannons. Additionally, since there are always exceptions this is fully controllable: 
+        - config: resolve to home  (unix cannons)
+        - file/dir names: 
+            - prefixing files with home. (i.e. home.some-config -> ~/.some-config)
+            - enclosing links under a _home directory or _xdg do the expect thing.
+        That is, if a you need to break convention, you get a simple, explicit mechanism for doing so. 
+
+
+
+
+
     :: note :: See [./terms-and-concepts.lex] for terminology used throughout.
 
 1. The Default Rule
 
-    Dodot respects the `XDG_CONFIG_HOME` specification. If the user has set the `XDG_CONFIG_HOME` environment variable, dodot honors it; otherwise it defaults to `~/.config`. For brevity, this document refers to it as `$XDG_CONFIG_HOME`.
+    Dodot respects the `XDG_CONFIG_HOME` specification. If the user has set the `XDG_CONFIG_HOME` environments variable, dodot honors it; otherwise it defaults to `~/.config`. For brevity, this document refers to it as `$XDG_CONFIG_HOME`.
 
     The default rule for every pack-root entry — file or directory — is:
 
@@ -80,8 +103,8 @@ Symlink Deployment Paths
 
     For a whole subtree of files, the `_home/` and `_xdg/` directory prefixes route every file under them to a fixed root, **skipping the pack-name namespace**:
 
-        <pack>/_home/aconf.ini   →  $HOME/.aconf.ini
-        <pack>/_xdg/aconfig.ini  →  $XDG_CONFIG_HOME/aconfig.ini
+        <pack>/_home/a-conf.ini   →  $HOME/.a-conf.ini
+        <pack>/_xdg/a-config.ini  →  $XDG_CONFIG_HOME/a-config.ini
 
     `_home/` is the per-subtree counterpart of the per-file `home.` convention (§2): use it when a group of files belongs at `$HOME/.X` rather than `$XDG_CONFIG_HOME/<pack>/X`.
 

--- a/docs/reference/terms-and-concepts.lex
+++ b/docs/reference/terms-and-concepts.lex
@@ -67,8 +67,17 @@ Terms and Concepts
     `dot.` prefix:
         A filename prefix dodot strips on deploy: `dot.bashrc` in a pack becomes `~/.bashrc`. Keeps dotfiles visible in your editor and `ls` output without losing the dot-file convention at the deployed location.
 
-    `_home/` and `_xdg/` directories:
-        Explicit routing overrides. Files under `<pack>/_home/` deploy to `$HOME` regardless of XDG settings; files under `<pack>/_xdg/` deploy to `$XDG_CONFIG_HOME`. See [./symlink-paths.lex].
+    `_home/`, `_xdg/`, `_app/`, and `_lib/` directories:
+        Explicit routing overrides. Files under `<pack>/_home/` deploy to `$HOME`; under `<pack>/_xdg/` to `$XDG_CONFIG_HOME`; under `<pack>/_app/` to `app_support_dir` (MacOs `~/Library/Application Support`, Linux `$XDG_CONFIG_HOME`); under `<pack>/_lib/` to `$HOME/Library/` (MacOs only — non-MacOs platforms emit a soft warning and skip). All four prefixes skip pack-namespacing. See [./symlink-paths.lex].
+
+    App-support root:
+        The third filesystem coordinate dodot routes against, alongside `$HOME` and `$XDG_CONFIG_HOME`. On MacOs it points at `~/Library/Application Support` (canonical home for GUI app config). On Linux it collapses onto `$XDG_CONFIG_HOME` so the same pack tree works on both. Toggleable on MacOs via `[symlink] app_uses_library = false`.
+
+    App alias:
+        A pack-name → app-folder-name rewrite declared via `[symlink.app_aliases]`. Lets a pack named `vscode` deploy to `<app_support_dir>/Code/...` so the pack name stays lowercase-ergonomic while the deployed folder name matches what the GUI app actually reads. Modifies the resolver's default rule only — explicit prefixes still win.
+
+    `force_app`:
+        Curated list of GUI-app folder names whose first path segment routes to `<app_support_dir>/<name>/<rest>` without requiring a `_app/` prefix. Mirror of `force_home` for the third coordinate. Case-sensitive, capped at 100 entries; ships with a small seed (Code, Cursor, Zed, Emacs).
 
     `.dodotignore`:
         A marker file that tells dodot to skip a pack entirely. Useful for directories that live in the dotfiles root but aren't meant to be deployed (scratch, notes, README-only packs).

--- a/docs/reference/terms-and-concepts.lex
+++ b/docs/reference/terms-and-concepts.lex
@@ -68,10 +68,10 @@ Terms and Concepts
         A filename prefix dodot strips on deploy: `dot.bashrc` in a pack becomes `~/.bashrc`. Keeps dotfiles visible in your editor and `ls` output without losing the dot-file convention at the deployed location.
 
     `_home/`, `_xdg/`, `_app/`, and `_lib/` directories:
-        Explicit routing overrides. Files under `<pack>/_home/` deploy to `$HOME`; under `<pack>/_xdg/` to `$XDG_CONFIG_HOME`; under `<pack>/_app/` to `app_support_dir` (MacOs `~/Library/Application Support`, Linux `$XDG_CONFIG_HOME`); under `<pack>/_lib/` to `$HOME/Library/` (MacOs only — non-MacOs platforms emit a soft warning and skip). All four prefixes skip pack-namespacing. See [./symlink-paths.lex].
+        Explicit routing overrides. Files under `<pack>/_home/` deploy to `$HOME`; under `<pack>/_xdg/` to `$XDG_CONFIG_HOME`; under `<pack>/_app/` to `app_support_dir` (macOS `~/Library/Application Support`, Linux `$XDG_CONFIG_HOME`); under `<pack>/_lib/` to `$HOME/Library/` (macOS only — non-macOS platforms emit a soft warning and skip). All four prefixes skip pack-namespacing. See [./symlink-paths.lex].
 
     App-support root:
-        The third filesystem coordinate dodot routes against, alongside `$HOME` and `$XDG_CONFIG_HOME`. On MacOs it points at `~/Library/Application Support` (canonical home for GUI app config). On Linux it collapses onto `$XDG_CONFIG_HOME` so the same pack tree works on both. Toggleable on MacOs via `[symlink] app_uses_library = false`.
+        The third filesystem coordinate dodot routes against, alongside `$HOME` and `$XDG_CONFIG_HOME`. On macOS it points at `~/Library/Application Support` (canonical home for GUI app config). On Linux it collapses onto `$XDG_CONFIG_HOME` so the same pack tree works on both. Toggleable on macOS via `[symlink] app_uses_library = false`.
 
     App alias:
         A pack-name → app-folder-name rewrite declared via `[symlink.app_aliases]`. Lets a pack named `vscode` deploy to `<app_support_dir>/Code/...` so the pack name stays lowercase-ergonomic while the deployed folder name matches what the GUI app actually reads. Modifies the resolver's default rule only — explicit prefixes still win.

--- a/tests/e2e/bats/test_macos_paths.bats
+++ b/tests/e2e/bats/test_macos_paths.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# E2E tests for the MacOs paths feature: _app/, _lib/, force_app, app_aliases.
+# E2E tests for the macOS paths feature: _app/, _lib/, force_app, app_aliases.
 #
 # These run on every host. Where macOS and Linux behave differently,
 # tests assert the platform-appropriate outcome:

--- a/tests/e2e/bats/test_macos_paths.bats
+++ b/tests/e2e/bats/test_macos_paths.bats
@@ -1,0 +1,195 @@
+#!/usr/bin/env bats
+# E2E tests for the MacOs paths feature: _app/, _lib/, force_app, app_aliases.
+#
+# These run on every host. Where macOS and Linux behave differently,
+# tests assert the platform-appropriate outcome:
+#
+# - `_app/` and `app_aliases` route through `~/Library/Application Support`
+#   on macOS; on Linux they collapse onto `$XDG_CONFIG_HOME` (the same
+#   place `_xdg/` lands).
+# - `_lib/` deploys to `$HOME/Library/<rest>` on macOS; on Linux it
+#   produces a soft warning and skips with no symlink.
+# - Adopting from `~/Library/Application Support/<X>/` is macOS-only —
+#   on Linux that path doesn't match a recognized adopt source.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+    APP_SUPPORT="$HOME/Library/Application Support"
+    mkdir -p "$APP_SUPPORT"
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+# Resolve the platform-appropriate app-support root for assertions.
+# Mirrors what XdgPather::app_support_dir produces.
+expected_app_root() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        echo "$HOME/Library/Application Support"
+    else
+        echo "$XDG_CONFIG_HOME"
+    fi
+}
+
+# ── _app/ prefix ────────────────────────────────────────────────
+
+@test "_app/ deploys under app_support_dir without pack namespacing" {
+    create_pack_file "vscode" "_app/Code/User/settings.json" '{"editor.fontSize": 14}'
+
+    dodot up
+
+    local root
+    root="$(expected_app_root)"
+    assert_exists "$root/Code/User/settings.json"
+    assert_file_contains "$root/Code/User/settings.json" "fontSize"
+}
+
+@test "_app/ rule outranks the pack-name default" {
+    # Pack literally named `Code` with `_app/Code/` subtree: priority 2c
+    # routes through app_support, not the pack-name default at $XDG/Code.
+    create_pack_file "Code" "_app/Code/marker.json" '{"x": 1}'
+
+    dodot up
+
+    local root
+    root="$(expected_app_root)"
+    assert_exists "$root/Code/marker.json"
+    # On Linux the app_support root *is* $XDG, so the file at
+    # $XDG_CONFIG_HOME/Code/marker.json is shared by the priority-2c
+    # routing and the priority-6 default. There's nothing extra to
+    # assert beyond "the file landed there"; the unit tests pin the
+    # priority order itself.
+}
+
+# ── force_app ───────────────────────────────────────────────────
+
+@test "default force_app routes Code/ first segment to app_support" {
+    # `Code` ships in the default force_app list, so a top-level
+    # `Code/` entry routes to <app_support_dir>/Code/... without any
+    # `_app/` prefix in the pack tree.
+    create_pack_file "macapps" "Code/User/settings.json" '{"theme": "Default"}'
+
+    dodot up
+
+    local root
+    root="$(expected_app_root)"
+    assert_exists "$root/Code/User/settings.json"
+    assert_file_contains "$root/Code/User/settings.json" "theme"
+}
+
+@test "force_app is case sensitive" {
+    # `code` (lowercase) is not in force_app, so a top-level `code/`
+    # entry falls through to the default rule under the pack name.
+    create_pack_file "macapps" "code/foo" "bar"
+
+    dodot up
+
+    # Default rule: $XDG_CONFIG_HOME/macapps/code/foo
+    assert_exists "$XDG_CONFIG_HOME/macapps/code/foo"
+    # And NOT under the app-support root with a lowercase folder.
+    assert_not_exists "$(expected_app_root)/code/foo"
+}
+
+# ── app_aliases ─────────────────────────────────────────────────
+
+@test "app_aliases reroutes the pack default to app_support_dir" {
+    # Pack `vscode` aliased to `Code`: top-level entries deploy under
+    # <app_support_dir>/Code/... without a `_app/` prefix.
+    create_pack_file "vscode" "User/settings.json" '{"x": 2}'
+    create_pack_config "vscode" '[symlink.app_aliases]\nvscode = "Code"\n'
+
+    dodot up
+
+    local root
+    root="$(expected_app_root)"
+    assert_exists "$root/Code/User/settings.json"
+    assert_file_contains "$root/Code/User/settings.json" '"x": 2'
+}
+
+@test "app_aliases lose to explicit _xdg/ prefix" {
+    # Aliases only modify the default rule. A `_xdg/` entry in an
+    # aliased pack still routes raw under XDG_CONFIG_HOME.
+    create_pack_file "vscode" "_xdg/Code/User/foo" "explicit"
+    create_pack_config "vscode" '[symlink.app_aliases]\nvscode = "Code"\n'
+
+    dodot up
+
+    assert_exists "$XDG_CONFIG_HOME/Code/User/foo"
+    assert_file_contains "$XDG_CONFIG_HOME/Code/User/foo" "explicit"
+}
+
+# ── _lib/ prefix ────────────────────────────────────────────────
+
+@test "_lib/ deploys to ~/Library on macOS, warns and skips on Linux" {
+    create_pack_file "macapps" "_lib/LaunchAgents/com.example.foo.plist" \
+        "<?xml version=\"1.0\"?><plist></plist>"
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    if [[ "$(uname)" == "Darwin" ]]; then
+        assert_exists "$HOME/Library/LaunchAgents/com.example.foo.plist"
+    else
+        # Soft warning on stderr (or stdout, BATS captures both via run);
+        # the file is *not* deployed. _lib/ is macOS-only.
+        assert_output_contains "macOS-only path"
+        assert_not_exists "$HOME/Library/LaunchAgents/com.example.foo.plist"
+    fi
+}
+
+# ── Adopt from AppSupport (macOS only) ──────────────────────────
+
+@test "adopt from ~/Library/Application Support/<X>/ round-trips via _app/" {
+    if [[ "$(uname)" != "Darwin" ]]; then
+        skip "AppSupport adopt is macOS-only (Linux app_support_dir collapses to XDG)"
+    fi
+
+    mkdir -p "$APP_SUPPORT/Code/User"
+    echo '{"editor.fontSize": 14}' > "$APP_SUPPORT/Code/User/settings.json"
+
+    run dodot adopt "$APP_SUPPORT/Code/User/settings.json"
+    [ "$status" -eq 0 ]
+
+    # File copied into pack at `Code/_app/Code/User/settings.json`
+    # (pack name `Code`, in-pack prefix `_app/Code/...`).
+    assert_exists "$DOTFILES_ROOT/Code/_app/Code/User/settings.json"
+    assert_file_contains "$DOTFILES_ROOT/Code/_app/Code/User/settings.json" "fontSize"
+
+    # Original is now a symlink — the round-trip property: `dodot up`
+    # would land it back at the same place.
+    [ -L "$APP_SUPPORT/Code/User/settings.json" ] || \
+        { echo "expected symlink at $APP_SUPPORT/Code/User/settings.json" >&2; return 1; }
+}
+
+@test "adopt of AppSupport source emits app_aliases tip (macOS only)" {
+    if [[ "$(uname)" != "Darwin" ]]; then
+        skip "AppSupport adopt is macOS-only"
+    fi
+
+    mkdir -p "$APP_SUPPORT/Cursor/User"
+    echo '{}' > "$APP_SUPPORT/Cursor/User/settings.json"
+
+    run dodot adopt "$APP_SUPPORT/Cursor/User/settings.json"
+    [ "$status" -eq 0 ]
+
+    # The capitalization heuristic identifies `Cursor` as a GUI-app
+    # folder name and suggests the `app_aliases` ergonomic.
+    assert_output_contains "app_aliases"
+    assert_output_contains "Cursor"
+}
+
+# ── Sandboxed Containers refusal (cross-platform) ──────────────
+
+@test "adopt refuses ~/Library/Containers/ paths" {
+    # The refusal is platform-agnostic so no one accidentally adopts a
+    # container's plist on a CI Linux box. We synthesize the path
+    # under the sandbox HOME rather than touching real ~/Library.
+    mkdir -p "$HOME/Library/Containers/com.example.app/Data/Library/Preferences"
+    echo "x" > "$HOME/Library/Containers/com.example.app/Data/Library/Preferences/foo.plist"
+
+    run dodot adopt "$HOME/Library/Containers/com.example.app/Data/Library/Preferences/foo.plist"
+    [ "$status" -ne 0 ]
+    assert_output_contains "sandboxed"
+}


### PR DESCRIPTION
## Summary

- Implements phases M1–M5 of `docs/proposals/macos-paths.lex`. Models `~/Library/Application Support/<App>/` as a third filesystem coordinate alongside `$HOME` and `$XDG_CONFIG_HOME`, so cross-platform packs deploy GUI-app config correctly on both macOS and Linux without `if os == "darwin"` branching.
- Adds resolver rules `_app/` (Priority 2c), `_lib/` (Priority 2d, macOS-only — emits a soft warning and skips on other platforms), `force_app` (Priority 4, curated case-sensitive list capped at 100, seeded with `Code`/`Cursor`/`Zed`/`Emacs`), and `app_aliases` (Priority 5, pack-name → app-folder rewrite of the default rule). New config keys: `[symlink] app_uses_library`, `force_app`, `[symlink.app_aliases]`.
- `dodot adopt ~/Library/Application Support/<X>/...` now works — infers pack `<X>`, produces `_app/<X>/<rest>` in-pack paths that round-trip back to the original location. When the inferred pack name passes the GUI-app heuristic (uppercase / space / reverse-DNS shape), adopt emits an advisory tip pointing at the `app_aliases` ergonomic.
- Phase M6 (homebrew-cask probing, `dodot probe app` subcommand) is deferred to a follow-up PR.

## Test plan

- [x] 46 new unit/integration tests in `dodot-lib` (Pather, resolver, adopt inference, capitalization heuristic, config defaults, force_app cap-100 invariant). Total suite: 638 passing.
- [x] 10 new e2e bats tests in `tests/e2e/bats/test_macos_paths.bats` covering `_app/`, `_lib/`, `force_app`, `app_aliases`, AppSupport adopt round-trip, sandboxed Containers refusal — with platform-aware assertions for macOS vs Linux divergence.
- [x] Existing bats suites (`test_up`, `test_adopt`, `test_status`, `test_home_prefix`) still green — no regressions.
- [x] `cargo fmt`, `cargo clippy --all-targets`, `scripts/check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)