### PR TITLE
feat(preprocessing): R1 — baseline cache + tracker swap for templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Template preprocessor produces a marker-tracked render and per-file baseline cache** (R1 of the template-magic track). Templates now flow through [burgertocow](https://crates.io/crates/burgertocow-lib)'s `Tracker`, which wraps every `{{ var }}` emission in invisible marker bytes alongside the visible render. Each successful expansion writes a JSON baseline to `<cache_dir>/preprocessor/<pack>/preprocessed/<filename>.json` carrying the rendered content, the marker-annotated tracked render, source/context hashes, and timestamp. This is the foundation the upcoming `dodot transform check` and template clean filter will read to compute reverse-merge diffs *without* re-rendering — re-rendering at clean-filter time would re-trigger any secret-provider auth prompts on every `git status`. See `docs/proposals/preprocessing-pipeline.lex` §5.2 and `docs/proposals/magic.lex` §"Cache That Makes It Cheap".
+- **`Pather::preprocessor_baseline_path` / `preprocessor_baseline_dir`** for routing baseline-cache reads/writes under XDG `cache_dir`.
+
+### Changed
+
+- `preprocess_pack` takes an extra `paths: Option<&dyn Pather>` argument. Active callers (`dodot up`) pass `Some(...)` so baselines are written; passive callers (`dodot status`) pass `None` so they don't overwrite the last-`up` baseline.
+- `ExpandedFile` gains optional `tracked_render` and `context_hash` fields, populated by generative preprocessors that support cache-backed reverse-merge (templates) and left `None` otherwise (identity, unarchive). Tests use `..Default::default()` for ad-hoc construction.
+
 ## [2.0.0] - 2026-05-01
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "burgertocow-lib"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173222fdaef545c0b3bc3740e5dff2dcc3930187f7909e586ca98001844900d7"
+dependencies = [
+ "minijinja",
+ "serde",
+ "serde_json",
+ "similar",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +687,7 @@ dependencies = [
 name = "dodot-lib"
 version = "2.0.0"
 dependencies = [
+ "burgertocow-lib",
  "clapfig",
  "confique",
  "flate2",
@@ -1205,6 +1218,7 @@ checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
 dependencies = [
  "memo-map",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1862,6 +1876,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -7,6 +7,7 @@ description = "Core library for dodot dotfiles manager"
 repository = "https://github.com/arthur-debert/dodot"
 
 [dependencies]
+burgertocow-lib = "0.3"
 clapfig = "0.16"
 confique = "0.4"
 flate2 = "1"

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -459,6 +459,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
                     &pack,
                     ctx.fs.as_ref(),
                     ctx.datastore.as_ref(),
+                    None,
                 ) {
                     Ok(r) => r,
                     Err(err) => {

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -422,6 +422,7 @@ fn plan_pack_inner(
                 pack,
                 ctx.fs.as_ref(),
                 ctx.datastore.as_ref(),
+                Some(ctx.paths.as_ref()),
             )?
         } else {
             crate::preprocessing::pipeline::PreprocessResult::passthrough(entries)

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -155,6 +155,35 @@ pub trait Pather: Send + Sync {
     fn prompts_path(&self) -> PathBuf {
         self.data_dir().join("prompts.json")
     }
+
+    /// Per-file baseline cache used by the preprocessing pipeline to
+    /// detect divergence and drive cache-backed reverse-merge.
+    ///
+    /// Layout: `<cache_dir>/preprocessor/<pack>/<handler>/<filename>.json`.
+    /// One JSON file per processed file, written on every successful
+    /// expansion in `dodot up`.
+    ///
+    /// Lives under `cache_dir` because the contents are rederivable —
+    /// losing them just forces the next `dodot up` to re-render and
+    /// re-baseline. See `docs/proposals/preprocessing-pipeline.lex` §5.2.
+    fn preprocessor_baseline_path(&self, pack: &str, handler: &str, filename: &str) -> PathBuf {
+        self.cache_dir()
+            .join("preprocessor")
+            .join(pack)
+            .join(handler)
+            .join(format!("{filename}.json"))
+    }
+
+    /// Root of the preprocessor baseline cache for a given pack and
+    /// handler — mostly useful for cache-cleanup operations like
+    /// `dodot down` and tests that want to scan an entire handler's
+    /// baselines.
+    fn preprocessor_baseline_dir(&self, pack: &str, handler: &str) -> PathBuf {
+        self.cache_dir()
+            .join("preprocessor")
+            .join(pack)
+            .join(handler)
+    }
 }
 
 /// XDG-compliant path resolver.

--- a/crates/dodot-lib/src/preprocessing/baseline.rs
+++ b/crates/dodot-lib/src/preprocessing/baseline.rs
@@ -1,0 +1,423 @@
+//! Per-file baseline cache for the preprocessing pipeline.
+//!
+//! Every successful expansion writes a JSON record at
+//! `<cache_dir>/preprocessor/<pack>/<handler>/<filename>.json` capturing
+//! enough state to (a) detect drift on the deployed file, (b) decide
+//! whether the source has changed, and (c) drive cache-backed
+//! reverse-merge without re-rendering the template.
+//!
+//! See `docs/proposals/preprocessing-pipeline.lex` §5.2 for the
+//! field-level contract and `docs/proposals/magic.lex` §"Cache That
+//! Makes It Cheap" for why the `tracked_render` field exists.
+//!
+//! # Lifecycle
+//!
+//! - **Write**: `preprocess_pack` calls [`Baseline::write`] after every
+//!   successful expansion. Re-running `dodot up` overwrites the file in
+//!   place.
+//! - **Read**: `dodot transform check` and the clean filter call
+//!   [`Baseline::load`] to drive divergence detection.
+//! - **Cleanup**: `dodot down` deletes the per-pack subdirectory; the
+//!   cache survives `dodot up` failures so partial deployments don't
+//!   strand baseline data for files that did succeed.
+//!
+//! # Schema versioning
+//!
+//! Records carry a `version` field. The current schema is `1`. Future
+//! changes that add fields can stay at `v1` (serde-default fills in the
+//! missing value); breaking changes bump the version, and load returns
+//! a clean error so the user can clear the cache and re-baseline.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::fs::Fs;
+use crate::paths::Pather;
+use crate::{DodotError, Result};
+
+/// Current baseline-cache schema version. Bump on incompatible changes.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// One baseline record — the cached state of a single processed file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Baseline {
+    /// Schema version — see [`SCHEMA_VERSION`].
+    pub version: u32,
+    /// SHA-256 of the rendered (visible, marker-free) output, hex-encoded.
+    pub rendered_hash: String,
+    /// The full rendered output verbatim. Stored so reverse-merge can
+    /// diff the deployed file against the baseline byte-for-byte
+    /// without re-rendering the template.
+    pub rendered_content: String,
+    /// SHA-256 of the source file's bytes at the moment of expansion,
+    /// hex-encoded. Used to distinguish "user edited the source" from
+    /// "user edited the deployed file" (the 4-state matrix in the
+    /// pipeline spec §6.1).
+    pub source_hash: String,
+    /// SHA-256 of the rendering context (variables, dodot.* values),
+    /// hex-encoded. Provided by the preprocessor; for templates this is
+    /// the deterministic projection computed by
+    /// [`compute_context_hash`](crate::preprocessing::template). May be
+    /// empty if the preprocessor has no meaningful context concept.
+    #[serde(default)]
+    pub context_hash: String,
+    /// Marker-annotated rendered output (burgertocow's "tracked"
+    /// stream). Empty when the preprocessor doesn't produce one.
+    /// Persisted so the clean filter can rehydrate a `TrackedRender`
+    /// via [`burgertocow::TrackedRender::from_tracked_string`] and
+    /// drive the reverse-diff without re-rendering — re-rendering at
+    /// clean-filter time would re-trigger any secret-provider auth
+    /// prompts on every `git status`.
+    #[serde(default)]
+    pub tracked_render: String,
+    /// Wall-clock unix timestamp (seconds) of when the baseline was
+    /// written. Used by `dodot transform status` to show "deployed
+    /// since …". Not load-bearing for divergence detection.
+    pub timestamp: u64,
+}
+
+impl Baseline {
+    /// Build a baseline from raw inputs. Hashes are computed here so
+    /// callers don't repeat the SHA setup; the optional `tracked_render`
+    /// and `context_hash` come straight off the preprocessor's
+    /// `ExpandedFile`.
+    pub fn build(
+        rendered_content: &[u8],
+        source_bytes: &[u8],
+        tracked_render: Option<&str>,
+        context_hash: Option<&[u8; 32]>,
+    ) -> Self {
+        Self {
+            version: SCHEMA_VERSION,
+            rendered_hash: hex_sha256(rendered_content),
+            rendered_content: String::from_utf8_lossy(rendered_content).into_owned(),
+            source_hash: hex_sha256(source_bytes),
+            context_hash: context_hash.map(hex_encode_32).unwrap_or_default(),
+            tracked_render: tracked_render.unwrap_or("").to_string(),
+            timestamp: now_secs_unix(),
+        }
+    }
+
+    /// Persist this baseline to its JSON path under the cache dir.
+    /// Creates parent directories as needed. Overwrites any existing
+    /// file at the target path.
+    pub fn write(
+        &self,
+        fs: &dyn Fs,
+        paths: &dyn Pather,
+        pack: &str,
+        handler: &str,
+        filename: &str,
+    ) -> Result<PathBuf> {
+        let path = paths.preprocessor_baseline_path(pack, handler, filename);
+        if let Some(parent) = path.parent() {
+            fs.mkdir_all(parent)?;
+        }
+        let body = serde_json::to_string_pretty(self).map_err(|e| {
+            DodotError::Other(format!(
+                "failed to serialise baseline for {pack}/{handler}/{filename}: {e}"
+            ))
+        })?;
+        fs.write_file(&path, body.as_bytes())?;
+        Ok(path)
+    }
+
+    /// Load a baseline from its JSON path. Returns `Ok(None)` if the
+    /// file does not exist (a file with no baseline is a normal state
+    /// for a brand-new pack); returns an error for parse failures or
+    /// unsupported schema versions so the caller can suggest a manual
+    /// clear.
+    pub fn load(
+        fs: &dyn Fs,
+        paths: &dyn Pather,
+        pack: &str,
+        handler: &str,
+        filename: &str,
+    ) -> Result<Option<Self>> {
+        let path = paths.preprocessor_baseline_path(pack, handler, filename);
+        if !fs.exists(&path) {
+            return Ok(None);
+        }
+        let raw = fs.read_to_string(&path)?;
+        let baseline: Self = serde_json::from_str(&raw).map_err(|e| {
+            DodotError::Other(format!(
+                "failed to parse baseline at {}: {e}\n  \
+                 Try `dodot up --force` to re-baseline.",
+                path.display()
+            ))
+        })?;
+        if baseline.version != SCHEMA_VERSION {
+            return Err(DodotError::Other(format!(
+                "baseline at {} has unsupported schema version {} (expected {}). \
+                 Clear the file and run `dodot up` to rebuild.",
+                path.display(),
+                baseline.version,
+                SCHEMA_VERSION
+            )));
+        }
+        Ok(Some(baseline))
+    }
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex_encode_32(&hasher.finalize().into())
+}
+
+fn hex_encode_32(bytes: &[u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for b in bytes {
+        out.push(hex_nibble(b >> 4));
+        out.push(hex_nibble(b & 0x0f));
+    }
+    out
+}
+
+fn hex_nibble(n: u8) -> char {
+    match n {
+        0..=9 => (b'0' + n) as char,
+        10..=15 => (b'a' + n - 10) as char,
+        _ => unreachable!(),
+    }
+}
+
+fn now_secs_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Canonical filename for a baseline given a logical (stripped) pack
+/// path. Strips parent directories and uses the bare basename, which
+/// matches the cache-path convention specified in the pipeline doc.
+///
+/// Subdirectory-bearing virtual entries (e.g. `subdir/config.toml`) get
+/// flattened to `config.toml` here. The pipeline disambiguates on its
+/// side via the per-pack-and-handler directory tree, but the cache
+/// layout intentionally mirrors a single per-file slot. Two files with
+/// the same basename in different subdirectories of the same pack would
+/// share a cache slot — uncommon for the dotfile-sized payloads
+/// preprocessors produce, but if it surfaces we can extend the
+/// filename encoding without touching callers.
+pub fn cache_filename_for(virtual_relative: &Path) -> String {
+    virtual_relative
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| virtual_relative.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TempEnvironment;
+
+    #[test]
+    fn build_then_write_then_load_round_trips() {
+        let env = TempEnvironment::builder().build();
+        let baseline = Baseline::build(
+            b"name = Alice\n",
+            b"name = {{ name }}\n",
+            Some("name = \u{1e}Alice\u{1f}\n"),
+            Some(&[0x42; 32]),
+        );
+        let path = baseline
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "config.toml",
+            )
+            .unwrap();
+        assert!(env.fs.exists(&path));
+
+        let loaded = Baseline::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "config.toml",
+        )
+        .unwrap()
+        .expect("baseline must exist after write");
+        assert_eq!(loaded, baseline);
+    }
+
+    #[test]
+    fn load_returns_none_for_missing_file() {
+        let env = TempEnvironment::builder().build();
+        let result = Baseline::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "nope.toml",
+        )
+        .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_rejects_unsupported_schema_version() {
+        let env = TempEnvironment::builder().build();
+        let path = env
+            .paths
+            .preprocessor_baseline_path("app", "preprocessed", "config.toml");
+        env.fs.mkdir_all(path.parent().unwrap()).unwrap();
+        env.fs
+            .write_file(
+                &path,
+                br#"{"version": 999, "rendered_hash": "x", "rendered_content": "x", "source_hash": "x", "timestamp": 0}"#,
+            )
+            .unwrap();
+
+        let err = Baseline::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "config.toml",
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").contains("unsupported schema version"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn load_rejects_corrupted_json() {
+        let env = TempEnvironment::builder().build();
+        let path = env
+            .paths
+            .preprocessor_baseline_path("app", "preprocessed", "config.toml");
+        env.fs.mkdir_all(path.parent().unwrap()).unwrap();
+        env.fs.write_file(&path, b"{not json").unwrap();
+
+        let err = Baseline::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "config.toml",
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("failed to parse"), "got: {msg}");
+        // Hint to clear the cache should be in the error so users have
+        // a recovery path.
+        assert!(
+            msg.contains("--force"),
+            "expected recovery hint, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn build_records_hashes_and_optional_fields() {
+        // Empty optionals → empty strings (serde default), not Null.
+        let b = Baseline::build(b"hello", b"hello", None, None);
+        assert_eq!(b.version, SCHEMA_VERSION);
+        assert_eq!(b.rendered_hash.len(), 64); // SHA-256 hex
+        assert_eq!(b.source_hash, b.rendered_hash); // same bytes
+        assert!(b.context_hash.is_empty());
+        assert!(b.tracked_render.is_empty());
+
+        // Provided optionals → encoded.
+        let b2 = Baseline::build(b"x", b"y", Some("tracked"), Some(&[0xff; 32]));
+        assert_eq!(b2.context_hash.len(), 64);
+        assert!(b2.context_hash.chars().all(|c| c == 'f'));
+        assert_eq!(b2.tracked_render, "tracked");
+    }
+
+    #[test]
+    fn rendered_content_preserves_lossy_utf8() {
+        // The cache holds rendered_content as UTF-8 (templates are
+        // text); this test pins the loss behaviour for non-UTF-8 bytes
+        // so a future change is a deliberate decision.
+        let b = Baseline::build(&[0x66, 0x6f, 0xff, 0x6f], b"src", None, None);
+        // Replacement character for the invalid 0xff.
+        assert_eq!(b.rendered_content, "fo\u{fffd}o");
+    }
+
+    #[test]
+    fn write_creates_nested_directories() {
+        // Pack-and-handler directories may not exist on first write;
+        // confirm we mkdir_all rather than expecting them to be there.
+        let env = TempEnvironment::builder().build();
+        let baseline = Baseline::build(b"x", b"y", None, None);
+        let path = baseline
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "deep",
+                "preprocessed",
+                "x",
+            )
+            .unwrap();
+        assert!(env.fs.exists(&path));
+        assert!(env.fs.is_dir(path.parent().unwrap()));
+    }
+
+    #[test]
+    fn write_overwrites_existing_baseline() {
+        // A second write at the same logical path replaces the first.
+        let env = TempEnvironment::builder().build();
+        let first = Baseline::build(b"first", b"src", None, None);
+        first
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "f",
+            )
+            .unwrap();
+        let second = Baseline::build(b"second", b"src", None, None);
+        second
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "f",
+            )
+            .unwrap();
+
+        let loaded = Baseline::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "f",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(loaded.rendered_content, "second");
+    }
+
+    #[test]
+    fn cache_filename_for_drops_parent_directories() {
+        assert_eq!(cache_filename_for(Path::new("config.toml")), "config.toml");
+        assert_eq!(
+            cache_filename_for(Path::new("subdir/config.toml")),
+            "config.toml"
+        );
+        assert_eq!(cache_filename_for(Path::new("a/b/c/leaf.txt")), "leaf.txt");
+    }
+
+    #[test]
+    fn hex_encoding_is_lowercase_and_padded() {
+        assert_eq!(hex_encode_32(&[0; 32]).len(), 64);
+        assert!(hex_encode_32(&[0; 32]).chars().all(|c| c == '0'));
+        assert_eq!(hex_encode_32(&[0xab; 32]).len(), 64);
+        // Lowercase by convention.
+        assert!(hex_encode_32(&[0xab; 32])
+            .chars()
+            .all(|c| c == 'a' || c == 'b'));
+    }
+}

--- a/crates/dodot-lib/src/preprocessing/identity.rs
+++ b/crates/dodot-lib/src/preprocessing/identity.rs
@@ -71,6 +71,8 @@ impl Preprocessor for IdentityPreprocessor {
             relative_path: PathBuf::from(stripped),
             content,
             is_dir: false,
+            tracked_render: None,
+            context_hash: None,
         }])
     }
 }

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -8,6 +8,7 @@
 //!
 //! See `docs/proposals/preprocessing-pipeline.lex` for the full design.
 
