### PR TITLE
feat(plist): clean/smudge filters — proposal revision + P1 conversion engine

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,6 +8,38 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
 `### Removed`, `### Fixed`, `### Security`) so they nest cleanly under the
 `## [version]` heading the release workflow inserts.
 
+### Added
+
+- **`dodot plist clean` / `dodot plist smudge` subcommands.** A pair
+  of stdin→stdout filters that translate macOS plists between binary
+  (what apps read at `~/Library/Preferences/...`) and canonical XML
+  (what git stores in the index). They are the conversion engine for
+  the upcoming git clean/smudge integration that brings GUI-app
+  preferences under the same review/diff/cherry-pick workflow as
+  plain-text dotfiles. Canonicalisation sorts dictionary keys
+  recursively (Unicode codepoint order) while preserving array order,
+  so the same logical plist always produces byte-identical XML
+  regardless of the encoder's internal layout. Powered by the `plist`
+  Rust crate; no `plutil` dependency at runtime. The full design
+  rationale (and why plists ship as filters rather than through the
+  preprocessing pipeline) lives in `docs/proposals/plists.lex`.
+
+### Changed
+
+- **Plist proposal revised to ship via clean/smudge filters.**
+  `docs/proposals/plists.lex` was rewritten around git clean/smudge
+  filters. The earlier draft modelled plist support as a
+  Representational preprocessor under `docs/proposals/preprocessing-pipeline.lex`,
+  with reverse conversion driven by `dodot transform check` from a
+  pre-commit hook. The revision keeps the lossless binary↔XML core
+  but moves the plumbing to git's own filter machinery, because
+  plists drift continuously (apps rewrite preferences on settings
+  changes) and the pre-commit-hook approach leaves drift invisible
+  to `git status` between commits. Clean/smudge attaches the reverse
+  to every git read, making `git status` reflect drift for free.
+  `preprocessing-pipeline.lex` and `magic.lex` were updated to point
+  at the new plists.lex and to drop stale references.
+
 ### Fixed
 
 - **Release notarization wait loop: 30 min → 60 min.** Apple's notary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +680,7 @@ dependencies = [
  "flate2",
  "glob",
  "minijinja",
+ "plist",
  "serde",
  "serde_json",
  "sha2",
@@ -1400,6 +1407,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml 0.39.2",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "polling"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1501,15 @@ checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1874,7 +1903,7 @@ dependencies = [
  "csv",
  "deunicode",
  "minijinja",
