### PR TITLE
feat: macOS advisory probes — brew, mdls/mdfind, dodot probe app (M6)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -54,3 +54,45 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
 
   Phase M6 (homebrew-cask probing, `dodot probe app` subcommand) is
   intentionally deferred to a separate PR.
+
+- **macOS paths advisory probes (Phase M6).** Adds an opt-in,
+  read-only enrichment layer on top of the deterministic resolver.
+  The cardinal rule from the proposal still holds: probes are
+  *advisory*, never authoritative — the resolver in §5 never consults
+  this code, and a probe failure (no `brew` on PATH, malformed JSON,
+  empty Spotlight result) never alters routing.
+    - **homebrew-cask probe** (`probe::brew`) — wraps
+      `brew list --cask --versions` and `brew info --json=v2 --cask
+      <token>` with on-disk caching at `<cache_dir>/probes/brew/`,
+      24-hour TTL, and `--refresh` invalidation. Parses each cask's
+      zap stanza to extract Application Support folder candidates and
+      Preferences plist paths.
+    - **macOS-native probes** (`probe::macos_native`) — thin wrappers
+      around `mdls` (bundle-id lookup) and `mdfind` (display-name →
+      `.app` bundle path). Both gate on `cfg!(target_os = "macos")`
+      and return `None` on every other host.
+    - **`dodot adopt` enrichment** — when an AppSupport source's pack
+      name matches an installed cask's app-support folder, adopt's
+      success result includes a confirmation line ("homebrew cask
+      `visual-studio-code` confirms this is …") and, when the cask's
+      zap stanza lists Preferences plists, a sibling-adoption hint
+      pointing at `dodot adopt ~/Library/Preferences/<file>`.
+    - **`dodot up` / `dodot status` missing-target hints** — when a
+      pack's planned deploy targets an `<app_support_dir>/<X>/`
+      folder that doesn't exist on disk, the planner emits a soft
+      warning (cask-enriched when the brew probe finds a match):
+      "looks like cask `X` isn't installed yet — `<X>/...` will
+      deploy but the app isn't here to read it". macOS-only;
+      suppressed on Linux where `app_support_dir` collapses onto
+      `xdg_config_home`.
+    - **`dodot probe app <pack> [--refresh]` subcommand** —
+      diagnostic surface listing every app-support folder a pack
+      will route to (alias / force_app / `_app/`), folder existence,
+      matching cask + install state, `.app` bundle, bundle ID, and
+      sibling-adoption candidates. Run on demand; not part of any
+      hot path.
+    - **`ExecutionContext.command_runner`** — the production runner
+      is now exposed on the orchestration context so probes (and any
+      future advisory subprocess wrapper) reuse the same
+      `CommandRunner` the datastore already drives. Tests inject a
+      `CannedRunner` mock for deterministic probe coverage.

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -252,6 +252,22 @@ pub fn probe_show_data_dir_handler(
     Ok(Output::Render(commands::probe::show_data_dir(&ctx, depth)?))
 }
 
+/// `dodot probe app <pack> [--refresh]` — advisory introspection of
+/// macOS app-support paths for a pack. See
+/// `docs/proposals/macos-paths.lex` §8.4.
+pub fn probe_app_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::probe::ProbeResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    let pack = matches
+        .get_one::<String>("pack")
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("missing required argument: pack"))?;
+    let refresh = flag_or_false(matches, "refresh");
+    Ok(Output::Render(commands::probe::app(&pack, refresh, &ctx)?))
+}
+
 /// `dodot probe shell-init` — most recent shell-startup profile.
 ///
 /// Five views, picked by argument shape:

--- a/crates/dodot-cli/src/help.rs
+++ b/crates/dodot-cli/src/help.rs
@@ -50,6 +50,7 @@ const HELP_TEXTS: &[(&str, &str)] = &[
         "probe.shell-init",
         include_str!("help/probe-shell-init.txt"),
     ),
+    ("probe.app", include_str!("help/probe-app.txt")),
     ("probe", include_str!("help/probe.txt")),
 ];
 

--- a/crates/dodot-cli/src/help/probe-app.txt
+++ b/crates/dodot-cli/src/help/probe-app.txt
@@ -1,0 +1,29 @@
+[header]dodot probe app[/header] — Introspect macOS app-support routing for a pack.
+
+[desc]Shows the app-support folders a pack will deploy to, whether
+they exist on disk, the matching homebrew cask (if any), the
+.app bundle, and its bundle identifier. On macOS the data is
+enriched via `brew info` and Spotlight (`mdls` / `mdfind`); on
+other platforms only folder existence is reported.
+
+This is purely advisory — `dodot up` and `dodot status` never
+consult the same data, and a stale or missing probe never
+affects deployment routing.[/desc]
+
+[header]USAGE[/header]
+  [usage]dodot probe app <pack> [--refresh][/usage]
+
+[header]ARGUMENTS[/header]
+  [item]<pack>[/item]                     [desc]Pack name (display or on-disk).[/desc]
+
+[header]OPTIONS[/header]
+  [item]--refresh[/item]                  [desc]Invalidate the brew cache for this pack's tokens before probing.
+                              The cache is otherwise refreshed automatically every 24 hours.[/desc]
+
+[header]EXAMPLES[/header]
+  [example]dodot probe app vscode               [dim]# typical pack with `[symlink.app_aliases]`[/dim]
+  dodot probe app cursor --refresh     [dim]# force a fresh `brew info` lookup[/dim][/example]
+
+[header]SEE ALSO[/header]
+  [item]dodot adopt[/item]                [desc]Move existing files into a pack (also surfaces cask metadata when available)[/desc]
+  [item]dodot status[/item]               [desc]Per-pack deployment status[/desc]

--- a/crates/dodot-cli/src/help/probe-app.txt
+++ b/crates/dodot-cli/src/help/probe-app.txt
@@ -6,9 +6,10 @@ they exist on disk, the matching homebrew cask (if any), the
 enriched via `brew info` and Spotlight (`mdls` / `mdfind`); on
 other platforms only folder existence is reported.
 
-This is purely advisory — `dodot up` and `dodot status` never
-consult the same data, and a stale or missing probe never
-affects deployment routing.[/desc]
+Probes are advisory: `dodot up` and `dodot status` may consult
+cached probe data for warnings or hints, but stale or missing
+probe data never affects deployment routing or resolver
+decisions.[/desc]
 
 [header]USAGE[/header]
   [usage]dodot probe app <pack> [--refresh][/usage]

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -184,6 +184,8 @@ fn build_app() -> App {
             "probe",
         )
         .expect("register probe.shell-init")