+pub mod baseline;
 pub mod identity;
 pub mod pipeline;
 pub mod template;
@@ -32,7 +33,11 @@ pub enum TransformType {
 }
 
 /// A single file produced by a preprocessor's expansion.
-#[derive(Debug, Clone)]
+///
+/// Construct ad-hoc via the struct literal; tests commonly use
+/// `ExpandedFile { relative_path, content, ..Default::default() }` to
+/// fill in the optional cache-related fields.
+#[derive(Debug, Clone, Default)]
 pub struct ExpandedFile {
     /// Path relative to the expansion output (usually just the filename).
     pub relative_path: PathBuf,
@@ -40,6 +45,25 @@ pub struct ExpandedFile {
     pub content: Vec<u8>,
     /// Whether this entry is a directory marker.
     pub is_dir: bool,
+    /// Marker-annotated rendered output, populated by Generative
+    /// preprocessors that support cache-backed reverse-diff (templates).
+    /// `None` for Representational, Opaque, or generative preprocessors
+    /// that don't track variable boundaries (e.g. unarchive).
+    ///
+    /// When present, the pipeline persists this string in the baseline
+    /// cache so the clean filter and `dodot transform check` can compute
+    /// reverse-diffs without re-rendering — the latter being important
+    /// because re-rendering can re-trigger secret-provider auth prompts.
+    pub tracked_render: Option<String>,
+    /// SHA-256 of the rendering context (variables, env values resolved
+    /// at render time). `None` for preprocessors that don't have a
+    /// meaningful context concept.
+    ///
+    /// The pipeline pairs this with the source-file hash and rendered
+    /// content hash in the baseline cache. `dodot up` re-rendering and
+    /// install/homebrew sentinels both use the context hash to decide
+    /// when work is stale.
+    pub context_hash: Option<[u8; 32]>,
 }
 
 /// The core preprocessor abstraction.

--- a/crates/dodot-lib/src/preprocessing/pipeline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline.rs
@@ -13,6 +13,8 @@ use tracing::{debug, info};
 use crate::datastore::DataStore;
 use crate::fs::Fs;
 use crate::packs::Pack;
+use crate::paths::Pather;
+use crate::preprocessing::baseline::{cache_filename_for, Baseline};
 use crate::preprocessing::PreprocessorRegistry;
 use crate::rules::PackEntry;
 use crate::{DodotError, Result};
@@ -113,13 +115,21 @@ const PREPROCESSED_HANDLER: &str = "preprocessed";
 /// 2. For each preprocessor file: expand, write results to datastore.
 /// 3. Create virtual PackEntries pointing to the datastore files.
 /// 4. Check for collisions between virtual and regular entries.
-/// 5. Return the result for merging into the handler pipeline.
+/// 5. If `paths` is `Some`, write a baseline-cache record for each
+///    expanded file (used by `dodot transform check` and the clean
+///    filter to detect drift without re-rendering).
+/// 6. Return the result for merging into the handler pipeline.
+///
+/// Pass `paths = None` from read-only call sites (e.g. `dodot status`)
+/// so passive runs don't overwrite a baseline that captured the state
+/// of the last `dodot up`.
 pub fn preprocess_pack(
     entries: Vec<PackEntry>,
     registry: &PreprocessorRegistry,
     pack: &Pack,
     fs: &dyn Fs,
     datastore: &dyn DataStore,
+    paths: Option<&dyn Pather>,
 ) -> Result<PreprocessResult> {
     let mut regular_entries = Vec::new();
     let mut preprocessor_entries = Vec::new();
@@ -261,6 +271,52 @@ pub fn preprocess_pack(
                 "wrote expanded entry"
             );
 
+            // Persist a baseline record so future `dodot transform
+            // check` / clean-filter calls can detect drift without
+            // re-rendering. Only write when:
+            //   - a Pather was provided (read-only callers like
+            //     `dodot status` pass None to keep baselines stable),
+            //   - the entry is a file (directory entries from archive
+            //     preprocessors carry no rendered content), AND
+            //   - the preprocessor produced a tracked render (i.e. it's
+            //     a generative-with-tracking preprocessor, currently
+            //     just templates). Plain Generative preprocessors that
+            //     don't support reverse-merge (unarchive) skip the
+            //     baseline because the cache is only meaningful when
+            //     paired with burgertocow tracking.
+            if let (Some(paths), false, Some(tracked)) =
+                (paths, expanded.is_dir, expanded.tracked_render.as_deref())
+            {
+                let cache_filename = cache_filename_for(&virtual_relative);
+                let source_bytes = fs.read_file(&entry.absolute_path)?;
+                let baseline = Baseline::build(
+                    &expanded.content,
+                    &source_bytes,
+                    Some(tracked),
+                    expanded.context_hash.as_ref(),
+                );
+                if let Err(err) =
+                    baseline.write(fs, paths, &pack.name, PREPROCESSED_HANDLER, &cache_filename)
+                {
+                    // Baseline write failures are reported but not
+                    // fatal: the deployment itself succeeded, and a
+                    // missing baseline only degrades the reverse-merge
+                    // experience (we'll re-baseline next `up`).
+                    debug!(
+                        pack = %pack.name,
+                        file = %cache_filename,
+                        error = %err,
+                        "baseline write failed (non-fatal)"
+                    );
+                } else {
+                    debug!(
+                        pack = %pack.name,
+                        file = %cache_filename,
+                        "baseline written"
+                    );
+                }
+            }
+
             claimed_paths.insert(virtual_relative.clone());
             source_map.insert(datastore_path.clone(), entry.absolute_path.clone());
 
@@ -336,7 +392,7 @@ mod tests {
         ];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert_eq!(result.regular_entries.len(), 2);
         assert!(result.virtual_entries.is_empty());
@@ -362,7 +418,7 @@ mod tests {
         }];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert!(result.regular_entries.is_empty());
         assert_eq!(result.virtual_entries.len(), 1);
@@ -409,7 +465,7 @@ mod tests {
         ];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert_eq!(result.regular_entries.len(), 1);
         assert_eq!(
@@ -450,8 +506,8 @@ mod tests {
             },
         ];
 
-        let err =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        let err = preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None)
+            .unwrap_err();
         assert!(
             matches!(err, DodotError::PreprocessorCollision { .. }),
             "expected PreprocessorCollision, got: {err}"
@@ -499,7 +555,7 @@ mod tests {
         }];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         // With no preprocessors registered, the file is treated as regular
         assert_eq!(result.regular_entries.len(), 1);
