### PR TITLE
feat: cask-aware rename tip in adopt for reverse-DNS folders

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -96,3 +96,12 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
       future advisory subprocess wrapper) reuse the same
       `CommandRunner` the datastore already drives. Tests inject a
       `CannedRunner` mock for deterministic probe coverage.
+    - **Cask-aware rename suggestion** — when M5's
+      capitalization-heuristic tip fires *and* the M6 brew probe
+      finds an installed cask matching the pack's app-support
+      folder, the suggested rename uses the cask token instead of a
+      whitespace-strip-lowercase fallback. For reverse-DNS bundle-ID
+      folders (`com.colliderli.iina` → cask `iina`) this is the
+      difference between `iina` (sane) and `comcolliderliiina`
+      (useless). The tip credits the cask so users know where the
+      recommendation came from.

--- a/crates/dodot-lib/src/commands/adopt/mod.rs
+++ b/crates/dodot-lib/src/commands/adopt/mod.rs
@@ -199,17 +199,20 @@ pub fn adopt(
         result.warnings.push(msg);
     }
 
-    // Capitalization-heuristic advisory (M5): when a successfully
-    // adopted source comes from AppSupport and its naturally-inferred
-    // pack name passes the GUI-app heuristic (uppercase / space /
-    // reverse-DNS), suggest the `app_aliases` ergonomic. The hint is
-    // purely advisory — the resolver and the actual pack tree are
-    // unaffected. See `docs/proposals/macos-paths.lex` §8.1.
+    // M5 capitalization-heuristic advisory + M6 brew enrichment.
     //