+        .command("probe.app", handlers::probe_app_handler, "probe")
+        .expect("register probe.app")
         .command_groups(vec![
             CommandGroup {
                 title: "Core".into(),
@@ -433,6 +435,25 @@ fn build_clap_command() -> ClapCommand {
                                 .help("Maximum tree depth (default 4)")
                                 .value_parser(clap::value_parser!(usize))
                                 .num_args(1),
+                        ),
+                )
+                .subcommand(
+                    ClapCommand::new("app")
+                        .about(
+                            "Introspect macOS app-support routing for a pack (folders, casks, bundles)",
+                        )
+                        .arg(
+                            Arg::new("pack")
+                                .help("Pack name to probe")
+                                .value_name("PACK")
+                                .required(true)
+                                .num_args(1),
+                        )
+                        .arg(
+                            Arg::new("refresh")
+                                .long("refresh")
+                                .help("Invalidate the brew cache for this pack's tokens before probing")
+                                .action(ArgAction::SetTrue),
                         ),
                 )
                 .subcommand(

--- a/crates/dodot-cli/src/tutorial.rs
+++ b/crates/dodot-cli/src/tutorial.rs
@@ -213,6 +213,7 @@ pub struct TutorialEnv {
     pub fs: Arc<dyn Fs>,
     pub paths: Arc<dyn Pather>,
     pub datastore: Arc<dyn DataStore>,
+    pub command_runner: Arc<dyn dodot_lib::datastore::CommandRunner>,
     pub config_manager: Arc<ConfigManager>,
     pub syntax_checker: Arc<dyn SyntaxChecker>,
     /// Where the dotfiles root came from (for the check_root step
@@ -236,15 +237,19 @@ impl TutorialEnv {
         let fs: Arc<dyn Fs> = Arc::new(dodot_lib::fs::OsFs::new());
         let runner: Arc<dyn dodot_lib::datastore::CommandRunner> =
             Arc::new(dodot_lib::datastore::ShellCommandRunner::new(false));
-        let datastore: Arc<dyn DataStore> = Arc::new(
-            dodot_lib::datastore::FilesystemDataStore::new(fs.clone(), paths.clone(), runner),
-        );
+        let datastore: Arc<dyn DataStore> =
+            Arc::new(dodot_lib::datastore::FilesystemDataStore::new(
+                fs.clone(),
+                paths.clone(),
+                runner.clone(),
+            ));
         let config_manager =
             Arc::new(ConfigManager::new(&root).map_err(|e| anyhow!("config: {e}"))?);
         Ok(Self {
             fs,
             paths,
             datastore,
+            command_runner: runner,
             config_manager,
             syntax_checker: Arc::new(dodot_lib::shell::SystemSyntaxChecker),
             root_origin: origin,
@@ -258,6 +263,7 @@ impl TutorialEnv {
             paths: self.paths.clone(),
             config_manager: self.config_manager.clone(),
             syntax_checker: self.syntax_checker.clone(),
+            command_runner: self.command_runner.clone(),
             dry_run,
             no_provision: false,
             provision_rerun: false,
@@ -837,13 +843,14 @@ mod tests {
         let datastore: Arc<dyn DataStore> = Arc::new(FilesystemDataStore::new(
             temp.fs.clone(),
             temp.paths.clone(),
-            runner,
+            runner.clone(),
         ));
         let config_manager = Arc::new(ConfigManager::new(&temp.dotfiles_root).unwrap());
         TutorialEnv {
             fs: temp.fs.clone() as Arc<dyn Fs>,
             paths: temp.paths.clone() as Arc<dyn Pather>,
             datastore,
+            command_runner: runner,
             config_manager,
             syntax_checker: Arc::new(NoopSyntaxChecker),
             root_origin: "test fixture".into(),

--- a/crates/dodot-lib/src/commands/adopt/mod.rs
+++ b/crates/dodot-lib/src/commands/adopt/mod.rs
@@ -259,14 +259,17 @@ pub fn adopt(
         let cache_dir = ctx.paths.probes_brew_cache_dir();
         let now = crate::probe::brew::now_secs_unix();
         let folders = vec![pack_display.clone()];
-        let hits = crate::probe::brew::match_folders_to_casks(
+        // adopt is an interactive, on-demand command — populating the
+        // cache here is fine.
+        let matches = crate::probe::brew::match_folders_to_installed_casks(
             &folders,
             ctx.command_runner.as_ref(),
             &cache_dir,
             now,
             ctx.fs.as_ref(),
+            /*cache_only=*/ false,
         );
-        if let Some(token) = hits.get(&pack_display) {
+        if let Some(token) = matches.folder_to_token.get(&pack_display) {
             result.warnings.push(format!(
                 "homebrew cask `{token}` confirms this is the app-support directory \
                  for pack `{pack_display}`."

--- a/crates/dodot-lib/src/commands/adopt/mod.rs
+++ b/crates/dodot-lib/src/commands/adopt/mod.rs
@@ -210,19 +210,20 @@ pub fn adopt(
     //   - `pack_override` is None (user didn't pre-pick a pack name)
     //   - the pack on disk is named `<X>` matching the heuristic
     //   - at least one source was AppSupport-rooted in this invocation
-    if pack_override.is_none() && infer::is_gui_app_folder(&pack_display) {
-        let force_home = ctx.config_manager.root_config()?.symlink.force_home.clone();
-        let any_app_support = sources.iter().any(|s| {
-            absolutize(s)
-                .ok()
-                .and_then(|abs| {
-                    let is_dir = ctx.fs.stat(&abs).map(|m| m.is_dir).unwrap_or(false);
-                    infer::infer_target(&abs, is_dir, ctx.paths.as_ref(), &force_home).ok()
-                })
-                .map(|t| t.source_root == infer::SourceRoot::AppSupport)
-                .unwrap_or(false)
-        });
-        if any_app_support {
+    let force_home = ctx.config_manager.root_config()?.symlink.force_home.clone();
+    let any_app_support = sources.iter().any(|s| {
+        absolutize(s)
+            .ok()
+            .and_then(|abs| {
+                let is_dir = ctx.fs.stat(&abs).map(|m| m.is_dir).unwrap_or(false);
+                infer::infer_target(&abs, is_dir, ctx.paths.as_ref(), &force_home).ok()
+            })
+            .map(|t| t.source_root == infer::SourceRoot::AppSupport)
+            .unwrap_or(false)
+    });
+
+    if pack_override.is_none() && infer::is_gui_app_folder(&pack_display) && any_app_support {
+        {
             // Pick a sensible lowercase suggestion: strip spaces and
             // lowercase the first segment. `Visual Studio Code` →
             // `visualstudiocode`; `Code` → `code`. The exact name is
@@ -241,6 +242,64 @@ pub fn adopt(
                      of `_app/{}/...`.",
                     pack_display, suggested_alias, suggested_alias, pack_display, pack_display,
                 ));
+            }
+        }
+    }
+
+    // Brew-cask enrichment (M6): when an AppSupport adopt's pack name
+    // matches a folder declared by an installed cask's zap stanza,
+    // append confirmation + sibling-adoption suggestions. macOS-only;
+    // probe::brew gates on cfg!(target_os = "macos") internally so on
+    // Linux this loop is a no-op even with mocked installed casks.
+    //
+    // Resolver/pack-tree state is unaffected — these are purely
+    // user-facing strings on PackStatusResult.warnings. See
+    // `docs/proposals/macos-paths.lex` §8.2.
+    if any_app_support {
+        let cache_dir = ctx.paths.probes_brew_cache_dir();
+        let now = crate::probe::brew::now_secs_unix();
+        let folders = vec![pack_display.clone()];
+        let hits = crate::probe::brew::match_folders_to_casks(
+            &folders,
+            ctx.command_runner.as_ref(),
+            &cache_dir,
+            now,
+            ctx.fs.as_ref(),
+        );
+        if let Some(token) = hits.get(&pack_display) {
+            result.warnings.push(format!(
+                "homebrew cask `{token}` confirms this is the app-support directory \
+                 for pack `{pack_display}`."
+            ));
+            // Pull cask info from cache (now warm) for sibling-plist
+            // suggestions. Failures are silent — the confirmation
+            // above is already enough signal.
+            if let Ok(Some(info)) = crate::probe::brew::info_cask(
+                token,
+                &cache_dir,
+                now,
+                ctx.fs.as_ref(),
+                ctx.command_runner.as_ref(),
+            ) {
+                let plists = info.preferences_plists();
+                let candidates: Vec<&str> = plists
+                    .iter()
+                    .filter_map(|p| {
+                        let leaf = p.split('/').next_back()?;
+                        if leaf.is_empty() {
+                            None
+                        } else {
+                            Some(leaf)
+                        }
+                    })
+                    .collect();
+                if !candidates.is_empty() {
+                    let list = candidates.join(", ");
+                    result.warnings.push(format!(
+                        "homebrew also reports preferences for cask `{token}`: {list}. \
+                         Adopt them too with `dodot adopt ~/Library/Preferences/<file> --into {pack_display}`."
+                    ));
+                }
             }
         }
     }

--- a/crates/dodot-lib/src/commands/fill.rs
+++ b/crates/dodot-lib/src/commands/fill.rs
@@ -144,11 +144,11 @@ mod tests {
     }
 
     fn make_ctx(env: &TempEnvironment) -> ExecutionContext {
-        let runner = Arc::new(NoopRunner);
+        let runner: Arc<dyn crate::datastore::CommandRunner> = Arc::new(NoopRunner);
         let datastore = Arc::new(FilesystemDataStore::new(
             env.fs.clone(),
             env.paths.clone(),
-            runner,
+            runner.clone(),
         ));
         let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
         ExecutionContext {
@@ -157,6 +157,7 @@ mod tests {
             paths: env.paths.clone() as Arc<dyn Pather>,
             config_manager,
             syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
+            command_runner: runner,
             dry_run: false,
             no_provision: false,
             provision_rerun: false,

--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -103,6 +103,57 @@ pub enum ProbeResult {
     /// least one non-zero exit across the examined window, grouped by
     /// target and sorted by failure count (most-broken first).
     ShellInitErrors(ShellInitErrorsView),
+    /// `dodot probe app <pack>` — advisory introspection of macOS
+    /// app-support paths for a single pack: which folder names this
+    /// pack will route to, whether they exist, matching homebrew cask
+    /// metadata, and `.app` bundle / bundle-id pairs from Spotlight.
+    /// See `docs/proposals/macos-paths.lex` §8.4.
+    App(AppProbeView),
+}
+
+/// Display payload for `dodot probe app <pack>`.
+#[derive(Debug, Clone, Serialize)]
+pub struct AppProbeView {
+    pub pack: String,
+    /// Whether the host platform supports the macOS-only probes
+    /// (homebrew cask + Spotlight). On Linux this is `false` and the
+    /// `entries` list reflects only the deterministic info available
+    /// from the resolver — no cask/bundle data.
+    pub macos: bool,
+    /// One row per app-folder name this pack would route to. May be
+    /// empty for a pack with no `_app/`/`force_app`/`app_aliases`
+    /// entries.
+    pub entries: Vec<AppProbeEntry>,
+    /// Sibling-adoption suggestions surfaced from the matching cask's
+    /// zap stanza (e.g. `~/Library/Preferences/<bundle>.plist`).
+    pub suggested_adoptions: Vec<String>,
+}
+
+/// One row per app-support folder a pack will deploy to.
+#[derive(Debug, Clone, Serialize)]
+pub struct AppProbeEntry {
+    /// The destination folder name, e.g. `"Code"`.
+    pub folder: String,
+    /// `<app_support_dir>/<folder>/` path. Always populated, even when
+    /// the folder doesn't exist on disk — the renderer shortens to
+    /// `~/...` for display.
+    pub target_path: String,
+    /// Whether `target_path` exists on the local filesystem.
+    pub target_exists: bool,
+    /// Source rule that produced this folder: `"alias"`, `"force_app"`,
+    /// or `"_app/"`. Drives display.
+    pub source_rule: String,
+    /// Matching homebrew cask token, when found.
+    pub cask: Option<String>,
+    /// Whether the matching cask is currently installed (per
+    /// `brew list --cask --versions`).
+    pub cask_installed: bool,
+    /// `.app` bundle name derived from cask metadata, e.g.
+    /// `"Visual Studio Code.app"`.
+    pub app_bundle: Option<String>,
+    /// `kMDItemCFBundleIdentifier` for the `.app` bundle, when
+    /// resolvable via `mdls`.
+    pub bundle_id: Option<String>,
 }
 
 /// Display payload for `--runs N`.
@@ -874,6 +925,175 @@ fn civil_from_days(z: i64) -> (i32, u32, u32) {
     let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
     let y = if m <= 2 { y + 1 } else { y };
     (y as i32, m as u32, d as u32)
+}
+
+/// `dodot probe app <pack>` — advisory introspection of macOS
+/// app-support paths for a pack.
+///
+/// Walks the pack's `_app/<X>/...` matches, configured `force_app`
+/// hits, and `[symlink.app_aliases]` entries; checks each candidate
+/// folder against the on-disk app-support root, and (on macOS)
+/// enriches with brew cask metadata and Spotlight bundle IDs.
+///
+/// `refresh = true` invalidates the brew cache for every cask token
+/// matched against this pack, forcing a fresh `brew info` fetch.
+///
+/// Resolver state is not consulted — this is purely advisory display.
+pub fn app(pack_name: &str, refresh: bool, ctx: &ExecutionContext) -> Result<ProbeResult> {
+    use std::collections::BTreeSet;
+
+    // Resolve pack: try display name, fall back to raw on-disk dir.
+    let pack_dir = crate::packs::orchestration::resolve_pack_dir_name(pack_name, ctx)
+        .unwrap_or_else(|_| {
+            // Pack may not exist on disk; we still return a result so
+            // the caller sees an empty-but-named view rather than an
+            // error. The folder existence column already conveys "not
+            // here."
+            pack_name.to_string()
+        });
+    let display_name = crate::packs::display_name_for(&pack_dir).to_string();
+    let pack_config = match ctx
+        .config_manager
+        .config_for_pack(&ctx.paths.pack_path(&pack_dir))
+    {
+        Ok(c) => c,
+        // Pack-level config is optional; fall back to root config so
+        // alias/force_app entries declared at root still surface for
+        // a pack that hasn't been created yet.
+        Err(_) => ctx.config_manager.root_config()?,
+    };
+
+    // Collect distinct folder names this pack would route to.
+    //
+    // Three sources:
+    //   - `app_aliases[<pack>]` value
+    //   - `force_app` entries that appear at the top of the pack's tree
+    //   - `_app/<X>/` subdirectory names found by walking the pack
+    let mut folders: Vec<(String, &'static str)> = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+
+    if let Some(alias) = pack_config.symlink.app_aliases.get(&display_name) {
+        if seen.insert(alias.clone()) {
+            folders.push((alias.clone(), "alias"));
+        }
+    }
+
+    let pack_path = ctx.paths.pack_path(&pack_dir);
+    if ctx.fs.exists(&pack_path) {
+        if let Ok(entries) = ctx.fs.read_dir(&pack_path) {
+            for e in entries {
+                if e.is_dir
+                    && pack_config.symlink.force_app.iter().any(|f| f == &e.name)
+                    && seen.insert(e.name.clone())
+                {
+                    folders.push((e.name.clone(), "force_app"));
+                }
+            }
+            // _app/<X>/ subtree
+            let app_dir = pack_path.join("_app");
+            if ctx.fs.exists(&app_dir) {
+                if let Ok(children) = ctx.fs.read_dir(&app_dir) {
+                    for e in children {
+                        if e.is_dir && seen.insert(e.name.clone()) {
+                            folders.push((e.name.clone(), "_app/"));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // On non-macOS we still produce a useful (if minimal) view: just
+    // the list of folders and their existence under the *collapsed*
+    // app-support root (= xdg). Skip the brew/mdls work entirely.
+    let macos = cfg!(target_os = "macos");
+    let app_support = ctx.paths.app_support_dir();
+
+    if refresh && macos {
+        let cache_dir = ctx.paths.probes_brew_cache_dir();
+        for (folder, _) in &folders {
+            crate::probe::brew::invalidate_cache(folder, &cache_dir, ctx.fs.as_ref());
+        }
+    }
+
+    let cache_dir = ctx.paths.probes_brew_cache_dir();
+    let now = crate::probe::brew::now_secs_unix();
+    let folder_names: Vec<String> = folders.iter().map(|(f, _)| f.clone()).collect();
+    let cask_hits = if macos {
+        crate::probe::brew::match_folders_to_casks(
+            &folder_names,
+            ctx.command_runner.as_ref(),
+            &cache_dir,
+            now,
+            ctx.fs.as_ref(),
+        )
+    } else {
+        std::collections::HashMap::new()
+    };
+    let installed: BTreeSet<String> = if macos {
+        crate::probe::brew::list_installed_casks(ctx.command_runner.as_ref())
+            .into_iter()
+            .collect()
+    } else {
+        BTreeSet::new()
+    };
+
+    let mut entries: Vec<AppProbeEntry> = Vec::new();
+    let mut suggested: BTreeSet<String> = BTreeSet::new();
+
+    for (folder, source_rule) in &folders {
+        let target = app_support.join(folder);
+        let target_exists = ctx.fs.exists(&target);
+        let cask = cask_hits.get(folder).cloned();
+        let cask_installed = cask
+            .as_ref()
+            .map(|t| installed.contains(t))
+            .unwrap_or(false);
+
+        let mut app_bundle = None;
+        let mut bundle_id = None;
+        if macos {
+            if let Some(token) = &cask {
+                if let Ok(Some(info)) = crate::probe::brew::info_cask(
+                    token,
+                    &cache_dir,
+                    now,
+                    ctx.fs.as_ref(),
+                    ctx.command_runner.as_ref(),
+                ) {
+                    app_bundle = info.app_bundle_name();
+                    if let Some(bundle_name) = &app_bundle {
+                        let app_path = std::path::PathBuf::from("/Applications").join(bundle_name);
+                        bundle_id = crate::probe::macos_native::bundle_id(
+                            &app_path,
+                            ctx.command_runner.as_ref(),
+                        );
+                    }
+                    for plist in info.preferences_plists() {
+                        suggested.insert(plist);
+                    }
+                }
+            }
+        }
+
+        entries.push(AppProbeEntry {
+            folder: folder.clone(),
+            target_path: display_path(&target, ctx.paths.home_dir()),
+            target_exists,
+            source_rule: (*source_rule).into(),
+            cask,
+            cask_installed,
+            app_bundle,
+            bundle_id,
+        });
+    }
+
+    Ok(ProbeResult::App(AppProbeView {
+        pack: display_name,
+        macos,
+        entries,
+        suggested_adoptions: suggested.into_iter().collect(),
+    }))
 }
 
 /// Render the data-dir tree.

--- a/crates/dodot-lib/src/commands/probe.rs
+++ b/crates/dodot-lib/src/commands/probe.rs
@@ -143,11 +143,12 @@ pub struct AppProbeEntry {
     /// Source rule that produced this folder: `"alias"`, `"force_app"`,
     /// or `"_app/"`. Drives display.
     pub source_rule: String,
-    /// Matching homebrew cask token, when found.
+    /// Matching homebrew cask token, when found. Always an
+    /// *installed* cask (matching only iterates `brew list --cask
+    /// --versions`); a `Some` value implies "installed". A `None`
+    /// value means either no installed cask declared this folder in
+    /// its zap stanza, or we're not on macOS.
     pub cask: Option<String>,
-    /// Whether the matching cask is currently installed (per
-    /// `brew list --cask --versions`).
-    pub cask_installed: bool,
     /// `.app` bundle name derived from cask metadata, e.g.
     /// `"Visual Studio Code.app"`.
     pub app_bundle: Option<String>,
@@ -942,25 +943,41 @@ fn civil_from_days(z: i64) -> (i32, u32, u32) {
 pub fn app(pack_name: &str, refresh: bool, ctx: &ExecutionContext) -> Result<ProbeResult> {
     use std::collections::BTreeSet;
 
-    // Resolve pack: try display name, fall back to raw on-disk dir.
+    // Resolve pack: try display name, fall back to a *validated* raw
+    // on-disk dir name. Untrusted CLI input (e.g. `dodot probe app
+    // ..` or `dodot probe app foo/bar`) must never reach
+    // `paths.pack_path`, which would let `read_dir` below traverse
+    // outside the dotfiles root.
     let pack_dir = crate::packs::orchestration::resolve_pack_dir_name(pack_name, ctx)
         .unwrap_or_else(|_| {
-            // Pack may not exist on disk; we still return a result so
-            // the caller sees an empty-but-named view rather than an
-            // error. The folder existence column already conveys "not
-            // here."
-            pack_name.to_string()
+            if is_single_normal_path_component(pack_name) {
+                pack_name.to_string()
+            } else {
+                // Invalid path-like input — produce an empty-but-named
+                // view rather than an error. `pack_dir == ""` is the
+                // sentinel the rest of the function checks to skip
+                // any filesystem traversal.
+                String::new()
+            }
         });
-    let display_name = crate::packs::display_name_for(&pack_dir).to_string();
-    let pack_config = match ctx
-        .config_manager
-        .config_for_pack(&ctx.paths.pack_path(&pack_dir))
-    {
-        Ok(c) => c,
-        // Pack-level config is optional; fall back to root config so
-        // alias/force_app entries declared at root still surface for
-        // a pack that hasn't been created yet.
-        Err(_) => ctx.config_manager.root_config()?,
+    let display_name = if pack_dir.is_empty() {
+        pack_name.to_string()
+    } else {
+        crate::packs::display_name_for(&pack_dir).to_string()
+    };
+    let pack_config = if pack_dir.is_empty() {
+        ctx.config_manager.root_config()?
+    } else {
+        match ctx
+            .config_manager
+            .config_for_pack(&ctx.paths.pack_path(&pack_dir))
+        {
+            Ok(c) => c,
+            // Pack-level config is optional; fall back to root config so
+            // alias/force_app entries declared at root still surface for
+            // a pack that hasn't been created yet.
+            Err(_) => ctx.config_manager.root_config()?,
+        }
     };
 
     // Collect distinct folder names this pack would route to.
@@ -979,7 +996,7 @@ pub fn app(pack_name: &str, refresh: bool, ctx: &ExecutionContext) -> Result<Pro
     }
 
     let pack_path = ctx.paths.pack_path(&pack_dir);
-    if ctx.fs.exists(&pack_path) {
+    if !pack_dir.is_empty() && ctx.fs.exists(&pack_path) {
         if let Ok(entries) = ctx.fs.read_dir(&pack_path) {
             for e in entries {
                 if e.is_dir
@@ -1008,34 +1025,33 @@ pub fn app(pack_name: &str, refresh: bool, ctx: &ExecutionContext) -> Result<Pro
     // app-support root (= xdg). Skip the brew/mdls work entirely.
     let macos = cfg!(target_os = "macos");
     let app_support = ctx.paths.app_support_dir();
+    let cache_dir = ctx.paths.probes_brew_cache_dir();
 
+    // `--refresh` clears the entire brew probe cache before any
+    // matching runs, so the next `brew info` call rehydrates fresh
+    // data. Per-folder invalidation can't work here because the cache
+    // is keyed by cask token (not folder name) — we don't know the
+    // tokens until matching has already populated the cache.
     if refresh && macos {
-        let cache_dir = ctx.paths.probes_brew_cache_dir();
-        for (folder, _) in &folders {
-            crate::probe::brew::invalidate_cache(folder, &cache_dir, ctx.fs.as_ref());
-        }
+        crate::probe::brew::invalidate_all_cache(&cache_dir, ctx.fs.as_ref());
     }
 
-    let cache_dir = ctx.paths.probes_brew_cache_dir();
     let now = crate::probe::brew::now_secs_unix();
     let folder_names: Vec<String> = folders.iter().map(|(f, _)| f.clone()).collect();
-    let cask_hits = if macos {
-        crate::probe::brew::match_folders_to_casks(
+    // The on-demand `dodot probe app` subcommand is allowed to
+    // populate the cache, so cache_only=false. The matcher returns
+    // the installed-token set so we don't re-run `brew list` below.
+    let matches = if macos {
+        crate::probe::brew::match_folders_to_installed_casks(
             &folder_names,
             ctx.command_runner.as_ref(),
             &cache_dir,
             now,
             ctx.fs.as_ref(),
+            /*cache_only=*/ false,
         )
     } else {
-        std::collections::HashMap::new()
-    };
-    let installed: BTreeSet<String> = if macos {
-        crate::probe::brew::list_installed_casks(ctx.command_runner.as_ref())
-            .into_iter()
-            .collect()
-    } else {
-        BTreeSet::new()
+        crate::probe::brew::InstalledCaskMatches::default()
     };
 
     let mut entries: Vec<AppProbeEntry> = Vec::new();
@@ -1044,11 +1060,7 @@ pub fn app(pack_name: &str, refresh: bool, ctx: &ExecutionContext) -> Result<Pro
     for (folder, source_rule) in &folders {
         let target = app_support.join(folder);
         let target_exists = ctx.fs.exists(&target);
-        let cask = cask_hits.get(folder).cloned();
-        let cask_installed = cask
-            .as_ref()
-            .map(|t| installed.contains(t))
-            .unwrap_or(false);
+        let cask = matches.folder_to_token.get(folder).cloned();
 
         let mut app_bundle = None;
         let mut bundle_id = None;
@@ -1082,7 +1094,6 @@ pub fn app(pack_name: &str, refresh: bool, ctx: &ExecutionContext) -> Result<Pro
             target_exists,
             source_rule: (*source_rule).into(),
             cask,
-            cask_installed,
             app_bundle,
             bundle_id,
         });
@@ -1094,6 +1105,22 @@ pub fn app(pack_name: &str, refresh: bool, ctx: &ExecutionContext) -> Result<Pro
         entries,
         suggested_adoptions: suggested.into_iter().collect(),
     }))
+}
+
+/// True iff `value` is a single, normal path component — no path
+/// separators, no `.`/`..` components, not empty. Used as a
+/// security guard before passing untrusted CLI input to
+/// `Pather::pack_path` (which would otherwise let traversal escape
+/// the dotfiles root via the resulting `read_dir` calls).
+fn is_single_normal_path_component(value: &str) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    let mut comps = std::path::Path::new(value).components();
+    matches!(
+        (comps.next(), comps.next()),
+        (Some(std::path::Component::Normal(_)), None)
+    )
 }
 
 /// Render the data-dir tree.

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -5105,8 +5105,10 @@ fn probe_app_collects_alias_force_and_underscore_entries() {
     // Cursor is the only pre-created folder → exists; others missing.
     let cursor_row = view.entries.iter().find(|e| e.folder == "Cursor").unwrap();
     assert!(cursor_row.target_exists);
+    // `cask` is always an *installed* token (matching iterates only
+    // `brew list --cask --versions`), so a `Some` value implies
+    // installed — there's no separate field for it any more.
     assert_eq!(cursor_row.cask.as_deref(), Some("cursor"));
-    assert!(cursor_row.cask_installed);
     assert_eq!(cursor_row.app_bundle.as_deref(), Some("Cursor.app"));
     assert_eq!(
         cursor_row.bundle_id.as_deref(),
@@ -5121,6 +5123,34 @@ fn probe_app_collects_alias_force_and_underscore_entries() {
         "suggested adoptions: {:?}",
         view.suggested_adoptions
     );
+}
+
+/// `dodot probe app ..` (or any other path-traversing input) must
+/// not let `pack_path` traversal escape the dotfiles root. Probe
+/// validates that `pack_name` is a single-component path before
+/// passing it to `Pather::pack_path`. Regression for review feedback
+/// on PR #91.
+#[test]
+fn probe_app_rejects_path_traversal_input() {
+    let env = TempEnvironment::builder().build();
+    let runner = Arc::new(CannedRunner::new());
+    let ctx = make_ctx_with_runner(&env, runner);
+
+    for evil in ["..", "foo/../bar", "../sibling", "/abs/path"] {
+        let result = commands::probe::app(evil, false, &ctx).unwrap();
+        let view = match result {
+            commands::probe::ProbeResult::App(v) => v,
+            other => panic!("expected App variant, got {other:?}"),
+        };
+        // Empty-but-named view: the pack name echoes back, but no
+        // entries are surfaced (filesystem traversal was skipped).
+        assert_eq!(view.pack, evil, "input echoed back unchanged");
+        assert!(
+            view.entries.is_empty(),
+            "path-traversing input must not produce entries: got {:?}",
+            view.entries
+        );
+    }
 }
 
 /// On non-macOS, probe::app still produces a useful view (folder
@@ -5193,6 +5223,20 @@ fn plan_pack_emits_missing_target_hint_with_cask_enrichment() {
     );
     let ctx = make_ctx_with_runner(&env, runner);
 
+    // The planner uses cache_only=true to keep `up`/`status` fast —
+    // an empty cache produces the unenriched message. Pre-warm the
+    // cache by calling info_cask once (the on-demand path that may
+    // spawn brew). Production users get the same warm cache via
+    // `dodot probe app` or `dodot adopt`.
+    let cache_dir = ctx.paths.probes_brew_cache_dir();
+    let _ = crate::probe::brew::info_cask(
+        "visual-studio-code",
+        &cache_dir,
+        crate::probe::brew::now_secs_unix(),
+        ctx.fs.as_ref(),
+        ctx.command_runner.as_ref(),
+    );
+
     // Synthesize a Pack matching the on-disk pack we built.
     let pack_path = env.dotfiles_root.join("vscode");
     let pack_config = ctx.config_manager.config_for_pack(&pack_path).unwrap();
@@ -5214,5 +5258,11 @@ fn plan_pack_emits_missing_target_hint_with_cask_enrichment() {
     assert!(
         hint_text.contains("visual-studio-code"),
         "expected cask-enriched hint, got: {hint_text}"
+    );
+    // Per review feedback: the cask is installed (we read it from
+    // `brew list`), so the message must NOT claim it isn't installed.
+    assert!(
+        !hint_text.contains("isn't installed"),
+        "hint should not falsely claim the cask is uninstalled, got: {hint_text}"
     );
 }

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -24,12 +24,53 @@ impl CommandRunner for MockCommandRunner {
     }
 }
 
+/// CommandRunner test double that returns canned outputs per `(exe,
+/// args...)` key. Used by probe::app integration tests so the brew /
+/// mdls / mdfind subprocesses don't actually run.
+struct CannedRunner {
+    responses: std::sync::Mutex<std::collections::HashMap<Vec<String>, CommandOutput>>,
+}
+
+impl CannedRunner {
+    fn new() -> Self {
+        Self {
+            responses: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+    fn respond(&self, args: &[&str], stdout: &str, exit_code: i32) {
+        let key: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        self.responses.lock().unwrap().insert(
+            key,
+            CommandOutput {
+                exit_code,
+                stdout: stdout.into(),
+                stderr: String::new(),
+            },
+        );
+    }
+}
+
+impl CommandRunner for CannedRunner {
+    fn run(&self, exe: &str, args: &[String]) -> Result<CommandOutput> {
+        let mut full = vec![exe.to_string()];
+        full.extend(args.iter().cloned());
+        self.responses
+            .lock()
+            .unwrap()
+            .get(&full)
+            .cloned()
+            .ok_or_else(|| {
+                crate::DodotError::Other(format!("CannedRunner: no canned response for {full:?}"))
+            })
+    }
+}
+
 fn make_ctx(env: &TempEnvironment) -> ExecutionContext {
-    let runner = Arc::new(MockCommandRunner);
+    let runner: Arc<dyn CommandRunner> = Arc::new(MockCommandRunner);
     let datastore = Arc::new(FilesystemDataStore::new(
         env.fs.clone(),
         env.paths.clone(),
-        runner,
+        runner.clone(),
     ));
     let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
 
@@ -39,6 +80,34 @@ fn make_ctx(env: &TempEnvironment) -> ExecutionContext {
         paths: env.paths.clone() as Arc<dyn Pather>,
         config_manager,
         syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
+        command_runner: runner,
+        dry_run: false,
+        no_provision: true,
+        provision_rerun: false,
+        force: false,
+        view_mode: crate::commands::ViewMode::Full,
+        group_mode: crate::commands::GroupMode::Name,
+        verbose: false,
+    }
+}
+
+/// Variant of make_ctx that swaps in a [`CannedRunner`] so probe
+/// tests can exercise the brew/mdls/mdfind enrichment paths without
+/// spawning processes.
+fn make_ctx_with_runner(env: &TempEnvironment, runner: Arc<dyn CommandRunner>) -> ExecutionContext {
+    let datastore = Arc::new(FilesystemDataStore::new(
+        env.fs.clone(),
+        env.paths.clone(),
+        runner.clone(),
+    ));
+    let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
+    ExecutionContext {
+        fs: env.fs.clone() as Arc<dyn Fs>,
+        datastore,
+        paths: env.paths.clone() as Arc<dyn Pather>,
+        config_manager,
+        syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
+        command_runner: runner,
         dry_run: false,
         no_provision: true,
         provision_rerun: false,
@@ -4961,4 +5030,189 @@ fn by_status_folds_ignored_packs_into_ignored_group() {
     assert!(output.contains("Ignored Packs"), "output: {output}");
     assert!(output.contains("disabled"), "output: {output}");
     assert!(output.contains("Pending Packs"), "output: {output}");
+}
+
+// ── M6: probe::app + advisory probes ─────────────────────────
+
+/// `dodot probe app <pack>` collects every folder this pack would
+/// route to (alias, force_app, _app/), checks each against the
+/// app-support root, and (with mocked brew + mdls) enriches the
+/// matching cask token, .app bundle, and bundle ID. The probe is
+/// advisory — resolver state is unchanged.
+#[test]
+#[cfg_attr(not(target_os = "macos"), ignore = "macOS-only enrichment paths")]
+fn probe_app_collects_alias_force_and_underscore_entries() {
+    let env = TempEnvironment::builder()
+        .pack("vscode")
+        .file("settings.json", "{}")
+        .file("_app/Cursor/User/keys.json", "[]")
+        .file("Code/User/extra.json", "{}")
+        .config("[symlink.app_aliases]\nvscode = \"VSCodeAliased\"\n")
+        .done()
+        .build();
+    // Pre-create one of the target folders so `target_exists` differs
+    // across rows and the test pins the existence column.
+    env.fs.mkdir_all(&env.app_support.join("Cursor")).unwrap();
+
+    let runner = Arc::new(CannedRunner::new());
+    runner.respond(
+        &["brew", "list", "--cask", "--versions"],
+        "cursor 0.42.0\n",
+        0,
+    );
+    runner.respond(
+        &["brew", "info", "--json=v2", "--cask", "cursor"],
+        r#"{"casks": [{
+            "token": "cursor",
+            "installed": "0.42.0",
+            "artifacts": [
+                {"app": ["Cursor.app"]},
+                {"zap": [{"trash": [
+                    "~/Library/Application Support/Cursor",
+                    "~/Library/Preferences/com.todesktop.Cursor.plist"
+                ]}]}
+            ]
+        }]}"#,
+        0,
+    );
+    runner.respond(
+        &[
+            "mdls",
+            "-name",
+            "kMDItemCFBundleIdentifier",
+            "/Applications/Cursor.app",
+        ],
+        "kMDItemCFBundleIdentifier = \"com.todesktop.Cursor\"\n",
+        0,
+    );
+    let ctx = make_ctx_with_runner(&env, runner);
+
+    let result = commands::probe::app("vscode", false, &ctx).unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::App(v) => v,
+        other => panic!("expected App variant, got {other:?}"),
+    };
+    assert_eq!(view.pack, "vscode");
+    assert!(view.macos);
+
+    // Three folders: VSCodeAliased (alias), Code (force_app default
+    // includes Code), Cursor (_app/ subtree).
+    let folders: Vec<&str> = view.entries.iter().map(|e| e.folder.as_str()).collect();
+    assert!(folders.contains(&"VSCodeAliased"), "folders: {folders:?}");
+    assert!(folders.contains(&"Code"), "folders: {folders:?}");
+    assert!(folders.contains(&"Cursor"), "folders: {folders:?}");
+
+    // Cursor is the only pre-created folder → exists; others missing.
+    let cursor_row = view.entries.iter().find(|e| e.folder == "Cursor").unwrap();
+    assert!(cursor_row.target_exists);
+    assert_eq!(cursor_row.cask.as_deref(), Some("cursor"));
+    assert!(cursor_row.cask_installed);
+    assert_eq!(cursor_row.app_bundle.as_deref(), Some("Cursor.app"));
+    assert_eq!(
+        cursor_row.bundle_id.as_deref(),
+        Some("com.todesktop.Cursor")
+    );
+
+    // Sibling-adoption suggestions surfaced from cask zap.
+    assert!(
+        view.suggested_adoptions
+            .iter()
+            .any(|s| s.contains("Cursor.plist")),
+        "suggested adoptions: {:?}",
+        view.suggested_adoptions
+    );
+}
+
+/// On non-macOS, probe::app still produces a useful view (folder
+/// existence under the collapsed app-support root) but skips brew /
+/// Spotlight enrichment entirely. `macos` is `false`.
+#[test]
+fn probe_app_non_macos_returns_minimal_view() {
+    if cfg!(target_os = "macos") {
+        // The cfg! gate inside probe::app keys off the host. On macOS
+        // hosts we can't simulate the Linux path; skip rather than
+        // contort the test fixture.
+        return;
+    }
+    let env = TempEnvironment::builder()
+        .pack("vscode")
+        .file("Code/User/foo", "{}")
+        .done()
+        .build();
+    let runner = Arc::new(CannedRunner::new());
+    let ctx = make_ctx_with_runner(&env, runner);
+
+    let result = commands::probe::app("vscode", false, &ctx).unwrap();
+    let view = match result {
+        commands::probe::ProbeResult::App(v) => v,
+        other => panic!("expected App variant, got {other:?}"),
+    };
+    assert!(!view.macos);
+    // No brew enrichment.
+    for entry in &view.entries {
+        assert!(entry.cask.is_none(), "row: {entry:?}");
+        assert!(entry.app_bundle.is_none(), "row: {entry:?}");
+        assert!(entry.bundle_id.is_none(), "row: {entry:?}");
+    }
+}
+
+/// `up` / `status` emit a missing-target hint when an app-support
+/// folder doesn't exist on disk and a brew cask matches. macOS-only
+/// — the orchestration gate is the same `cfg!(target_os = "macos")`.
+#[test]
+#[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+fn plan_pack_emits_missing_target_hint_with_cask_enrichment() {
+    use crate::packs::orchestration;
+    use crate::packs::Pack;
+
+    let env = TempEnvironment::builder()
+        .pack("vscode")
+        .file("settings.json", "{}")
+        .config("[symlink.app_aliases]\nvscode = \"Code\"\n")
+        .done()
+        .build();
+    // `Code` folder is intentionally absent — the hint should fire.
+    assert!(!env.app_support.join("Code").exists());
+
+    let runner = Arc::new(CannedRunner::new());
+    runner.respond(
+        &["brew", "list", "--cask", "--versions"],
+        "visual-studio-code 1.95.0\n",
+        0,
+    );
+    runner.respond(
+        &["brew", "info", "--json=v2", "--cask", "visual-studio-code"],
+        r#"{"casks": [{
+            "token": "visual-studio-code",
+            "artifacts": [
+                {"app": ["Visual Studio Code.app"]},
+                {"zap": [{"trash": ["~/Library/Application Support/Code"]}]}
+            ]
+        }]}"#,
+        0,
+    );
+    let ctx = make_ctx_with_runner(&env, runner);
+
+    // Synthesize a Pack matching the on-disk pack we built.
+    let pack_path = env.dotfiles_root.join("vscode");
+    let pack_config = ctx.config_manager.config_for_pack(&pack_path).unwrap();
+    let pack = Pack {
+        name: "vscode".into(),
+        display_name: "vscode".into(),
+        path: pack_path,
+        config: pack_config.to_handler_config(),
+    };
+
+    let plan = orchestration::plan_pack(&pack, &ctx).unwrap();
+    let hint = plan.warnings.iter().find(|w| w.contains("Code"));
+    assert!(
+        hint.is_some(),
+        "expected missing-target hint mentioning `Code`; got {:?}",
+        plan.warnings
+    );
+    let hint_text = hint.unwrap();
+    assert!(
+        hint_text.contains("visual-studio-code"),
+        "expected cask-enriched hint, got: {hint_text}"
+    );
 }

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -568,29 +568,37 @@ fn missing_target_hints(
         return Vec::new();
     }
 
-    // Brew enrichment: try to associate each missing folder with a
-    // cask token. Failures are silent — the unenriched message is
-    // still useful.
+    // Brew enrichment: try to associate each missing folder with an
+    // *installed* cask token. Cache-only mode keeps the planner fast:
+    // a stale or missing cache entry silently degrades to the
+    // unenriched message rather than spawning a `brew info` subprocess
+    // per installed cask. The on-demand `dodot probe app` subcommand
+    // populates the cache; this hint just consumes it.
     let cache_dir = ctx.paths.probes_brew_cache_dir();
     let now = crate::probe::brew::now_secs_unix();
-    let cask_hits = crate::probe::brew::match_folders_to_casks(
+    let matches = crate::probe::brew::match_folders_to_installed_casks(
         &missing,
         ctx.command_runner.as_ref(),
         &cache_dir,
         now,
         ctx.fs.as_ref(),
+        /*cache_only=*/ true,
     );
 
     missing
         .into_iter()
-        .map(|folder| match cask_hits.get(&folder) {
+        .map(|folder| match matches.folder_to_token.get(&folder) {
+            // The cask IS installed (we got the token from `brew list`)
+            // but the folder is empty — usually the user pre-deployed
+            // dotfiles before launching the app for the first time.
             Some(token) => format!(
-                "looks like cask `{token}` isn't installed yet — `{folder}/...` \
-                 will deploy but the app isn't here to read it"
+                "cask `{token}` is installed but `{folder}/` is missing — \
+                 entries will deploy, but the app may not have created its \
+                 config directory yet (try launching it once)"
             ),
             None => format!(
                 "target directory `{}/{folder}` doesn't exist yet — entries will \
-                 deploy but no matching app appears to be installed",
+                 deploy but no matching installed app appears to provide it",
                 app_support.display()
             ),
         })

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -32,6 +32,13 @@ pub struct ExecutionContext {
     /// up [`SystemSyntaxChecker`](crate::shell::SystemSyntaxChecker)
     /// (spawns real `bash`/`zsh -n`); tests inject a mock.
     pub syntax_checker: Arc<dyn crate::shell::SyntaxChecker>,
+    /// Subprocess runner for advisory probes (homebrew-cask lookup,
+    /// macOS `mdls`/`mdfind`). Production reuses the same
+    /// [`ShellCommandRunner`](crate::datastore::ShellCommandRunner)
+    /// the datastore uses for handler-driven commands; tests inject a
+    /// mock that returns canned outputs without spawning processes.
+    /// See `docs/proposals/macos-paths.lex` §8.
+    pub command_runner: Arc<dyn crate::datastore::CommandRunner>,
     pub dry_run: bool,
     pub no_provision: bool,
     pub provision_rerun: bool,
@@ -104,7 +111,7 @@ impl ExecutionContext {
         let datastore: Arc<dyn DataStore> = Arc::new(crate::datastore::FilesystemDataStore::new(
             fs.clone(),
             paths.clone(),
-            runner,
+            runner.clone(),
         ));
 
         Ok(Self {
@@ -113,6 +120,7 @@ impl ExecutionContext {
             paths,
             config_manager,
             syntax_checker: Arc::new(crate::shell::SystemSyntaxChecker),
+            command_runner: runner,
             dry_run: false,
             no_provision: false,
             provision_rerun: false,
@@ -484,6 +492,22 @@ fn plan_pack_inner(
         }
     }
 
+    // Missing-target hints (M6 §8.2) — macOS only.
+    //
+    // For each Link intent that lands under `app_support_dir`, check
+    // whether the immediate child folder exists on disk. If not, the
+    // user is about to deploy GUI-app config to a directory the app
+    // hasn't created yet — usually because the app isn't installed.
+    // Surface a soft hint, optionally enriched with a matching brew
+    // cask token. Resolver/intent state is unaffected.
+    //
+    // On Linux `app_support_dir` collapses to `xdg_config_home`, so
+    // this check would fire for *every* `~/.config/<X>/` deploy —
+    // not what we want. Gate on macOS strictly.
+    if cfg!(target_os = "macos") {
+        all_warnings.extend(missing_target_hints(&all_intents, ctx));
+    }
+
     info!(
         pack = %pack.name,
         intents = all_intents.len(),
@@ -494,6 +518,83 @@ fn plan_pack_inner(
         intents: all_intents,
         warnings: all_warnings,
     })
+}
+
+/// Probe each `Link` intent that targets `app_support_dir/<X>/...` and
+/// emit a soft hint when the `<X>/` folder is missing on disk.
+///
+/// macOS-only — caller checks `cfg!(target_os = "macos")` first to
+/// avoid firing on Linux where every XDG-routed entry would otherwise
+/// hit this branch.
+fn missing_target_hints(
+    intents: &[crate::operations::HandlerIntent],
+    ctx: &ExecutionContext,
+) -> Vec<String> {
+    use std::collections::BTreeSet;
+    let app_support = ctx.paths.app_support_dir();
+    if app_support == ctx.paths.xdg_config_home() {
+        // `app_uses_library = false` collapsed the app-support root
+        // onto XDG; same Linux-style suppression applies.
+        return Vec::new();
+    }
+
+    // Distinct `<X>` folders referenced by intents — one warning per
+    // missing folder, regardless of how many files target it.
+    let mut needed: BTreeSet<String> = BTreeSet::new();
+    for intent in intents {
+        if let crate::operations::HandlerIntent::Link { user_path, .. } = intent {
+            if let Ok(rel) = user_path.strip_prefix(app_support) {
+                if let Some(first) = rel.components().find_map(|c| match c {
+                    std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+                    _ => None,
+                }) {
+                    needed.insert(first);
+                }
+            }
+        }
+    }
+    if needed.is_empty() {
+        return Vec::new();
+    }
+
+    let mut missing: Vec<String> = Vec::new();
+    for folder in &needed {
+        let target = app_support.join(folder);
+        if !ctx.fs.exists(&target) {
+            missing.push(folder.clone());
+        }
+    }
+    if missing.is_empty() {
+        return Vec::new();
+    }
+
+    // Brew enrichment: try to associate each missing folder with a
+    // cask token. Failures are silent — the unenriched message is
+    // still useful.
+    let cache_dir = ctx.paths.probes_brew_cache_dir();
+    let now = crate::probe::brew::now_secs_unix();
+    let cask_hits = crate::probe::brew::match_folders_to_casks(
+        &missing,
+        ctx.command_runner.as_ref(),
+        &cache_dir,
+        now,
+        ctx.fs.as_ref(),
+    );
+
+    missing
+        .into_iter()
+        .map(|folder| match cask_hits.get(&folder) {
+            Some(token) => format!(
+                "looks like cask `{token}` isn't installed yet — `{folder}/...` \
+                 will deploy but the app isn't here to read it"
+            ),
+            None => format!(
+                "target directory `{}/{folder}` doesn't exist yet — entries will \
+                 deploy but no matching app appears to be installed",
+                app_support.display()
+            ),
+        })
+        .collect()
 }
 
 /// Execute a pre-collected set of intents.
@@ -641,11 +742,11 @@ mod tests {
     }
 
     fn make_context(env: &TempEnvironment) -> ExecutionContext {
-        let runner = Arc::new(MockCommandRunner::new());
+        let runner: Arc<dyn crate::datastore::CommandRunner> = Arc::new(MockCommandRunner::new());
         let datastore = Arc::new(FilesystemDataStore::new(
             env.fs.clone(),
             env.paths.clone(),
-            runner,
+            runner.clone(),
         ));
         let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
 
@@ -655,6 +756,7 @@ mod tests {
             paths: env.paths.clone() as Arc<dyn Pather>,
             config_manager,
             syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
+            command_runner: runner,
             dry_run: false,
             no_provision: true, // skip install/homebrew in tests
             provision_rerun: false,
@@ -882,11 +984,11 @@ mod tests {
             .done()
             .build();
 
-        let runner = Arc::new(MockCommandRunner::new());
+        let runner: Arc<dyn crate::datastore::CommandRunner> = Arc::new(MockCommandRunner::new());
         let datastore = Arc::new(FilesystemDataStore::new(
             env.fs.clone(),
             env.paths.clone(),
-            runner,
+            runner.clone(),
         ));
         let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
 
@@ -896,6 +998,7 @@ mod tests {
             paths: env.paths.clone() as Arc<dyn Pather>,
             config_manager,
             syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
+            command_runner: runner,
             dry_run: true,
             no_provision: true,
             provision_rerun: false,

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -135,6 +135,17 @@ pub trait Pather: Send + Sync {
     fn probes_shell_init_dir(&self) -> PathBuf {
         self.data_dir().join("probes").join("shell-init")
     }
+
+    /// On-disk cache for homebrew-cask probe data. One JSON file per
+    /// cask token; TTL-based invalidation. See
+    /// `docs/proposals/macos-paths.lex` §8.2.
+    ///
+    /// Lives under `cache_dir` (not `data_dir`) because the contents are
+    /// rederivable — losing them is fine, the next probe re-runs `brew
+    /// info`. Co-located with future probe caches under `probes/`.
+    fn probes_brew_cache_dir(&self) -> PathBuf {
+        self.cache_dir().join("probes").join("brew")
+    }
 }
 
 /// XDG-compliant path resolver.

--- a/crates/dodot-lib/src/probe/brew.rs
+++ b/crates/dodot-lib/src/probe/brew.rs
@@ -297,34 +297,88 @@ pub fn now_secs_unix() -> u64 {
         .unwrap_or(0)
 }
 
-/// Match `app_aliases` map values + every pack-relative `_app/<X>/...`
-/// folder against a cask's app-support candidates. Used by the
-/// `dodot probe app` subcommand to pair pack entries with installed
-/// casks.
+/// Outcome of a folder-to-cask matching pass.
 ///
-/// Returns a map of `(folder_name → cask_token)` so callers can
-/// surface the link without re-running the matching loop.
-pub fn match_folders_to_casks(
+/// `installed_tokens` carries the result of `brew list --cask
+/// --versions` so callers don't re-spawn the same subprocess for it.
+/// `folder_to_token` is the actual matches: each entry pairs a
+/// pack-relative folder name with the cask token that declares it in
+/// its zap stanza.
+#[derive(Debug, Clone, Default)]
+pub struct InstalledCaskMatches {
+    pub installed_tokens: Vec<String>,
+    pub folder_to_token: HashMap<String, String>,
+}
+
+/// Match `app_aliases` map values + every pack-relative `_app/<X>/...`
+/// folder against installed casks' Application Support candidates.
+///
+/// **Installed-only** — this iterates only the tokens
+/// `brew list --cask --versions` reports. A cask the user hasn't
+/// installed will never appear here. The name reflects that. If you
+/// need broader matching, you'd have to drive it off some other
+/// source (zap data isn't available for non-installed casks without
+/// further `brew info` calls per known token).
+///
+/// `cache_only` controls whether a cache miss triggers a fresh
+/// `brew info --json=v2 --cask <token>` subprocess: callers on a hot
+/// path (planner hints during `up`/`status`) pass `true` so a stale
+/// cache silently degrades to "no enrichment" rather than spawning
+/// dozens of subprocesses; the on-demand `dodot probe app` subcommand
+/// passes `false` to populate the cache fully.
+pub fn match_folders_to_installed_casks(
     folders: &[String],
     runner: &dyn CommandRunner,
     cache_dir: &Path,
     now_secs: u64,
     fs: &dyn Fs,
-) -> HashMap<String, String> {
-    let mut hits = HashMap::new();
+    cache_only: bool,
+) -> InstalledCaskMatches {
+    let mut out = InstalledCaskMatches::default();
     if !cfg!(target_os = "macos") {
-        return hits;
+        return out;
     }
-    for token in list_installed_casks(runner) {
-        if let Ok(Some(info)) = info_cask(&token, cache_dir, now_secs, fs, runner) {
+    out.installed_tokens = list_installed_casks(runner);
+    for token in &out.installed_tokens {
+        let info = if cache_only {
+            // Cache-only mode: read the on-disk entry if fresh, never
+            // spawn `brew info`. A miss leaves this token unmatched.
+            read_cache(&cache_path_for(cache_dir, token), fs)
+                .filter(|e| now_secs.saturating_sub(e.fetched_at) < CACHE_TTL_SECS)
+                .map(|e| e.info)
+        } else {
+            info_cask(token, cache_dir, now_secs, fs, runner)
+                .ok()
+                .flatten()
+        };
+        if let Some(info) = info {
             for cand in info.app_support_candidates() {
                 if folders.iter().any(|f| f == &cand) {
-                    hits.insert(cand, token.clone());
+                    out.folder_to_token.insert(cand, token.clone());
                 }
             }
         }
     }
-    hits
+    out
+}
+
+/// Best-effort wipe of the entire brew probe cache directory.
+///
+/// `dodot probe app --refresh` calls this so the user's "I want
+/// fresh data" gesture isn't bottlenecked by per-token invalidation
+/// requiring the caller to know which tokens to invalidate (which
+/// they wouldn't, before matching).
+pub fn invalidate_all_cache(cache_dir: &Path, fs: &dyn Fs) {
+    if !fs.exists(cache_dir) {
+        return;
+    }
+    if let Ok(entries) = fs.read_dir(cache_dir) {
+        for entry in entries {
+            if entry.name.ends_with(".json") {
+                let _ = fs.remove_file(&entry.path);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -562,6 +616,72 @@ mod tests {
         // On macOS hosts we'd hit the "no mock response" path which
         // returns Err → empty Vec via the function's loss-tolerant
         // outer match. Still expect no panic either way.
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn match_folders_cache_only_skips_brew_info_on_miss() {
+        // With cache_only=true and an empty cache, the matcher must
+        // not call `brew info` — the planner path uses this mode to
+        // keep `up`/`status` fast.
+        let (env, cache) = make_env();
+        let runner = MockRunner::new();
+        runner.respond(
+            &["list", "--cask", "--versions"],
+            "visual-studio-code 1.95.0\n",
+            0,
+        );
+        // No brew info response registered: a call would fail
+        // CannedRunner's lookup → propagating to info_cask returning
+        // None silently. We assert the call count remains 0.
+
+        let now = 1_000_000;
+        let result = match_folders_to_installed_casks(
+            &["Code".into()],
+            &runner,
+            &cache,
+            now,
+            env.fs.as_ref(),
+            /*cache_only=*/ true,
+        );
+        // Installed list still populated (brew list was called).
+        assert!(result
+            .installed_tokens
+            .contains(&"visual-studio-code".into()));
+        // No info → no folder match.
+        assert!(result.folder_to_token.is_empty());
+        // And brew info was never invoked.
+        assert_eq!(
+            runner.call_count(&["brew", "info", "--json=v2", "--cask", "visual-studio-code"]),
+            0,
+            "cache_only=true must not spawn brew info"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn invalidate_all_cache_clears_every_token() {
+        let (env, cache) = make_env();
+        let runner = MockRunner::new();
+        runner.respond(
+            &["info", "--json=v2", "--cask", "alpha"],
+            r#"{"casks": [{"token": "alpha"}]}"#,
+            0,
+        );
+        runner.respond(
+            &["info", "--json=v2", "--cask", "beta"],
+            r#"{"casks": [{"token": "beta"}]}"#,
+            0,
+        );
+        let now = 1_000_000;
+        let _ = info_cask("alpha", &cache, now, env.fs.as_ref(), &runner).unwrap();
+        let _ = info_cask("beta", &cache, now, env.fs.as_ref(), &runner).unwrap();
+        assert!(env.fs.exists(&cache.join("alpha.json")));
+        assert!(env.fs.exists(&cache.join("beta.json")));
+
+        invalidate_all_cache(&cache, env.fs.as_ref());
+        assert!(!env.fs.exists(&cache.join("alpha.json")));
+        assert!(!env.fs.exists(&cache.join("beta.json")));
     }
 
     #[test]

--- a/crates/dodot-lib/src/probe/brew.rs
+++ b/crates/dodot-lib/src/probe/brew.rs
@@ -1,0 +1,584 @@
+//! Homebrew-cask probe — advisory lookup of cask metadata.
+//!
+//! Implements Phase M6 of `docs/proposals/macos-paths.lex` §8.2. The
+//! cardinal rule from §8 holds: probes are *advisory*, never
+//! authoritative. The symlink resolver in §5 never consults this
+//! module, and a probe failure (no `brew` on PATH, malformed JSON,
+//! cache miss) never alters routing — it just means the user sees a
+//! less-rich suggestion or warning.
+//!
+//! ## What the probe surfaces
+//!
+//! Two shells over `brew`:
+//!
+//! - [`list_installed_casks`] → `brew list --cask --versions`. Cheap.
+//!   Used to short-circuit `brew info` when a token isn't installed.
+//! - [`info_cask`] → `brew info --json=v2 --cask <token>`. Expensive
+//!   the first time (network), so we cache it on disk.
+//!
+//! Plus zap-stanza parsing from the JSON: app-folder candidates,
+//! Application Support entries, and Preferences plists for
+//! sibling-adoption suggestions in `dodot adopt`.
+//!
+//! ## Cache layout
+//!
+//! `<cache_dir>/probes/brew/<token>.json` carries:
+//!
+//! ```json
+//! { "fetched_at": <unix_ts>, "info": { ...brew info JSON... } }
+//! ```
+//!
+//! Entries older than [`CACHE_TTL_SECS`] are treated as stale and
+//! re-fetched. `dodot probe app --refresh` blows the cache for that
+//! pack's tokens.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::datastore::CommandRunner;
+use crate::fs::Fs;
+use crate::Result;
+
+/// Cache lifetime in seconds. 24 hours: brew zap data changes rarely
+/// enough that a daily refresh is plenty, and the cost of a
+/// `brew info` call is high enough to want the cache hit.
+pub const CACHE_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// Minimal subset of `brew info --json=v2 --cask <token>` we read.
+///
+/// The full JSON shape is large and brew owns it; we deserialise only
+/// the fields the proposal calls out and tolerate everything else via
+/// `#[serde(default)]` so a brew schema bump doesn't break the probe.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CaskInfo {
+    /// Cask token (e.g. `"visual-studio-code"`).
+    #[serde(default)]
+    pub token: String,
+    /// Human-readable display name (`"Visual Studio Code"`).
+    #[serde(default)]
+    pub name: Vec<String>,
+    /// Bundle filenames declared by the cask's `app` artifact (e.g.
+    /// `["Visual Studio Code.app"]`).
+    #[serde(default)]
+    pub artifacts: Vec<serde_json::Value>,
+    /// Whether the cask is currently installed locally. The brew JSON
+    /// reports this via the `installed` field on each cask entry.
+    #[serde(default)]
+    pub installed: Option<String>,
+}
+
+impl CaskInfo {
+    /// Extract leaf names of `~/Library/Application Support/<X>` paths
+    /// declared in the cask's zap stanza. Each is a candidate
+    /// app-support folder name for matching against an `_app/<X>/`
+    /// pack entry.
+    pub fn app_support_candidates(&self) -> Vec<String> {
+        zap_paths(&self.artifacts)
+            .filter_map(|p| {
+                let needle = "Library/Application Support/";
+                let idx = p.find(needle)?;
+                let rest = &p[idx + needle.len()..];
+                let leaf = rest.split('/').next()?.trim();
+                if leaf.is_empty() {
+                    None
+                } else {
+                    Some(leaf.to_string())
+                }
+            })
+            .collect()
+    }
+
+    /// Preferences plist paths declared in the zap stanza. Used by
+    /// `dodot adopt` to suggest sibling adoptions
+    /// (`~/Library/Preferences/<bundle-id>.plist`).
+    pub fn preferences_plists(&self) -> Vec<String> {
+        zap_paths(&self.artifacts)
+            .filter(|p| p.contains("Library/Preferences/"))
+            .collect()
+    }
+
+    /// `.app` bundle leaf name from the cask's `app` artifact, e.g.
+    /// `"Visual Studio Code.app"`. Used to drive `mdls` lookups.
+    pub fn app_bundle_name(&self) -> Option<String> {
+        for artifact in &self.artifacts {
+            if let Some(arr) = artifact.get("app").and_then(|v| v.as_array()) {
+                if let Some(first) = arr.first().and_then(|v| v.as_str()) {
+                    return Some(first.to_string());
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Iterate every string path declared anywhere in any cask `zap`
+/// stanza. Brew's JSON nests these under `artifacts[].zap[].trash`
+/// and similar arrays; we walk the JSON tree generically rather than
+/// pinning the exact path so a schema tweak doesn't bite us.
+fn zap_paths(artifacts: &[serde_json::Value]) -> impl Iterator<Item = String> + '_ {
+    artifacts.iter().flat_map(|art| {
+        let mut out: Vec<String> = Vec::new();
+        if let Some(zap) = art.get("zap") {
+            walk_strings(zap, &mut out);
+        }
+        out.into_iter()
+    })
+}
+
+fn walk_strings(v: &serde_json::Value, out: &mut Vec<String>) {
+    match v {
+        serde_json::Value::String(s) => out.push(s.clone()),
+        serde_json::Value::Array(a) => {
+            for child in a {
+                walk_strings(child, out);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for child in map.values() {
+                walk_strings(child, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// On-disk cache wrapper around [`CaskInfo`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheEntry {
+    fetched_at: u64,
+    info: CaskInfo,
+}
+
+/// Run `brew list --cask --versions` and return the set of installed
+/// cask tokens. Empty on non-macOS or when `brew` isn't on PATH.
+///
+/// This is intentionally lossy: any error path returns an empty set,
+/// not a `Result::Err`. The probe is advisory — a failure to enumerate
+/// installed casks must never block adopt or up.
+pub fn list_installed_casks(runner: &dyn CommandRunner) -> Vec<String> {
+    if !cfg!(target_os = "macos") {
+        return Vec::new();
+    }
+    let output = match runner.run(
+        "brew",
+        &["list".into(), "--cask".into(), "--versions".into()],
+    ) {
+        Ok(o) if o.exit_code == 0 => o,
+        _ => return Vec::new(),
+    };
+    output
+        .stdout
+        .lines()
+        .filter_map(|line| line.split_whitespace().next().map(str::to_string))
+        .collect()
+}
+
+/// Look up `brew info --json=v2 --cask <token>` with on-disk caching.
+///
+/// `now_secs` is the wall-clock unix timestamp the caller considers
+/// "now" for TTL evaluation; passing it in keeps the cache testable
+/// without a clock dependency. Production callers pass
+/// `SystemTime::now()` via [`now_secs_unix`].
+///
+/// Returns `Ok(None)` when the cask is unknown to brew, or when we're
+/// running on a host without `brew`. Returns `Ok(Some(_))` for a
+/// fresh cache hit, a stale-entry refresh, or a successful first
+/// fetch.
+///
+/// Cache writes are best-effort — a non-writable cache dir downgrades
+/// the probe to "no caching" but doesn't propagate the error.
+pub fn info_cask(
+    token: &str,
+    cache_dir: &Path,
+    now_secs: u64,
+    fs: &dyn Fs,
+    runner: &dyn CommandRunner,
+) -> Result<Option<CaskInfo>> {
+    if !cfg!(target_os = "macos") {
+        return Ok(None);
+    }
+    let cache_path = cache_path_for(cache_dir, token);
+    if let Some(entry) = read_cache(&cache_path, fs) {
+        if now_secs.saturating_sub(entry.fetched_at) < CACHE_TTL_SECS {
+            return Ok(Some(entry.info));
+        }
+    }
+
+    let info = match fetch_from_brew(token, runner) {
+        Some(i) => i,
+        None => return Ok(None),
+    };
+
+    let entry = CacheEntry {
+        fetched_at: now_secs,
+        info: info.clone(),
+    };
+    let _ = write_cache(&cache_path, &entry, fs);
+    Ok(Some(info))
+}
+
+/// Force a refresh by deleting any cached entry for `token`. Errors
+/// are swallowed — the cache is best-effort.
+pub fn invalidate_cache(token: &str, cache_dir: &Path, fs: &dyn Fs) {
+    let path = cache_path_for(cache_dir, token);
+    if fs.exists(&path) {
+        let _ = fs.remove_file(&path);
+    }
+}
+
+fn cache_path_for(cache_dir: &Path, token: &str) -> PathBuf {
+    // Token can contain `/` in theory (formula taps); flatten to a safe
+    // filename. Brew cask tokens in practice are kebab-case ASCII, but
+    // a defensive replace keeps the cache key total.
+    let safe = token.replace(['/', '\\', ':', ' '], "_");
+    cache_dir.join(format!("{safe}.json"))
+}
+
+fn read_cache(path: &Path, fs: &dyn Fs) -> Option<CacheEntry> {
+    if !fs.exists(path) {
+        return None;
+    }
+    let bytes = fs.read_to_string(path).ok()?;
+    serde_json::from_str(&bytes).ok()
+}
+
+fn write_cache(path: &Path, entry: &CacheEntry, fs: &dyn Fs) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !fs.exists(parent) {
+            fs.mkdir_all(parent)?;
+        }
+    }
+    let json = serde_json::to_string(entry)
+        .map_err(|e| crate::DodotError::Other(format!("brew cache encode failed: {e}")))?;
+    fs.write_file(path, json.as_bytes())?;
+    Ok(())
+}
+
+fn fetch_from_brew(token: &str, runner: &dyn CommandRunner) -> Option<CaskInfo> {
+    let output = runner
+        .run(
+            "brew",
+            &[
+                "info".into(),
+                "--json=v2".into(),
+                "--cask".into(),
+                token.to_string(),
+            ],
+        )
+        .ok()?;
+    if output.exit_code != 0 {
+        return None;
+    }
+    parse_info_json(&output.stdout)
+}
+
+/// Parse a `brew info --json=v2 --cask` payload, returning the first
+/// cask entry (brew nests them under `casks: []`).
+fn parse_info_json(stdout: &str) -> Option<CaskInfo> {
+    #[derive(Deserialize)]
+    struct Wrapper {
+        #[serde(default)]
+        casks: Vec<CaskInfo>,
+    }
+    let w: Wrapper = serde_json::from_str(stdout).ok()?;
+    w.casks.into_iter().next()
+}
+
+/// Wall-clock unix timestamp helper used by callers that want the
+/// real current time. Tests pass a fixed value so cache TTL is
+/// deterministic.
+pub fn now_secs_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Match `app_aliases` map values + every pack-relative `_app/<X>/...`
+/// folder against a cask's app-support candidates. Used by the
+/// `dodot probe app` subcommand to pair pack entries with installed
+/// casks.
+///
+/// Returns a map of `(folder_name → cask_token)` so callers can
+/// surface the link without re-running the matching loop.
+pub fn match_folders_to_casks(
+    folders: &[String],
+    runner: &dyn CommandRunner,
+    cache_dir: &Path,
+    now_secs: u64,
+    fs: &dyn Fs,
+) -> HashMap<String, String> {
+    let mut hits = HashMap::new();
+    if !cfg!(target_os = "macos") {
+        return hits;
+    }
+    for token in list_installed_casks(runner) {
+        if let Ok(Some(info)) = info_cask(&token, cache_dir, now_secs, fs, runner) {
+            for cand in info.app_support_candidates() {
+                if folders.iter().any(|f| f == &cand) {
+                    hits.insert(cand, token.clone());
+                }
+            }
+        }
+    }
+    hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datastore::CommandOutput;
+    use std::sync::Mutex;
+
+    /// CommandRunner mock that returns canned outputs per command.
+    struct MockRunner {
+        responses: Mutex<HashMap<Vec<String>, CommandOutput>>,
+        calls: Mutex<Vec<Vec<String>>>,
+    }
+
+    impl MockRunner {
+        fn new() -> Self {
+            Self {
+                responses: Mutex::new(HashMap::new()),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+        fn respond(&self, args: &[&str], stdout: &str, exit_code: i32) {
+            let key: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+            self.responses.lock().unwrap().insert(
+                key,
+                CommandOutput {
+                    exit_code,
+                    stdout: stdout.into(),
+                    stderr: String::new(),
+                },
+            );
+        }
+        fn call_count(&self, args: &[&str]) -> usize {
+            let key: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+            self.calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|c| **c == key)
+                .count()
+        }
+    }
+
+    impl CommandRunner for MockRunner {
+        fn run(&self, exe: &str, args: &[String]) -> Result<CommandOutput> {
+            let mut full = vec![exe.to_string()];
+            full.extend(args.iter().cloned());
+            self.calls.lock().unwrap().push(full.clone());
+            // Strip the executable prefix for response lookup so test
+            // fixtures stay readable.
+            let key: Vec<String> = full.iter().skip(1).cloned().collect();
+            self.responses
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .ok_or_else(|| crate::DodotError::Other(format!("no mock response for {full:?}")))
+        }
+    }
+
+    fn make_env() -> (crate::testing::TempEnvironment, std::path::PathBuf) {
+        let env = crate::testing::TempEnvironment::builder().build();
+        let cache = env.home.join("brew-probe-cache");
+        env.fs.mkdir_all(&cache).unwrap();
+        (env, cache)
+    }
+
+    #[test]
+    fn parse_info_json_extracts_first_cask() {
+        let payload = r#"{
+            "casks": [
+                {
+                    "token": "visual-studio-code",
+                    "name": ["Visual Studio Code"],
+                    "installed": "1.95.0",
+                    "artifacts": [
+                        {"app": ["Visual Studio Code.app"]},
+                        {"zap": [
+                            {"trash": [
+                                "~/Library/Application Support/Code",
+                                "~/Library/Preferences/com.microsoft.VSCode.plist"
+                            ]}
+                        ]}
+                    ]
+                }
+            ]
+        }"#;
+        let info = parse_info_json(payload).expect("parse");
+        assert_eq!(info.token, "visual-studio-code");
+        assert_eq!(info.installed.as_deref(), Some("1.95.0"));
+        assert_eq!(
+            info.app_bundle_name().as_deref(),
+            Some("Visual Studio Code.app")
+        );
+        let candidates = info.app_support_candidates();
+        assert!(candidates.iter().any(|c| c == "Code"), "got {candidates:?}");
+        let plists = info.preferences_plists();
+        assert!(
+            plists
+                .iter()
+                .any(|p| p.contains("com.microsoft.VSCode.plist")),
+            "got {plists:?}"
+        );
+    }
+
+    #[test]
+    fn parse_info_json_missing_casks_array_returns_none() {
+        assert!(parse_info_json("{}").is_none());
+        assert!(parse_info_json("not json").is_none());
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn info_cask_caches_first_result_then_serves_from_cache() {
+        let (env, cache) = make_env();
+        let runner = MockRunner::new();
+        runner.respond(
+            &["info", "--json=v2", "--cask", "visual-studio-code"],
+            r#"{"casks": [{"token": "visual-studio-code", "installed": "1.95.0"}]}"#,
+            0,
+        );
+
+        let now = 1_000_000;
+        let first = info_cask("visual-studio-code", &cache, now, env.fs.as_ref(), &runner)
+            .unwrap()
+            .expect("first call returns Some");
+        assert_eq!(first.token, "visual-studio-code");
+        assert_eq!(
+            runner.call_count(&["brew", "info", "--json=v2", "--cask", "visual-studio-code"]),
+            1
+        );
+
+        // Within TTL → cache hit, no second subprocess.
+        let _ = info_cask(
+            "visual-studio-code",
+            &cache,
+            now + 100,
+            env.fs.as_ref(),
+            &runner,
+        )
+        .unwrap();
+        assert_eq!(
+            runner.call_count(&["brew", "info", "--json=v2", "--cask", "visual-studio-code"]),
+            1,
+            "fresh cache must not re-fetch"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn info_cask_refetches_when_ttl_expires() {
+        let (env, cache) = make_env();
+        let runner = MockRunner::new();
+        runner.respond(
+            &["info", "--json=v2", "--cask", "cursor"],
+            r#"{"casks": [{"token": "cursor"}]}"#,
+            0,
+        );
+
+        let now = 1_000_000;
+        let _ = info_cask("cursor", &cache, now, env.fs.as_ref(), &runner).unwrap();
+        // Simulate clock advance past TTL.
+        let _ = info_cask(
+            "cursor",
+            &cache,
+            now + CACHE_TTL_SECS + 1,
+            env.fs.as_ref(),
+            &runner,
+        )
+        .unwrap();
+        assert_eq!(
+            runner.call_count(&["brew", "info", "--json=v2", "--cask", "cursor"]),
+            2,
+            "stale cache should re-fetch"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn invalidate_cache_forces_refetch() {
+        let (env, cache) = make_env();
+        let runner = MockRunner::new();
+        runner.respond(
+            &["info", "--json=v2", "--cask", "zed"],
+            r#"{"casks": [{"token": "zed"}]}"#,
+            0,
+        );
+
+        let now = 1_000_000;
+        let _ = info_cask("zed", &cache, now, env.fs.as_ref(), &runner).unwrap();
+        invalidate_cache("zed", &cache, env.fs.as_ref());
+        let _ = info_cask("zed", &cache, now + 10, env.fs.as_ref(), &runner).unwrap();
+        assert_eq!(
+            runner.call_count(&["brew", "info", "--json=v2", "--cask", "zed"]),
+            2
+        );
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn info_cask_returns_none_on_brew_failure() {
+        let (env, cache) = make_env();
+        let runner = MockRunner::new();
+        runner.respond(
+            &["info", "--json=v2", "--cask", "nonexistent"],
+            "",
+            1, // brew exits non-zero on unknown cask
+        );
+        let got = info_cask("nonexistent", &cache, 100, env.fs.as_ref(), &runner).unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn list_installed_casks_parses_first_column() {
+        let runner = MockRunner::new();
+        runner.respond(
+            &["list", "--cask", "--versions"],
+            "visual-studio-code 1.95.0\ncursor 0.42.0\nzed 0.150.0\n",
+            0,
+        );
+        let got = list_installed_casks(&runner);
+        assert_eq!(got, vec!["visual-studio-code", "cursor", "zed"]);
+    }
+
+    #[test]
+    fn list_installed_casks_silent_on_non_macos() {
+        // The function is gated by cfg!(target_os = "macos"). On every
+        // other host it returns empty regardless of mock state.
+        let runner = MockRunner::new();
+        let got = list_installed_casks(&runner);
+        if !cfg!(target_os = "macos") {
+            assert!(got.is_empty());
+        }
+        // On macOS hosts we'd hit the "no mock response" path which
+        // returns Err → empty Vec via the function's loss-tolerant
+        // outer match. Still expect no panic either way.
+    }
+
+    #[test]
+    fn cache_path_sanitizes_token() {
+        // Hypothetical token containing path separators — brew tokens
+        // don't actually do this today but the sanitization keeps the
+        // cache key total. Path component check is what matters: no
+        // entry should resolve outside the cache dir via `..`.
+        use std::path::Component;
+        let cache = Path::new("/tmp/brew-cache");
+        let p = cache_path_for(cache, "evil/../token");
+        assert!(p.starts_with(cache));
+        let escapes = p.components().any(|c| matches!(c, Component::ParentDir));
+        assert!(
+            !escapes,
+            "sanitized path must not contain a ParentDir component: {}",
+            p.display()
+        );
+    }
+}

--- a/crates/dodot-lib/src/probe/macos_native.rs
+++ b/crates/dodot-lib/src/probe/macos_native.rs
@@ -1,0 +1,251 @@
+//! macOS-native metadata probes: `mdls` and `mdfind`.
+//!
+//! Implements Phase M6 of `docs/proposals/macos-paths.lex` §8.3. Same
+//! advisory-only contract as `probe::brew`: failures return `None`
+//! and never propagate; the resolver in §5 doesn't consult these
+//! either.
+//!
+//! ## Why these and not the others
+//!
+//! - `mdls` — Spotlight metadata for a single bundle path. Cheap,
+//!   scriptable. Used to resolve `/Applications/<X>.app` to its
+//!   `kMDItemCFBundleIdentifier` (e.g. `com.microsoft.VSCode`).
+//! - `mdfind` — Spotlight query. Used to resolve a friendly display
+//!   name ("Cursor") to a `.app` bundle path when only the name is
+//!   known.
+//!
+//! `lsregister -dump` (full LaunchServices DB) is comprehensive but
+//! heavy and out of scope. `defaults domains` is for plist preference
+//! domains, also out of scope. `NSFileManager.URLsForDirectory(...)`
+//! would require linking AppKit and isn't worth the dependency
+//! burden.
+
+use std::path::Path;
+
+use crate::datastore::CommandRunner;
+
+/// Read the bundle identifier from a `.app` bundle's Spotlight
+/// metadata. Returns `None` on non-macOS, missing `mdls`, missing
+/// bundle, or unparseable output.
+///
+/// Example mdls output:
+///
+/// ```text
+/// kMDItemCFBundleIdentifier = "com.microsoft.VSCode"
+/// ```
+pub fn bundle_id(app_path: &Path, runner: &dyn CommandRunner) -> Option<String> {
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+    let output = runner
+        .run(
+            "mdls",
+            &[
+                "-name".into(),
+                "kMDItemCFBundleIdentifier".into(),
+                app_path.to_string_lossy().into_owned(),
+            ],
+        )
+        .ok()?;
+    if output.exit_code != 0 {
+        return None;
+    }
+    parse_mdls_value(&output.stdout)
+}
+
+/// Resolve a friendly display name (e.g. `"Cursor"`) to a `.app`
+/// bundle path via Spotlight. Returns the first match.
+///
+/// We construct the query at the call site rather than letting the
+/// caller pass arbitrary mdfind args — keeps the surface narrow and
+/// shell-injection safe (CommandRunner already isolates args from
+/// the shell, but query simplicity matters for testability too).
+pub fn find_app_bundle(display_name: &str, runner: &dyn CommandRunner) -> Option<String> {
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+    let query = format!(
+        "kMDItemKind == 'Application' && kMDItemDisplayName == '{}'",
+        display_name.replace('\'', "")
+    );
+    let output = runner.run("mdfind", &[query]).ok()?;
+    if output.exit_code != 0 {
+        return None;
+    }
+    output
+        .stdout
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .map(str::to_string)
+}
+
+/// Parse `mdls -name kMDItemCFBundleIdentifier <path>` output.
+///
+/// Handles both the typical quoted form (`= "com.x.y"`) and the
+/// `(null)` form mdls emits when a bundle has no value set for the
+/// requested key.
+fn parse_mdls_value(stdout: &str) -> Option<String> {
+    for line in stdout.lines() {
+        if let Some((_key, rest)) = line.split_once('=') {
+            let trimmed = rest.trim();
+            if trimmed == "(null)" || trimmed.is_empty() {
+                return None;
+            }
+            // Strip surrounding double quotes if present.
+            let unquoted = trimmed
+                .strip_prefix('"')
+                .and_then(|s| s.strip_suffix('"'))
+                .unwrap_or(trimmed);
+            return Some(unquoted.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datastore::CommandOutput;
+    use crate::Result;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// Minimal CommandRunner mock — duplicated from probe::brew::tests
+    /// rather than shared via a test_util module so each probe's tests
+    /// stay self-contained.
+    struct MockRunner {
+        responses: Mutex<HashMap<Vec<String>, CommandOutput>>,
+    }
+
+    impl MockRunner {
+        fn new() -> Self {
+            Self {
+                responses: Mutex::new(HashMap::new()),
+            }
+        }
+        fn respond(&self, args: &[&str], stdout: &str, exit_code: i32) {
+            let key: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+            self.responses.lock().unwrap().insert(
+                key,
+                CommandOutput {
+                    exit_code,
+                    stdout: stdout.into(),
+                    stderr: String::new(),
+                },
+            );
+        }
+    }
+
+    impl CommandRunner for MockRunner {
+        fn run(&self, exe: &str, args: &[String]) -> Result<CommandOutput> {
+            let mut full = vec![exe.to_string()];
+            full.extend(args.iter().cloned());
+            let key: Vec<String> = full.iter().skip(1).cloned().collect();
+            self.responses
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .ok_or_else(|| crate::DodotError::Other(format!("no mock response for {full:?}")))
+        }
+    }
+
+    #[test]
+    fn parse_mdls_value_quoted() {
+        let out = "kMDItemCFBundleIdentifier = \"com.microsoft.VSCode\"";
+        assert_eq!(
+            parse_mdls_value(out).as_deref(),
+            Some("com.microsoft.VSCode")
+        );
+    }
+
+    #[test]
+    fn parse_mdls_value_null() {
+        // mdls emits `(null)` for absent metadata.
+        assert_eq!(parse_mdls_value("kMDItemCFBundleIdentifier = (null)"), None);
+    }
+
+    #[test]
+    fn parse_mdls_value_unquoted() {
+        // Some keys (e.g. integers) come back unquoted; we tolerate it.
+        let out = "kMDItemPixelHeight = 1080";
+        assert_eq!(parse_mdls_value(out).as_deref(), Some("1080"));
+    }
+
+    #[test]
+    fn parse_mdls_value_empty_input() {
+        assert_eq!(parse_mdls_value(""), None);
+        assert_eq!(parse_mdls_value("no-equals-sign-here"), None);
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn bundle_id_returns_value_on_success() {
+        let runner = MockRunner::new();
+        runner.respond(
+            &[
+                "-name",
+                "kMDItemCFBundleIdentifier",
+                "/Applications/Visual Studio Code.app",
+            ],
+            "kMDItemCFBundleIdentifier = \"com.microsoft.VSCode\"\n",
+            0,
+        );
+        let got = bundle_id(Path::new("/Applications/Visual Studio Code.app"), &runner);
+        assert_eq!(got.as_deref(), Some("com.microsoft.VSCode"));
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn bundle_id_returns_none_on_nonzero_exit() {
+        let runner = MockRunner::new();
+        runner.respond(
+            &[
+                "-name",
+                "kMDItemCFBundleIdentifier",
+                "/Applications/Missing.app",
+            ],
+            "",
+            1,
+        );
+        let got = bundle_id(Path::new("/Applications/Missing.app"), &runner);
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn bundle_id_silent_on_non_macos() {
+        let runner = MockRunner::new();
+        // No mock response set; on non-macOS we exit early before
+        // ever calling runner.run, so no error surfaces.
+        if !cfg!(target_os = "macos") {
+            assert!(bundle_id(Path::new("/Applications/X.app"), &runner).is_none());
+        }
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn find_app_bundle_returns_first_path() {
+        let runner = MockRunner::new();
+        runner.respond(
+            &["kMDItemKind == 'Application' && kMDItemDisplayName == 'Cursor'"],
+            "/Applications/Cursor.app\n/Applications/Old/Cursor.app\n",
+            0,
+        );
+        let got = find_app_bundle("Cursor", &runner);
+        assert_eq!(got.as_deref(), Some("/Applications/Cursor.app"));
+    }
+
+    #[test]
+    #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only behavior")]
+    fn find_app_bundle_returns_none_when_no_results() {
+        let runner = MockRunner::new();
+        runner.respond(
+            &["kMDItemKind == 'Application' && kMDItemDisplayName == 'NonexistentApp'"],
+            "",
+            0,
+        );
+        let got = find_app_bundle("NonexistentApp", &runner);
+        assert!(got.is_none());
+    }
+}

--- a/crates/dodot-lib/src/probe/mod.rs
+++ b/crates/dodot-lib/src/probe/mod.rs
@@ -14,9 +14,11 @@
 //! `<data_dir>/probes/shell-init/`; that state lives in a sibling
 //! submodule when it lands.
 
+pub mod brew;
 pub mod data_dir_tree;
 pub mod deployment_map;
 pub mod last_up;
+pub mod macos_native;
 pub mod shell_init;
 
 pub use data_dir_tree::{collect_data_dir_tree, TreeNode};

--- a/crates/dodot-lib/src/templates/probe.jinja
+++ b/crates/dodot-lib/src/templates/probe.jinja
@@ -103,4 +103,16 @@
   [dim] run `dodot up`, then start a new shell)[/dim]
 {% endif %}{% endif %}
   [dim]profiles dir:[/dim] {{ profiles_dir }}
+{%- elif kind == "app" -%}
+[header]App-support probe: [pack-name]{{ pack }}[/pack-name][/header]
+{% if not macos %}  [dim](non-macOS host — brew/Spotlight metadata not available; folder existence reflects collapsed app_support_dir)[/dim]
+{% endif %}{% if entries %}{% for e in entries %}  [filename]{{ e.folder }}[/filename] [dim]({{ e.source_rule }})[/dim] {{ e.target_path }} {% if e.target_exists %}[deployed][exists][/deployed]{% else %}[warning][missing][/warning]{% endif %}
+{% if e.cask %}    cask:   [filename]{{ e.cask }}[/filename] {% if e.cask_installed %}[deployed][installed][/deployed]{% else %}[warning][not installed][/warning]{% endif %}
+{% endif %}{% if e.app_bundle %}    app:    [dim]/Applications/{{ e.app_bundle }}[/dim]
+{% endif %}{% if e.bundle_id %}    bundle: [dim]{{ e.bundle_id }}[/dim]
+{% endif %}{% endfor %}{% else %}  [dim](pack has no `_app/`, `force_app`, or `app_aliases` entries)[/dim]
+{% endif %}{% if suggested_adoptions %}
+[header]Suggested sibling adoptions[/header] [dim](from cask zap)[/dim]
+{% for s in suggested_adoptions %}  [dim]{{ s }}[/dim]
+{% endfor %}{% endif %}
 {%- endif -%}

--- a/crates/dodot-lib/src/templates/probe.jinja
+++ b/crates/dodot-lib/src/templates/probe.jinja
@@ -107,7 +107,7 @@
 [header]App-support probe: [pack-name]{{ pack }}[/pack-name][/header]
 {% if not macos %}  [dim](non-macOS host — brew/Spotlight metadata not available; folder existence reflects collapsed app_support_dir)[/dim]
 {% endif %}{% if entries %}{% for e in entries %}  [filename]{{ e.folder }}[/filename] [dim]({{ e.source_rule }})[/dim] {{ e.target_path }} {% if e.target_exists %}[deployed][exists][/deployed]{% else %}[warning][missing][/warning]{% endif %}
-{% if e.cask %}    cask:   [filename]{{ e.cask }}[/filename] {% if e.cask_installed %}[deployed][installed][/deployed]{% else %}[warning][not installed][/warning]{% endif %}
+{% if e.cask %}    cask:   [filename]{{ e.cask }}[/filename] [dim](installed)[/dim]
 {% endif %}{% if e.app_bundle %}    app:    [dim]/Applications/{{ e.app_bundle }}[/dim]
 {% endif %}{% if e.bundle_id %}    bundle: [dim]{{ e.bundle_id }}[/dim]
 {% endif %}{% endfor %}{% else %}  [dim](pack has no `_app/`, `force_app`, or `app_aliases` entries)[/dim]

--- a/docs/reference/symlink-paths.lex
+++ b/docs/reference/symlink-paths.lex
@@ -350,3 +350,41 @@ Symlink Deployment Paths
     9.4. Auto-Creating Packs
 
         When inference picks a single pack name and that pack does not exist on disk, adopt creates it (an empty directory). `--into <pack>` does *not* auto-create — the explicit name is a typo guard. Run `dodot init <pack>` first to bootstrap an explicit pack.
+
+10. macOS Advisory Probes
+
+    Everything in §1–§9 is deterministic: the resolver operates on textual prefixes and configured lists, nothing else. On top of that deterministic core, dodot ships an *advisory* layer that consults macOS-native metadata to make adopt suggestions richer and `up`/`status` warnings more specific. The cardinal rule: *probes are advisory, never authoritative*. The resolver in §5 never consults them; a probe failure surfaces as a less-rich suggestion, not a wrong deployment.
+
+    10.1. The `dodot probe app` Subcommand
+
+        Diagnostic introspection for a single pack:
+
+            dodot probe app <pack> [--refresh]
+
+        :: text ::
+
+        Reports each app-support folder the pack would route to (via `[symlink.app_aliases]`, `force_app`, or `_app/<X>/` subtree), folder existence under `app_support_dir`, the matching homebrew cask token and install state, the `.app` bundle name and `kMDItemCFBundleIdentifier`, and sibling-adoption candidates surfaced from the cask's zap stanza.
+
+        On non-macOS hosts (or when `app_uses_library = false` collapses `app_support_dir` onto `$XDG_CONFIG_HOME`) the brew/Spotlight enrichment is skipped — the subcommand still renders the basic folder layout and existence check.
+
+        `--refresh` invalidates the brew cache for this pack's tokens, forcing a fresh `brew info` lookup on the next call. The cache is otherwise refreshed automatically every 24 hours.
+
+    10.2. Adopt Enrichment
+
+        When `dodot adopt ~/Library/Application Support/<X>/...` succeeds and `<X>` matches an installed cask's app-support folder, adopt appends two informational lines to `PackStatusResult.warnings`:
+
+            - a confirmation: "homebrew cask `<token>` confirms this is the app-support directory for pack `<X>`",
+            - a sibling-adoption suggestion when the cask's zap stanza lists Preferences plists: "homebrew also reports preferences for cask `<token>`: <plist-list>. Adopt them too with `dodot adopt ~/Library/Preferences/<file> --into <X>`."
+
+    10.3. Missing-Target Hints
+
+        `dodot up` and `dodot status` plan-pack passes check whether each `<app_support_dir>/<X>/` folder a pack will deploy into actually exists on disk. Missing folders surface a soft warning, optionally enriched with a matching cask token: "looks like cask `<token>` isn't installed yet — `<X>/...` will deploy but the app isn't here to read it." Resolver state is unaffected; the symlinks still get created.
+
+    10.4. What Probes Don't Do
+
+        Out of scope, deliberately:
+
+            - Auto-derive `force_app` from cask zap data — the curated list (§3.1) stays curated.
+            - Run a long-running daemon that watches LaunchServices.
+            - Use `defaults read/write` to manage plist contents — see [./../proposals/plists.lex] for that path.
+            - Mirror mackup's bundled app database. The combination of `_app/`, `app_aliases`, the curated `force_app`, and homebrew probing covers the same ground without the curation cost.

--- a/tests/e2e/bats/test_macos_paths.bats
+++ b/tests/e2e/bats/test_macos_paths.bats
@@ -180,6 +180,44 @@ expected_app_root() {
     assert_output_contains "Cursor"
 }
 
+# ── Probe app subcommand (M6) ──────────────────────────────────
+
+@test "probe app reports folder existence for a force_app pack" {
+    # `Code` ships in the default force_app list. With a top-level
+    # `Code/` directory in the pack and the target folder absent on
+    # disk, probe should mark it as `[missing]`.
+    create_pack_file "macapps" "Code/User/settings.json" '{}'
+
+    run dodot probe app macapps
+    [ "$status" -eq 0 ]
+    assert_output_contains "App-support probe"
+    assert_output_contains "Code"
+    assert_output_contains "force_app"
+}
+
+@test "probe app surfaces app_aliases entries" {
+    # A pack with an alias should show the aliased folder name.
+    create_pack_file "vscode" "User/settings.json" '{}'
+    create_pack_config "vscode" '[symlink.app_aliases]\nvscode = "Code"\n'
+
+    run dodot probe app vscode
+    [ "$status" -eq 0 ]
+    assert_output_contains "Code"
+    assert_output_contains "alias"
+}
+
+@test "probe app refresh flag works without brew" {
+    # The --refresh flag invalidates any cached brew probe data. Even
+    # with brew unavailable, the subcommand should still succeed and
+    # render the basic folder layout.
+    create_pack_file "vscode" "User/settings.json" '{}'
+    create_pack_config "vscode" '[symlink.app_aliases]\nvscode = "Code"\n'
+
+    run dodot probe app vscode --refresh
+    [ "$status" -eq 0 ]
+    assert_output_contains "Code"
+}
+
 # ── Sandboxed Containers refusal (cross-platform) ──────────────
 
 @test "adopt refuses ~/Library/Containers/ paths" {


### PR DESCRIPTION
## Summary

- Implements Phase M6 of `docs/proposals/macos-paths.lex` §8 — the advisory layer on top of the deterministic resolver landed in #90. **Cardinal rule from §8 holds**: probes are *advisory*, never authoritative. The resolver in §5 doesn't consult any of this code; a probe failure (no `brew`, malformed JSON, empty Spotlight result) never alters routing.
- New `probe::brew` (`brew list --cask --versions`, `brew info --json=v2 --cask <token>`) with on-disk caching at `<cache_dir>/probes/brew/`, 24h TTL, and explicit `--refresh` invalidation. New `probe::macos_native` thin wrappers around `mdls` and `mdfind`. Both gate on `cfg!(target_os = "macos")`.
- New `dodot probe app <pack> [--refresh]` subcommand — diagnostic surface listing every app-support folder the pack will route to (alias / `force_app` / `_app/`), folder existence, matching cask + install state, `.app` bundle, bundle ID, and sibling-adoption candidates from cask zap data.
- Adopt enrichment: AppSupport adopts whose pack name matches an installed cask now surface a confirmation + sibling-plist suggestion. Up/status missing-target hints fire when a planned `<app_support_dir>/<X>/` folder doesn't exist on disk (cask-enriched when the brew probe finds a match).
- `ExecutionContext.command_runner` now exposes the production `CommandRunner` on the orchestration context so probes reuse the same runner the datastore drives.

## Test plan

- [x] 15 new unit tests covering brew JSON parsing, cache TTL + invalidation, mdls parsing, macOS/Linux gating.
- [x] 5 new integration tests in `commands::tests` exercising `probe::app` and the missing-target hint via a `CannedRunner` mock that returns canned brew/mdls output.
- [x] 3 new e2e bats tests in `tests/e2e/bats/test_macos_paths.bats` for the subcommand shape on a real binary (no `brew` required).
- [x] Total suite: 660 passing (was 638 pre-M6). Full CI green; `cargo fmt`, `cargo clippy --all-targets`, `scripts/check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)