- "quick-xml",
+ "quick-xml 0.36.2",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1955,7 +1984,7 @@ dependencies = [
  "deunicode",
  "minijinja",
  "once_cell",
- "quick-xml",
+ "quick-xml 0.36.2",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -357,3 +357,33 @@ pub fn init_sh_passthrough() -> Result<(), anyhow::Error> {
     print!("{script}");
     Ok(())
 }
+
+/// `dodot plist clean` — read any plist on stdin, write canonical XML on stdout.
+///
+/// Used as a git clean filter: `git add` invokes this on the working-tree
+/// binary and stores the resulting XML in the index.
+pub fn plist_clean_passthrough() -> Result<(), anyhow::Error> {
+    use std::io::{Read, Write};
+    let mut buf = Vec::new();
+    std::io::stdin().lock().read_to_end(&mut buf)?;
+    let out = dodot_lib::plists::clean(&buf)?;
+    let mut stdout = std::io::stdout().lock();
+    stdout.write_all(&out)?;
+    stdout.flush()?;
+    Ok(())
+}
+
+/// `dodot plist smudge` — read XML on stdin, write binary plist on stdout.
+///
+/// Used as a git smudge filter: `git checkout` invokes this on the indexed
+/// XML and writes the resulting binary into the working tree.
+pub fn plist_smudge_passthrough() -> Result<(), anyhow::Error> {
+    use std::io::{Read, Write};
+    let mut buf = Vec::new();
+    std::io::stdin().lock().read_to_end(&mut buf)?;
+    let out = dodot_lib::plists::smudge(&buf)?;
+    let mut stdout = std::io::stdout().lock();
+    stdout.write_all(&out)?;
+    stdout.flush()?;
+    Ok(())
+}

--- a/crates/dodot-cli/src/help.rs
+++ b/crates/dodot-cli/src/help.rs
@@ -37,6 +37,7 @@ const HELP_TEXTS: &[(&str, &str)] = &[
     ("addignore", include_str!("help/addignore.txt")),
     ("tutorial", include_str!("help/tutorial.txt")),
     ("init-sh", include_str!("help/init-sh.txt")),
+    ("plist", include_str!("help/plist.txt")),
     ("config", include_str!("help/config.txt")),
     (
         "probe.deployment-map",

--- a/crates/dodot-cli/src/help/plist.txt
+++ b/crates/dodot-cli/src/help/plist.txt
@@ -1,0 +1,43 @@
+[header]dodot plist[/header] — Plist clean/smudge filters for git.
+
+[desc]A pair of stdin→stdout filters that translate macOS plists between
+their two on-disk forms:
+
+  [dim]•[/dim] [item]binary[/item]   — what apps read at [item]~/Library/Preferences/...[/item]
+  [dim]•[/dim] [item]canonical XML[/item] — what git stores in the index
+
+[item]dodot plist clean[/item] reads any plist on stdin and emits canonical XML on
+stdout: dictionary keys sorted recursively, byte-stable formatting.
+This is the [item]clean filter[/item] direction (working tree → index).
+
+[item]dodot plist smudge[/item] reads XML on stdin and emits a binary plist on
+stdout. This is the [item]smudge filter[/item] direction (index → working tree).
+
+You normally do not invoke these by hand. They are wired into git
+via [item].gitattributes[/item] + [item].git/config[/item]; see [item]docs/proposals/plists.lex[/item]
+§5 for the install flow.[/desc]
+
+[header]USAGE[/header]
+  [usage]dodot plist clean   < binary.plist > canonical.xml[/usage]
+  [usage]dodot plist smudge  < canonical.xml > binary.plist[/usage]
+
+[header]GIT CONFIG[/header]
+  [desc]The filter binding lives in two places. [item].gitattributes[/item] (committed
+  with the repo) attaches the filter to plist files:
+
+    [example]*.plist filter=dodot-plist[/example]
+
+  [item].git/config[/item] (per-clone, per-machine) registers the filter binary:
+
+    [example][filter "dodot-plist"]
+        clean  = dodot plist clean
+        smudge = dodot plist smudge
+        required = true[/example][/desc]
+
+[header]EXAMPLES[/header]
+  [example]plutil -convert binary1 -o - foo.xml | dodot plist clean   [dim]# canonicalise[/dim]
+  dodot plist smudge < foo.xml > foo.plist                       [dim]# render binary[/dim][/example]
+
+[header]SEE ALSO[/header]
+  [item]docs/proposals/plists.lex[/item]   [desc]Architecture and rationale[/desc]
+  [item]docs/proposals/magic.lex[/item]    [desc]The broader clean/smudge story[/desc]

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -29,6 +29,33 @@ fn main() {
     // parse_with handles help rendering (with command groups) and exits if help requested
     let matches = app.parse_with(build_clap_command());
 
+    // Passthrough: plist clean/smudge (git filter binary stdin/stdout).
+    // Dispatched BEFORE logging::init so git filters — which fire on
+    // every `git status` / `git diff` / `git add` — don't pay for
+    // log-dir creation, rotation, and the file-handle guard on every
+    // invocation. These filters also must bypass standout entirely —
+    // smudge emits binary plist bytes, and any extra logging on stdout
+    // would corrupt the filter output git stages or checks out.
+    if let Some(("plist", sub)) = matches.subcommand() {
+        let result = match sub.subcommand_name() {
+            Some("clean") => handlers::plist_clean_passthrough(),
+            Some("smudge") => handlers::plist_smudge_passthrough(),
+            _ => {
+                let _ = build_clap_command()
+                    .find_subcommand("plist")
+                    .cloned()
+                    .map(|mut c| c.print_help());
+                println!();
+                return;
+            }
+        };
+        if let Err(e) = result {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
     // Initialize logging based on CLI flags
     let verbosity = if matches.get_flag("debug") {
         logging::Verbosity::Debug
@@ -68,30 +95,6 @@ fn main() {
     // Passthrough: init-sh (raw stdout for shell eval)
     if matches.subcommand_matches("init-sh").is_some() {
         if let Err(e) = handlers::init_sh_passthrough() {
-            eprintln!("error: {e}");
-            std::process::exit(1);
-        }
-        return;
-    }
-
-    // Passthrough: plist clean/smudge (git filter binary stdin/stdout).
-    // These must bypass standout entirely — smudge emits binary plist
-    // bytes, and any extra logging on stdout would corrupt the filter
-    // output git stages or checks out.
-    if let Some(("plist", sub)) = matches.subcommand() {
-        let result = match sub.subcommand_name() {
-            Some("clean") => handlers::plist_clean_passthrough(),
-            Some("smudge") => handlers::plist_smudge_passthrough(),
-            _ => {
-                let _ = build_clap_command()
-                    .find_subcommand("plist")
-                    .cloned()
-                    .map(|mut c| c.print_help());
-                println!();
-                return;
-            }
-        };
-        if let Err(e) = result {
             eprintln!("error: {e}");
             std::process::exit(1);
         }

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -74,6 +74,30 @@ fn main() {
         return;
     }
 
+    // Passthrough: plist clean/smudge (git filter binary stdin/stdout).
+    // These must bypass standout entirely — smudge emits binary plist
+    // bytes, and any extra logging on stdout would corrupt the filter
+    // output git stages or checks out.
+    if let Some(("plist", sub)) = matches.subcommand() {
+        let result = match sub.subcommand_name() {
+            Some("clean") => handlers::plist_clean_passthrough(),
+            Some("smudge") => handlers::plist_smudge_passthrough(),
+            _ => {
+                let _ = build_clap_command()
+                    .find_subcommand("plist")
+                    .cloned()
+                    .map(|mut c| c.print_help());
+                println!();
+                return;
+            }
+        };
+        if let Err(e) = result {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
     // Passthrough: tutorial (interactive — multiple prompts and outputs,
     // doesn't fit standout's one-shot render-and-print dispatch).
     if let Some(("tutorial", sub)) = matches.subcommand() {
@@ -218,6 +242,7 @@ fn build_app() -> App {
                 commands: vec![
                     Some("tutorial".into()),
                     Some("init-sh".into()),
+                    Some("plist".into()),
                     Some("config".into()),
                     Some("help".into()),
                 ],
@@ -399,6 +424,20 @@ fn build_clap_command() -> ClapCommand {
         )
         .subcommand(
             ClapCommand::new("init-sh").about("Print shell init script for eval in .zshrc/.bashrc"),
+        )
+        .subcommand(
+            ClapCommand::new("plist")
+                .about("Plist clean/smudge filters (stdin → stdout)")
+                .subcommand_required(true)
+                .arg_required_else_help(true)
+                .subcommand(
+                    ClapCommand::new("clean")
+                        .about("Convert any plist on stdin to canonical XML on stdout"),
+                )
+                .subcommand(
+                    ClapCommand::new("smudge")
+                        .about("Convert XML plist on stdin to binary plist on stdout"),
+                ),
         )
         .subcommand(
             ClapCommand::new("tutorial")

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -12,6 +12,7 @@ confique = "0.4"
 flate2 = "1"
 glob = "0.3"
 minijinja = "2"
+plist = "1.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/dodot-lib/src/lib.rs
+++ b/crates/dodot-lib/src/lib.rs
@@ -10,6 +10,7 @@ pub mod handlers;
 pub mod operations;
 pub mod packs;
 pub mod paths;
+pub mod plists;
 pub mod preprocessing;
 pub mod probe;
 pub mod render;

--- a/crates/dodot-lib/src/plists/mod.rs
+++ b/crates/dodot-lib/src/plists/mod.rs
@@ -26,14 +26,30 @@ pub fn clean(input: &[u8]) -> Result<Vec<u8>> {
     let mut value = Value::from_reader(Cursor::new(input)).map_err(plist_err)?;
     sort_keys_recursive(&mut value);
 
-    let mut out = Vec::with_capacity(input.len());
+    let mut raw = Vec::with_capacity(input.len());
     value
-        .to_writer_xml_with_options(&mut out, &XmlWriteOptions::default())
+        .to_writer_xml_with_options(&mut raw, &XmlWriteOptions::default())
         .map_err(plist_err)?;
 
-    // The crate emits trailing CRLFs in places; we want LF-only canonical
-    // output. quick-xml's writer already uses LF, but we make the contract
-    // explicit by ending the file with a single newline.
+    // Canonical output uses LF only. The current `plist`/quick-xml stack
+    // emits LF, but we don't want determinism to depend on upstream
+    // behaviour: normalise any CRLF or lone CR to LF, then ensure a
+    // single trailing LF. One pass, no allocation beyond the output.
+    let mut out = Vec::with_capacity(raw.len() + 1);
+    let mut i = 0;
+    while i < raw.len() {
+        let b = raw[i];
+        if b == b'\r' {
+            out.push(b'\n');
+            // Skip the following LF if this was a CRLF pair.
+            if raw.get(i + 1) == Some(&b'\n') {
+                i += 1;
+            }
+        } else {
+            out.push(b);
+        }
+        i += 1;
+    }
     if !out.ends_with(b"\n") {
         out.push(b'\n');
     }
@@ -245,6 +261,21 @@ mod tests {
     fn clean_emits_trailing_newline() {
         let xml = clean(UNSORTED_XML.as_bytes()).expect("clean");
         assert_eq!(xml.last().copied(), Some(b'\n'), "must end with LF");
+    }
+
+    #[test]
+    fn clean_output_contains_no_carriage_returns() {
+        // Whatever the underlying serialiser does, our output must be
+        // LF-only. Feeding CRLF-rich input also exercises the parser.
+        let crlf_xml = UNSORTED_XML.replace('\n', "\r\n");
+        let xml = clean(crlf_xml.as_bytes()).expect("clean");
+        assert!(
+            !xml.contains(&b'\r'),
+            "clean output must contain no CR bytes"
+        );
+        // And the canonical output is identical to the LF-input case.
+        let lf_xml = clean(UNSORTED_XML.as_bytes()).expect("clean lf");
+        assert_eq!(xml, lf_xml, "CRLF and LF inputs must produce same output");
     }
 
     #[test]

--- a/crates/dodot-lib/src/plists/mod.rs
+++ b/crates/dodot-lib/src/plists/mod.rs
@@ -1,0 +1,261 @@
+//! Plist binary↔XML conversion for git clean/smudge filters.
+//!
+//! Two operations:
+//!
+//! - [`clean`] reads any plist (binary or XML) and emits canonical XML —
+//!   dictionary keys sorted recursively, deterministic formatting. This
+//!   is what git stores in the index.
+//! - [`smudge`] reads XML and emits binary. This is what the working
+//!   tree holds and what apps read at `~/Library/Preferences/...`.
+//!
+//! See `docs/proposals/plists.lex` for the architectural rationale.
+
+use std::io::Cursor;
+
+use plist::{Value, XmlWriteOptions};
+
+use crate::{DodotError, Result};
+
+/// Clean filter: parse any plist representation, canonicalise key order,
+/// emit XML.
+///
+/// Determinism is the contract: the same logical plist must produce
+/// byte-identical XML across runs, regardless of whether the source was
+/// binary or XML and regardless of the encoder's internal key order.
+pub fn clean(input: &[u8]) -> Result<Vec<u8>> {
+    let mut value = Value::from_reader(Cursor::new(input)).map_err(plist_err)?;
+    sort_keys_recursive(&mut value);
+
+    let mut out = Vec::with_capacity(input.len());
+    value
+        .to_writer_xml_with_options(&mut out, &XmlWriteOptions::default())
+        .map_err(plist_err)?;
+
+    // The crate emits trailing CRLFs in places; we want LF-only canonical
+    // output. quick-xml's writer already uses LF, but we make the contract
+    // explicit by ending the file with a single newline.
+    if !out.ends_with(b"\n") {
+        out.push(b'\n');
+    }
+    Ok(out)
+}
+
+/// Smudge filter: parse XML, emit binary.
+///
+/// Accepts XML input (the index form). Output is the binary plist that
+/// macOS apps read.
+pub fn smudge(input: &[u8]) -> Result<Vec<u8>> {
+    let value = Value::from_reader_xml(Cursor::new(input)).map_err(plist_err)?;
+    let mut out = Vec::new();
+    value.to_writer_binary(&mut out).map_err(plist_err)?;
+    Ok(out)
+}
+
+/// Recursively sort dictionary keys at every level of a plist value tree.
+///
+/// Arrays are walked into (their elements may contain dicts) but their
+/// own ordering is preserved — array order is semantically meaningful in
+/// plists (e.g. `LSHandlers`, recent-files lists, ordered toolbar items).
+fn sort_keys_recursive(value: &mut Value) {
+    match value {
+        Value::Dictionary(dict) => {
+            dict.sort_keys();
+            for (_, v) in dict.iter_mut() {
+                sort_keys_recursive(v);
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                sort_keys_recursive(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn plist_err(e: plist::Error) -> DodotError {
+    DodotError::Other(format!("plist conversion failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal XML plist with two keys in non-alphabetical order.
+    const UNSORTED_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>zebra</key>
+	<string>last</string>
+	<key>apple</key>
+	<string>first</string>
+</dict>
+</plist>"#;
+
+    #[test]
+    fn clean_sorts_top_level_keys() {
+        let xml = clean(UNSORTED_XML.as_bytes()).expect("clean");
+        let xml_str = std::str::from_utf8(&xml).expect("utf8");
+        let apple_pos = xml_str.find("apple").expect("apple key present");
+        let zebra_pos = xml_str.find("zebra").expect("zebra key present");
+        assert!(
+            apple_pos < zebra_pos,
+            "expected `apple` to appear before `zebra` after canonicalisation, got:\n{xml_str}"
+        );
+    }
+
+    #[test]
+    fn clean_sorts_nested_dict_keys() {
+        let nested = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>outer</key>
+	<dict>
+		<key>z_inner</key>
+		<string>last</string>
+		<key>a_inner</key>
+		<string>first</string>
+	</dict>
+</dict>
+</plist>"#;
+        let xml = clean(nested.as_bytes()).expect("clean");
+        let xml_str = std::str::from_utf8(&xml).expect("utf8");
+        let a_pos = xml_str.find("a_inner").expect("a_inner present");
+        let z_pos = xml_str.find("z_inner").expect("z_inner present");
+        assert!(
+            a_pos < z_pos,
+            "nested dict keys should be sorted, got:\n{xml_str}"
+        );
+    }
+
+    #[test]
+    fn clean_preserves_array_order() {
+        let arr_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<string>third</string>
+	<string>first</string>
+	<string>second</string>
+</array>
+</plist>"#;
+        let xml = clean(arr_xml.as_bytes()).expect("clean");
+        let xml_str = std::str::from_utf8(&xml).expect("utf8");
+        let third = xml_str.find("third").expect("third");
+        let first = xml_str.find("first").expect("first");
+        let second = xml_str.find("second").expect("second");
+        assert!(
+            third < first && first < second,
+            "array order must be preserved, got:\n{xml_str}"
+        );
+    }
+
+    #[test]
+    fn smudge_then_clean_roundtrips_to_canonical_xml() {
+        let canonical = clean(UNSORTED_XML.as_bytes()).expect("first clean");
+        let binary = smudge(&canonical).expect("smudge");
+        let back = clean(&binary).expect("second clean");
+        assert_eq!(
+            canonical, back,
+            "binary→clean must reproduce the canonical XML"
+        );
+    }
+
+    /// The contract test from §4.3 of the proposal: binary→clean→smudge→clean
+    /// must produce identical XML across runs.
+    #[test]
+    fn determinism_property_test() {
+        // Start from a plist with deliberately unstable encoder ordering.
+        let canonical = clean(UNSORTED_XML.as_bytes()).expect("clean 1");
+
+        // Round-trip several times. If anything is non-deterministic
+        // (HashMap iteration, etc.), divergence shows up here.
+        let mut current = canonical.clone();
+        for i in 0..5 {
+            let binary = smudge(&current).unwrap_or_else(|e| panic!("smudge iter {i}: {e}"));
+            let xml = clean(&binary).unwrap_or_else(|e| panic!("clean iter {i}: {e}"));
+            assert_eq!(
+                canonical, xml,
+                "round-trip {i} diverged from canonical form"
+            );
+            current = xml;
+        }
+    }
+
+    #[test]
+    fn clean_accepts_binary_input() {
+        // Build canonical XML, convert to binary, ensure clean accepts it.
+        let canonical = clean(UNSORTED_XML.as_bytes()).expect("clean");
+        let binary = smudge(&canonical).expect("smudge");
+        let from_binary = clean(&binary).expect("clean from binary");
+        assert_eq!(canonical, from_binary);
+    }
+
+    #[test]
+    fn clean_handles_mixed_value_types() {
+        let mixed = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>string_key</key>
+	<string>hello</string>
+	<key>int_key</key>
+	<integer>42</integer>
+	<key>bool_key</key>
+	<true/>
+	<key>real_key</key>
+	<real>3.14</real>
+	<key>arr_key</key>
+	<array>
+		<string>a</string>
+		<dict>
+			<key>z</key>
+			<string>z</string>
+			<key>a</key>
+			<string>a</string>
+		</dict>
+	</array>
+</dict>
+</plist>"#;
+        let xml = clean(mixed.as_bytes()).expect("clean");
+        let xml_str = std::str::from_utf8(&xml).expect("utf8");
+
+        // Top-level keys sorted: arr_key, bool_key, int_key, real_key, string_key.
+        let positions = ["arr_key", "bool_key", "int_key", "real_key", "string_key"]
+            .iter()
+            .map(|k| xml_str.find(k).unwrap_or_else(|| panic!("missing {k}")))
+            .collect::<Vec<_>>();
+        assert!(
+            positions.windows(2).all(|w| w[0] < w[1]),
+            "top-level keys not sorted, got:\n{xml_str}"
+        );
+
+        // Nested dict in array: a before z.
+        let a_inner = xml_str.rfind(">a<").expect("inner a");
+        let z_inner = xml_str.rfind(">z<").expect("inner z");
+        assert!(
+            a_inner < z_inner,
+            "nested dict keys not sorted in array element"
+        );
+    }
+
+    #[test]
+    fn clean_emits_trailing_newline() {
+        let xml = clean(UNSORTED_XML.as_bytes()).expect("clean");
+        assert_eq!(xml.last().copied(), Some(b'\n'), "must end with LF");
+    }
+
+    #[test]
+    fn smudge_rejects_garbage_input() {
+        let bad = b"not actually XML at all";
+        assert!(smudge(bad).is_err(), "smudge should reject non-XML input");
+    }
+
+    #[test]
+    fn clean_rejects_garbage_input() {
+        let bad = b"\x00\x01\x02neither binary nor XML";
+        assert!(clean(bad).is_err(), "clean should reject non-plist garbage");
+    }
+}

--- a/docs/proposals/magic.lex
+++ b/docs/proposals/magic.lex
@@ -34,7 +34,7 @@ This is a revised version of an earlier draft. Two things changed our thinking. 
     4.1. Representational Transformations
 
         For perfectly revertible transforms, clean and smudge filters are all you need. They can deterministically describe their files, and hence produce correct `git diff` and `git status` output with no ambiguity.
-        Plists are the canonical example: `plutil -convert xml1` and `plutil -convert binary1` round-trip losslessly. Git stores the XML (canonical, diffable); the working tree holds the binary (what the application actually reads). The clean filter converts binary → XML on `git add`; the smudge filter converts XML → binary on `git checkout`. The user never sees the transform happen; `git diff` shows a sensible XML diff of what is otherwise a binary file.
+        Plists are the canonical example: XML and binary round-trip losslessly via the `plist` Rust crate (with recursive dict-key sort applied for byte-stable output). Git stores the canonical XML (diffable); the working tree holds the binary (what the application actually reads). The clean filter converts binary → XML on `git add`; the smudge filter converts XML → binary on `git checkout`. The user never sees the transform happen; `git diff` shows a sensible XML diff of what is otherwise a binary file. The full design lives in [./plists.lex].
         This case is clean, low-risk, and high-value. It's also logically independent of the rest of this proposal, so we plan to ship it on its own track.
 
     4.2. Generative Transformations
@@ -162,7 +162,7 @@ The User Experience
         Ship the preprocessing pipeline, the baseline cache (including the tracked-render field), burgertocow integration, `dodot transform check`, and the pre-commit hook (tier 1 above). At this point, users who adopt preprocessors get correct template-space diffs at commit time with no filter installed. This is the minimum viable magic.
 
     Phase 2: plist clean/smudge.
-        Ship plist support as an independent track — clean/smudge filters for `plutil` conversion, with their own install flow. Doesn't depend on anything in phase 1; can ship in parallel.
+        Ship plist support as an independent track — clean/smudge filters for binary↔canonical-XML conversion (via the `plist` crate, with recursive key sorting), with their own install flow shared with phase 3. Doesn't depend on anything in phase 1; can ship in parallel. Full spec in [./plists.lex].
 
     Phase 3: the template clean filter.
         Layer the clean filter on top of the phase-1 cache. This is the thin wrapper: hash-compare, fast-path, burgertocow on the slow path. The commit-time gate from phase 1 handles conflict markers. Opt-in filter install (the Y/n prompt on first deploy).

--- a/docs/proposals/plists.lex
+++ b/docs/proposals/plists.lex
@@ -1,6 +1,6 @@
 Design Specification: macOS Plist Support
 
-    This document specifies how dodot manages macOS property list (plist) files. It is a concrete implementation of a Representational (Two-Way) transformation as defined in the Preprocessing Pipeline design [./preprocessing-pipeline.lex].
+    This document specifies how dodot manages macOS property list (plist) files. Plist support is implemented as a pair of git clean/smudge filters — the architecture sketched as Phase 2 of the Magical Git Experience [./magic.lex]. It is *not* a preprocessor in the sense of [./preprocessing-pipeline.lex], and intentionally so: the trade-offs that make the pipeline-and-pre-commit-hook approach right for templates make it the wrong shape for plists. The reasoning is in §2.
 
     Plists are where macOS GUI applications store their preferences. Bringing them under dodot's control means a dotfiles repo can carry not just shell and config-file state but also GUI-app state — Finder settings, Terminal profile, Xcode preferences, per-app panes — and still deliver the review/diff/cherry-pick/revert workflow users expect from plain-text dotfiles.
 
@@ -26,179 +26,326 @@ Design Specification: macOS Plist Support
 
         The dotfiles repo becomes a backup, not a history.
 
-    1.3. The Goal
+    1.3. Apps Drift Continuously
+
+        Unlike templates — where the user has a single explicit editing moment ("I opened `config.toml.tmpl` in vim") — plists drift continuously and silently. macOS apps rewrite preferences on settings changes, on quit, sometimes on launch. A plist that was clean five minutes ago can be dirty now, with no user-visible action.
+
+        This shapes the right architecture. Whatever mechanism surfaces drift back to git must do so passively, on every `git status`, not only at commit time. Otherwise users will go days or weeks unaware that their committed source is stale.
+
+    1.4. The Goal
 
         Bring macOS GUI app settings under the same discipline as plain-text dotfiles:
 
-            - Source-controlled form: human-readable XML
+            - Source-controlled form: human-readable XML, with a canonical key ordering so diffs reflect *settings* changes, not encoder noise
             - Deployed form: binary at the location the app expects
             - User interaction: edit through the normal macOS UI, or edit the XML directly
-            - Git history: a meaningful record of which settings changed, when, and why
+            - Drift visibility: `git status` and `git diff` reflect the truth at all times, with no dodot-specific commands required
 
-        The user treats plists like any other dotfile. The preprocessing pipeline handles the format juggle.
+2. Architecture: Clean/Smudge Filters
 
-2. Pipeline Classification
+    2.1. The Mechanism
 
-    2.1. Representational Transform
+        Plist support uses git's native `clean` and `smudge` filter machinery. The relationship between the working tree, the git index, and the deployed location is:
 
-        Plist conversion is a Representational (Two-Way) transform per preprocessing-pipeline.lex section 2.2:
+        Layout:
 
-            - XML and binary are different representations of the same data
-            - `plutil` converts losslessly in both directions
-            - The reverse path is exact: no heuristics, no ambiguity, no user-facing conflict markers
+            <pack>/<x>.plist                  # working tree: BINARY (what apps read)
+            git index entry for <x>.plist     # canonical XML (what `git diff` shows)
+            ~/Library/Preferences/<x>.plist   # symlink → <pack>/<x>.plist
 
-        This is the cleanest preprocessor case. Contrast with template expansion, where reverse-merge requires heuristics because the transform is generative and loses information.
+        :: text ::
 
-    2.2. Source of Truth
+        The working-tree file is the binary. The deployed file is the same binary, reached via a normal dodot symlink. The XML form exists only inside git's object database, materialised by the clean filter on `git add` / `git status` / `git diff`, and rematerialised as a binary by the smudge filter on `git checkout`.
 
-        Unlike templates — where the `.tmpl` in the repo is the authoritative source — plists have a split source of truth:
+        Filter behaviour:
 
-        The live binary at `~/Library/Preferences/...`:
-            Authoritative during use. Apps modify it continuously (window positions, recent files, last-used tabs, as well as user-meaningful settings).
+            clean   (binary -> canonical XML):  invoked when git reads a working-tree file for staging or comparison
+            smudge  (XML -> binary):            invoked when git writes a working-tree file from the index
 
-        The XML in the repo:
-            Git-friendly mirror. Canonical only at commit time.
+        :: text ::
 
-        This matters operationally: dodot cannot assume the repo is always up-to-date. `dodot transform check` before each commit is what reconciles the two.
+    2.2. Why This Shape
+
+        Clean/smudge is uniquely suited to representational transforms whose reverse path is lossless and deterministic. Plists check both boxes:
+
+            - `plutil` (and the `plist` Rust crate) round-trip XML and binary without information loss.
+            - With canonical key ordering applied (§4), the reverse output is byte-stable: the same binary always produces the same XML.
+
+        This combination is what unlocks "git status tells the truth for free." When the app writes the deployed binary, the working-tree file's mtime updates. Git's next `status` invokes the clean filter, gets fresh canonical XML, compares against the index, and reports the diff. No dodot command runs. No pre-commit hook is required for visibility.
+
+    2.3. Why Not the Preprocessing Pipeline
+
+        An earlier draft of this document specified plist support as a Representational preprocessor under [./preprocessing-pipeline.lex], with reverse conversion driven by `dodot transform check` invoked from a pre-commit hook. That approach was sound for uniformity with templates, but wrong for plists in three ways:
+
+            1. **Drift visibility lag.** A pre-commit hook only fires when the user runs `git commit`. Between commits, `git status` says clean even when the deployed binary has been rewritten by the app. Given §1.3, this gap can stretch to days. Clean/smudge closes it.
+            2. **Architectural overkill.** The pipeline's reverse-merge framework exists to handle generative transforms with ambiguous reversal (templates with conflict markers, secret-line sidecars). Plists need none of that — the reverse is exact. Routing them through the pipeline imports machinery they will never exercise.
+            3. **Extra files for no benefit.** The pipeline model puts the rendered binary in the datastore (`<state>/dodot/packs/<pack>/symlink/<x>.plist`) and the source XML in the pack. That is three on-disk artefacts per plist. The clean/smudge model has two: pack working-tree binary and the deployed symlink. The datastore is unused.
+
+        Templates still belong in the pipeline. Their reverse is generative, their rendering can touch secret-providers (auth-fatigue under clean/smudge would be hostile), and their reverse-merge needs human review. Plists have none of those properties; they're the textbook clean/smudge case.
+
+    2.4. The Working-Tree-Binary Trade-Off
+
+        The cost of this architecture, stated plainly: the file in the pack is binary. `cat pack/com.app.plist` shows noise. A user editing the pack directly with an editor will see binary garbage.
+
+        What is *not* lost:
+
+            - `git diff`, `git show <ref>:<path>`, `git log -p` all show XML — that is what git stores.
+            - `git status` shows whether the binary differs from the canonical XML in the index.
+            - PR reviews show XML diffs.
+            - The user authors plists by editing through the app's normal GUI, or by editing the deployed file with a plist editor — they almost never want to hand-edit the file in the pack.
+
+        For users who do want a hand-editable XML in the pack, the recommended workflow is `plutil -convert xml1 pack/com.app.plist`, edit, `plutil -convert binary1 pack/com.app.plist`. dodot does not ship a sugar command for this; it's a one-liner against `plutil`, and surfacing it as a dodot command would imply a workflow that should remain rare.
 
 3. Engine
 
-    3.1. plutil
+    3.1. The `plist` Rust Crate
 
-        `plutil` ships with macOS; no external dependency. Two invocations cover the pipeline:
+        Format conversion uses the `plist` crate (https://crates.io/crates/plist). It parses both XML and binary plists and re-serialises in either format from the same in-memory representation. This is the only third-party dependency needed for the conversion path; `plutil` is not required at runtime.
 
-            plutil -convert binary1 -o - <path>   # XML -> binary  (forward, for dodot up)
-            plutil -convert xml1 -o - <path>      # binary -> XML  (reverse, for transform check)
+        Why not shell out to `plutil`:
 
-        Both operations are lossless and deterministic. dodot shells out; no Rust-native plist library is required.
+            - `plutil` has no flag to canonicalise key order. Sorting (§4) needs to happen between parse and serialise, which means an in-process AST regardless. Once the AST is in process, calling `plutil` adds a subprocess for nothing.
+            - The `plist` crate works on every platform. `plutil` is macOS-only. Tests can run on Linux CI; Linux machines that happen to have plists in a synced repo can still smudge them.
+            - One code path for both directions is simpler than mixing subprocess and library calls.
 
-    3.2. Platform Gating
+        `plutil` remains useful as a debugging tool the user invokes by hand. dodot does not depend on it.
 
-        The plist preprocessor is active only on macOS. On other platforms its `matches_file()` returns false and `expand()` is never called. The preprocessor is still registered (for config consistency and for test coverage via a mock plutil CommandRunner) but contributes nothing to non-macOS deployments.
+    3.2. Filter Subcommands
 
-4. Deployment Flow
+        The clean and smudge filters are exposed as two thin subcommands on the dodot CLI:
 
-    4.1. Forward: `dodot up`
+            dodot plist clean   # stdin: binary,  stdout: canonical XML
+            dodot plist smudge  # stdin: XML,     stdout: binary
 
-        Standard preprocessing pipeline flow (preprocessing-pipeline.lex section 3.1):
+        :: text ::
 
-            1. Scan identifies `com.app.plist.xml` in a pack
-            2. The plist preprocessor strips `.xml`: expanded filename is `com.app.plist`
-            3. `expand()` invokes `plutil -convert binary1` on the XML source
-            4. Binary output is written to the datastore as a regular file
-            5. Virtual RuleMatch for `com.app.plist` enters the normal pipeline
-            6. The symlink handler links it into the destination (e.g., `~/Library/Preferences/com.app.plist`)
+        Both read from stdin and write to stdout, the contract git's filter mechanism expects. Both are pure functions of their input — no environment, no config, no filesystem access — which makes them trivially testable and safe to run in arbitrary git contexts (rebase, cherry-pick, archive, etc.).
 
-        The app sees a normal binary plist at its expected location.
+4. Canonical XML Form
 
-    4.2. Reverse: `dodot transform check`
+    A representational transform that produces non-deterministic output is useless: every `git status` would invent a diff. The clean filter must emit byte-stable XML for any given binary input.
 
-        Because the transform is Representational, reverse is automatic:
+    4.1. Sources of Non-Determinism
 
-            1. Divergence detection finds that the deployed binary's hash differs from the baseline
-            2. The preprocessor's `contract()` invokes `plutil -convert xml1` on the deployed binary
-            3. The resulting XML overwrites the source file in the working tree
-            4. `dodot transform check` reports what changed and (as a pre-commit hook) blocks the commit so the user can review the updated XML
+        Three things can shuffle on round-trip if not actively controlled:
 
-        No conflict markers are ever produced. The reverse is exact, so any deployed state can be round-tripped back to a committable XML form.
+            - **Top-level dictionary key order.** Binary plists store dict keys in encoder-defined order. macOS rewrites can shuffle keys with no semantic change.
+            - **Nested dictionary key order.** Same problem, recursively.
+            - **Whitespace and serialiser quirks.** Indent width, trailing newlines, attribute ordering on tags.
 
-    4.3. cfprefsd Considerations
+        Arrays are *not* a source of non-determinism. Array order is semantically meaningful in plists — `LSHandlers`, ordered toolbar items, recent-files lists — and must be preserved verbatim.
 
-        macOS's `cfprefsd` caches plist values in memory. Writing directly to the file on disk — as dodot does via symlink — may not be picked up by a running app until cfprefsd is restarted or the app re-reads its preferences.
+    4.2. Canonicalisation Rules
 
-        Baseline behavior: document the caveat and let the user run `killall cfprefsd` when immediate visibility is required. A future extension may opt into `defaults import <domain> <file>` for deployments where bundle-id to file mapping is unambiguous, which goes through the proper APIs and invalidates the cache correctly.
+        The clean filter applies, in order:
 
-5. Git Integration
+            1. Parse binary input via the `plist` crate.
+            2. Walk the AST. For every `Dictionary` node (top-level or nested), sort its entries by key, lexicographically (Unicode codepoint order, stable).
+            3. Re-serialise as XML with fixed formatting: tab indent, LF line endings, no trailing whitespace, no XML declaration variation.
+            4. Emit on stdout.
 
-    5.1. Shared Mechanism With Template Expansion
+        Arrays are walked into (their elements may contain dicts that need sorting) but their own order is preserved.
 
-        Plist support reuses the git-integration layer specified in Template Expansion [./template-expansion.lex]:
+        The smudge filter is the inverse and does not need to canonicalise — XML in, binary out, any valid XML accepted.
 
-            - `dodot transform install-hook` installs a pre-commit hook that calls `dodot transform check` before every commit
-            - `dodot transform check` iterates over all preprocessed files and invokes the appropriate reverse behavior per transform type
-            - The user's git workflow is unchanged: `git add`, `git commit`, and the hook keeps XML sources in sync with whatever the apps wrote to the deployed binaries
+    4.3. Determinism Test
 
-        One setup step enables both templates and plists. A mixed dotfiles repo gets the same ergonomics for both.
+        A round-trip test (binary → clean → smudge → clean) must produce the same XML twice. This is the simplest property test that catches every form of non-determinism in one shot, and is wired into the unit suite from day one.
 
-    5.2. What's Simpler Than Template Expansion
+5. Filter Installation
 
-        Where template expansion's pre-commit behavior runs heuristics (static-vs-dynamic line classification, conflict-marker insertion, user review), plist's pre-commit behavior is a direct conversion:
+    Filters live in `.git/config` and `.gitattributes`. Splitting responsibility:
 
-            - No line-level reasoning
-            - No user-facing conflicts
-            - No `no_reverse` opt-out needed
+    5.1. `.gitattributes` (in the repo)
 
-        The entire Phase-2 reverse-merge framework from template expansion collapses to one `plutil -convert xml1` call per diverged file. This is the payoff of being a Representational transform: the "magic" that makes the user experience seamless is cheap to implement because the math is on our side.
+        The dotfiles repo carries a `.gitattributes` entry binding `*.plist` files to the `dodot-plist` filter:
 
-6. Adopt Flow
+            *.plist filter=dodot-plist
 
-    A user with existing settings in `~/Library/Preferences/com.app.plist` brings them into dodot via the existing adopt command, extended to recognize binary plists:
+        :: text ::
 
-        dodot adopt <pack> ~/Library/Preferences/com.app.plist
+        This file is committed and travels with the repo. Every clone gets the binding for free. Without the matching `filter.dodot-plist.*` entries in `.git/config`, however, git falls back to the identity filter (no transform) — so `.gitattributes` alone is harmless but inert.
 
-    The extended adopt:
+    5.2. `.git/config` (per clone, per machine)
 
-        1. Reads the existing binary
-        2. Invokes `plutil -convert xml1` to produce XML
-        3. Writes `<pack>/com.app.plist.xml` into the dotfiles repo
-        4. Moves the binary into the datastore and creates the symlink back to `~/Library/Preferences/` (standard adopt behavior)
+        The active filter is registered in the local `.git/config`:
 
-        From then on, the file participates in the normal pipeline: XML in git, binary deployed, round-trip via `transform check`.
+            [filter "dodot-plist"]
+                clean  = dodot plist clean
+                smudge = dodot plist smudge
+                required = true
 
-7. Configuration
+        :: text ::
 
-    7.1. Schema
+        `required = true` means git aborts loudly if the filter binary is missing or fails — preferable to silently storing or checking out the wrong representation.
 
-        [preprocessor.plist]
-        enabled = true                        # default true on macOS, false elsewhere
-        extensions = ["plist.xml"]            # only files ending in .plist.xml are preprocessed
+    5.3. The Install Flow
 
-    7.2. Inheritance
+        Filter registration is a one-time, per-clone, per-machine step. dodot exposes:
 
-        Follows the 3-layer hierarchy (compiled defaults < root .dodot.toml < pack .dodot.toml) like all dodot configuration. A pack that contains no plists can set `[preprocessor.plist] enabled = false` to skip the preprocessor entirely for that pack.
+            dodot git-install-filters     # writes the [filter "dodot-plist"] block to .git/config
+            dodot git-show-filters        # prints what would be written, for inspection or manual install
 
-8. User Workflow
+        :: text ::
 
-    8.1. First-time Setup
+        On the first `dodot up` of a pack containing `*.plist` files, dodot checks whether the filter is registered. If not, it prompts:
 
-        1. User drops `com.app.plist.xml` into a pack (or runs `dodot adopt`)
-        2. `dodot up` converts XML to binary and deploys
-        3. `dodot transform install-hook` installs the pre-commit hook
-        4. The app runs normally, modifying the binary live
+            dodot detected plist files in pack `mac-defaults`.
+            Plist support uses git filters to keep the source diffable.
+            Install filters now? [Y/n/show]
 
-    8.2. Day-to-day
+              y    run `dodot git-install-filters`
+              n    skip (and ask again next time)
+              show print the config block for manual install
 
-        User runs normal git commands. Before each commit the hook runs `dodot transform check`, which reverse-converts any divergent plists. The XML changes are included in the commit and `git diff` shows a readable diff of what settings moved.
+        :: text ::
 
-    8.3. Cross-machine Sync
+        One Y/n per machine. The `magic.lex` document specifies the same install flow as the entry point for templates' Phase 3 clean filter; both reuse this command, so a user who has done the prompt once is set up for both.
+
+    5.4. Filter Discovery
+
+        `dodot plist clean` and `dodot plist smudge` are subcommands of the same `dodot` binary the user already has on their PATH. No extra installation. If `dodot` is not on PATH at git-filter-invocation time (rare, but possible in restricted shells or hooks), `required = true` makes the failure loud and recoverable.
+
+6. Deployment and Drift Flow
+
+    6.1. First `dodot up` for a Pack
+
+        For each `*.plist` in the pack:
+
+            1. The smudge filter has already materialised the working-tree file as a binary at clone time (assuming filters were installed). If filters were not installed at clone, the working-tree file is XML; dodot up detects this, prompts the user to install filters, and re-runs `git checkout -- <path>` to smudge.
+            2. The symlink handler links `<pack>/<x>.plist` into the destination (e.g., `~/Library/Preferences/<x>.plist`).
+            3. The app sees a normal binary plist at its expected location.
+
+        No datastore involvement. No virtual matches. No collision detection beyond what the symlink handler already does.
+
+    6.2. App Modifies Settings
+
+        Standard macOS behaviour: the app writes a new binary plist at the deploy location. The symlink resolves to the working-tree file in the pack. The working-tree file's bytes change; its mtime updates.
+
+        From git's perspective:
+
+            1. `git status` is invoked (by the user, by an editor's git gutter, by lazygit, etc.).
+            2. Git compares the working-tree file's mtime to its index entry. They differ, so git runs the configured filter on the working-tree file.
+            3. The clean filter emits canonical XML.
+            4. Git compares the resulting XML to the canonical XML stored in the index. If they differ, the file is reported as modified.
+            5. `git diff` shows the XML diff.
+
+        The user reviews, runs `git add <path>`, and commits. The committed object is canonical XML. No `dodot` command was involved in surfacing the change.
+
+    6.3. Cross-Machine Sync
 
         On another machine:
 
             git pull
             dodot up
 
-        The pulled XML is converted to binary and deployed. Running apps may need `killall cfprefsd` to see the new values (see 4.3).
+        :: text ::
 
-9. Implementation Phases
+        `git pull` invokes the smudge filter on any updated `.plist` files, materialising the new binary in the working tree. `dodot up` ensures the symlinks are in place. Running apps may need `killall cfprefsd` to see the new values (see §7.1).
 
-    Plist support depends on Phase 1 of the preprocessing pipeline (core pipeline infrastructure).
+    6.4. cfprefsd Caching
 
-    Phase P1: Core Conversion
-        - PlistPreprocessor implementing the Preprocessor trait (Representational)
-        - `plutil -convert binary1` for `expand()`
-        - macOS platform gating
-        - Basic deployment via the pipeline
-        - Unit tests using a mock plutil CommandRunner
+        macOS's `cfprefsd` caches plist values in memory. Writing to the working-tree binary — even via the deploy symlink — may not be picked up by a running app until cfprefsd is restarted or the app re-reads its preferences.
 
-    Phase P2: Reverse Conversion
-        - `contract()` implementation (`plutil -convert xml1`)
-        - Integration with `dodot transform check` for automatic reverse
-        - `dodot transform status` output for plist files
+        Baseline behaviour: document the caveat. Users run `killall cfprefsd` when immediate visibility is required. A future ergonomics pass may detect plist deployments and offer to invalidate cfprefsd automatically; not in scope for the initial implementation.
+
+7. Adopt Flow
+
+    A user with existing settings in `~/Library/Preferences/com.app.plist` brings them into dodot via the existing adopt command:
+
+        dodot adopt <pack> ~/Library/Preferences/com.app.plist
+
+    :: text ::
+
+    With clean/smudge in the picture, adopt is simpler than it would be under the pipeline model:
+
+        1. Move the binary into the pack: `mv ~/Library/Preferences/com.app.plist <pack>/com.app.plist`.
+        2. Symlink back: `ln -s <pack>/com.app.plist ~/Library/Preferences/com.app.plist`.
+        3. Print a hint pointing at `dodot git-install-filters` if filters are not yet registered.
+
+    No extension renaming. No XML emission at adopt time. The first `git add` after adopt invokes the clean filter and produces canonical XML for the index.
+
+    7.1. Sandboxed Apps
+
+        macOS sandboxed apps write to `~/Library/Containers/<bundle-id>/Data/...` rather than the canonical location. As specified in [./macos-paths.lex] §7.8, `dodot adopt` refuses sources under `~/Library/Containers/`. Plist support inherits this refusal — the container path's contents are not intended for external editing, and the same refusal text applies whether or not the source happens to be a plist.
+
+8. Configuration
+
+    8.1. Schema
+
+        Plist support has minimal configuration. The relevant block lives under `[symlink]` because plists deploy via the symlink handler:
+
+            [symlink]
+            plist_extensions = ["plist"]   # filename suffixes treated as plists for adopt hints
+
+        :: toml ::
+
+        The extension list controls *adopt hints and prompts*, not deployment. Deployment is governed by the symlink handler and the file's location, the same as any other file. The list exists so that adopt can produce plist-aware prompts ("install filters?") and so future advisory layers (e.g. linting hints) have a place to hang off.
+
+        There is no `[preprocessor.plist]` section. Plists are not preprocessed.
+
+    8.2. Inheritance
+
+        Follows the existing 3-layer hierarchy (compiled defaults < root .dodot.toml < pack .dodot.toml). A pack that contains no plists is unaffected by any of this — the filter only fires on tracked `*.plist` files, governed by `.gitattributes`.
+
+9. User Workflow
+
+    9.1. First-Time Setup
+
+        1. User runs `dodot adopt <pack> ~/Library/Preferences/com.app.plist` (or drops a plist into a pack manually).
+        2. `dodot up` deploys the symlink and prompts to install git filters if needed.
+        3. User runs `dodot git-install-filters` (or chooses `y` at the prompt).
+        4. The app runs normally, modifying the binary live.
+
+    9.2. Day-to-Day
+
+        User runs normal git commands. `git status` reflects whether app-driven settings changes are pending. `git diff` shows XML. `git add` and `git commit` proceed with no extra steps. There is no dodot-specific command in the daily loop.
+
+    9.3. Cross-Machine Sync
+
+        `git pull` followed by `dodot up`. The smudge filter handles XML→binary; dodot ensures the symlink is in place. `killall cfprefsd` if immediate visibility is needed.
+
+10. Implementation Phases
+
+    Plist support ships as an independent track. It does *not* depend on the preprocessing pipeline; it can land before, after, or in parallel with that work.
+
+    Phase P1: Conversion Engine
+        - `plist` crate dependency
+        - Parser/serialiser pair with recursive dict-key sort
+        - Determinism property test (binary → clean → smudge → clean)
+        - `dodot plist clean` and `dodot plist smudge` subcommands (stdin/stdout)
+        - Unit tests covering: nested dicts, arrays preserved, mixed scalars, edge cases (empty plist, plist with binary data values)
+
+    Phase P2: Filter Installation
+        - `dodot git-install-filters` writes the `[filter "dodot-plist"]` block
+        - `dodot git-show-filters` prints the config without writing
+        - On `dodot up`, detect tracked `*.plist` files and prompt to install if filters are unregistered
+        - `.gitattributes` template emitted by `dodot init` (or merged into existing `.gitattributes`)
 
     Phase P3: Adopt
-        - `dodot adopt` support for existing binary plists
+        - Extend `dodot adopt` to recognise binary plists at the source
+        - First-use hint pointing at filter installation
+        - Tests: round-trip adopt → up → app modifies → git status shows XML diff
 
     Phase P4: Ergonomics
-        - cfprefsd handling documentation and/or `defaults import` mode
-        - Error messages for common issues (plutil not found, malformed XML, permission denied on ~/Library/Preferences)
-        - First-use onboarding hint pointing at `dodot transform install-hook`
+        - cfprefsd handling documentation, optional `killall` prompt after large changes
+        - Error messages for missing `dodot` on PATH at filter-invocation time
+        - `dodot probe app` integration: when probing a pack, surface plist-related cask/preferences associations
+
+11. Open Questions and Future Work
+
+    11.1. Defaults Import for cfprefsd
+
+        Writing directly to the file on disk works but does not invalidate cfprefsd's cache. A future extension may opt into `defaults import <domain> <file>` for deployments where bundle-id-to-file mapping is unambiguous, which goes through the proper APIs and invalidates the cache correctly. Not in scope for the initial implementation; called out so the design space is recorded.
+
+    11.2. Hand-Editable XML in the Pack
+
+        Some users may prefer the source-of-truth pack file to be XML, accepting that the deployed binary is generated at deploy time. That is the architecture this document explicitly rejects in §2.3, but it is a coherent alternative for a user who never wants binary in their working tree. If the demand is real, it could be supported as a per-pack opt-in (`[pack] plist_storage = "xml"`), routing through the preprocessing pipeline for those packs only. Not implemented; tracked here as a known alternative.
+
+    11.3. Non-`.plist` Extensions
+
+        Some apps store plists with non-standard suffixes (`.savedState`, `.mobileconfig`, etc.). The `plist_extensions` config key (§8.1) is the extension point for this; the default list covers the common case.
+
+    11.4. Plist Subset of `_lib/Preferences/`
+
+        [./macos-paths.lex] §11.3 notes that `_lib/Preferences/<bundle-id>.plist` is a syntactically valid path and that this proposal covers the format-management half. The two compose: the `_lib/` prefix routes the file to `~/Library/Preferences/`; the clean/smudge filter handles the binary↔XML translation. No further coordination is required.

--- a/docs/proposals/preprocessing-pipeline.lex
+++ b/docs/proposals/preprocessing-pipeline.lex
@@ -1,6 +1,6 @@
 Design Specification: Preprocessing Pipeline
 
-    This document specifies the generic preprocessing pipeline for dodot. The pipeline provides a unified architecture for files where the version-controlled source must be transformed before deployment. Template expansion, plist conversion, and secret decryption are concrete implementations of this design.
+    This document specifies the generic preprocessing pipeline for dodot. The pipeline provides a unified architecture for files where the version-controlled source must be transformed before deployment. Template expansion and secret decryption are concrete implementations of this design. Plist support, originally drafted as a Representational preprocessor, ships instead as a pair of git clean/smudge filters — see [./plists.lex] §2.3 for the rationale. The pipeline is still illustrated with plists in places below for didactic reasons (they remain a useful canonical example of a Representational transform), but the actual plist implementation does not flow through this pipeline.
 
     The preprocessing pipeline is a new phase in dodot's execution model, not a handler. It runs before handler dispatch, producing expanded files that downstream handlers (symlink, shell, path, install, homebrew) consume transparently.
 
@@ -119,7 +119,7 @@ Design Specification: Preprocessing Pipeline
     4.1. Shared Interface
 
         trait Preprocessor:
-            name()             -> &str               ("template", "plist", "gpg")
+            name()             -> &str               ("template", "gpg", ...)
             transform_type()   -> TransformType       (Generative, Representational, Opaque)
             matches_file()     -> bool                (extension check against config)
             expanded_filename() -> String             (strip .tmpl, .gpg, etc.)
@@ -141,7 +141,7 @@ Design Specification: Preprocessing Pipeline
 
         Each preprocessor provides:
 
-        - The transformation engine (MiniJinja for templates, plutil for plists, gpg for secrets)
+        - The transformation engine (MiniJinja for templates, gpg for secrets, etc.)
         - File extension matching rules
         - Filename stripping logic
         - For Representational: the reverse transformation (contract)
@@ -275,8 +275,8 @@ Design Specification: Preprocessing Pipeline
             extensions = ["tmpl", "template"] # which extensions trigger this preprocessor
             # ... preprocessor-specific config (variables, engine options, etc.)
 
-            [preprocessor.plist]
-            extensions = ["plist.xml"]
+            # Note: plists do not appear here — they ship as git clean/smudge
+            # filters, not as a preprocessor. See [./plists.lex] §2.3.
 
     7.2. Opt-Out Levels
 
@@ -350,16 +350,13 @@ Design Specification: Preprocessing Pipeline
 
         This is the most universal use case and the first to be implemented. See companion proposal: Template Expansion.
 
-    9.2. Plist Conversion (Representational)
+    9.2. Plist Conversion — Representational, but Not Through This Pipeline
 
-        Source: `com.app.plist.xml` (human-readable XML)
-        Expanded: `com.app.plist` (binary plist for macOS)
-        Reverse: Lossless via `plutil -convert xml1` (no heuristics needed)
-        Engine: system `plutil` command
+        Plists are the canonical Representational transform: `plutil` (and the `plist` Rust crate) round-trip XML and binary losslessly, so reverse is exact and no conflict markers are ever needed.
 
-        Unique property: as a representational transform, the reverse path is exact. Divergence detection still applies (to trigger the reverse conversion), but the merge workflow is fully automatic. The user never sees conflict markers.
+        Despite that fit on paper, plist support does *not* ship as a preprocessor in this pipeline. It ships as git clean/smudge filters instead. The reasoning is in [./plists.lex] §2.3; in summary: plists drift continuously (apps rewrite them on settings changes), and the pipeline's pre-commit-hook reverse path leaves drift invisible to `git status` between commits. Clean/smudge closes that gap by attaching the reverse to every git read, not just to commits.
 
-        Additionally, plist support can leverage git clean/smudge filters for seamless integration where the binary-to-XML conversion happens transparently on git add/checkout.
+        This pipeline retains plists as a didactic example of the Representational category, and the `Preprocessor::contract()` hook stays in the trait so that future Representational preprocessors with less continuous drift (one-off binary configs that don't rewrite themselves) can still go through it.
 
     9.3. Encrypted Files (Opaque)
 


### PR DESCRIPTION
## Summary

Pivots the plist proposal from a preprocessing-pipeline preprocessor to git clean/smudge filters, and lands P1: the binary↔canonical-XML conversion engine plus `dodot plist clean` / `dodot plist smudge` subcommands.

The architectural pivot (commit 1) is the substantive part — see `docs/proposals/plists.lex` §2.3 for the rationale. In short: plists drift continuously (apps rewrite preferences on settings changes), and the pipeline's pre-commit-hook reverse path leaves drift invisible to `git status` between commits. Clean/smudge attaches the reverse to every git read, making `git status` reflect drift for free. Templates still belong in the pipeline (auth-fatigue under clean/smudge would be hostile, and reverse-merge needs human review); plists are the textbook clean/smudge case.

P1 (commit 2) implements the conversion engine:

- `dodot-lib::plists::clean` / `smudge` — recursive dict-key sort, array-order preserved, deterministic XML output via the `plist` crate (no `plutil` dependency at runtime).
- `dodot plist clean` / `dodot plist smudge` CLI subcommands — stdin/stdout passthroughs, suitable for git's filter contract.
- 10 unit tests including the §4.3 determinism property test (5-iteration `binary→clean→smudge→clean` roundtrip asserts byte-equal output).

End-to-end manually verified: shuffled-key XML → smudge → clean produces alphabetised XML, `bplist00` magic confirmed in binary output, two consecutive cleans produce identical SHA256.

## Checklist

- [x] Changelog `Unreleased` section updated
- [x] Project umbrella check passes locally — `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` all green (675 tests)
- [x] Tests added or updated for behavior changes

## Notes for reviewers

The proposal pivot supersedes the previous `plists.lex` design. `preprocessing-pipeline.lex` and `magic.lex` got companion edits to keep cross-references consistent — the pipeline doc no longer claims plists as a use case, and `magic.lex` Phase 2 now points at the revised `plists.lex`.

Phasing: this is **P1 of 4**. Next up is P2 (`dodot git-install-filters` + `up`-time prompt that detects unregistered filters), then P3 (adopt extension), then P4 (cfprefsd ergonomics + probe integration). Each phase ships independently; the conversion engine here is enough to use the filters by hand-installing the `.git/config` block today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)