@@ -525,7 +581,7 @@ mod tests {
         }];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert_eq!(result.regular_entries.len(), 1);
         assert!(result.virtual_entries.is_empty());
@@ -550,7 +606,7 @@ mod tests {
         }];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert_eq!(result.virtual_entries.len(), 1);
         assert_eq!(
@@ -586,7 +642,7 @@ mod tests {
         ];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert!(result.regular_entries.is_empty());
         assert_eq!(result.virtual_entries.len(), 2);
@@ -622,7 +678,7 @@ mod tests {
         }];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert!(result.regular_entries.is_empty());
         assert_eq!(result.virtual_entries.len(), 1);
@@ -662,7 +718,7 @@ mod tests {
         ];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         // Every virtual entry must have a source_map entry
         for ve in &result.virtual_entries {
@@ -708,6 +764,7 @@ mod tests {
             &pack,
             env.fs.as_ref(),
             &datastore,
+            None,
         )
         .unwrap();
         let result2 = preprocess_pack(
@@ -716,6 +773,7 @@ mod tests {
             &pack,
             env.fs.as_ref(),
             &datastore,
+            None,
         )
         .unwrap();
 
@@ -756,8 +814,8 @@ mod tests {
             is_dir: false,
         }];
 
-        let err =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        let err = preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None)
+            .unwrap_err();
         assert!(
             matches!(err, DodotError::Fs { .. }),
             "expected Fs error for missing file, got: {err}"
@@ -797,8 +855,8 @@ mod tests {
             },
         ];
 
