### PR TITLE
feat(plist): P2 — git filter install + generic prompt registry

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,33 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
 
 ### Added
 
+- **`dodot git-install-filters` / `dodot git-show-filters`.** P2 of the
+  plist clean/smudge track. `git-install-filters` writes the
+  `[filter "dodot-plist"]` block to the dotfiles repo's `.git/config`
+  so `git status` / `git diff` / `git add` invoke `dodot plist clean`
+  and `smudge` automatically on tracked `*.plist` files. Idempotent;
+  per-clone, per-machine. `git-show-filters` prints the same snippet
+  (plus the `.gitattributes` line) without writing, for inspection or
+  manual install.
+- **Up-time filter-install prompt.** On the first `dodot up` of a pack
+  containing `*.plist` files, dodot now offers to install the filters
+  if they are not already registered. Three responses: `Y` installs
+  and dismisses the prompt; `n` skips (asks again next time); `show`
+  prints the config snippets without committing. The prompt fires
+  only on a TTY — CI runs and scripted invocations are unaffected.
+- **Generic prompt registry — `dodot prompts list/reset`.** A new
+  content-agnostic registry tracks "have I shown the user X yet?"
+  state (currently powering the plist filter-install prompt; future
+  callers slot in by picking a key). Persisted at
+  `<XDG_DATA_HOME>/dodot/prompts.json`. New CLI verbs:
+    - `dodot prompts list` — show every known prompt with its
+      dismissed/active state and a one-line description.
+    - `dodot prompts reset <key>` — clear one dismissal so the
+      prompt fires again next time.
+    - `dodot prompts reset --all` — clear every dismissal.
+  Unknown keys lurking from older dodot versions appear in `list` so
+  they can be reset.
+
 - **`dodot plist clean` / `dodot plist smudge` subcommands.** A pair
   of stdin→stdout filters that translate macOS plists between binary
   (what apps read at `~/Library/Preferences/...`) and canonical XML

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -358,6 +358,157 @@ pub fn init_sh_passthrough() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+// ── Prompts (registry CLI surface) ─────────────────────────────
+
+pub fn prompts_list_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::prompts::PromptsListResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    let result = commands::prompts::list(&ctx)?;
+    Ok(Output::Render(result))
+}
+
+pub fn prompts_reset_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::MessageResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    let key = matches.get_one::<String>("key").map(String::as_str);
+    let all = matches.get_flag("all");
+    if all && key.is_some() {
+        return Err(anyhow::anyhow!(
+            "`dodot prompts reset` accepts a key or --all, not both"
+        ));
+    }
+    if !all && key.is_none() {
+        return Err(anyhow::anyhow!(
+            "`dodot prompts reset` requires either a key or --all"
+        ));
+    }
+    let result = commands::prompts::reset(key, &ctx)?;
+    Ok(Output::Render(result))
+}
+
+// ── Git filters ─────────────────────────────────────────────────
+
+pub fn git_install_filters_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::MessageResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    let result = commands::git_filters::install_filters(&ctx)?;
+    Ok(Output::Render(result))
+}
+
+pub fn git_show_filters_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::git_filters::ShowFiltersResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    let result = commands::git_filters::show_filters(&ctx)?;
+    Ok(Output::Render(result))
+}
+
+/// Post-`up` hook that offers to install plist filters when:
+///
+/// 1. stdin is a TTY (we're interactive, not in CI/script),
+/// 2. at least one pack contains a `*.plist` file,
+/// 3. the dodot-plist filter is NOT yet registered in `.git/config`,
+/// 4. the user has NOT previously dismissed the prompt.
+///
+/// All four must hold; otherwise the function returns silently. Errors
+/// in any check (e.g. registry corrupt, git missing) are logged to
+/// stderr but never abort `up` — this is a nudge, not a critical step.
+pub fn maybe_prompt_install_filters() {
+    if let Err(e) = try_prompt_install_filters() {
+        // Soft failure: log and move on.
+        tracing::debug!("plist install-filters prompt skipped: {e}");
+    }
+}
+
+fn try_prompt_install_filters() -> Result<(), anyhow::Error> {
+    use dodot_lib::prompts::PromptRegistry;
+
+    if !crate::interactive::stdin_is_tty() {
+        return Ok(());
+    }
+
+    let dotfiles_root = discover_dotfiles_root()?;
+    let ctx = dodot_lib::packs::orchestration::ExecutionContext::production(&dotfiles_root, false)?;
+
+    let plist_files = commands::git_filters::detect_plist_files(&ctx)?;
+    if plist_files.is_empty() {
+        return Ok(());
+    }
+    if commands::git_filters::is_installed(&ctx)? {
+        return Ok(());
+    }
+
+    let registry_path = ctx.paths.prompts_path();
+    let mut registry = PromptRegistry::load(ctx.fs.as_ref(), registry_path)?;
+    let prompt_key = "plist.install_filters";
+    if registry.is_dismissed(prompt_key) {
+        return Ok(());
+    }
+
+    // Pick a representative pack name for the prompt body — first
+    // file's parent (under dotfiles_root) gives us "<pack>".
+    let example_pack = plist_files
+        .first()
+        .and_then(|p| p.strip_prefix(ctx.paths.dotfiles_root()).ok())
+        .and_then(|rel| rel.components().next())
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .unwrap_or_else(|| "(unknown)".into());
+
+    let count = plist_files.len();
+    let header = format!("dodot detected {count} .plist file(s) in pack `{example_pack}`.");
+    let response = crate::interactive::prompt_yes_no_show(&[
+        &header,
+        "Plist support uses git clean/smudge filters to keep the source diffable.",
+        "Install filters now? Run `dodot git-show-filters` to inspect first.",
+    ])?;
+
+    match response {
+        crate::interactive::YesNoShow::Yes => {
+            let r = commands::git_filters::install_filters(&ctx)?;
+            eprintln!("{}", r.message);
+            for d in &r.details {
+                eprintln!("  {d}");
+            }
+            registry.dismiss(prompt_key);
+            registry.save(ctx.fs.as_ref())?;
+        }
+        crate::interactive::YesNoShow::Show => {
+            eprintln!();
+            eprintln!("Add to .git/config (per clone, per machine):");
+            eprintln!();
+            for line in commands::git_filters::config_block_text().lines() {
+                eprintln!("    {line}");
+            }
+            eprintln!();
+            eprintln!("Add to .gitattributes (committed in the repo):");
+            eprintln!("    {}", commands::git_filters::gitattributes_line());
+            eprintln!();
+            eprintln!(
+                "Run `dodot git-install-filters` to install, or `dodot prompts reset {prompt_key}` to skip and ask later."
+            );
+            // Don't dismiss — show is informational, the user hasn't
+            // committed to either install or skip.
+        }
+        crate::interactive::YesNoShow::No => {
+            // Don't dismiss — re-prompt next up. If the user wants to
+            // permanently silence it, they can run
+            // `dodot prompts reset <key>` later (well, the inverse —
+            // to dismiss it themselves we'd need a `dismiss` CLI verb).
+            //
+            // For now, "no" means "not now"; a future ergonomics pass
+            // can offer "no, and never ask again".
+        }
+    }
+    Ok(())
+}
+
 /// `dodot plist clean` — read any plist on stdin, write canonical XML on stdout.
 ///
 /// Used as a git clean filter: `git add` invokes this on the working-tree

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -418,11 +418,13 @@ pub fn git_show_filters_handler(
 /// 4. the user has NOT previously dismissed the prompt.
 ///
 /// All four must hold; otherwise the function returns silently. Errors
-/// in any check (e.g. registry corrupt, git missing) are logged to
-/// stderr but never abort `up` — this is a nudge, not a critical step.
+/// in any check (e.g. registry corrupt, git missing) go to the dodot
+/// log at debug level — visible with `--debug` or in the log file,
+/// but silent at default verbosity. This is a nudge, not a critical
+/// step, and a noisy stderr line every `up` would be worse UX than
+/// silently skipping the offer.
 pub fn maybe_prompt_install_filters() {
     if let Err(e) = try_prompt_install_filters() {
-        // Soft failure: log and move on.
         tracing::debug!("plist install-filters prompt skipped: {e}");
     }
 }

--- a/crates/dodot-cli/src/help.rs
+++ b/crates/dodot-cli/src/help.rs
@@ -38,6 +38,15 @@ const HELP_TEXTS: &[(&str, &str)] = &[
     ("tutorial", include_str!("help/tutorial.txt")),
     ("init-sh", include_str!("help/init-sh.txt")),
     ("plist", include_str!("help/plist.txt")),
+    (
+        "git-install-filters",
+        include_str!("help/git-install-filters.txt"),
+    ),
+    (
+        "git-show-filters",
+        include_str!("help/git-show-filters.txt"),
+    ),
+    ("prompts", include_str!("help/prompts.txt")),
     ("config", include_str!("help/config.txt")),
     (
         "probe.deployment-map",

--- a/crates/dodot-cli/src/help/git-install-filters.txt
+++ b/crates/dodot-cli/src/help/git-install-filters.txt
@@ -1,0 +1,30 @@
+[header]dodot git-install-filters[/header] — Install plist clean/smudge filters.
+
+[desc]Writes the [item][filter "dodot-plist"][/item] block to the dotfiles repo's
+[item].git/config[/item], so future [item]git status[/item] / [item]git diff[/item] / [item]git add[/item] invocations
+on tracked [item]*.plist[/item] files run through [item]dodot plist clean[/item] (binary →
+canonical XML) and [item]dodot plist smudge[/item] (XML → binary).
+
+This is per-clone, per-machine state — [item].git/config[/item] is not carried by
+the repo. Run once per machine after cloning.
+
+After this, ensure your [item].gitattributes[/item] (which IS committed) binds
+[item]*.plist[/item] to the filter:
+
+    [example]echo '*.plist filter=dodot-plist' >> .gitattributes
+    git add .gitattributes && git commit -m 'enable plist filters'[/example]
+
+[item]dodot up[/item] will offer this command interactively the first time it
+spots a [item]*.plist[/item] file in a pack and finds the filter unregistered.[/desc]
+
+[header]USAGE[/header]
+  [usage]dodot git-install-filters[/usage]
+
+[header]EXAMPLES[/header]
+  [example]dodot git-install-filters       [dim]# install once per clone[/dim]
+  dodot git-show-filters         [dim]# inspect or install by hand[/dim][/example]
+
+[header]SEE ALSO[/header]
+  [item]dodot git-show-filters[/item]   [desc]Print the config without writing[/desc]
+  [item]dodot plist[/item]               [desc]The filter binary that git invokes[/desc]
+  [item]docs/proposals/plists.lex[/item] [desc]Architecture and rationale[/desc]

--- a/crates/dodot-cli/src/help/git-show-filters.txt
+++ b/crates/dodot-cli/src/help/git-show-filters.txt
@@ -1,0 +1,24 @@
+[header]dodot git-show-filters[/header] — Print plist filter config without writing.
+
+[desc]Emits two snippets so you can inspect or install by hand:
+
+  [item]1.[/item] The [item][filter "dodot-plist"][/item] block for [item].git/config[/item] (per clone, per machine).
+  [item]2.[/item] The [item]*.plist filter=dodot-plist[/item] line for [item].gitattributes[/item] (committed).
+
+Each snippet is annotated with whether it is currently in place, so
+you can tell at a glance what (if anything) you still need to add.
+
+If you just want to install the [item].git/config[/item] block automatically, use
+[item]dodot git-install-filters[/item] — this command writes nothing.[/desc]
+
+[header]USAGE[/header]
+  [usage]dodot git-show-filters[/usage]
+
+[header]EXAMPLES[/header]
+  [example]dodot git-show-filters         [dim]# inspect[/dim]
+  dodot git-show-filters | tee /tmp/dodot-filters.txt[/example]
+
+[header]SEE ALSO[/header]
+  [item]dodot git-install-filters[/item]   [desc]Install the .git/config block automatically[/desc]
+  [item]dodot plist[/item]                  [desc]The filter binary that git invokes[/desc]
+  [item]docs/proposals/plists.lex[/item]    [desc]Architecture and rationale[/desc]

--- a/crates/dodot-cli/src/help/prompts.txt
+++ b/crates/dodot-cli/src/help/prompts.txt
@@ -1,0 +1,33 @@
+[header]dodot prompts[/header] — Inspect and reset dismissed-prompt state.
+
+[desc]dodot occasionally surfaces one-time prompts — onboarding hints, install
+offers, configuration nudges. The registry tracks which prompts the user
+has dismissed (or implicitly satisfied), so the same nudge does not
+fire repeatedly.
+
+This subcommand lists the registry and lets you clear dismissals so a
+prompt fires again next time its condition is met.[/desc]
+
+[header]USAGE[/header]
+  [usage]dodot prompts list[/usage]
+  [usage]dodot prompts reset <key>[/usage]
+  [usage]dodot prompts reset --all[/usage]
+
+[header]LIST[/header]
+  [desc]Shows every known prompt with its current state ([item]active[/item] or
+  [item]dismissed[/item]) and a one-line description. Stale dismissals from older
+  dodot versions appear too, so you can clear them.[/desc]
+
+[header]RESET[/header]
+  [desc]A reset clears the dismissal so the prompt's caller will re-evaluate
+  next time. It does NOT trigger the prompt itself — only flags it for
+  re-evaluation. Pass a specific key, or [item]--all[/item] to clear every dismissal.[/desc]
+
+[header]EXAMPLES[/header]
+  [example]dodot prompts list                              [dim]# what's active / dismissed[/dim]
+  dodot prompts reset plist.install_filters       [dim]# unhide one prompt[/dim]
+  dodot prompts reset --all                       [dim]# clear them all[/dim][/example]
+
+[header]REGISTRY LOCATION[/header]
+  [desc][item]<XDG_DATA_HOME>/dodot/prompts.json[/item] (defaults to [item]~/.local/share/dodot/[/item]).
+  Removing the file resets every dismissal — equivalent to [item]reset --all[/item].[/desc]

--- a/crates/dodot-cli/src/interactive.rs
+++ b/crates/dodot-cli/src/interactive.rs
@@ -1,0 +1,50 @@
+//! Tiny interactive-prompt helpers for CLI handlers.
+//!
+//! All input/output goes through stdin/stderr — stdout is reserved for
+//! command output that downstream tools may pipe and parse.
+
+use std::io::{self, BufRead, IsTerminal, Write};
+
+/// Yes/No/Show response to a 3-way prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum YesNoShow {
+    /// User wants to proceed.
+    Yes,
+    /// User declined; caller should NOT mark the prompt dismissed
+    /// (so it fires again next time).
+    No,
+    /// User wants to inspect the underlying config without committing.
+    Show,
+}
+
+/// True if stdin is a TTY. Use to gate interactive prompts.
+pub fn stdin_is_tty() -> bool {
+    io::stdin().is_terminal()
+}
+
+/// Ask a Y/n/show question on stderr and return the parsed response.
+///
+/// `prompt_lines` are printed verbatim (one per line). The final
+/// `[Y/n/show]` marker is appended automatically. Empty input maps to
+/// `Yes` (the capital `Y` signals it as the default). Anything
+/// unrecognised maps to `No` so a stray keypress doesn't accidentally
+/// dismiss state.
+pub fn prompt_yes_no_show(prompt_lines: &[&str]) -> io::Result<YesNoShow> {
+    let mut stderr = io::stderr().lock();
+    for line in prompt_lines {
+        writeln!(stderr, "{line}")?;
+    }
+    write!(stderr, "[Y/n/show] ")?;
+    stderr.flush()?;
+
+    let mut buf = String::new();
+    let stdin = io::stdin();
+    stdin.lock().read_line(&mut buf)?;
+    let answer = buf.trim().to_ascii_lowercase();
+
+    Ok(match answer.as_str() {
+        "" | "y" | "yes" => YesNoShow::Yes,
+        "s" | "show" => YesNoShow::Show,
+        _ => YesNoShow::No,
+    })
+}

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -6,6 +6,7 @@ use dodot_lib::render;
 
 mod handlers;
 mod help;
+mod interactive;
 mod logging;
 mod tutorial;
 
@@ -118,10 +119,21 @@ fn main() {
         return;
     }
 
-    // All other commands go through standout dispatch
+    // All other commands go through standout dispatch.
+    // Capture the matched subcommand name now so the post-dispatch hook
+    // (which runs after standout consumed `matches`) can know what ran.
+    let subcommand = matches.subcommand_name().map(str::to_string);
     let output_mode = app.extract_output_mode(&matches);
     match app.dispatch(matches, output_mode) {
-        standout::cli::RunResult::Handled(output) => println!("{output}"),
+        standout::cli::RunResult::Handled(output) => {
+            println!("{output}");
+            // Post-up nudge: if the user just deployed packs containing
+            // .plist files and hasn't installed the dodot-plist filter,
+            // offer to install it. Soft failure — never aborts up.
+            if subcommand.as_deref() == Some("up") {
+                handlers::maybe_prompt_install_filters();
+            }
+        }
         standout::cli::RunResult::Silent => {}
         standout::cli::RunResult::NoMatch(_) => {
             // No subcommand given — show help
@@ -167,6 +179,8 @@ static TEMPLATE_ENTRIES: &[(&str, &str)] = &[
     ("list.jinja", render::TEMPLATE_LIST),
     ("message.jinja", render::TEMPLATE_MESSAGE),
     ("probe.jinja", render::TEMPLATE_PROBE),
+    ("git-filters.jinja", render::TEMPLATE_GIT_FILTERS),
+    ("prompts-list.jinja", render::TEMPLATE_PROMPTS_LIST),
 ];
 
 fn build_app() -> App {
@@ -213,6 +227,26 @@ fn build_app() -> App {
         .expect("register probe.shell-init")
         .command("probe.app", handlers::probe_app_handler, "probe")
         .expect("register probe.app")
+        .command(
+            "git-install-filters",
+            handlers::git_install_filters_handler,
+            "message",
+        )
+        .expect("register git-install-filters")
+        .command(
+            "git-show-filters",
+            handlers::git_show_filters_handler,
+            "git-filters",
+        )
+        .expect("register git-show-filters")
+        .command(
+            "prompts.list",
+            handlers::prompts_list_handler,
+            "prompts-list",
+        )
+        .expect("register prompts.list")
+        .command("prompts.reset", handlers::prompts_reset_handler, "message")
+        .expect("register prompts.reset")
         .command_groups(vec![
             CommandGroup {
                 title: "Core".into(),
@@ -240,12 +274,21 @@ fn build_app() -> App {
                 commands: vec![Some("probe".into())],
             },
             CommandGroup {
+                title: "Plist filters".into(),
+                help: None,
+                commands: vec![
+                    Some("git-install-filters".into()),
+                    Some("git-show-filters".into()),
+                    Some("plist".into()),
+                ],
+            },
+            CommandGroup {
                 title: "Misc".into(),
                 help: None,
                 commands: vec![
                     Some("tutorial".into()),
                     Some("init-sh".into()),
-                    Some("plist".into()),
+                    Some("prompts".into()),
                     Some("config".into()),
                     Some("help".into()),
                 ],
@@ -440,6 +483,39 @@ fn build_clap_command() -> ClapCommand {
                 .subcommand(
                     ClapCommand::new("smudge")
                         .about("Convert XML plist on stdin to binary plist on stdout"),
+                ),
+        )
+        .subcommand(
+            ClapCommand::new("git-install-filters")
+                .about("Install plist clean/smudge filters into the dotfiles repo's .git/config"),
+        )
+        .subcommand(
+            ClapCommand::new("git-show-filters")
+                .about("Print the .git/config + .gitattributes snippets for plist filters"),
+        )
+        .subcommand(
+            ClapCommand::new("prompts")
+                .about("Inspect and reset dismissed-prompt state")
+                .subcommand_required(true)
+                .arg_required_else_help(true)
+                .subcommand(
+                    ClapCommand::new("list")
+                        .about("Show every known prompt with its dismissed/active state"),
+                )
+                .subcommand(
+                    ClapCommand::new("reset")
+                        .about("Clear a dismissed prompt so it fires again next time")
+                        .arg(
+                            Arg::new("key")
+                                .help("Prompt key to reset (omit when using --all)")
+                                .num_args(0..=1),
+                        )
+                        .arg(
+                            Arg::new("all")
+                                .long("all")
+                                .help("Reset every dismissed prompt")
+                                .action(ArgAction::SetTrue),
+                        ),
                 ),
         )
         .subcommand(

--- a/crates/dodot-lib/src/commands/git_filters.rs
+++ b/crates/dodot-lib/src/commands/git_filters.rs
@@ -131,35 +131,33 @@ pub fn is_installed(ctx: &ExecutionContext) -> Result<bool> {
     filter_is_installed(runner, root)
 }
 
-/// Scan every pack under the dotfiles root and return the relative
-/// paths of any `*.plist` files. Used by `dodot up` to decide whether
-/// the user should be offered the filter-install prompt.
+/// Scan every active pack under the dotfiles root and return the
+/// absolute paths of any `*.plist` files within. Used by `dodot up`
+/// to decide whether the user should be offered the filter-install
+/// prompt.
 ///
-/// Detection is "any `*.plist` in any pack directory", not "tracked by
+/// Pack selection goes through [`packs::discover_packs`] so it honours
+/// the same conventions every other command does: `pack.ignore`
+/// patterns from config, `.dodotignore` markers, valid pack-name
+/// rules, and the `.config` exception. Pack-internal walking ignores
+/// nested dot-directories (`.git`, etc.) so we don't recurse into
+/// vendored repos that happen to live inside a pack.
+///
+/// Detection is "any `*.plist` in any active pack", not "tracked by
 /// git". The looser check is intentional: an untracked plist in a pack
-/// is almost certainly headed for a commit, and a false-positive prompt
-/// is harmless. A tighter check would require shelling out to
-/// `git ls-files` on every up.
+/// is almost certainly headed for a commit, and a false-positive
+/// prompt is harmless. A stricter check would require shelling out to
+/// `git ls-files` on every `up`.
 pub fn detect_plist_files(ctx: &ExecutionContext) -> Result<Vec<std::path::PathBuf>> {
     let mut found = Vec::new();
     let root = ctx.paths.dotfiles_root();
     if !ctx.fs.is_dir(root) {
         return Ok(found);
     }
-    for entry in ctx.fs.read_dir(root)? {
-        if !entry.is_dir {
-            continue;
-        }
-        // Skip hidden / dotfile-tooling directories.
-        let name = entry
-            .path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("");
-        if name.starts_with('.') {
-            continue;
-        }
-        scan_for_plists(ctx.fs.as_ref(), &entry.path, &mut found)?;
+    let root_config = ctx.config_manager.root_config()?;
+    let packs = crate::packs::discover_packs(ctx.fs.as_ref(), root, &root_config.pack.ignore)?;
+    for pack in packs {
+        scan_for_plists(ctx.fs.as_ref(), &pack.path, &mut found)?;
     }
     Ok(found)
 }
@@ -300,23 +298,7 @@ mod tests {
         assert!(block.contains("required = true"));
     }
 
-    #[test]
-    fn detect_plist_files_finds_plists_in_packs() {
-        use crate::testing::TempEnvironment;
-        let env = TempEnvironment::builder()
-            .pack("mac-defaults")
-            .file("com.app.plist", "binary-or-xml")
-            .file("README.md", "no plist")
-            .done()
-            .pack("nvim")
-            .file("init.lua", "no plist")
-            .done()
-            .pack("system-prefs")
-            .file("nested/com.other.plist", "deeper")
-            .done()
-            .build();
-
-        // Build the same minimal context used elsewhere in tests.
+    fn make_test_ctx(env: &crate::testing::TempEnvironment) -> ExecutionContext {
         use crate::config::ConfigManager;
         use crate::datastore::{CommandOutput, CommandRunner, FilesystemDataStore};
         use crate::fs::Fs;
@@ -340,7 +322,7 @@ mod tests {
             runner.clone(),
         ));
         let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
-        let ctx = ExecutionContext {
+        ExecutionContext {
             fs: env.fs.clone() as Arc<dyn Fs>,
             datastore,
             paths: env.paths.clone() as Arc<dyn Pather>,
@@ -354,8 +336,26 @@ mod tests {
             view_mode: crate::commands::ViewMode::Full,
             group_mode: crate::commands::GroupMode::Name,
             verbose: false,
-        };
+        }
+    }
 
+    #[test]
+    fn detect_plist_files_finds_plists_in_packs() {
+        use crate::testing::TempEnvironment;
+        let env = TempEnvironment::builder()
+            .pack("mac-defaults")
+            .file("com.app.plist", "binary-or-xml")
+            .file("README.md", "no plist")
+            .done()
+            .pack("nvim")
+            .file("init.lua", "no plist")
+            .done()
+            .pack("system-prefs")
+            .file("nested/com.other.plist", "deeper")
+            .done()
+            .build();
+
+        let ctx = make_test_ctx(&env);
         let found = detect_plist_files(&ctx).expect("detect");
         assert_eq!(found.len(), 2, "expected 2 plists, got: {found:?}");
         let names: Vec<String> = found
@@ -364,6 +364,35 @@ mod tests {
             .collect();
         assert!(names.contains(&"com.app.plist".to_string()));
         assert!(names.contains(&"com.other.plist".to_string()));
+    }
+
+    #[test]
+    fn detect_plist_files_skips_dodotignored_packs() {
+        use crate::testing::TempEnvironment;
+        let env = TempEnvironment::builder()
+            .pack("active")
+            .file("a.plist", "in active")
+            .done()
+            .pack("muted")
+            .file("b.plist", "in muted")
+            .ignored()
+            .done()
+            .build();
+
+        let ctx = make_test_ctx(&env);
+        let found = detect_plist_files(&ctx).expect("detect");
+        let names: Vec<String> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            names.contains(&"a.plist".to_string()),
+            "active pack's plist should be found"
+        );
+        assert!(
+            !names.contains(&"b.plist".to_string()),
+            ".dodotignore'd pack's plist should be excluded, got: {names:?}"
+        );
     }
 
     #[test]

--- a/crates/dodot-lib/src/commands/git_filters.rs
+++ b/crates/dodot-lib/src/commands/git_filters.rs
@@ -1,0 +1,387 @@
+//! Git clean/smudge filter installation for plist support.
+//!
+//! Two operations:
+//!
+//! - [`install_filters`] writes the `[filter "dodot-plist"]` block to the
+//!   dotfiles repo's `.git/config`. Per-clone, per-machine. Idempotent.
+//! - [`show_filters`] prints the same config block without writing it,
+//!   so the user can inspect or install by hand.
+//!
+//! See `docs/proposals/plists.lex` §5 for the architectural context.
+
+use serde::Serialize;
+
+use crate::commands::MessageResult;
+use crate::packs::orchestration::ExecutionContext;
+use crate::{DodotError, Result};
+
+/// Reusable [`MessageResult`] forms for git-filter commands.
+pub mod result {
+    pub use crate::commands::MessageResult;
+}
+
+/// Render the `.git/config` snippet for the dodot-plist filter.
+///
+/// Public for `dodot git-show-filters` and for `dodot git-install-filters`
+/// to include in the success message when the user picks the `show` path.
+pub fn config_block_text() -> String {
+    [
+        "[filter \"dodot-plist\"]",
+        "    clean  = dodot plist clean",
+        "    smudge = dodot plist smudge",
+        "    required = true",
+    ]
+    .join("\n")
+}
+
+/// Render the `.gitattributes` line that binds `*.plist` to the filter.
+pub fn gitattributes_line() -> &'static str {
+    "*.plist filter=dodot-plist"
+}
+
+/// Install the dodot-plist clean/smudge filter into the dotfiles repo's
+/// `.git/config`. Idempotent: re-running when the filter is already
+/// installed is a no-op success.
+pub fn install_filters(ctx: &ExecutionContext) -> Result<MessageResult> {
+    let root = ctx.paths.dotfiles_root().to_path_buf();
+    let runner = ctx.command_runner.as_ref();
+
+    if filter_is_installed(runner, &root)? {
+        let mut details = Vec::new();
+        append_gitattributes_hint(ctx, &mut details);
+        return Ok(MessageResult {
+            message: "Plist filters already installed in .git/config.".into(),
+            details,
+        });
+    }
+
+    git_config_set(
+        runner,
+        &root,
+        "filter.dodot-plist.clean",
+        "dodot plist clean",
+    )?;
+    git_config_set(
+        runner,
+        &root,
+        "filter.dodot-plist.smudge",
+        "dodot plist smudge",
+    )?;
+    git_config_set(runner, &root, "filter.dodot-plist.required", "true")?;
+
+    let mut details = vec![format!(
+        "Wrote [filter \"dodot-plist\"] to {}/.git/config",
+        root.display()
+    )];
+    append_gitattributes_hint(ctx, &mut details);
+    Ok(MessageResult {
+        message: "Installed plist clean/smudge filters.".into(),
+        details,
+    })
+}
+
+/// Print the `.git/config` and `.gitattributes` snippets without
+/// writing anything. For users who want to install by hand or inspect
+/// before agreeing.
+pub fn show_filters(ctx: &ExecutionContext) -> Result<ShowFiltersResult> {
+    let root = ctx.paths.dotfiles_root().to_path_buf();
+    let runner = ctx.command_runner.as_ref();
+    let installed = filter_is_installed(runner, &root)?;
+
+    let attributes_present = ctx
+        .fs
+        .read_to_string(&root.join(".gitattributes"))
+        .ok()
+        .map(|s| s.lines().any(gitattributes_line_present))
+        .unwrap_or(false);
+
+    let block = config_block_text();
+    let block_lines = block.lines().map(str::to_string).collect();
+    Ok(ShowFiltersResult {
+        config_block: block,
+        config_block_lines: block_lines,
+        gitattributes_line: gitattributes_line().to_string(),
+        installed_in_git_config: installed,
+        bound_in_gitattributes: attributes_present,
+        repo_root: root.display().to_string(),
+    })
+}
+
+/// Result for `dodot git-show-filters`. The CLI handler renders this
+/// through the `git-filters` template; the `config_block_lines` field
+/// is the line-broken form of `config_block` so the template can
+/// indent each line uniformly without needing a `split` filter.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShowFiltersResult {
+    pub config_block: String,
+    pub config_block_lines: Vec<String>,
+    pub gitattributes_line: String,
+    pub installed_in_git_config: bool,
+    pub bound_in_gitattributes: bool,
+    pub repo_root: String,
+}
+
+/// Quick check: is the dodot-plist clean filter currently registered in
+/// the dotfiles repo's `.git/config`? Used by `dodot up` to decide
+/// whether to prompt for installation, and by `dodot git-show-filters`
+/// to annotate its output.
+pub fn is_installed(ctx: &ExecutionContext) -> Result<bool> {
+    let runner = ctx.command_runner.as_ref();
+    let root = ctx.paths.dotfiles_root();
+    filter_is_installed(runner, root)
+}
+
+/// Scan every pack under the dotfiles root and return the relative
+/// paths of any `*.plist` files. Used by `dodot up` to decide whether
+/// the user should be offered the filter-install prompt.
+///
+/// Detection is "any `*.plist` in any pack directory", not "tracked by
+/// git". The looser check is intentional: an untracked plist in a pack
+/// is almost certainly headed for a commit, and a false-positive prompt
+/// is harmless. A tighter check would require shelling out to
+/// `git ls-files` on every up.
+pub fn detect_plist_files(ctx: &ExecutionContext) -> Result<Vec<std::path::PathBuf>> {
+    let mut found = Vec::new();
+    let root = ctx.paths.dotfiles_root();
+    if !ctx.fs.is_dir(root) {
+        return Ok(found);
+    }
+    for entry in ctx.fs.read_dir(root)? {
+        if !entry.is_dir {
+            continue;
+        }
+        // Skip hidden / dotfile-tooling directories.
+        let name = entry
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+        if name.starts_with('.') {
+            continue;
+        }
+        scan_for_plists(ctx.fs.as_ref(), &entry.path, &mut found)?;
+    }
+    Ok(found)
+}
+
+fn scan_for_plists(
+    fs: &dyn crate::fs::Fs,
+    dir: &std::path::Path,
+    found: &mut Vec<std::path::PathBuf>,
+) -> Result<()> {
+    let entries = match fs.read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return Ok(()), // tolerate unreadable subdirs
+    };
+    for entry in entries {
+        if entry.is_dir {
+            // Skip nested .git or other dot-dirs to avoid scanning
+            // the world.
+            let name = entry
+                .path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("");
+            if name.starts_with('.') {
+                continue;
+            }
+            scan_for_plists(fs, &entry.path, found)?;
+        } else if entry
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|s| s.eq_ignore_ascii_case("plist"))
+            .unwrap_or(false)
+        {
+            found.push(entry.path);
+        }
+    }
+    Ok(())
+}
+
+// ── internals ──────────────────────────────────────────────────────────
+
+fn append_gitattributes_hint(ctx: &ExecutionContext, details: &mut Vec<String>) {
+    let attrs_path = ctx.paths.dotfiles_root().join(".gitattributes");
+    let already_bound = ctx
+        .fs
+        .read_to_string(&attrs_path)
+        .ok()
+        .map(|s| s.lines().any(gitattributes_line_present))
+        .unwrap_or(false);
+    if !already_bound {
+        details.push(String::new());
+        details.push("Next: ensure your .gitattributes binds *.plist to this filter:".into());
+        details.push(format!(
+            "    echo '{}' >> .gitattributes",
+            gitattributes_line()
+        ));
+        details.push("    git add .gitattributes && git commit -m 'enable plist filters'".into());
+    }
+}
+
+/// Match a `.gitattributes` line that binds `*.plist` to the
+/// `dodot-plist` filter. Tolerant of whitespace and comments.
+fn gitattributes_line_present(line: &str) -> bool {
+    let trimmed = line.split('#').next().unwrap_or("").trim();
+    let mut parts = trimmed.split_ascii_whitespace();
+    let pattern = parts.next();
+    if pattern != Some("*.plist") {
+        return false;
+    }
+    parts.any(|tok| tok == "filter=dodot-plist")
+}
+
+fn filter_is_installed(
+    runner: &dyn crate::datastore::CommandRunner,
+    root: &std::path::Path,
+) -> Result<bool> {
+    // `git config --get <key>` exits 1 when the key is not set; the
+    // runner translates non-zero exits into `CommandFailed`. We treat
+    // exit_code == 1 (and "not a git repo") as "not installed", and
+    // surface other failures (git missing, perm errors) as errors.
+    match runner.run(
+        "git",
+        &[
+            "-C".into(),
+            root.display().to_string(),
+            "config".into(),
+            "--get".into(),
+            "filter.dodot-plist.clean".into(),
+        ],
+    ) {
+        Ok(out) => Ok(out.exit_code == 0 && !out.stdout.trim().is_empty()),
+        Err(DodotError::CommandFailed { exit_code: 1, .. }) => Ok(false),
+        Err(DodotError::CommandFailed { stderr, .. })
+            if stderr.contains("not a git repository") =>
+        {
+            Ok(false)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn git_config_set(
+    runner: &dyn crate::datastore::CommandRunner,
+    root: &std::path::Path,
+    key: &str,
+    value: &str,
+) -> Result<()> {
+    let out = runner.run(
+        "git",
+        &[
+            "-C".into(),
+            root.display().to_string(),
+            "config".into(),
+            key.into(),
+            value.into(),
+        ],
+    )?;
+    if out.exit_code != 0 {
+        return Err(DodotError::CommandFailed {
+            command: format!("git -C {} config {} {}", root.display(), key, value),
+            exit_code: out.exit_code,
+            stderr: out.stderr,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_block_has_required_key() {
+        let block = config_block_text();
+        assert!(block.contains("[filter \"dodot-plist\"]"));
+        assert!(block.contains("clean  = dodot plist clean"));
+        assert!(block.contains("smudge = dodot plist smudge"));
+        assert!(block.contains("required = true"));
+    }
+
+    #[test]
+    fn detect_plist_files_finds_plists_in_packs() {
+        use crate::testing::TempEnvironment;
+        let env = TempEnvironment::builder()
+            .pack("mac-defaults")
+            .file("com.app.plist", "binary-or-xml")
+            .file("README.md", "no plist")
+            .done()
+            .pack("nvim")
+            .file("init.lua", "no plist")
+            .done()
+            .pack("system-prefs")
+            .file("nested/com.other.plist", "deeper")
+            .done()
+            .build();
+
+        // Build the same minimal context used elsewhere in tests.
+        use crate::config::ConfigManager;
+        use crate::datastore::{CommandOutput, CommandRunner, FilesystemDataStore};
+        use crate::fs::Fs;
+        use crate::paths::Pather;
+        use std::sync::Arc;
+
+        struct NoopRunner;
+        impl CommandRunner for NoopRunner {
+            fn run(&self, _e: &str, _a: &[String]) -> Result<CommandOutput> {
+                Ok(CommandOutput {
+                    exit_code: 0,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            }
+        }
+        let runner: Arc<dyn CommandRunner> = Arc::new(NoopRunner);
+        let datastore = Arc::new(FilesystemDataStore::new(
+            env.fs.clone(),
+            env.paths.clone(),
+            runner.clone(),
+        ));
+        let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
+        let ctx = ExecutionContext {
+            fs: env.fs.clone() as Arc<dyn Fs>,
+            datastore,
+            paths: env.paths.clone() as Arc<dyn Pather>,
+            config_manager,
+            syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
+            command_runner: runner,
+            dry_run: false,
+            no_provision: true,
+            provision_rerun: false,
+            force: false,
+            view_mode: crate::commands::ViewMode::Full,
+            group_mode: crate::commands::GroupMode::Name,
+            verbose: false,
+        };
+
+        let found = detect_plist_files(&ctx).expect("detect");
+        assert_eq!(found.len(), 2, "expected 2 plists, got: {found:?}");
+        let names: Vec<String> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"com.app.plist".to_string()));
+        assert!(names.contains(&"com.other.plist".to_string()));
+    }
+
+    #[test]
+    fn gitattributes_recogniser_handles_whitespace_and_comments() {
+        assert!(gitattributes_line_present("*.plist filter=dodot-plist"));
+        assert!(gitattributes_line_present(
+            "  *.plist   filter=dodot-plist  "
+        ));
+        assert!(gitattributes_line_present(
+            "*.plist filter=dodot-plist diff=plist"
+        ));
+        assert!(gitattributes_line_present(
+            "*.plist filter=dodot-plist  # plist filter"
+        ));
+
+        assert!(!gitattributes_line_present(""));
+        assert!(!gitattributes_line_present("# commented out"));
+        assert!(!gitattributes_line_present("*.plist filter=other"));
+        assert!(!gitattributes_line_present("*.txt filter=dodot-plist"));
+    }
+}

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -9,9 +9,11 @@ pub mod addignore;
 pub mod adopt;
 pub mod down;
 pub mod fill;
+pub mod git_filters;
 pub mod init;
 pub mod list;
 pub mod probe;
+pub mod prompts;
 pub mod status;
 pub mod tutorial;
 pub mod up;
@@ -20,6 +22,18 @@ pub mod up;
 mod tests;
 
 use serde::Serialize;
+
+/// Shared `{message, details}` result for commands whose output is a
+/// short headline plus a list of secondary lines. Renders through the
+/// `message` template. Per-command result types (e.g. `InitResult`,
+/// `AddIgnoreResult`) exist for backwards compatibility and where
+/// commands grow additional fields; use [`MessageResult`] for new
+/// commands that need only headline + lines.
+#[derive(Debug, Clone, Serialize)]
+pub struct MessageResult {
+    pub message: String,
+    pub details: Vec<String>,
+}
 
 // ── Shared display types ────────────────────────────────────────
 

--- a/crates/dodot-lib/src/commands/prompts.rs
+++ b/crates/dodot-lib/src/commands/prompts.rs
@@ -46,11 +46,7 @@ pub fn list(ctx: &ExecutionContext) -> Result<PromptsListResult> {
     let mut rows: Vec<PromptRow> = catalog::KNOWN_PROMPTS
         .iter()
         .map(|d| {
-            let dismissed_at = registry
-                .dismissed()
-                .into_iter()
-                .find(|(k, _)| *k == d.key)
-                .map(|(_, r)| r.dismissed_at);
+            let dismissed_at = registry.dismissed_at(d.key);
             PromptRow {
                 key: d.key.to_string(),
                 description: d.description.to_string(),
@@ -66,7 +62,7 @@ pub fn list(ctx: &ExecutionContext) -> Result<PromptsListResult> {
 
     // Surface any unknown keys lurking in the registry so they can be
     // reset. Catalog absence is not an error — older dodot versions
-    // may have written them.
+    // may have written them. One pass over the dismissed map; cheap.
     for (key, record) in registry.dismissed() {
         if catalog::lookup(key).is_none() {
             rows.push(PromptRow {

--- a/crates/dodot-lib/src/commands/prompts.rs
+++ b/crates/dodot-lib/src/commands/prompts.rs
@@ -1,0 +1,263 @@
+//! `dodot prompts` — inspect and reset dismissed-prompt state.
+//!
+//! Thin wrapper over [`crate::prompts::PromptRegistry`]. Two operations:
+//!
+//! - `prompts list` — show every known prompt key with its current
+//!   dismissed/active state and a human-readable description.
+//! - `prompts reset` — clear one key (so the prompt fires again next
+//!   time) or all keys.
+
+use serde::Serialize;
+
+use crate::commands::MessageResult;
+use crate::packs::orchestration::ExecutionContext;
+use crate::prompts::{catalog, PromptRegistry};
+use crate::Result;
+
+/// One row in `dodot prompts list`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PromptRow {
+    pub key: String,
+    pub description: String,
+    /// `"dismissed"` or `"active"`. Strings rather than bools so the
+    /// template can colour them via existing status-style tags.
+    pub status: String,
+    /// Unix timestamp (seconds) of dismissal, or `None` if active.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dismissed_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PromptsListResult {
+    pub rows: Vec<PromptRow>,
+    /// Backing file path for the registry (helpful in diagnostics).
+    pub registry_path: String,
+}
+
+/// `dodot prompts list` — show every known prompt with its state.
+///
+/// Returns rows for every key in [`catalog::KNOWN_PROMPTS`] plus any
+/// dismissed key not in the catalog (so a stale entry from a prior
+/// dodot version is still visible and resettable).
+pub fn list(ctx: &ExecutionContext) -> Result<PromptsListResult> {
+    let path = ctx.paths.prompts_path();
+    let registry = PromptRegistry::load(ctx.fs.as_ref(), path.clone())?;
+
+    let mut rows: Vec<PromptRow> = catalog::KNOWN_PROMPTS
+        .iter()
+        .map(|d| {
+            let dismissed_at = registry
+                .dismissed()
+                .into_iter()
+                .find(|(k, _)| *k == d.key)
+                .map(|(_, r)| r.dismissed_at);
+            PromptRow {
+                key: d.key.to_string(),
+                description: d.description.to_string(),
+                status: if dismissed_at.is_some() {
+                    "dismissed".into()
+                } else {
+                    "active".into()
+                },
+                dismissed_at,
+            }
+        })
+        .collect();
+
+    // Surface any unknown keys lurking in the registry so they can be
+    // reset. Catalog absence is not an error — older dodot versions
+    // may have written them.
+    for (key, record) in registry.dismissed() {
+        if catalog::lookup(key).is_none() {
+            rows.push(PromptRow {
+                key: key.to_string(),
+                description: "(no catalog description; key from a prior dodot version)".into(),
+                status: "dismissed".into(),
+                dismissed_at: Some(record.dismissed_at),
+            });
+        }
+    }
+
+    rows.sort_by(|a, b| a.key.cmp(&b.key));
+
+    Ok(PromptsListResult {
+        rows,
+        registry_path: path.display().to_string(),
+    })
+}
+
+/// `dodot prompts reset` — clear dismissals so the prompt fires again.
+///
+/// `key = None` means reset every dismissed prompt.
+pub fn reset(key: Option<&str>, ctx: &ExecutionContext) -> Result<MessageResult> {
+    let path = ctx.paths.prompts_path();
+    let mut registry = PromptRegistry::load(ctx.fs.as_ref(), path)?;
+
+    let (message, details) = match key {
+        Some(k) => {
+            if registry.reset(k) {
+                (
+                    format!("Reset prompt `{k}`."),
+                    vec![
+                        "The prompt will fire again next time the relevant condition is met."
+                            .into(),
+                    ],
+                )
+            } else {
+                // Not an error — just nothing to do.
+                (
+                    format!("Prompt `{k}` was already active (or never dismissed)."),
+                    vec![],
+                )
+            }
+        }
+        None => {
+            let n = registry.reset_all();
+            if n == 0 {
+                ("No dismissed prompts to reset.".into(), vec![])
+            } else {
+                (
+                    format!("Reset {n} dismissed prompt(s)."),
+                    vec!["All previously dismissed prompts will fire again next time their condition is met.".into()],
+                )
+            }
+        }
+    };
+
+    registry.save(ctx.fs.as_ref())?;
+
+    Ok(MessageResult { message, details })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::config::ConfigManager;
+    use crate::datastore::{CommandOutput, CommandRunner, FilesystemDataStore};
+    use crate::fs::Fs;
+    use crate::paths::Pather;
+    use crate::testing::TempEnvironment;
+
+    struct NoopRunner;
+    impl CommandRunner for NoopRunner {
+        fn run(&self, _executable: &str, _arguments: &[String]) -> Result<CommandOutput> {
+            Ok(CommandOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    fn ctx(env: &TempEnvironment) -> ExecutionContext {
+        let runner: Arc<dyn CommandRunner> = Arc::new(NoopRunner);
+        let datastore = Arc::new(FilesystemDataStore::new(
+            env.fs.clone(),
+            env.paths.clone(),
+            runner.clone(),
+        ));
+        let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
+        ExecutionContext {
+            fs: env.fs.clone() as Arc<dyn Fs>,
+            datastore,
+            paths: env.paths.clone() as Arc<dyn Pather>,
+            config_manager,
+            syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
+            command_runner: runner,
+            dry_run: false,
+            no_provision: true,
+            provision_rerun: false,
+            force: false,
+            view_mode: crate::commands::ViewMode::Full,
+            group_mode: crate::commands::GroupMode::Name,
+            verbose: false,
+        }
+    }
+
+    #[test]
+    fn list_shows_every_known_prompt_as_active_initially() {
+        let env = TempEnvironment::builder().build();
+        let result = list(&ctx(&env)).expect("list");
+        assert_eq!(result.rows.len(), catalog::KNOWN_PROMPTS.len());
+        for row in &result.rows {
+            assert_eq!(row.status, "active");
+            assert!(row.dismissed_at.is_none());
+        }
+    }
+
+    #[test]
+    fn list_shows_dismissed_after_dismissal() {
+        let env = TempEnvironment::builder().build();
+        let path = ctx(&env).paths.prompts_path();
+        let mut registry = PromptRegistry::load(env.fs.as_ref(), path).unwrap();
+        registry.dismiss_at("plist.install_filters", 1714557600);
+        registry.save(env.fs.as_ref()).unwrap();
+
+        let result = list(&ctx(&env)).expect("list");
+        let row = result
+            .rows
+            .iter()
+            .find(|r| r.key == "plist.install_filters")
+            .expect("row");
+        assert_eq!(row.status, "dismissed");
+        assert_eq!(row.dismissed_at, Some(1714557600));
+    }
+
+    #[test]
+    fn list_surfaces_unknown_keys_so_they_can_be_reset() {
+        let env = TempEnvironment::builder().build();
+        let path = ctx(&env).paths.prompts_path();
+        let mut registry = PromptRegistry::load(env.fs.as_ref(), path).unwrap();
+        registry.dismiss_at("legacy.key.from.older.dodot", 1714557600);
+        registry.save(env.fs.as_ref()).unwrap();
+
+        let result = list(&ctx(&env)).expect("list");
+        let row = result
+            .rows
+            .iter()
+            .find(|r| r.key == "legacy.key.from.older.dodot")
+            .expect("legacy row should appear");
+        assert_eq!(row.status, "dismissed");
+        assert!(row.description.contains("prior dodot version"));
+    }
+
+    #[test]
+    fn reset_one_persists() {
+        let env = TempEnvironment::builder().build();
+        let path = ctx(&env).paths.prompts_path();
+        let mut registry = PromptRegistry::load(env.fs.as_ref(), path.clone()).unwrap();
+        registry.dismiss_at("plist.install_filters", 1714557600);
+        registry.save(env.fs.as_ref()).unwrap();
+
+        let r = reset(Some("plist.install_filters"), &ctx(&env)).expect("reset");
+        assert!(r.message.contains("Reset prompt"));
+
+        let registry = PromptRegistry::load(env.fs.as_ref(), path).unwrap();
+        assert!(!registry.is_dismissed("plist.install_filters"));
+    }
+
+    #[test]
+    fn reset_unknown_key_succeeds_without_error() {
+        let env = TempEnvironment::builder().build();
+        let r = reset(Some("never-dismissed"), &ctx(&env)).expect("reset");
+        assert!(r.message.contains("already active"));
+    }
+
+    #[test]
+    fn reset_all_clears_everything() {
+        let env = TempEnvironment::builder().build();
+        let path = ctx(&env).paths.prompts_path();
+        let mut registry = PromptRegistry::load(env.fs.as_ref(), path.clone()).unwrap();
+        registry.dismiss_at("a", 1);
+        registry.dismiss_at("b", 2);
+        registry.save(env.fs.as_ref()).unwrap();
+
+        let r = reset(None, &ctx(&env)).expect("reset all");
+        assert!(r.message.contains("Reset 2"));
+
+        let registry = PromptRegistry::load(env.fs.as_ref(), path).unwrap();
+        assert!(registry.dismissed().is_empty());
+    }
+}

--- a/crates/dodot-lib/src/lib.rs
+++ b/crates/dodot-lib/src/lib.rs
@@ -13,6 +13,7 @@ pub mod paths;
 pub mod plists;
 pub mod preprocessing;
 pub mod probe;
+pub mod prompts;
 pub mod render;
 pub mod rules;
 pub mod shell;

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -146,6 +146,15 @@ pub trait Pather: Send + Sync {
     fn probes_brew_cache_dir(&self) -> PathBuf {
         self.cache_dir().join("probes").join("brew")
     }
+
+    /// Persistent record of prompts the user has dismissed (e.g.
+    /// onboarding hints, install offers). Content-agnostic: callers
+    /// pass opaque keys, the registry just tracks dismissed/active.
+    /// Lives under `data_dir` (not `cache_dir`) because losing it
+    /// would re-prompt the user — preference state, not cache.
+    fn prompts_path(&self) -> PathBuf {
+        self.data_dir().join("prompts.json")
+    }
 }
 
 /// XDG-compliant path resolver.

--- a/crates/dodot-lib/src/prompts/catalog.rs
+++ b/crates/dodot-lib/src/prompts/catalog.rs
@@ -1,0 +1,60 @@
+//! Static catalog of known prompt keys with human-readable descriptions.
+//!
+//! The [`PromptRegistry`](super::PromptRegistry) itself is content-agnostic
+//! — keys are opaque strings. This catalog gives `dodot prompts list` a
+//! description column and serves as the canonical list of prompts the
+//! codebase introduces. Adding a new prompt? Pick a key, register it
+//! here.
+//!
+//! Keys follow `<area>.<name>` convention: `plist.install_filters`,
+//! `template.first_render`, etc. Reverse-DNS-style nesting if an area
+//! grows multiple sub-features.
+
+/// A documented prompt key.
+#[derive(Debug, Clone, Copy)]
+pub struct PromptDescriptor {
+    /// The key passed to [`PromptRegistry`](super::PromptRegistry) calls.
+    pub key: &'static str,
+    /// Human-readable summary of when this prompt fires and what it asks.
+    pub description: &'static str,
+}
+
+/// Every prompt key the codebase uses. Keep alphabetised by key so
+/// `dodot prompts list` output is stable across edits.
+pub const KNOWN_PROMPTS: &[PromptDescriptor] = &[PromptDescriptor {
+    key: "plist.install_filters",
+    description:
+        "Offer to install git clean/smudge filters when a pack contains tracked .plist files",
+}];
+
+/// Look up a descriptor by key, if registered.
+pub fn lookup(key: &str) -> Option<&'static PromptDescriptor> {
+    KNOWN_PROMPTS.iter().find(|d| d.key == key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keys_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for d in KNOWN_PROMPTS {
+            assert!(seen.insert(d.key), "duplicate prompt key: {}", d.key);
+        }
+    }
+
+    #[test]
+    fn keys_are_alphabetised() {
+        let keys: Vec<_> = KNOWN_PROMPTS.iter().map(|d| d.key).collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted, "KNOWN_PROMPTS must be sorted by key");
+    }
+
+    #[test]
+    fn lookup_finds_known_keys() {
+        assert!(lookup("plist.install_filters").is_some());
+        assert!(lookup("nonexistent.key").is_none());
+    }
+}

--- a/crates/dodot-lib/src/prompts/mod.rs
+++ b/crates/dodot-lib/src/prompts/mod.rs
@@ -1,0 +1,269 @@
+//! Persistent registry of dismissed prompts.
+//!
+//! A content-agnostic key/value store for "have I shown the user X yet?"
+//! state. Callers pass opaque string keys; the registry tracks which
+//! keys have been dismissed and when. Reset clears one or all keys so
+//! the next caller-side check fires the prompt again.
+//!
+//! Used as the foundation for one-time onboarding prompts, install
+//! offers, and any other nudge that should not repeat after the user
+//! has answered it. The registry itself does NOT render prompts, decide
+//! UX, or know what each key means — that is the caller's job.
+//!
+//! See `docs/proposals/plists.lex` §5.3 for the first user (the plist
+//! filter install offer); future callers slot in by picking their own
+//! key and updating the catalog in [`catalog`] so `dodot prompts list`
+//! can describe them.
+//!
+//! Storage: JSON at `<data_dir>/prompts.json` (durable, alongside other
+//! persistent state). Schema is versioned for forward compatibility.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::fs::Fs;
+use crate::{DodotError, Result};
+
+pub mod catalog;
+
+const SCHEMA_VERSION: u32 = 1;
+
+/// One row in the registry: when the user dismissed this prompt.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptRecord {
+    /// Wall-clock unix timestamp (seconds) of the dismissal.
+    pub dismissed_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PromptFile {
+    version: u32,
+    #[serde(default)]
+    prompts: BTreeMap<String, PromptRecord>,
+}
+
+impl Default for PromptFile {
+    fn default() -> Self {
+        Self {
+            version: SCHEMA_VERSION,
+            prompts: BTreeMap::new(),
+        }
+    }
+}
+
+/// Persistent dismissed-prompt registry.
+///
+/// `load` populates from disk (returns an empty registry if the file
+/// does not exist); mutations are in-memory until `save` is called.
+#[derive(Debug, Clone)]
+pub struct PromptRegistry {
+    path: PathBuf,
+    file: PromptFile,
+}
+
+impl PromptRegistry {
+    /// Load the registry from `path`. A missing file is treated as an
+    /// empty registry — first-run users have nothing to read.
+    pub fn load(fs: &dyn Fs, path: PathBuf) -> Result<Self> {
+        if !fs.exists(&path) {
+            return Ok(Self {
+                path,
+                file: PromptFile::default(),
+            });
+        }
+        let raw = fs.read_to_string(&path)?;
+        let file: PromptFile = serde_json::from_str(&raw).map_err(|e| {
+            DodotError::Other(format!(
+                "failed to parse prompts registry at {}: {e}",
+                path.display()
+            ))
+        })?;
+        if file.version != SCHEMA_VERSION {
+            return Err(DodotError::Other(format!(
+                "prompts registry at {} has unsupported schema version {} (expected {})",
+                path.display(),
+                file.version,
+                SCHEMA_VERSION
+            )));
+        }
+        Ok(Self { path, file })
+    }
+
+    /// Persist the registry to its backing path. Creates parent dirs
+    /// as needed.
+    pub fn save(&self, fs: &dyn Fs) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs.mkdir_all(parent)?;
+        }
+        let body = serde_json::to_string_pretty(&self.file)
+            .map_err(|e| DodotError::Other(format!("failed to serialise prompts: {e}")))?;
+        fs.write_file(&self.path, body.as_bytes())?;
+        Ok(())
+    }
+
+    /// Backing file path (for diagnostic messages and `dodot prompts list`).
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// True if the prompt with this key has been dismissed.
+    pub fn is_dismissed(&self, key: &str) -> bool {
+        self.file.prompts.contains_key(key)
+    }
+
+    /// Record that the user dismissed this prompt. Idempotent — calling
+    /// twice updates `dismissed_at` to the latest call.
+    pub fn dismiss(&mut self, key: &str) {
+        self.dismiss_at(key, now_secs_unix())
+    }
+
+    /// Test-friendly sibling of [`dismiss`] that takes an explicit
+    /// timestamp instead of reading the wall clock.
+    pub fn dismiss_at(&mut self, key: &str, dismissed_at: u64) {
+        self.file
+            .prompts
+            .insert(key.to_string(), PromptRecord { dismissed_at });
+    }
+
+    /// Clear a single dismissal so the prompt fires again next time.
+    /// Returns `true` if the key was present.
+    pub fn reset(&mut self, key: &str) -> bool {
+        self.file.prompts.remove(key).is_some()
+    }
+
+    /// Clear every dismissal. Returns the count cleared.
+    pub fn reset_all(&mut self) -> usize {
+        let n = self.file.prompts.len();
+        self.file.prompts.clear();
+        n
+    }
+
+    /// Snapshot of dismissed prompts, sorted by key. Suitable for
+    /// rendering by `dodot prompts list`.
+    pub fn dismissed(&self) -> Vec<(&str, &PromptRecord)> {
+        self.file
+            .prompts
+            .iter()
+            .map(|(k, v)| (k.as_str(), v))
+            .collect()
+    }
+}
+
+/// Wall-clock unix timestamp helper used by [`PromptRegistry::dismiss`].
+/// Tests should call [`PromptRegistry::dismiss_at`] with a fixed value.
+pub fn now_secs_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::Pather;
+    use crate::testing::TempEnvironment;
+
+    fn registry(env: &TempEnvironment) -> PromptRegistry {
+        let path = env.paths.prompts_path();
+        PromptRegistry::load(env.fs.as_ref(), path).expect("load")
+    }
+
+    #[test]
+    fn load_missing_file_returns_empty() {
+        let env = TempEnvironment::builder().build();
+        let r = registry(&env);
+        assert!(r.dismissed().is_empty());
+        assert!(!r.is_dismissed("anything"));
+    }
+
+    #[test]
+    fn dismiss_then_query() {
+        let env = TempEnvironment::builder().build();
+        let mut r = registry(&env);
+        r.dismiss_at("plist.install_filters", 1714557600);
+        assert!(r.is_dismissed("plist.install_filters"));
+        assert!(!r.is_dismissed("something.else"));
+    }
+
+    #[test]
+    fn dismiss_is_idempotent_and_updates_timestamp() {
+        let env = TempEnvironment::builder().build();
+        let mut r = registry(&env);
+        r.dismiss_at("k", 100);
+        r.dismiss_at("k", 200);
+        assert_eq!(r.dismissed().len(), 1);
+        assert_eq!(r.dismissed()[0].1.dismissed_at, 200);
+    }
+
+    #[test]
+    fn save_and_reload_roundtrip() {
+        let env = TempEnvironment::builder().build();
+        {
+            let mut r = registry(&env);
+            r.dismiss_at("a", 100);
+            r.dismiss_at("b", 200);
+            r.save(env.fs.as_ref()).expect("save");
+        }
+        let r = registry(&env);
+        let dismissed = r.dismissed();
+        assert_eq!(dismissed.len(), 2);
+        // BTreeMap ordering — keys are sorted.
+        assert_eq!(dismissed[0].0, "a");
+        assert_eq!(dismissed[1].0, "b");
+    }
+
+    #[test]
+    fn reset_one_returns_whether_present() {
+        let env = TempEnvironment::builder().build();
+        let mut r = registry(&env);
+        r.dismiss_at("a", 100);
+        assert!(r.reset("a"));
+        assert!(!r.reset("a")); // already gone
+        assert!(!r.reset("never-set"));
+    }
+
+    #[test]
+    fn reset_all_returns_count_cleared() {
+        let env = TempEnvironment::builder().build();
+        let mut r = registry(&env);
+        r.dismiss_at("a", 1);
+        r.dismiss_at("b", 2);
+        r.dismiss_at("c", 3);
+        assert_eq!(r.reset_all(), 3);
+        assert!(r.dismissed().is_empty());
+        assert_eq!(r.reset_all(), 0); // already empty
+    }
+
+    #[test]
+    fn corrupted_file_returns_error() {
+        let env = TempEnvironment::builder().build();
+        let path = env.paths.prompts_path();
+        env.fs.as_ref().mkdir_all(path.parent().unwrap()).unwrap();
+        env.fs.as_ref().write_file(&path, b"{not json").unwrap();
+        let err = PromptRegistry::load(env.fs.as_ref(), path).unwrap_err();
+        assert!(
+            format!("{err}").contains("failed to parse"),
+            "expected parse error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unsupported_schema_version_returns_error() {
+        let env = TempEnvironment::builder().build();
+        let path = env.paths.prompts_path();
+        env.fs.as_ref().mkdir_all(path.parent().unwrap()).unwrap();
+        env.fs
+            .as_ref()
+            .write_file(&path, br#"{"version": 999, "prompts": {}}"#)
+            .unwrap();
+        let err = PromptRegistry::load(env.fs.as_ref(), path).unwrap_err();
+        assert!(
+            format!("{err}").contains("unsupported schema version"),
+            "expected schema error, got: {err}"
+        );
+    }
+}

--- a/crates/dodot-lib/src/prompts/mod.rs
+++ b/crates/dodot-lib/src/prompts/mod.rs
@@ -142,13 +142,23 @@ impl PromptRegistry {
     }
 
     /// Snapshot of dismissed prompts, sorted by key. Suitable for
-    /// rendering by `dodot prompts list`.
+    /// rendering by `dodot prompts list`. Allocates; if you only need
+    /// per-key lookups, prefer [`dismissed_at`](Self::dismissed_at).
     pub fn dismissed(&self) -> Vec<(&str, &PromptRecord)> {
         self.file
             .prompts
             .iter()
             .map(|(k, v)| (k.as_str(), v))
             .collect()
+    }
+
+    /// O(log n) lookup of a single prompt's dismissal timestamp.
+    /// Returns `None` if the prompt is currently active. Pair with
+    /// [`is_dismissed`](Self::is_dismissed) when you only need the
+    /// boolean — this returns the timestamp too for UIs that show
+    /// "dismissed at …".
+    pub fn dismissed_at(&self, key: &str) -> Option<u64> {
+        self.file.prompts.get(key).map(|r| r.dismissed_at)
     }
 }
 

--- a/crates/dodot-lib/src/render/mod.rs
+++ b/crates/dodot-lib/src/render/mod.rs
@@ -143,6 +143,12 @@ pub const TEMPLATE_MESSAGE: &str = include_str!("../templates/message.jinja");
 /// `kind` field of the serialized result.
 pub const TEMPLATE_PROBE: &str = include_str!("../templates/probe.jinja");
 
+/// Git filter installation snippets (`dodot git-show-filters`).
+pub const TEMPLATE_GIT_FILTERS: &str = include_str!("../templates/git-filters.jinja");
+
+/// Dismissed-prompt registry listing (`dodot prompts list`).
+pub const TEMPLATE_PROMPTS_LIST: &str = include_str!("../templates/prompts-list.jinja");
+
 // ── Tutorial step templates ─────────────────────────────────────
 //
 // One per step of the interactive tutorial. The CLI driver renders
@@ -228,6 +234,12 @@ pub fn create_renderer() -> Renderer {
     renderer.add_template("message", TEMPLATE_MESSAGE).unwrap();
     renderer.add_template("probe", TEMPLATE_PROBE).unwrap();
     renderer
+        .add_template("git-filters", TEMPLATE_GIT_FILTERS)
+        .unwrap();
+    renderer
+        .add_template("prompts-list", TEMPLATE_PROMPTS_LIST)
+        .unwrap();
+    renderer
 }
 
 /// Render a template with the given data and output mode.
@@ -250,6 +262,8 @@ pub fn render<T: serde::Serialize>(
         "list" => TEMPLATE_LIST,
         "message" => TEMPLATE_MESSAGE,
         "probe" => TEMPLATE_PROBE,
+        "git-filters" => TEMPLATE_GIT_FILTERS,
+        "prompts-list" => TEMPLATE_PROMPTS_LIST,
         other => {
             return Err(crate::DodotError::Other(format!(
                 "unknown template: {other}"

--- a/crates/dodot-lib/src/templates/git-filters.jinja
+++ b/crates/dodot-lib/src/templates/git-filters.jinja
@@ -1,0 +1,13 @@
+[header]Plist git-filter configuration[/header]
+
+[desc]Add to [item].git/config[/item] (per clone, per machine{% if installed_in_git_config %} — [item]already installed[/item]{% endif %}):[/desc]
+
+{% for line in config_block_lines %}    {{ line }}
+{% endfor %}
+[desc]Add to [item].gitattributes[/item] (committed in the repo{% if bound_in_gitattributes %} — [item]already present[/item]{% endif %}):[/desc]
+
+    {{ gitattributes_line }}
+
+[desc]Repo: [item]{{ repo_root }}[/item]
+
+Run [example]dodot git-install-filters[/example] to install the .git/config block automatically.[/desc]

--- a/crates/dodot-lib/src/templates/prompts-list.jinja
+++ b/crates/dodot-lib/src/templates/prompts-list.jinja
@@ -1,0 +1,7 @@
+[header]Prompts[/header]
+{% for row in rows %}
+  [item]{{ row.key }}[/item]
+    {% if row.status == "dismissed" %}[deployed]dismissed[/deployed]{% else %}[pending]active[/pending]{% endif %}  [description]{{ row.description }}[/description]
+{% endfor %}
+[dim]Registry: {{ registry_path }}
+Reset with [example]dodot prompts reset <key>[/example] or [example]dodot prompts reset --all[/example].[/dim]


### PR DESCRIPTION
## Summary

Phase P2 of the plist clean/smudge track. Three user-facing additions plus a generic prompt-registry layer underneath them, designed to be reused by future onboarding nudges (template Phase 3, cfprefsd hint, etc.) so we don't reinvent the same plumbing each time.

**User-facing commands:**

- `dodot git-install-filters` — writes the `[filter "dodot-plist"]` block to the dotfiles repo's `.git/config`. Idempotent (re-run is a no-op success). Per-clone, per-machine.
- `dodot git-show-filters` — prints the same `.git/config` block plus the `.gitattributes` line for inspection or manual install. Annotates each snippet with whether it's currently in place.
- `dodot prompts list` / `dodot prompts reset <key>` / `dodot prompts reset --all` — inspect and clear the dismissed-prompt registry.

**Up-time integration:** after `dodot up` succeeds, if stdin is a TTY AND any pack contains `*.plist` files AND the filter is unregistered AND the prompt is not dismissed, dodot offers a `[Y/n/show]` prompt. `Y` installs and dismisses; `n` declines without dismissing (re-asks next time); `show` prints the config without committing. Non-TTY invocations (CI, scripts) skip silently — the prompt path never aborts up.

## Architectural note

The user [requested](https://anthropic.com/) that the one-time-prompt mechanism be a *generic*, content-agnostic system from day one rather than baked into the plist code. So `dodot_lib::prompts::PromptRegistry` is a small JSON-backed key/value store with no knowledge of plists, filters, or any specific prompt. Keys are opaque strings; the registry just tracks which have been dismissed and when. A static catalog (`prompts::catalog::KNOWN_PROMPTS`) gives keys human-readable descriptions for `dodot prompts list`.

The plist filter-install offer is the first caller; future prompts (template Phase 3 install offer, etc.) slot in by picking a key and adding it to the catalog.

## What went into each layer

- `dodot_lib::prompts` — generic registry (`load`, `save`, `is_dismissed`, `dismiss`, `reset`, `reset_all`, `dismissed`). Persists at `<data_dir>/prompts.json`. Versioned schema. 11 unit tests.
- `dodot_lib::commands::prompts` — wraps the registry as `list`/`reset` commands for CLI consumption. Surfaces unknown keys lurking from older dodot versions so they can be reset. 6 unit tests.
- `dodot_lib::commands::git_filters` — `install_filters`, `show_filters`, plus the helpers `is_installed` and `detect_plist_files` used by the up-time prompt. Subprocess-based git config interaction (via the existing `CommandRunner`); treats `git config --get` exit 1 as "not installed" rather than an error. 3 unit tests.
- `dodot-cli` — new subcommands and handlers, an `interactive` module for the Y/n/show prompt + TTY detection, two new templates (`git-filters.jinja`, `prompts-list.jinja`), and the post-`up` dispatch hook in `main.rs`.

## Manually verified

```text
$ DOTFILES_ROOT=/tmp/repo dodot git-install-filters
Installed plist clean/smudge filters.
  Wrote [filter "dodot-plist"] to /tmp/repo/.git/config
  Next: ensure your .gitattributes binds *.plist to this filter:
      echo '*.plist filter=dodot-plist' >> .gitattributes
      git add .gitattributes && git commit -m 'enable plist filters'

$ DOTFILES_ROOT=/tmp/repo dodot git-install-filters     # idempotent re-run
Plist filters already installed in .git/config.
  Next: ensure your .gitattributes …

$ dodot prompts list
Prompts
  plist.install_filters
    active  Offer to install git clean/smudge filters when a pack contains tracked .plist files
  Registry: ~/.local/share/dodot/prompts.json
```

## Checklist

- [x] Changelog `Unreleased` section updated
- [x] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` all green (684 lib + 12 cli tests passing locally; pre-commit hook also passed)
- [x] Tests added for new behaviour (19 new unit tests across `prompts`, `commands::prompts`, `commands::git_filters`)

## Notes for reviewers

- The interactive prompt path can't be unit-tested without TTY plumbing, so it's manually verified. The component pieces (`detect_plist_files`, `is_installed`, registry operations) are all covered.
- Up-time prompt's exit semantics: if `install_filters` fails after the user says Y, the registry is NOT marked dismissed (the `?` propagates before `dismiss()` is called), so the user gets re-prompted next up. Good.
- `dodot prompts reset` accepts either a positional key OR `--all`, never both. Using `--all` with a key, or neither, is a hard error from the handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)