### PR TITLE
docs: sync proposals + reference docs with shipped plist track

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ dodot uses a double-symlink architecture (`~/.config/nvim/init.lua → datastore
 
 All conventions can be overridden via `.dodot.toml` in the pack or the dotfiles root.
 
+## macOS Plists
+
+dodot brings macOS GUI app preferences (binary `*.plist` files at `~/Library/Preferences/...` and `~/Library/Application Support/<App>/...`) under the same review/diff/cherry-pick workflow as plain-text dotfiles, by translating them through git clean/smudge filters:
+
+- The file in your pack is the binary the app reads.
+- What git stores is canonical, alphabetically-sorted XML.
+- `git status` and `git diff` show settings changes the way they show every other dotfile change.
+
+Setup is a one-liner per machine plus a single `.gitattributes` line in the repo:
+
+```sh
+$ dodot git-install-filters
+$ echo '*.plist filter=dodot-plist' >> .gitattributes
+$ git add .gitattributes && git commit -m 'enable plist filters'
+```
+
+Adopt existing settings with `dodot adopt --into <pack> ~/Library/Preferences/com.app.plist`. The full reference is at `docs/reference/plists.lex`. macOS-only at deploy time; the CLI surface (`dodot plist clean/smudge`) is platform-agnostic.
+
 ## Commands
 
 | Command      | Description                                      |
@@ -117,6 +135,10 @@ All conventions can be overridden via `.dodot.toml` in the pack or the dotfiles 
 | `addignore`  | Mark a pack as ignored                           |
 | `init-sh`    | Print shell init script for `eval`               |
 | `config`     | Inspect and modify configuration                 |
+| `plist`      | clean/smudge filters for macOS plists (stdin→stdout) |
+| `git-install-filters` | Wire plist filters into the repo's `.git/config`  |
+| `git-show-filters`    | Print plist filter config snippets without writing |
+| `prompts`    | Inspect/reset dismissed one-time prompts         |
 
 All commands accept pack names as arguments (`dodot up git nvim`) or operate on all packs when run without arguments.
 

--- a/docs/proposals/plists.lex
+++ b/docs/proposals/plists.lex
@@ -1,5 +1,8 @@
 Design Specification: macOS Plist Support
 
+    :: note ::
+        **Status: implemented and shipped.** Phases P1–P4 landed in PRs #95, #96, and #97. The user-facing reference for the resulting feature lives in [./../reference/plists.lex] (filter setup, adopt flow, day-to-day workflow) and [./../reference/pre-processors.lex] §3 (Representational transform shape). This proposal is preserved as historical design context — *not* a maintained spec. Where this document and the reference docs disagree about behavior, the reference docs are authoritative; where this document and the source disagree, the source is authoritative. See "Implementation Notes vs. Spec" at the bottom of this document for the deviations that were accepted during implementation.
+
     This document specifies how dodot manages macOS property list (plist) files. Plist support is implemented as a pair of git clean/smudge filters — the architecture sketched as Phase 2 of the Magical Git Experience [./magic.lex]. It is *not* a preprocessor in the sense of [./preprocessing-pipeline.lex], and intentionally so: the trade-offs that make the pipeline-and-pre-commit-hook approach right for templates make it the wrong shape for plists. The reasoning is in §2.
 
     Plists are where macOS GUI applications store their preferences. Bringing them under dodot's control means a dotfiles repo can carry not just shell and config-file state but also GUI-app state — Finder settings, Terminal profile, Xcode preferences, per-app panes — and still deliver the review/diff/cherry-pick/revert workflow users expect from plain-text dotfiles.
@@ -355,3 +358,27 @@ Design Specification: macOS Plist Support
     11.4. Plist Subset of `_lib/Preferences/`
 
         [./macos-paths.lex] §11.3 notes that `_lib/Preferences/<bundle-id>.plist` is a syntactically valid path and that this proposal covers the format-management half. The two compose: the `_lib/` prefix routes the file to `~/Library/Preferences/`; the clean/smudge filter handles the binary↔XML translation. No further coordination is required.
+
+12. Implementation Notes vs. Spec
+
+    The implementation deviates from the spec above in a few places. Listed here so future readers don't mistake the spec for the source of truth:
+
+    12.1. P2 `.gitattributes` Template via `dodot init`
+
+        Spec §10 P2 calls for *".gitattributes template emitted by `dodot init` (or merged into existing `.gitattributes`)"*. Not implemented. `dodot git-install-filters` prints the line as a hint instead, and the user adds it to `.gitattributes` once. Deferred until init grows other dotfiles-repo-bootstrap concerns; tracked as future polish.
+
+    12.2. P3 `dodot adopt` In-Pack Encoding
+
+        Spec §7.1 (the original) suggested moving the binary to `<pack>/com.app.plist` (top of pack) and relying on per-file `[symlink.targets]` to route back to `~/Library/Preferences/`. The shipped implementation uses `<pack>/_lib/Preferences/com.app.plist` instead, which round-trips automatically via the existing Priority 2d `_lib/` resolver — no per-file config needed. The proposal text in §7 was updated to reflect this; the spec sketch above is preserved as-is for historical context.
+
+    12.3. P3 Source-Root Generality
+
+        The spec frames adopt as plist-specific. The implementation generalises: any `~/Library/<sub>/<file>` source on macOS lands at `<pack>/_lib/<sub>/<file>` — covering `Preferences/`, `LaunchAgents/`, `Fonts/`, `Services/`, etc. This is a strict superset of the plist case and falls out of using the existing `SourceRoot` inference framework. `--into <pack>` is required because the bundle-ID-style filenames (`com.colliderli.iina.plist`) don't infer a useful pack name.
+
+    12.4. P4 `dodot probe app` Integration
+
+        Spec §10 P4 calls for *"`dodot probe app` integration: when probing a pack, surface plist-related cask/preferences associations"*. Already shipped as part of the macOS-paths M6 work (PR #91/#92) — `probe app` reads cask `zap` data and surfaces preferences plists as sibling-adoption suggestions. No additional plist-specific work was needed.
+
+    12.5. P4 Missing-`dodot`-on-PATH Detection
+
+        Spec §10 P4 calls for *"Error messages for missing `dodot` on PATH at filter-invocation time"*. dodot itself can't reliably detect what `$PATH` git will see (especially in GUI git clients with reduced environments), so detection is left to git's own loud failure (the `required = true` setting promotes it to a hard error). The shipped polish is documentation in `dodot git-install-filters --help` covering the failure mode and the absolute-path workaround.

--- a/docs/reference/plists.lex
+++ b/docs/reference/plists.lex
@@ -1,0 +1,226 @@
+macOS Plists
+
+    macOS GUI applications store their preferences as binary plists at `~/Library/Preferences/<bundle-id>.plist` and `~/Library/Application Support/<App>/...`. dodot brings these under source control by translating them to canonical XML on `git add` and back to binary on `git checkout` — the file in your pack is the binary the app reads, and what git stores is human-diffable XML. There is no "render step", no datastore copy, no separate workflow. `git status` and `git diff` show settings changes the way they show every other dotfile change.
+
+    This document is the user-facing reference. The architectural rationale (why clean/smudge filters rather than a preprocessing pipeline; why working-tree binary rather than working-tree XML) is in [./../proposals/plists.lex].
+
+    :: note :: Plist support is macOS-only at deploy time. The CLI surface (`dodot plist clean/smudge`) works on every platform and is exercised in CI on Linux runners; the deploy-side `_lib/` resolver and the up-time prompt are gated on macOS.
+
+1. The Mechanism
+
+    Three files; one symlink:
+
+    Layout:
+
+        <pack>/foo.plist                    # working-tree file: BINARY
+        git index entry for <pack>/foo.plist # canonical XML (what `git diff` shows)
+        ~/Library/Preferences/foo.plist     # symlink → <pack>/foo.plist
+
+    :: text ::
+
+    The deployed file IS the working-tree file (via dodot's normal symlink). When the macOS app writes settings, the bytes land at `<pack>/foo.plist` directly and that file's mtime updates. The next `git status` stats the working-tree path, sees the mtime mismatch against the index, and re-runs the clean filter on it. No injected timestamps, no `dodot refresh`, no separate datastore copy.
+
+    What's in the index is canonical XML: dictionary keys sorted recursively (Unicode codepoint order), array order preserved, deterministic formatting, single trailing LF. The same logical plist always produces byte-identical XML regardless of the encoder's internal layout, so `git diff` only reports semantic changes — never encoder noise.
+
+2. Setup
+
+    Two pieces wire git to dodot's filters:
+
+    2.1. `.gitattributes` (committed in the repo)
+
+        Add a single line that binds `*.plist` files to the dodot-plist filter:
+
+            *.plist filter=dodot-plist
+
+        :: text ::
+
+        This file is part of the repo and travels with every clone. Without the matching `.git/config` registration described below, `.gitattributes` alone is harmless but inert — git falls back to the identity filter.
+
+    2.2. `.git/config` (per clone, per machine)
+
+        Run once per machine:
+
+            dodot git-install-filters
+
+        :: text ::
+
+        Writes the `[filter "dodot-plist"]` block:
+
+            [filter "dodot-plist"]
+                clean  = dodot plist clean
+                smudge = dodot plist smudge
+                required = true
+
+        :: text ::
+
+        `required = true` means git aborts loudly if the filter binary is missing or fails — preferable to silently storing the wrong representation. Re-running `dodot git-install-filters` is idempotent.
+
+        To inspect or install by hand instead:
+
+            dodot git-show-filters
+
+        :: text ::
+
+        prints both snippets (the `.git/config` block and the `.gitattributes` line) without writing anything. Each is annotated with whether it is currently in place.
+
+    2.3. The Up-Time Prompt
+
+        On the first `dodot up` of a pack containing `*.plist` files, dodot offers to install the filters interactively if they are not yet registered:
+
+            dodot detected N .plist file(s) in pack `mac-defaults`.
+            Plist support uses git clean/smudge filters to keep the source diffable.
+            Install filters now? Run `dodot git-show-filters` to inspect first.
+            [Y/n/show]
+
+        :: text ::
+
+        - **Y** (or empty input): runs `dodot git-install-filters` and dismisses the prompt for this machine.
+        - **n**: skips. The prompt fires again on the next `up` until you install (or your filter setup is complete via some other path).
+        - **show**: prints the config without installing. Doesn't dismiss the prompt.
+
+        The prompt fires only on a TTY — non-interactive invocations (CI, shell scripts) skip it silently. To re-enable a dismissed prompt, run `dodot prompts reset plist.install_filters`.
+
+3. Day-to-Day Workflow
+
+    Once filters are wired, plist work uses vanilla git:
+
+    Workflow:
+
+        # The app writes settings via its UI. The working-tree binary
+        # has new bytes; mtime updates.
+
+        $ git status
+        modified:   mac-defaults/com.app.plist
+
+        $ git diff mac-defaults/com.app.plist
+        # ... XML diff showing exactly which keys changed ...
+
+        $ git add mac-defaults/com.app.plist
+        $ git commit -m "tweak terminal font size"
+
+    :: text ::
+
+    No dodot command is invoked. The clean filter renders canonical XML for the index on `git add`; the smudge filter renders binary for the working tree on `git checkout`.
+
+    On another machine:
+
+        $ git pull
+        $ dodot up
+        $ killall cfprefsd  # see §5
+
+    :: text ::
+
+    `git pull` invokes the smudge filter on any updated `.plist` files, materialising the new binary in the working tree. `dodot up` ensures the symlinks are in place.
+
+4. Adopting Existing Plists
+
+    To bring a plist already in `~/Library/Preferences/` (or any `~/Library/<sub>/`) under dodot:
+
+        dodot adopt --into <pack> ~/Library/Preferences/com.app.plist
+
+    :: text ::
+
+    The file moves to `<pack>/_lib/Preferences/com.app.plist` (the `_lib/` prefix routes back to `~/Library/Preferences/` on `dodot up`). A symlink replaces the original. `--into <pack>` is required — plist filenames are typically reverse-DNS bundle IDs that don't make useful pack names.
+
+    Same flow works for `~/Library/LaunchAgents/...`, `~/Library/Fonts/...`, etc. — anything under `~/Library/` not nested in `Application Support` (which routes through `_app/` instead — see [./symlink-paths.lex] §6) or `Containers` (refused as sandboxed-app data).
+
+    If filters aren't yet installed when you adopt, dodot prints a one-line tip pointing at `dodot git-install-filters`. You can install before or after adopting; the next `git add` runs the clean filter regardless.
+
+5. cfprefsd: Why You May Need `killall`
+
+    macOS's `cfprefsd` daemon caches plist values in memory. Writing to the on-disk binary — even via the deploy symlink — may not be picked up by a running app until cfprefsd re-reads its preferences. After pulling plist changes from another machine and running `dodot up`, run:
+
+        killall cfprefsd
+
+    :: text ::
+
+    cfprefsd auto-respawns immediately; no data is lost. dodot prints this reminder in the `git-install-filters` success output.
+
+6. Filter Failure Modes
+
+    `required = true` makes filter failures hard errors. Three things can trigger them:
+
+    6.1. `dodot` not on `$PATH`
+
+        The filter entry uses bare `dodot plist clean/smudge`, so the binary must be on `$PATH` for whatever process invokes git — shell, editor, GUI git client, etc. GUI git clients sometimes run from a reduced environment that doesn't see your shell's `$PATH`. The fix is to either put `dodot` on the system `$PATH` (e.g. `/usr/local/bin/dodot`) or hand-edit the `.git/config` block to use an absolute path.
+
+    6.2. Corrupt or non-plist input
+
+        If `.gitattributes` binds `*.plist` to the filter but a file matching that pattern isn't a valid plist (typo'd extension, corrupt download), the filter exits non-zero and git refuses the operation. dodot's error message names both common causes and points at `dodot git-show-filters` for inspection. To diagnose:
+
+            plutil -lint <file>            # is the file a valid plist?
+            plutil -convert xml1 <file>    # what does it look like as XML?
+            dodot git-show-filters          # which files are bound to the filter?
+
+        :: text ::
+
+    6.3. Determinism contract violations
+
+        Two consecutive `git status` invocations on an unchanged file should produce the same blob SHA. If they don't, the canonicalisation has a non-deterministic dependency. dodot's unit suite includes a property test (`determinism_property_test`) that round-trips `binary → clean → smudge → clean` five times and asserts byte-equality; the e2e suite (`tests/e2e/bats/test_plists.bats`) verifies the same property through real `git add`. If you see drift in practice, file an issue with the offending plist attached.
+
+7. The Working-Tree-Binary Trade-Off
+
+    The cost of this architecture, stated plainly: the file in your pack is binary. `cat pack/com.app.plist` shows noise. An editor opening the pack file directly sees binary garbage.
+
+    What is *not* lost:
+
+        - `git diff`, `git show <ref>:<path>`, `git log -p` all show XML — that is what git stores.
+        - `git status` shows whether the binary differs from the canonical XML in the index.
+        - PR reviews show XML diffs.
+        - Settings are authored by editing through the app's normal GUI, or by editing the deployed file with a plist editor — almost no one wants to hand-edit the file in the pack.
+
+    For the rare case where you do want to hand-edit the XML in the pack:
+
+        plutil -convert xml1 pack/com.app.plist
+        $EDITOR pack/com.app.plist
+        plutil -convert binary1 pack/com.app.plist
+
+    :: text ::
+
+    dodot does not ship a sugar command for this — it's a one-liner against `plutil`, and surfacing it as a dodot command would imply a workflow that should remain rare.
+
+8. The Generic Prompt Registry
+
+    The up-time install offer goes through a content-agnostic registry at `<XDG_DATA_HOME>/dodot/prompts.json`. Two CLI verbs:
+
+    Commands:
+
+        dodot prompts list                              # show every known prompt + state
+        dodot prompts reset plist.install_filters       # un-dismiss one prompt
+        dodot prompts reset --all                       # un-dismiss all
+
+    :: text ::
+
+    `dodot prompts list` shows known prompts as `active` (will fire when the condition is next met) or `dismissed` (suppressed). Future onboarding nudges use the same machinery — there's only one prompt today, but the registry is the right place to look when something does or doesn't fire.
+
+9. Configuration
+
+    Plist support has minimal configuration. The relevant block lives under `[symlink]` because plists deploy via the symlink handler:
+
+    Schema:
+
+        [symlink]
+        plist_extensions = ["plist"]   # filename suffixes treated as plists for adopt hints
+
+    :: toml ::
+
+    The extension list controls *adopt hints and prompts*, not deployment. Deployment is governed by the symlink handler and the file's location, the same as any other file.
+
+    There is no `[preprocessor.plist]` section. Plists do not go through the preprocessing pipeline.
+
+10. Commands at a Glance
+
+    Plist-related verbs and what they do:
+
+    Reference:
+        | Command                              | Purpose                                                  |
+        | `dodot plist clean`                  | stdin binary → stdout canonical XML (filter direction 1) |
+        | `dodot plist smudge`                 | stdin XML → stdout binary plist (filter direction 2)     |
+        | `dodot git-install-filters`          | write `[filter "dodot-plist"]` to `.git/config`          |
+        | `dodot git-show-filters`             | print config + .gitattributes snippets without writing   |
+        | `dodot adopt --into <p> <path>`      | move existing `~/Library/<sub>/` files into pack `<p>`   |
+        | `dodot prompts list`                 | show dismissed-prompt state                              |
+        | `dodot prompts reset <key>`/`--all`  | clear dismissals so the prompt fires again               |
+    :: table align=ll ::
+
+    `dodot plist clean/smudge` are filters: they read stdin and write stdout. You don't normally invoke them by hand; git invokes them via the filter mechanism. Running them manually is fine for inspection (`dodot plist clean < some.plist | head` shows the canonical XML form) but not part of any workflow.

--- a/docs/reference/plists.lex
+++ b/docs/reference/plists.lex
@@ -4,7 +4,7 @@ macOS Plists
 
     This document is the user-facing reference. The architectural rationale (why clean/smudge filters rather than a preprocessing pipeline; why working-tree binary rather than working-tree XML) is in [./../proposals/plists.lex].
 
-    :: note :: Plist support is macOS-only at deploy time. The CLI surface (`dodot plist clean/smudge`) works on every platform and is exercised in CI on Linux runners; the deploy-side `_lib/` resolver and the up-time prompt are gated on macOS.
+    :: note :: macOS-only behaviour is the deploy-side `_lib/` resolver (which routes `_lib/<rest>` to `~/Library/<rest>`) and the `~/Library/...` adopt inference. The CLI surface (`dodot plist clean/smudge`, `dodot git-install-filters/show-filters`), the canonical-XML transform, the determinism property, and the up-time install prompt all work on every platform — exercised in CI on Linux runners against real git. macOS is not a hard requirement to *use* plist filters in a dotfiles repo; it is the platform where the deployed file is what an OS app reads.
 
 1. The Mechanism
 
@@ -195,18 +195,9 @@ macOS Plists
 
 9. Configuration
 
-    Plist support has minimal configuration. The relevant block lives under `[symlink]` because plists deploy via the symlink handler:
+    Plist support currently has no configuration knobs. Plist detection (for adopt hints and the up-time prompt) is hard-coded to the `.plist` extension; deployment is governed by the symlink handler and the file's location, the same as any other file. There is no `[preprocessor.plist]` section either — plists do not go through the preprocessing pipeline.
 
-    Schema:
-
-        [symlink]
-        plist_extensions = ["plist"]   # filename suffixes treated as plists for adopt hints
-
-    :: toml ::
-
-    The extension list controls *adopt hints and prompts*, not deployment. Deployment is governed by the symlink handler and the file's location, the same as any other file.
-
-    There is no `[preprocessor.plist]` section. Plists do not go through the preprocessing pipeline.
+    A configurable `plist_extensions` list was sketched in [./../proposals/plists.lex] §8.1 to cover non-`.plist` suffixes some apps use (`.savedState`, `.mobileconfig`, …). It has not been implemented; if real-world demand surfaces, it would slot in under `[symlink]`.
 
 10. Commands at a Glance
 

--- a/docs/reference/pre-processors.lex
+++ b/docs/reference/pre-processors.lex
@@ -43,7 +43,7 @@ Preprocessors
 
         Source of truth: whichever form the tooling modifies. For plists, the app writes the binary continuously, so the binary is authoritative at any given moment; the XML is the git-friendly mirror.
 
-        Divergence: handled automatically. When the deployed file changes, `dodot transform check` reverse-converts it and writes the result back to the source file. No heuristics needed, no user-facing conflicts — the math is on our side.
+        Divergence: handled automatically. The exact mechanism depends on the preprocessor — for plists, it's git's own clean/smudge filter machinery (see [./plists.lex]); for any future Representational preprocessor running through the pipeline, it would be a `dodot transform check` pass that reverse-converts and writes back. Either way, no heuristics are needed and no user-facing conflicts arise — the math is on our side.
 
     3.3. Opaque (write-only)
 
@@ -74,9 +74,10 @@ Preprocessors
 
 6. What's Implemented, What's Planned
 
-    - Template preprocessing is implemented. Write `config.toml.tmpl`, it renders on `dodot up`, downstream handlers deploy the output. See [./../user/templates.lex].
-    - Plist support, secret injection, and whole-file encryption are designed in [./../proposals] but not yet shipped. Each is a concrete preprocessor implementing the shapes described above.
-    - The git-integration layer (pre-commit hook, clean/smudge filters, reverse-merge) is designed in [./../proposals/magic.lex] and will ship alongside the remaining preprocessors.
+    - **Template preprocessing is implemented.** Write `config.toml.tmpl`, it renders on `dodot up` via MiniJinja, downstream handlers deploy the output. See [./../user/templates.lex] for usage. The preprocessing pipeline itself (the phase that turns source files into rendered outputs and feeds them into handlers) is shipped — templates are its first user.
+    - **Plist support is also implemented**, but does NOT go through this preprocessing pipeline. It ships as a pair of git clean/smudge filters that translate macOS `*.plist` files between binary (working tree) and canonical XML (git index) on the fly. The architectural reasoning — why plists ducked out of the pipeline despite being a textbook Representational transform — is in [./../proposals/plists.lex] §2.3, and the user-facing reference is at [./plists.lex]. Shipped: `dodot plist clean/smudge` (the conversion engine), `dodot git-install-filters/show-filters` (the per-clone setup), `dodot prompts list/reset` (a generic dismissed-prompt registry that powers the up-time install offer).
+    - **The git-integration layer for templates is NOT yet shipped.** What's planned: `dodot refresh` to copy deployed-side mtimes onto sources so git re-runs filters; a baseline cache `(rendered_hash, source_hash, context_hash, rendered_content, tracked_render)` for cheap divergence detection without re-rendering; a clean filter that uses the cache as a fast path before falling back to burgertocow's reverse-merge; conflict markers for ambiguous lines that touch template expressions. The design is in [./../proposals/magic.lex] (Phases 1, 3, 4); Phase 2 (plist clean/smudge) has already shipped on its own track.
+    - Secret injection and whole-file encryption preprocessors are designed in [./../proposals] (`secrets.lex`) but not yet shipped.
 
 7. Where Rendered Output Lives
 

--- a/docs/user/commands.lex
+++ b/docs/user/commands.lex
@@ -95,9 +95,9 @@ Commands
             dodot adopt --into mac-defaults ~/Library/Preferences/com.app.plist
             dodot adopt --into agents ~/Library/LaunchAgents/com.example.foo.plist
 
-        Source-root recognition (see [./../reference/symlink-paths.lex] §7 for the full table):
+        Source-root recognition (see [./../reference/symlink-paths.lex] §9 for the full table):
             - `$XDG_CONFIG_HOME/<X>/<rest>` → pack `<X>`, in-pack `<rest>`
-            - `$HOME/.<X>` (file/dir) → require `--into`, in-pack `home.<X>` or `_home/<X>/...`
+            - `$HOME/.<X>` (file/dir) → require `--into`. Usually in-pack `home.<X>` or `_home/<X>/...`; for entries on the `[symlink].force_home` list (e.g. `.ssh/`, `.gnupg/`) the in-pack path is bare `<X>` since `force_home` already routes deploys back to `$HOME/.<X>`
             - `~/Library/Application Support/<X>/<rest>` → pack `<X>`, in-pack `_app/<X>/<rest>`
             - `~/Library/<sub>/<file>` (macOS) → require `--into`, in-pack `_lib/<sub>/<file>`
             - `~/Library/Containers/...` → refused (sandboxed-app data)

--- a/docs/user/commands.lex
+++ b/docs/user/commands.lex
@@ -70,23 +70,39 @@ Commands
 
     2.3. adopt
 
-        Move an existing system file into a pack and replace the original with a symlink. Useful for bringing legacy `$HOME` dotfiles (`~/.bashrc`, `~/.zshrc`, `~/.gitconfig`, …) under dodot's control.
+        Move an existing system file into a pack and replace the original with a symlink. Useful for bringing legacy `$HOME` dotfiles (`~/.bashrc`, `~/.zshrc`, `~/.gitconfig`, …), XDG-rooted configs (`~/.config/nvim/init.lua`, …), and macOS-specific paths (`~/Library/Application Support/Code/...`, `~/Library/Preferences/com.app.plist`) under dodot's control.
 
         Flags:
+            - `--into <pack>` — force a single destination pack regardless of inference; required when the source carries no useful pack-name structure (HOME canonicals, `~/Library/...` bundle-ID filenames, etc.)
             - `--force` — overwrite an existing destination file in the pack
             - `--dry-run` — show what would be adopted without making changes
             - `--no-follow` — when the source is a symlink, move the link itself rather than its target
 
         Usage:
 
-            dodot adopt shell ~/.bashrc
-            dodot adopt git ~/.gitconfig ~/.gitignore_global
-            dodot adopt shell ~/.bashrc --force
-            dodot adopt shell ~/.bashrc --dry-run
+            # XDG-rooted: pack name inferred from the path
+            dodot adopt ~/.config/nvim/init.lua             # pack `nvim`, in-pack `init.lua`
+            dodot adopt ~/.config/helix/                    # expands children, pack `helix`
 
-        Adopt currently only accepts sources whose parent is `$HOME` directly — files nested under `~/.config/<tool>/...` aren't yet supported. To bring an XDG-rooted file under dodot, copy it into the pack manually.
+            # HOME-rooted: pack must be specified
+            dodot adopt --into shell ~/.bashrc
+            dodot adopt --into git ~/.gitconfig ~/.gitignore_global
 
-        Naming inside the pack: a `$HOME/.<name>` source is renamed to `<pack>/home.<name>` if `<name>` isn't already a `force_home` canonical (ssh, gpg, bashrc, zshrc, …). The `home.X` prefix preserves the round-trip — re-deploying with `dodot up` puts the symlink back at `$HOME/.<name>`. For canonical force_home names the file lands under the pack as `<name>` (the `force_home` rule already routes deploys back to `$HOME/.<name>`).
+            # macOS Application Support: inferred pack, _app/ encoding
+            dodot adopt ~/Library/Application\ Support/Code/User/settings.json
+
+            # macOS ~/Library/* (Preferences, LaunchAgents, Fonts, …): require --into
+            dodot adopt --into mac-defaults ~/Library/Preferences/com.app.plist
+            dodot adopt --into agents ~/Library/LaunchAgents/com.example.foo.plist
+
+        Source-root recognition (see [./../reference/symlink-paths.lex] §7 for the full table):
+            - `$XDG_CONFIG_HOME/<X>/<rest>` → pack `<X>`, in-pack `<rest>`
+            - `$HOME/.<X>` (file/dir) → require `--into`, in-pack `home.<X>` or `_home/<X>/...`
+            - `~/Library/Application Support/<X>/<rest>` → pack `<X>`, in-pack `_app/<X>/<rest>`
+            - `~/Library/<sub>/<file>` (macOS) → require `--into`, in-pack `_lib/<sub>/<file>`
+            - `~/Library/Containers/...` → refused (sandboxed-app data)
+
+        When an adopted source is a `.plist` and the dodot-plist git filter isn't yet registered, adopt prints a one-line tip pointing at `dodot git-install-filters`. See [./../reference/plists.lex] for the full plist workflow.
 
         :: shell ::
 
@@ -134,7 +150,54 @@ Commands
 
         :: shell ::
 
-4. Global Flags
+4. Plist Commands (macOS)
+
+    These are the user-facing surface for dodot's macOS plist support — git clean/smudge filters that translate `*.plist` files between binary (working tree) and canonical XML (git index). See [./../reference/plists.lex] for the full reference; this section covers the commands themselves.
+
+    4.1. git-install-filters
+
+        Write the `[filter "dodot-plist"]` block to the dotfiles repo's `.git/config` so future `git status` / `git diff` / `git add` invocations on tracked `*.plist` files run through dodot's clean/smudge filters automatically. Per-clone, per-machine state. Idempotent on re-run. Pair with a `*.plist filter=dodot-plist` line in `.gitattributes` (committed).
+
+        Usage:
+
+            dodot git-install-filters
+
+        :: shell ::
+
+    4.2. git-show-filters
+
+        Print the `.git/config` block and the `.gitattributes` line without writing anything, for inspection or manual install. Each is annotated with whether it's currently in place.
+
+        Usage:
+
+            dodot git-show-filters
+
+        :: shell ::
+
+    4.3. plist clean / plist smudge
+
+        stdin→stdout filters that git invokes via `dodot git-install-filters`. You don't normally run them by hand; running them manually is fine for inspection but not part of any workflow.
+
+        Usage:
+
+            dodot plist clean   < binary.plist > canonical.xml
+            dodot plist smudge  < canonical.xml > binary.plist
+
+        :: shell ::
+
+    4.4. prompts list / prompts reset
+
+        Inspect and reset dismissed one-time prompts. Currently the only registered prompt is `plist.install_filters` (the up-time offer to install plist filters), but the registry is content-agnostic and future onboarding nudges use the same machinery.
+
+        Usage:
+
+            dodot prompts list                              # show every known prompt + state
+            dodot prompts reset plist.install_filters       # clear one dismissal
+            dodot prompts reset --all                       # clear every dismissal
+
+        :: shell ::
+
+5. Global Flags
 
     Every command accepts:
 


### PR DESCRIPTION
## Summary

Pre-release docs sweep to make sure the proposals reflect implementation status and the user-facing docs actually describe the shipped plist features. Code-only diff: zero. Pure docs.

## Changes

**Proposal status banners** — `docs/proposals/plists.lex` now opens with the same "implemented and shipped" banner pattern that `macos-paths.lex` uses, listing the PRs that landed each phase and pointing at the new reference doc. New §12 Implementation Notes vs. Spec documents the five places the implementation diverged from the spec (dodot init .gitattributes template deferred; in-pack encoding refined to `_lib/`; source-root inference generalised beyond plists; `probe app` integration absorbed into existing M6 work; missing-PATH detection deferred to git's own loud failure).

**New `docs/reference/plists.lex`** — full user-facing reference modelled on the pattern set by `symlink-paths.lex`. Covers: mechanism (working-tree binary, index XML), setup (`.gitattributes` + `.git/config`), day-to-day workflow, adopt for `~/Library/*`, cfprefsd, the three filter failure modes, the working-tree-binary trade-off, the prompt registry, configuration, commands-at-a-glance.

**`docs/reference/pre-processors.lex` corrections** — §6 had stale claims:
- Said templates were shipped (✓ correct, kept) but plist support wasn't (✗ wrong, fixed)
- Treated the entire `magic.lex` git layer as one unshipped block (✗ wrong — Phase 2 plist clean/smudge has shipped on its own track; Phases 1/3/4 for templates remain unshipped)

§3.2 also still described plist divergence as going through `dodot transform check`, which we never shipped — corrected to reference both possible mechanisms (git filters for plists, the future pipeline-based check for any future Representational preprocessor).

**`docs/user/commands.lex` updates** — new §4 covering the four plist-related command groups (`git-install-filters`, `git-show-filters`, `plist clean/smudge`, `prompts list/reset`). §2.3 (adopt) had a stale claim that adopt only accepts `$HOME` children — the M4 work landed XDG/AppSupport recognition months ago, and P3 added Library. Updated to document all four source roots actually recognised today.

**`README.md`** — new "macOS Plists" section after Handlers, plus four new rows in the commands table (`plist`, `git-install-filters`, `git-show-filters`, `prompts`).

## Checklist

- [x] Changelog `Unreleased` section updated — N/A, this PR is docs-only and the user-facing changes it documents are already in `CHANGELOG_UNRELEASED.md` from PRs #95–#97.
- [x] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` all green (no code changes; ran the lib suite as a sanity check, 690 tests passing).
- [x] No new behavior to test — pure docs.

## Notes for reviewers

The reference doc (`docs/reference/plists.lex`) is the meaty one — written from a "user who just heard about plist support and wants to understand it" angle, not as a recap of the proposal. It includes things the proposal doesn't: the three filter failure modes, the hand-edit-XML-in-pack escape hatch via `plutil`, the explicit non-determinism diagnostic flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)