-        let err =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        let err = preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None)
+            .unwrap_err();
         assert!(
             matches!(err, DodotError::PreprocessorCollision { .. }),
             "expected PreprocessorCollision for inter-preprocessor clash, got: {err}"
@@ -826,7 +884,7 @@ mod tests {
         }];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert_eq!(result.virtual_entries.len(), 1);
         let datastore_path = &result.virtual_entries[0].absolute_path;
@@ -879,7 +937,7 @@ mod tests {
         ];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert_eq!(result.virtual_entries.len(), 2);
 
@@ -955,6 +1013,7 @@ mod tests {
                 relative_path: PathBuf::from("/etc/passwd"),
                 content: b"pwn".to_vec(),
                 is_dir: false,
+                ..Default::default()
             }],
         }));
 
@@ -967,8 +1026,8 @@ mod tests {
             is_dir: false,
         }];
 
-        let err =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        let err = preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None)
+            .unwrap_err();
         assert!(
             matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("unsafe path")),
             "expected unsafe-path error, got: {err}"
@@ -993,6 +1052,7 @@ mod tests {
                 relative_path: PathBuf::from("../../escape.txt"),
                 content: b"pwn".to_vec(),
                 is_dir: false,
+                ..Default::default()
             }],
         }));
 
@@ -1005,8 +1065,8 @@ mod tests {
             is_dir: false,
         }];
 
-        let err =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        let err = preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None)
+            .unwrap_err();
         assert!(
             matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("unsafe path")),
             "expected unsafe-path error, got: {err}"
@@ -1034,11 +1094,13 @@ mod tests {
                     relative_path: PathBuf::from("sub"),
                     content: Vec::new(),
                     is_dir: true,
+                    ..Default::default()
                 },
                 crate::preprocessing::ExpandedFile {
                     relative_path: PathBuf::from("sub/nested.txt"),
                     content: b"hello".to_vec(),
                     is_dir: false,
+                    ..Default::default()
                 },
             ],
         }));
@@ -1053,7 +1115,7 @@ mod tests {
         }];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert_eq!(result.virtual_entries.len(), 2);
 
@@ -1100,6 +1162,7 @@ mod tests {
                 relative_path: PathBuf::from(""),
                 content: b"nope".to_vec(),
                 is_dir: false,
+                ..Default::default()
             }],
         }));
 
@@ -1112,8 +1175,8 @@ mod tests {
             is_dir: false,
         }];
 
-        let err =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        let err = preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None)
+            .unwrap_err();
         assert!(
             matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("empty output path")),
             "expected empty-path error, got: {err}"
@@ -1137,6 +1200,7 @@ mod tests {
                 relative_path: PathBuf::from("."),
                 content: b"nope".to_vec(),
                 is_dir: false,
+                ..Default::default()
             }],
         }));
 
@@ -1149,8 +1213,8 @@ mod tests {
             is_dir: false,
         }];
 
-        let err =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        let err = preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None)
+            .unwrap_err();
         assert!(
             matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("empty output path")),
             "expected empty-path error, got: {err}"