-    // We only emit the hint when:
-    //   - `pack_override` is None (user didn't pre-pick a pack name)
-    //   - the pack on disk is named `<X>` matching the heuristic
-    //   - at least one source was AppSupport-rooted in this invocation
+    // Both gate on the same precondition (at least one AppSupport
+    // source) and consume the same brew probe data (the matching
+    // installed-cask token for the pack name). They were separate
+    // blocks pre-cask-aware-rename — the consolidation here lets the
+    // M5 rename suggestion *prefer the cask token* over a
+    // whitespace-stripped-lowercase folder name, which matters for
+    // reverse-DNS bundle IDs (`com.colliderli.iina` → `iina`, not
+    // `comcolliderliiina`). See `docs/proposals/macos-paths.lex`
+    // §8.1–§8.2.
+    //
+    // Resolver/pack-tree state is unaffected throughout — these are
+    // purely user-facing strings on `PackStatusResult.warnings`.
     let force_home = ctx.config_manager.root_config()?.symlink.force_home.clone();
     let any_app_support = sources.iter().any(|s| {
         absolutize(s)
@@ -222,87 +225,94 @@ pub fn adopt(
             .unwrap_or(false)
     });
 
-    if pack_override.is_none() && infer::is_gui_app_folder(&pack_display) && any_app_support {
-        {
-            // Pick a sensible lowercase suggestion: strip spaces and
-            // lowercase the first segment. `Visual Studio Code` →
-            // `visualstudiocode`; `Code` → `code`. The exact name is
-            // up to the user — this is a starting point, not a rule.
-            let suggested_alias: String = pack_display
-                .chars()
-                .filter(|c| !c.is_whitespace())
-                .flat_map(char::to_lowercase)
-                .collect();
-            if !suggested_alias.is_empty() && suggested_alias != pack_display {
-                result.warnings.push(format!(
-                    "tip: pack `{}` looks like a macOS GUI-app folder. Consider \
-                     renaming the pack to `{}` and adding\n  \
-                     [symlink.app_aliases]\n  {} = \"{}\"\n\
-                     to your .dodot.toml so future files can use bare paths instead \
-                     of `_app/{}/...`.",
-                    pack_display, suggested_alias, suggested_alias, pack_display, pack_display,
-                ));
-            }
-        }
-    }
-
-    // Brew-cask enrichment (M6): when an AppSupport adopt's pack name
-    // matches a folder declared by an installed cask's zap stanza,
-    // append confirmation + sibling-adoption suggestions. macOS-only;
-    // probe::brew gates on cfg!(target_os = "macos") internally so on
-    // Linux this loop is a no-op even with mocked installed casks.
-    //
-    // Resolver/pack-tree state is unaffected — these are purely
-    // user-facing strings on PackStatusResult.warnings. See
-    // `docs/proposals/macos-paths.lex` §8.2.
-    if any_app_support {
-        let cache_dir = ctx.paths.probes_brew_cache_dir();
-        let now = crate::probe::brew::now_secs_unix();
-        let folders = vec![pack_display.clone()];
-        // adopt is an interactive, on-demand command — populating the
-        // cache here is fine.
-        let matches = crate::probe::brew::match_folders_to_installed_casks(
-            &folders,
+    // Compute the cask match once — both the M5 rename tip and the
+    // M6 confirmation/sibling-plist block read from `matches`. adopt
+    // is an interactive, on-demand command so populating the cache
+    // here is fine (cache_only=false).
+    let cache_dir = ctx.paths.probes_brew_cache_dir();
+    let now = crate::probe::brew::now_secs_unix();
+    let cask_matches = if any_app_support {
+        crate::probe::brew::match_folders_to_installed_casks(
+            std::slice::from_ref(&pack_display),
             ctx.command_runner.as_ref(),
             &cache_dir,
             now,
             ctx.fs.as_ref(),
             /*cache_only=*/ false,
-        );
-        if let Some(token) = matches.folder_to_token.get(&pack_display) {
+        )
+    } else {
+        crate::probe::brew::InstalledCaskMatches::default()
+    };
+    let cask_token: Option<&str> = cask_matches
+        .folder_to_token
+        .get(&pack_display)
+        .map(String::as_str);
+
+    if pack_override.is_none() && infer::is_gui_app_folder(&pack_display) && any_app_support {
+        // Prefer the cask token as the rename suggestion when we have
+        // one — for reverse-DNS bundle IDs that's a *much* better
+        // suggestion than whitespace-strip-lowercase
+        // (`com.colliderli.iina` → `iina` instead of
+        // `comcolliderliiina`). Falls back to the lowercase fallback
+        // for the spaces/uppercase cases the heuristic also catches.
+        let lowercase_fallback: String = pack_display
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .flat_map(char::to_lowercase)
+            .collect();
+        let suggested_alias = cask_token.unwrap_or(lowercase_fallback.as_str());
+        if !suggested_alias.is_empty() && suggested_alias != pack_display {
+            let cask_credit = match cask_token {
+                Some(token) => format!(" (matches homebrew cask `{token}`)"),
+                None => String::new(),
+            };
             result.warnings.push(format!(
-                "homebrew cask `{token}` confirms this is the app-support directory \
-                 for pack `{pack_display}`."
+                "tip: pack `{pack_display}` looks like a macOS GUI-app folder{cask_credit}. \
+                 Consider renaming the pack to `{suggested_alias}` and adding\n  \
+                 [symlink.app_aliases]\n  {suggested_alias} = \"{pack_display}\"\n\
+                 to your .dodot.toml so future files can use bare paths instead \
+                 of `_app/{pack_display}/...`."
             ));
-            // Pull cask info from cache (now warm) for sibling-plist
-            // suggestions. Failures are silent — the confirmation
-            // above is already enough signal.
-            if let Ok(Some(info)) = crate::probe::brew::info_cask(
-                token,
-                &cache_dir,
-                now,
-                ctx.fs.as_ref(),
-                ctx.command_runner.as_ref(),
-            ) {
-                let plists = info.preferences_plists();
-                let candidates: Vec<&str> = plists
-                    .iter()
-                    .filter_map(|p| {
-                        let leaf = p.split('/').next_back()?;
-                        if leaf.is_empty() {
-                            None
-                        } else {
-                            Some(leaf)
-                        }
-                    })
-                    .collect();
-                if !candidates.is_empty() {
-                    let list = candidates.join(", ");
-                    result.warnings.push(format!(
-                        "homebrew also reports preferences for cask `{token}`: {list}. \
-                         Adopt them too with `dodot adopt ~/Library/Preferences/<file> --into {pack_display}`."
-                    ));
-                }
+        }
+    }
+
+    // Brew-cask enrichment (M6): when the pack name matched an
+    // installed cask, append confirmation + sibling-adoption
+    // suggestions. macOS-only via `match_folders_to_installed_casks`;
+    // on Linux `cask_token` stays `None` and this block is skipped.
+    if let Some(token) = cask_token {
+        result.warnings.push(format!(
+            "homebrew cask `{token}` confirms this is the app-support directory \
+             for pack `{pack_display}`."
+        ));
+        // Pull cask info from cache (now warm) for sibling-plist
+        // suggestions. Failures are silent — the confirmation above
+        // is already enough signal.
+        if let Ok(Some(info)) = crate::probe::brew::info_cask(
+            token,
+            &cache_dir,
+            now,
+            ctx.fs.as_ref(),
+            ctx.command_runner.as_ref(),
+        ) {
+            let plists = info.preferences_plists();
+            let candidates: Vec<&str> = plists
+                .iter()
+                .filter_map(|p| {
+                    let leaf = p.split('/').next_back()?;
+                    if leaf.is_empty() {
+                        None
+                    } else {
+                        Some(leaf)
+                    }
+                })
+                .collect();
+            if !candidates.is_empty() {
+                let list = candidates.join(", ");
+                result.warnings.push(format!(
+                    "homebrew also reports preferences for cask `{token}`: {list}. \
+                     Adopt them too with `dodot adopt ~/Library/Preferences/<file> --into {pack_display}`."
+                ));
             }
         }
     }

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -1947,6 +1947,122 @@ fn adopt_app_support_emits_capitalization_hint() {
     );
 }
 
+/// Reverse-DNS bundle-ID folders (`com.colliderli.iina`,
+/// `dev.warp.Warp-Stable`) get a much better rename suggestion when
+/// the M6 brew probe identifies a matching cask: prefer the cask
+/// token (`iina`) over the awful whitespace-strip-lowercase fallback
+/// (`comcolliderliiina`). Real IINA case from user testing on PR #91.
+#[test]
+#[cfg_attr(not(target_os = "macos"), ignore = "macOS-only enrichment paths")]
+fn adopt_app_support_reverse_dns_uses_cask_token_in_tip() {
+    let env = TempEnvironment::builder()
+        .home_file(
+            "Library/Application Support/com.colliderli.iina/input_conf/mine.conf",
+            "x",
+        )
+        .build();
+
+    let runner = Arc::new(CannedRunner::new());
+    runner.respond(&["brew", "list", "--cask", "--versions"], "iina 1.4.0\n", 0);
+    runner.respond(
+        &["brew", "info", "--json=v2", "--cask", "iina"],
+        r#"{"casks": [{
+            "token": "iina",
+            "artifacts": [
+                {"app": ["IINA.app"]},
+                {"zap": [{"trash": ["~/Library/Application Support/com.colliderli.iina"]}]}
+            ]
+        }]}"#,
+        0,
+    );
+    let ctx = make_ctx_with_runner(&env, runner);
+    let source = env
+        .app_support
+        .join("com.colliderli.iina/input_conf/mine.conf");
+
+    let result = commands::adopt::adopt(
+        /*pack_override=*/ None,
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    let tip = result
+        .warnings
+        .iter()
+        .find(|w| w.contains("app_aliases"))
+        .unwrap_or_else(|| panic!("expected an app_aliases tip, got: {:?}", result.warnings));
+
+    // The good outcome: tip suggests `iina` as the rename target.
+    assert!(
+        tip.contains("renaming the pack to `iina`"),
+        "expected cask-token-based rename suggestion (`iina`), got: {tip}"
+    );
+    // And explicitly NOT the whitespace-strip-lowercase fallback,
+    // which would be `comcolliderliiina` for this folder.
+    assert!(
+        !tip.contains("comcolliderliiina"),
+        "rename suggestion fell back to lowercase mangling instead of cask token: {tip}"
+    );
+    // The tip credits the cask so the user knows where the
+    // recommendation came from.
+    assert!(
+        tip.contains("matches homebrew cask"),
+        "tip should credit the cask source, got: {tip}"
+    );
+}
+
+/// When no installed cask matches the folder, the tip falls back to
+/// the original whitespace-strip-lowercase suggestion. Pins the
+/// fallback so a refactor doesn't accidentally regress the no-cask
+/// path (the heuristic still triggers on uppercase folders even when
+/// brew has nothing to say).
+#[test]
+#[cfg_attr(not(target_os = "macos"), ignore = "macOS-only enrichment paths")]
+fn adopt_app_support_falls_back_to_lowercase_when_no_cask_match() {
+    // `Tinkerbell` — uppercase enough to trigger the heuristic, but
+    // no real cask owns it, so the brew probe returns empty and the
+    // tip falls back to the lowercase suggestion.
+    let env = TempEnvironment::builder()
+        .home_file("Library/Application Support/Tinkerbell/settings.json", "{}")
+        .build();
+
+    let runner = Arc::new(CannedRunner::new());
+    runner.respond(&["brew", "list", "--cask", "--versions"], "", 0);
+    let ctx = make_ctx_with_runner(&env, runner);
+    let source = env.app_support.join("Tinkerbell/settings.json");
+
+    let result = commands::adopt::adopt(
+        None,
+        std::slice::from_ref(&source),
+        false,
+        false,
+        false,
+        &ctx,
+    )
+    .unwrap();
+
+    let tip = result
+        .warnings
+        .iter()
+        .find(|w| w.contains("app_aliases"))
+        .unwrap_or_else(|| panic!("expected an app_aliases tip, got: {:?}", result.warnings));
+
+    // Fallback suggestion: lowercased pack name (no spaces here, but
+    // the casing transformation still applies).
+    assert!(
+        tip.contains("renaming the pack to `tinkerbell`"),
+        "expected fallback rename suggestion, got: {tip}"
+    );
+    assert!(
+        !tip.contains("matches homebrew cask"),
+        "tip should not claim a cask match when none exists: {tip}"
+    );
+}
+
 /// The advisory is suppressed when the user passed `--into <pack>`:
 /// they already chose their pack name, so suggesting another one
 /// would be noise. The pack used here (`Code`) only exists to satisfy


### PR DESCRIPTION
## Summary

Follow-up to #90 / #91. When `dodot adopt` runs the M5 capitalization-heuristic tip after adopting from `~/Library/Application Support/<X>/...`, prefer the M6 brew probe's matching cask token as the rename suggestion instead of a whitespace-strip-lowercase fallback.

For reverse-DNS bundle-ID folders this is the difference between a sane suggestion and a useless one — surfaced by a real user-test case on PR #91:

| Folder | Before | After |
|---|---|---|
| `com.colliderli.iina` | `comcolliderliiina` | `iina` (matches cask `iina`) |
| `dev.warp.Warp-Stable` | `devwarpwarp-stable` | `warp` (when `dev.warp.Warp-Stable` is in cask `warp`'s zap) |
| `Code` (no installed cask) | `code` | `code` (unchanged fallback) |

The tip now credits the cask so users know where the recommendation came from. Resolver state is unaffected — this is purely a smarter user-facing string.

## Test plan

- [x] 2 new integration tests in `commands::tests`:
  - `adopt_app_support_reverse_dns_uses_cask_token_in_tip` — pins the IINA case (cask `iina` match → tip recommends `iina`, not `comcolliderliiina`).
  - `adopt_app_support_falls_back_to_lowercase_when_no_cask_match` — pins the no-cask path so refactors don't regress the fallback.
- [x] All existing M5/M6 tests still pass. Total suite: 665 (was 663).
- [x] `cargo fmt`, `cargo clippy --all-targets`, `scripts/check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)