### PR TITLE
ci: bump notarization wait to 60 min, surface submission ID on timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,7 +359,7 @@ jobs:
             fi
             sleep 30
           done
-          echo "::warning::Notarization timed out after 60 min — submission $ID still In Progress. Binary is signed but Apple has not confirmed notarization yet. Check status with: xcrun notarytool info $ID --key <p8> --key-id <id> --issuer <id>. The published binary will still pass Gatekeeper online checks once Apple finishes (online verification only — not stapled, since stapling a standalone Mach-O is not supported)."
+          echo "::warning::Notarization timed out after 60 min — submission $ID last status: $STATUS. Binary is signed but Apple has not confirmed notarization yet. Check status with: xcrun notarytool info $ID --key <p8> --key-id <id> --issuer <id>. The published binary will still pass Gatekeeper online checks once Apple finishes (online verification only — not stapled, since stapling a standalone Mach-O is not supported)."
 
       - name: Package binary
         id: package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,7 +335,11 @@ jobs:
         if: matrix.sign && steps.notarize-submit.outputs.submission-id
         run: |
           ID="${{ steps.notarize-submit.outputs.submission-id }}"
-          for i in $(seq 1 60); do
+          # 120 polls × 30s = 60 min cap. Apple's queue usually returns
+          # in under 5 min, but slow-queue days can stretch past 30 min
+          # (observed in run 25177595282). 60 min absorbs that without
+          # holding a runner forever.
+          for i in $(seq 1 120); do
             RESULT=$(xcrun notarytool info "$ID" \
               --key "$RUNNER_TEMP/AuthKey.p8" \
               --key-id "${{ secrets.ASC_API_KEY_ID }}" \
@@ -344,7 +348,7 @@ jobs:
             STATUS=$(echo "$RESULT" | python3 -c \
               "import sys,json; print(json.load(sys.stdin).get('status','Unknown'))" \
               2>/dev/null || echo "Unknown")
-            echo "  [$i/60] status=$STATUS ($(date -u +%H:%M:%S))"
+            echo "  [$i/120] status=$STATUS ($(date -u +%H:%M:%S))"
             if [ "$STATUS" = "Accepted" ]; then exit 0; fi
             if [ "$STATUS" = "Invalid" ] || [ "$STATUS" = "Rejected" ]; then
               xcrun notarytool log "$ID" \
@@ -355,7 +359,7 @@ jobs:
             fi
             sleep 30
           done
-          echo "::warning::Notarization timed out after 30 min. Binary is signed but not notarized."
+          echo "::warning::Notarization timed out after 60 min — submission $ID still In Progress. Binary is signed but Apple has not confirmed notarization yet. Check status with: xcrun notarytool info $ID --key <p8> --key-id <id> --issuer <id>. The published binary will still pass Gatekeeper online checks once Apple finishes (online verification only — not stapled, since stapling a standalone Mach-O is not supported)."
 
       - name: Package binary
         id: package

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -7,3 +7,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
 `### Removed`, `### Fixed`, `### Security`) so they nest cleanly under the
 `## [version]` heading the release workflow inserts.
+
+### Fixed
+
+- **Release notarization wait loop: 30 min → 60 min.** Apple's notary
+  service usually returns in under 5 min, but on slow-queue days it
+  can stretch past 30 min (observed during the v1.1.1 release re-run,
+  where the submission stayed `In Progress` for the full 30-min
+  window). The release workflow now polls for up to 60 min before
+  giving up, and the timeout warning includes the submission ID so the
+  result can be checked manually with `xcrun notarytool info`. Note:
+  stapling the ticket into the binary is not done — Apple's stapler
+  only supports `.app` / `.dmg` / `.pkg` containers, not standalone
+  Mach-O binaries. Direct downloads still pass Gatekeeper via online
+  verification (requires internet); Homebrew installs are unaffected
+  either way (no quarantine bit on `brew install`).


### PR DESCRIPTION
## Summary

- Doubles the notarization poll cap from 30 min to 60 min so slow-queue days at Apple's notary service don't fail the release workflow.
- Timeout warning now includes the submission ID and the exact `xcrun notarytool info` command to finish the check by hand.

## Context

The v1.1.1 release workflow tripped this timeout today. The original run (`25143351305`) succeeded in 30 seconds — Apple was responsive, status went `In Progress` → `Accepted` between polls 1 and 2, asset uploaded normally. The published v1.1.1 binary is signed and notarized; verified locally (`spctl -a -vv -t install` reports `accepted, source=Notarized Developer ID`).

A re-run later that day (`25177595282`) re-submitted the same binary and Apple sat on it for the full 30-min window. Workflow gave up; the published asset wasn't replaced (asset-exists guard on the upload step), so users are unaffected. But the failure mode logged a generic warning that dropped the submission ID, which made it hard to verify whether the slowness was on Apple's side or ours.

## Why no stapling

Considered adding `xcrun stapler staple` so binaries pass Gatekeeper offline. Apple doesn't support stapling standalone Mach-O binaries — only `.app`, `.dmg`, and `.pkg` containers. Tested locally:

```
$ xcrun stapler staple /tmp/dodot
Processing: /tmp/dodot
The staple and validate action failed! Error 73.
```

dodot ships a raw binary, so this isn't an option without changing the distribution format. Direct downloads still pass Gatekeeper via online verification (requires internet); Homebrew installs are unaffected either way (no quarantine bit on `brew install`).

## Test plan

- [ ] Next release: confirm the macOS job logs `[N/120]` instead of `[N/60]`.
- [ ] If notarization is fast (typical), behavior is unchanged — exits on `Accepted`.
- [ ] If notarization times out: warning surfaces the submission ID and the `xcrun notarytool info` command verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)