@@ -1178,11 +1242,13 @@ mod tests {
                     relative_path: PathBuf::from("foo"),
                     content: b"first".to_vec(),
                     is_dir: false,
+                    ..Default::default()
                 },
                 crate::preprocessing::ExpandedFile {
                     relative_path: PathBuf::from("./foo"),
                     content: b"second".to_vec(),
                     is_dir: false,
+                    ..Default::default()
                 },
             ],
         }));
@@ -1196,8 +1262,8 @@ mod tests {
             is_dir: false,
         }];
 
-        let err =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap_err();
+        let err = preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None)
+            .unwrap_err();
         assert!(
             matches!(err, DodotError::PreprocessorCollision { .. }),
             "expected PreprocessorCollision for ./foo vs foo, got: {err}"
@@ -1224,6 +1290,7 @@ mod tests {
                 relative_path: PathBuf::from("./nested/file.txt"),
                 content: b"hi".to_vec(),
                 is_dir: false,
+                ..Default::default()
             }],
         }));
 
@@ -1237,7 +1304,7 @@ mod tests {
         }];
 
         let result =
-            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore).unwrap();
+            preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
 
         assert_eq!(result.virtual_entries.len(), 1);
         assert_eq!(
@@ -1245,5 +1312,308 @@ mod tests {
             PathBuf::from("nested/file.txt"),
             "CurDir components must be stripped from virtual entry"
         );
+    }
+
+    // ── Baseline cache integration ──────────────────────────────
+
+    #[test]
+    fn baseline_is_written_when_paths_provided_and_tracked_render_present() {
+        // End-to-end: a scripted preprocessor that produces a tracked
+        // render should result in a baseline JSON on disk under
+        // `<cache>/preprocessor/<pack>/preprocessed/<file>.json`. The
+        // baseline must round-trip through Baseline::load with all the
+        // documented fields populated.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.tracked", "name = original")
+            .done()
+            .build();
+
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(ScriptedPreprocessor {
+            name: "tracked-scripted",
+            extension: ".tracked",
+            outputs: vec![crate::preprocessing::ExpandedFile {
+                relative_path: PathBuf::from("config.toml"),
+                content: b"name = rendered".to_vec(),
+                is_dir: false,
+                tracked_render: Some("name = \u{1e}rendered\u{1f}".into()),
+                context_hash: Some([0xab; 32]),
+            }],
+        }));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+
+        let entries = vec![PackEntry {
+            relative_path: "config.toml.tracked".into(),
+            absolute_path: env.dotfiles_root.join("app/config.toml.tracked"),
+            is_dir: false,
+        }];
+
+        preprocess_pack(
+            entries,
+            &registry,
+            &pack,
+            env.fs.as_ref(),
+            &datastore,
+            Some(env.paths.as_ref()),
+        )
+        .unwrap();
+
+        let baseline = crate::preprocessing::baseline::Baseline::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "config.toml",
+        )
+        .unwrap()
+        .expect("baseline must be written for a tracked-render expansion");
+
+        assert_eq!(baseline.rendered_content, "name = rendered");
+        assert_eq!(baseline.tracked_render, "name = \u{1e}rendered\u{1f}");
+        // Source hash is the SHA of the source file's bytes.
+        assert_eq!(baseline.source_hash.len(), 64);
+        // Context hash matches the one the preprocessor emitted.
+        assert!(
+            baseline.context_hash.chars().all(|c| c == 'a' || c == 'b'),
+            "context hash should be 0xab repeated, got: {}",
+            baseline.context_hash
+        );
+        assert_eq!(baseline.context_hash.len(), 64);
+    }
+
+    #[test]
+    fn baseline_is_skipped_when_paths_is_none() {
+        // Read-only callers (`dodot status`) pass `None`. No baseline
+        // should be written in that case — overwriting it would erase
+        // the divergence-detection ground truth.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.tracked", "src")
+            .done()
+            .build();
+
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(ScriptedPreprocessor {
+            name: "tracked-scripted",
+            extension: ".tracked",
+            outputs: vec![crate::preprocessing::ExpandedFile {
+                relative_path: PathBuf::from("config.toml"),
+                content: b"x".to_vec(),
+                is_dir: false,
+                tracked_render: Some("x".into()),
+                context_hash: Some([0; 32]),
+            }],
+        }));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+        let entries = vec![PackEntry {
+            relative_path: "config.toml.tracked".into(),
+            absolute_path: env.dotfiles_root.join("app/config.toml.tracked"),
+            is_dir: false,
+        }];
+
+        preprocess_pack(entries, &registry, &pack, env.fs.as_ref(), &datastore, None).unwrap();
+
+        let path = env
+            .paths
+            .preprocessor_baseline_path("app", "preprocessed", "config.toml");
+        assert!(
+            !env.fs.exists(&path),
+            "no baseline should exist after a paths=None run, but found: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn baseline_is_skipped_for_preprocessors_without_tracked_render() {
+        // The identity preprocessor (and unarchive) don't produce a
+        // tracked render. They still go through the pipeline, but no
+        // baseline is written — the cache is only meaningful when paired
+        // with burgertocow's marker stream.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.identity", "data")
+            .done()
+            .build();
+
+        let registry = make_registry(); // identity-only
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+        let entries = vec![PackEntry {
+            relative_path: "config.toml.identity".into(),
+            absolute_path: env.dotfiles_root.join("app/config.toml.identity"),
+            is_dir: false,
+        }];
+
+        preprocess_pack(
+            entries,
+            &registry,
+            &pack,
+            env.fs.as_ref(),
+            &datastore,
+            Some(env.paths.as_ref()),
+        )
+        .unwrap();
+
+        let path = env
+            .paths
+            .preprocessor_baseline_path("app", "preprocessed", "config.toml");
+        assert!(
+            !env.fs.exists(&path),
+            "identity preprocessor (no tracked render) should not write a baseline"
+        );
+    }
+
+    #[test]
+    fn baseline_overwrites_on_repeated_up() {
+        // Re-running `up` with a changed source file must replace the
+        // baseline, not leave the stale one in place — otherwise drift
+        // detection would compare against an out-of-date baseline.
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("config.toml.tracked", "first")
+            .done()
+            .build();
+
+        let outputs_first = vec![crate::preprocessing::ExpandedFile {
+            relative_path: PathBuf::from("config.toml"),
+            content: b"FIRST".to_vec(),
+            is_dir: false,
+            tracked_render: Some("FIRST".into()),
+            context_hash: Some([1; 32]),
+        }];
+        let outputs_second = vec![crate::preprocessing::ExpandedFile {
+            relative_path: PathBuf::from("config.toml"),
+            content: b"SECOND".to_vec(),
+            is_dir: false,
+            tracked_render: Some("SECOND".into()),
+            context_hash: Some([2; 32]),
+        }];
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+        let make_entries = || {
+            vec![PackEntry {
+                relative_path: "config.toml.tracked".into(),
+                absolute_path: env.dotfiles_root.join("app/config.toml.tracked"),
+                is_dir: false,
+            }]
+        };
+
+        // First run.
+        let mut registry1 = PreprocessorRegistry::new();
+        registry1.register(Box::new(ScriptedPreprocessor {
+            name: "ts",
+            extension: ".tracked",
+            outputs: outputs_first,
+        }));
+        preprocess_pack(
+            make_entries(),
+            &registry1,
+            &pack,
+            env.fs.as_ref(),
+            &datastore,
+            Some(env.paths.as_ref()),
+        )
+        .unwrap();
+
+        // Second run with changed outputs.
+        let mut registry2 = PreprocessorRegistry::new();
+        registry2.register(Box::new(ScriptedPreprocessor {
+            name: "ts",
+            extension: ".tracked",
+            outputs: outputs_second,
+        }));
+        preprocess_pack(
+            make_entries(),
+            &registry2,
+            &pack,
+            env.fs.as_ref(),
+            &datastore,
+            Some(env.paths.as_ref()),
+        )
+        .unwrap();
+
+        let baseline = crate::preprocessing::baseline::Baseline::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "config.toml",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(baseline.rendered_content, "SECOND");
+    }
+
+    #[test]
+    fn end_to_end_baseline_for_real_template_preprocessor() {
+        // Exercise the cache write through the actual TemplatePreprocessor
+        // (rather than ScriptedPreprocessor). This pins the integration
+        // contract: a `.tmpl` file in a pack produces a baseline that
+        // contains the rendered content, the tracked render with markers,
+        // and a non-empty context hash.
+        use std::collections::HashMap;
+        let env = TempEnvironment::builder()
+            .pack("app")
+            .file("greet.tmpl", "hello {{ name }}")
+            .done()
+            .build();
+
+        let mut vars = HashMap::new();
+        vars.insert("name".into(), "Alice".into());
+        let template_pp = crate::preprocessing::template::TemplatePreprocessor::new(
+            vec!["tmpl".into()],
+            vars,
+            env.paths.as_ref(),
+        )
+        .unwrap();
+        let mut registry = PreprocessorRegistry::new();
+        registry.register(Box::new(template_pp));
+
+        let datastore = make_datastore(&env);
+        let pack = make_pack("app", env.dotfiles_root.join("app"));
+        let entries = vec![PackEntry {
+            relative_path: "greet.tmpl".into(),
+            absolute_path: env.dotfiles_root.join("app/greet.tmpl"),
+            is_dir: false,
+        }];
+
+        preprocess_pack(
+            entries,
+            &registry,
+            &pack,
+            env.fs.as_ref(),
+            &datastore,
+            Some(env.paths.as_ref()),
+        )
+        .unwrap();
+
+        let baseline = crate::preprocessing::baseline::Baseline::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "greet",
+        )
+        .unwrap()
+        .expect("template baseline must be written");
+
+        assert_eq!(baseline.rendered_content, "hello Alice");
+        // The tracked render must contain marker bytes around "Alice".
+        assert!(
+            baseline.tracked_render.contains(burgertocow::VAR_START),
+            "tracked render must contain marker bytes, got: {:?}",
+            baseline.tracked_render
+        );
+        // Context hash is the template preprocessor's deterministic
+        // hex; non-empty.
+        assert_eq!(baseline.context_hash.len(), 64);
+        // Rendered hash is SHA-256 hex.
+        assert_eq!(baseline.rendered_hash.len(), 64);
     }
 }

--- a/crates/dodot-lib/src/preprocessing/template.rs
+++ b/crates/dodot-lib/src/preprocessing/template.rs
@@ -1,4 +1,5 @@
-//! Template preprocessor — renders Jinja2-style templates via MiniJinja.
+//! Template preprocessor — renders Jinja2-style templates via MiniJinja
+//! through burgertocow's [`Tracker`].
 //!
 //! Matches files with configurable extensions (default: `.tmpl`,
 //! `.template`), renders them against a variable context with three
@@ -12,13 +13,29 @@
 //!
 //! Uses MiniJinja strict undefined-behaviour: references to missing vars
 //! raise a render error rather than silently producing empty strings.
+//!
+//! # Tracked render
+//!
+//! Rendering goes through [`burgertocow::Tracker`] rather than a raw
+//! `minijinja::Environment`. The tracker installs a custom formatter that
+//! wraps every variable emission in marker bytes, producing a
+//! [`TrackedRender`] alongside the visible output. The visible output is
+//! identical to the plain-MiniJinja path (modulo the
+//! `keep_trailing_newline` setting that Tracker also applies). The
+//! marker-annotated string is persisted in the baseline cache so the
+//! reverse-merge pipeline (`dodot transform check`, the clean filter)
+//! can compute template-space diffs without re-rendering — re-rendering
+//! at clean-filter time would re-trigger any secret-provider auth
+//! prompts on every `git status`.
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
+use burgertocow::Tracker;
 use minijinja::value::{Enumerator, Object, ObjectRepr, Value};
-use minijinja::{Environment, UndefinedBehavior};
+use minijinja::UndefinedBehavior;
+use sha2::{Digest, Sha256};
 
 use crate::fs::Fs;
 use crate::paths::Pather;
@@ -54,9 +71,29 @@ impl Object for EnvLookup {
 }
 
 /// Template rendering preprocessor. Generative (one-way) transform.
+///
+/// Holds the resolved `dodot.*` map, the user-defined variables, and a
+/// pre-computed context hash. Each `expand` call constructs a fresh
+/// [`Tracker`], installs the namespaces, registers the source file as a
+/// named template, and renders. We don't share the `Tracker` across
+/// renders because `add_template` requires `&mut` while `Preprocessor::
+/// expand` runs through a `&self` trait method — a per-call tracker is
+/// the simplest way to keep the pipeline's existing concurrency shape.
 pub struct TemplatePreprocessor {
     extensions: Vec<String>,
-    env: Environment<'static>,
+    dodot_ns: BTreeMap<String, String>,
+    user_vars: BTreeMap<String, String>,
+    /// SHA-256 of the deterministic projection of `dodot_ns` and
+    /// `user_vars` (sorted keys, length-prefixed). Reused as the
+    /// `context_hash` for every render this preprocessor performs.
+    ///
+    /// Limitation: `env.*` references are *not* part of the context
+    /// hash because doing so would require parsing the template AST to
+    /// know which env vars are read. Rotating an env var that a
+    /// template references will not invalidate the cache; users hit
+    /// that case with `dodot up --force`. Refining this is tracked for
+    /// the secrets/sentinel work (see `secrets.lex` §3.5).
+    context_hash: [u8; 32],
 }
 
 impl std::fmt::Debug for TemplatePreprocessor {
@@ -71,9 +108,9 @@ impl TemplatePreprocessor {
     /// Construct a new template preprocessor.
     ///
     /// Validates that no user-defined variable uses a reserved name
-    /// (`dodot` or `env`). Populates the MiniJinja environment with
-    /// the `dodot.*` builtins from `pather` + system info, an `env.*`
-    /// dynamic lookup, and each user variable as a bare global.
+    /// (`dodot` or `env`). Resolves the `dodot.*` builtins from
+    /// `pather` + system info and computes the context hash now so
+    /// every subsequent `expand` reuses the same value.
     ///
     /// Extensions are normalized at construction: a leading dot (e.g.
     /// `".tmpl"`) is stripped so both `"tmpl"` and `".tmpl"` work.
@@ -93,17 +130,31 @@ impl TemplatePreprocessor {
             .map(|e| e.trim_start_matches('.').to_string())
             .collect();
 
-        let mut env = Environment::new();
+        let dodot_ns = build_dodot_context(pather);
+        let user_vars: BTreeMap<String, String> = user_vars.into_iter().collect();
+        let context_hash = compute_context_hash(&dodot_ns, &user_vars);
+
+        Ok(Self {
+            extensions,
+            dodot_ns,
+            user_vars,
+            context_hash,
+        })
+    }
+
+    /// Build a fresh tracker with this preprocessor's namespaces
+    /// installed and `UndefinedBehavior::Strict` set. Called per render
+    /// because `Tracker::add_template` requires `&mut self`.
+    fn make_tracker(&self) -> Tracker {
+        let mut tracker = Tracker::new();
+        let env = tracker.env_mut();
         env.set_undefined_behavior(UndefinedBehavior::Strict);
-
-        env.add_global("dodot", Value::from(build_dodot_context(pather)));
+        env.add_global("dodot", Value::from(self.dodot_ns.clone()));
         env.add_global("env", Value::from_object(EnvLookup));
-
-        for (name, val) in user_vars {
-            env.add_global(name, Value::from(val));
+        for (name, val) in &self.user_vars {
+            env.add_global(name.clone(), Value::from(val.clone()));
         }
-
-        Ok(Self { extensions, env })
+        tracker
     }
 }
 
@@ -148,9 +199,22 @@ impl Preprocessor for TemplatePreprocessor {
     fn expand(&self, source: &Path, fs: &dyn Fs) -> Result<Vec<ExpandedFile>> {
         let template_str = fs.read_to_string(source)?;
 
-        let rendered =
-            self.env
-                .render_str(&template_str, ())
+        // Use the source file's path as the template name. Tracker
+        // requires named templates; the path is unique per file and
+        // surfaces sensibly in any error MiniJinja produces.
+        let template_name = source.to_string_lossy().into_owned();
+
+        let mut tracker = self.make_tracker();
+        tracker
+            .add_template(&template_name, &template_str)
+            .map_err(|e| DodotError::TemplateRender {
+                source_file: source.to_path_buf(),
+                message: format_minijinja_error(&e),
+            })?;
+
+        let tracked =
+            tracker
+                .render(&template_name, ())
                 .map_err(|e| DodotError::TemplateRender {
                     source_file: source.to_path_buf(),
                     message: format_minijinja_error(&e),
@@ -163,12 +227,49 @@ impl Preprocessor for TemplatePreprocessor {
             .into_owned();
         let stripped = self.stripped_name(&filename);
 
+        let (rendered, tracked_str) = tracked.into_parts();
+
         Ok(vec![ExpandedFile {
             relative_path: PathBuf::from(stripped),
             content: rendered.into_bytes(),
             is_dir: false,
+            tracked_render: Some(tracked_str),
+            context_hash: Some(self.context_hash),
         }])
     }
+}
+
+/// Produce a deterministic SHA-256 over the rendering context.
+///
+/// The hash is order-independent (BTreeMap iteration is sorted) and
+/// includes both the `dodot.*` namespace and the user-defined variables.
+/// Layout: each entry is encoded as `<ns>\x1F<key>\x1F<value>\x1E` so
+/// rearranging the boundaries between any two adjacent fields cannot
+/// produce a collision (`\x1E` and `\x1F` are the same control bytes
+/// burgertocow uses internally; they don't appear in normal
+/// configuration content).
+fn compute_context_hash(
+    dodot_ns: &BTreeMap<String, String>,
+    user_vars: &BTreeMap<String, String>,
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    for (k, v) in dodot_ns {
+        hasher.update(b"dodot");
+        hasher.update([0x1f]);
+        hasher.update(k.as_bytes());
+        hasher.update([0x1f]);
+        hasher.update(v.as_bytes());
+        hasher.update([0x1e]);
+    }
+    for (k, v) in user_vars {
+        hasher.update(b"vars");
+        hasher.update([0x1f]);
+        hasher.update(k.as_bytes());
+        hasher.update([0x1f]);
+        hasher.update(v.as_bytes());
+        hasher.update([0x1e]);
+    }
+    hasher.finalize().into()
 }
 
 /// Build the `dodot.*` namespace map.
@@ -782,5 +883,165 @@ mod tests {
         // Optional keys: present iff the detection helper returned Some.
         assert_eq!(ctx.contains_key("username"), detect_username().is_some());
         assert_eq!(ctx.contains_key("hostname"), detect_hostname().is_some());
+    }
+
+    // ── Tracked render + context hash ────────────────────────────
+
+    #[test]
+    fn expand_emits_tracked_render_with_markers_around_each_variable() {
+        // The cache layer needs the marker-annotated render to drive
+        // burgertocow's reverse-diff. Confirm that each `{{ var }}`
+        // emission produces exactly one VAR_START / VAR_END pair in
+        // the tracked string.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("cfg.tmpl", "name={{ name }} count={{ count }}")
+            .done()
+            .build();
+
+        let mut vars = HashMap::new();
+        vars.insert("name".into(), "Alice".into());
+        vars.insert("count".into(), "3".into());
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], vars, env.paths.as_ref()).unwrap();
+
+        let source = env.dotfiles_root.join("app/cfg.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let tracked = result[0]
+            .tracked_render
+            .as_ref()
+            .expect("tracked render must be present for a generative preprocessor");
+        assert_eq!(
+            tracked.matches(burgertocow::VAR_START).count(),
+            2,
+            "two variable emissions should produce two start markers, got: {tracked:?}"
+        );
+        assert_eq!(
+            tracked.matches(burgertocow::VAR_END).count(),
+            2,
+            "two variable emissions should produce two end markers, got: {tracked:?}"
+        );
+    }
+
+    #[test]
+    fn expand_visible_output_matches_tracked_with_markers_stripped() {
+        // The visible content (what the symlink target sees) must equal
+        // the tracked string with marker bytes removed. Otherwise the
+        // baseline cache's `rendered_content` and the deployed file
+        // would diverge by exactly the marker characters.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("cfg.tmpl", "user={{ name }} home={{ dodot.home }}")
+            .done()
+            .build();
+
+        let mut vars = HashMap::new();
+        vars.insert("name".into(), "Alice".into());
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], vars, env.paths.as_ref()).unwrap();
+
+        let source = env.dotfiles_root.join("app/cfg.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let visible = String::from_utf8(result[0].content.clone()).unwrap();
+        let tracked = result[0].tracked_render.as_ref().unwrap();
+
+        let stripped: String = tracked
+            .chars()
+            .filter(|c| *c != burgertocow::VAR_START && *c != burgertocow::VAR_END)
+            .collect();
+        assert_eq!(visible, stripped);
+    }
+
+    #[test]
+    fn context_hash_is_populated_and_stable() {
+        // Same constructor inputs should produce the same context hash
+        // across runs and across `expand` calls. This is what lets the
+        // baseline cache decide "input didn't change" without re-rendering.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("a.tmpl", "x={{ name }}")
+            .done()
+            .build();
+
+        let mut vars = HashMap::new();
+        vars.insert("name".into(), "Alice".into());
+        let pp1 = TemplatePreprocessor::new(vec!["tmpl".into()], vars.clone(), env.paths.as_ref())
+            .unwrap();
+        let pp2 = TemplatePreprocessor::new(vec!["tmpl".into()], vars, env.paths.as_ref()).unwrap();
+
+        assert_eq!(
+            pp1.context_hash, pp2.context_hash,
+            "identical inputs must yield identical context hashes"
+        );
+
+        let source = env.dotfiles_root.join("app/a.tmpl");
+        let r1 = pp1.expand(&source, env.fs.as_ref()).unwrap();
+        let r2 = pp1.expand(&source, env.fs.as_ref()).unwrap();
+        assert_eq!(r1[0].context_hash, r2[0].context_hash);
+        assert_eq!(r1[0].context_hash, Some(pp1.context_hash));
+    }
+
+    #[test]
+    fn context_hash_changes_when_user_var_changes() {
+        // A different user-var value MUST produce a different context
+        // hash. Without this, secret rotation through user vars wouldn't
+        // re-run install/homebrew sentinels (whose freshness is keyed off
+        // the context hash via §3.5 of the secrets spec).
+        let mut vars1 = HashMap::new();
+        vars1.insert("name".into(), "Alice".into());
+
+        let mut vars2 = HashMap::new();
+        vars2.insert("name".into(), "Bob".into());
+
+        let pather = make_pather();
+        let pp1 = TemplatePreprocessor::new(vec!["tmpl".into()], vars1, &pather).unwrap();
+        let pp2 = TemplatePreprocessor::new(vec!["tmpl".into()], vars2, &pather).unwrap();
+        assert_ne!(pp1.context_hash, pp2.context_hash);
+    }
+
+    #[test]
+    fn context_hash_is_order_independent_for_user_vars() {
+        // Hash inputs are gathered from a HashMap, so iteration order
+        // is non-deterministic. Sorting via BTreeMap before hashing must
+        // produce a stable hash regardless of insertion order.
+        let pather = make_pather();
+
+        let mut a = HashMap::new();
+        a.insert("alpha".into(), "1".into());
+        a.insert("zeta".into(), "26".into());
+
+        let mut b = HashMap::new();
+        b.insert("zeta".into(), "26".into());
+        b.insert("alpha".into(), "1".into());
+
+        let pp_a = TemplatePreprocessor::new(vec!["tmpl".into()], a, &pather).unwrap();
+        let pp_b = TemplatePreprocessor::new(vec!["tmpl".into()], b, &pather).unwrap();
+        assert_eq!(pp_a.context_hash, pp_b.context_hash);
+    }
+
+    #[test]
+    fn empty_template_still_emits_tracked_render() {
+        // Edge case: a template with no `{{ ... }}` emissions. The
+        // tracked string should be the same as the visible content
+        // (no markers added) and still be present, not None.
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("plain.tmpl", "no vars at all")
+            .done()
+            .build();
+
+        let pp = TemplatePreprocessor::new(vec!["tmpl".into()], HashMap::new(), env.paths.as_ref())
+            .unwrap();
+
+        let source = env.dotfiles_root.join("app/plain.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let tracked = result[0].tracked_render.as_ref().unwrap();
+        assert!(
+            !tracked.contains(burgertocow::VAR_START) && !tracked.contains(burgertocow::VAR_END),
+            "no variables → no markers, got: {tracked:?}"
+        );
+        // And still equal to the visible content.
+        assert_eq!(
+            String::from_utf8(result[0].content.clone()).unwrap(),
+            *tracked
+        );
     }
 }

--- a/crates/dodot-lib/src/preprocessing/unarchive.rs
+++ b/crates/dodot-lib/src/preprocessing/unarchive.rs
@@ -116,6 +116,8 @@ impl Preprocessor for UnarchivePreprocessor {
                     relative_path: entry_path,
                     content: Vec::new(),
                     is_dir: true,
+                    tracked_render: None,
+                    context_hash: None,
                 });
             } else if entry_type.is_file() {
                 let mut content = Vec::new();
@@ -131,6 +133,8 @@ impl Preprocessor for UnarchivePreprocessor {
                     relative_path: entry_path,
                     content,
                     is_dir: false,
+                    tracked_render: None,
+                    context_hash: None,
                 });
             } else {
                 return Err(DodotError::PreprocessorError {


### PR DESCRIPTION
## Summary

R1 of the template-magic track from `docs/proposals/magic.lex` — the foundation that R2+R3 build on. Lays the per-file baseline cache that an upcoming `dodot transform check` and template clean filter will read to compute reverse-merge diffs *without* re-rendering. Re-rendering at clean-filter time would re-trigger any secret-provider auth prompts on every \`git status\` — that's the bug this cache prevents.

### What changes user-visible

Nothing yet. Templates render the same content; downstream handlers see the same rendered files. The new cache is silent infrastructure for the upcoming check command and clean filter.

### What changes under the hood

- **TemplatePreprocessor swaps to `burgertocow::Tracker`**. Every \`{{ var }}\` emission is now wrapped in invisible marker bytes alongside the visible render, producing a \`TrackedRender\` we persist for later reverse-merge. Visible output is byte-identical to the prior MiniJinja path (modulo \`keep_trailing_newline\`, which fixes a small spurious-diff source).
- **Per-file baseline cache** at \`<cache_dir>/preprocessor/<pack>/<handler>/<filename>.json\`. Schema v1, fields per \`docs/proposals/preprocessing-pipeline.lex\` §5.2 plus \`tracked_render\` from \`magic.lex\` §"Cache That Makes It Cheap": rendered_hash, rendered_content, source_hash, context_hash, tracked_render, timestamp.
- **\`preprocess_pack\` gains \`paths: Option<&dyn Pather>\`**. Active callers (\`dodot up\`) pass \`Some(..)\` to write baselines; passive callers (\`dodot status\`) pass \`None\` so they don't overwrite the last-\`up\` baseline.
- **\`ExpandedFile\` gains optional \`tracked_render\` and \`context_hash\`** fields. Populated by generative preprocessors that support reverse-merge (templates today); \`None\` for identity / unarchive — the cache isn't meaningful without tracking.

### Why these specific shapes

- **Per-render Tracker** rather than a shared one: \`Tracker::add_template\` requires \`&mut self\` while \`Preprocessor::expand\` runs through \`&self\`. Per-call construction is cheaper than a trait refactor and keeps the existing concurrency shape.
- **Context hash excludes \`env.*\` references** because including them would require AST parsing the template to know which env vars are read. Documented limitation; \`dodot up --force\` is the escape hatch until the secrets-track refines it.
- **Baseline writes degrade to debug logs on failure**: the deployment itself succeeded, and a missing baseline only degrades the next reverse-merge run. Log-and-continue beats fail-the-up.
- **No second \"deployment map\"**: the per-file baseline cache *is* the lookup structure for the upcoming clean filter and \`dodot refresh\`. The existing \`probe deployment-map\` stays a display-only walk of the datastore.

## Test plan

- [x] \`cargo test -p dodot-lib --lib\` — **711 tests pass** (no regressions).
- [x] **6 new template-preprocessor tests** pin Tracker swap behavior: markers around each variable, output-equals-tracked-with-markers-stripped, context-hash stability + order-independence + change-on-input-change, empty template.
- [x] **10 new baseline-module tests** cover round-trip / missing-file / corrupt-JSON / unsupported-schema / overwrite / nested-mkdir / lossy-utf8 / hex-encoding paths.
- [x] **5 new pipeline integration tests** cover the matrix: paths=Some+tracked → baseline written, paths=None → not written, preprocessors-without-tracked-render → not written, repeated up → overwrites, end-to-end through real TemplatePreprocessor.
- [x] \`bats tests/e2e/bats/test_preprocessing.bats\` — **6/6 pass** (existing template e2e suite).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.

## Follow-ups

R2 (conflict markers + safety gate), R3 (\`dodot transform check\`), R4+ (hook, refresh, clean filter) per \`docs/proposals/magic.lex\`. Each ships standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)