### PR TITLE
feat(refresh): R5 — dodot refresh (mtime touch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`dodot refresh [--quiet] [--list-paths]`** (R5 of the template-magic track). Walks the per-file baseline cache, hashes the deployed file at `<data_dir>/packs/<pack>/<handler>/<filename>`, and copies the deployed file's mtime onto the template source when the hashes differ. Why: git's stat-cache skips re-reading working-tree files when their mtime is unchanged, so a deployed-side edit to a template never surfaces in `git status` until the source mtime is bumped — refresh is the bump. `--quiet` suppresses output (for the Tier 2 shell alias `alias git='dodot refresh --quiet && command git'`); `--list-paths` prints out-of-sync source paths and exits without writing (for editor / file-watcher integrations). Exit 0 in all healthy cases. See `docs/proposals/magic.lex` §"Update Trigger Bit".
+- **`Fs::modified` / `Fs::set_modified`** trait methods for reading/writing file mtimes — used by `refresh` to copy mtimes between deployed and source files.
+
+### Added (R4, prior)
+
 - **`dodot transform install-hook`** (R4 of the template-magic track). Writes `<dotfiles_root>/.git/hooks/pre-commit` with a guarded block that runs `dodot transform check --strict || exit 1` on every `git commit`. Idempotent (re-running detects the guard line and no-ops) and additive (preserves any existing hook content). The installed hook refuses to commit when reverse-merge has work to do or unresolved `dodot-conflict` markers remain — matching the contract R3 set up. See `docs/proposals/magic.lex` §"The Commit Tier".
 - **First-template-deploy prompt.** After a successful `dodot up` that leaves at least one template baseline in the cache, dodot offers (interactively, only when stdin is a TTY) to install the pre-commit hook. Y/n/show via the existing `PromptRegistry`; new catalog entry `template.install_hook`; soft failure pattern matching the plist filter prompt — never aborts `up`, and any background failures (registry parse error, etc.) go to the debug log rather than stderr. The interactive prompt body itself prints to stderr by design (Y/n/show + the resulting confirmation/show output).
 

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -303,6 +303,25 @@ pub fn transform_check_handler(
     Ok(Output::Render(result))
 }
 
+/// `dodot refresh [--quiet] [--list-paths]` — copy deployed mtimes
+/// onto template sources where they've drifted from the baseline.
+/// Used by the Tier 2 shell alias and by the upcoming clean filter
+/// flow so `git status` / `git diff` reflect deployed-side edits.
+pub fn refresh_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::refresh::RefreshResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    let mode = if flag_or_false(matches, "list-paths") {
+        commands::refresh::RefreshMode::ListPaths
+    } else if flag_or_false(matches, "quiet") {
+        commands::refresh::RefreshMode::Quiet
+    } else {
+        commands::refresh::RefreshMode::Report
+    };
+    Ok(Output::Render(commands::refresh::refresh(&ctx, mode)?))
+}
+
 /// `dodot transform install-hook` — write `.git/hooks/pre-commit` with
 /// our `dodot transform check --strict` block. Idempotent and additive
 /// (preserves any existing hook content). See `commands::transform::

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -197,6 +197,7 @@ static TEMPLATE_ENTRIES: &[(&str, &str)] = &[
         "transform-install-hook.jinja",
         render::TEMPLATE_TRANSFORM_INSTALL_HOOK,
     ),
+    ("refresh.jinja", render::TEMPLATE_REFRESH),
 ];
 
 fn build_app() -> App {
@@ -275,6 +276,8 @@ fn build_app() -> App {
             "transform-install-hook",
         )
         .expect("register transform.install-hook")
+        .command("refresh", handlers::refresh_handler, "refresh")
+        .expect("register refresh")
         .command_groups(vec![
             CommandGroup {
                 title: "Core".into(),
@@ -315,6 +318,7 @@ fn build_app() -> App {
                 help: None,
                 commands: vec![
                     Some("transform".into()),
+                    Some("refresh".into()),
                     Some("tutorial".into()),
                     Some("init-sh".into()),
                     Some("prompts".into()),
@@ -545,6 +549,28 @@ fn build_clap_command() -> ClapCommand {
                                 .help("Reset every dismissed prompt")
                                 .action(ArgAction::SetTrue),
                         ),
+                ),
+        )
+        .subcommand(
+            ClapCommand::new("refresh")
+                .about(
+                    "Touch template-source mtimes when deployed files have drifted, so `git \
+                     status` and `git diff` re-read them and surface the changes.",
+                )
+                .arg(
+                    Arg::new("quiet")
+                        .long("quiet")
+                        .help("Suppress all output (use this in shell aliases).")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("list-paths")
+                        .long("list-paths")
+                        .help(
+                            "Print the source paths that need a touch and exit, without \
+                             writing any mtimes. Use this in editor / file-watcher integrations.",
+                        )
+                        .action(ArgAction::SetTrue),
                 ),
         )
         .subcommand(

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -561,7 +561,8 @@ fn build_clap_command() -> ClapCommand {
                     Arg::new("quiet")
                         .long("quiet")
                         .help("Suppress all output (use this in shell aliases).")
-                        .action(ArgAction::SetTrue),
+                        .action(ArgAction::SetTrue)
+                        .conflicts_with("list-paths"),
                 )
                 .arg(
                     Arg::new("list-paths")

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod init;
 pub mod list;
 pub mod probe;
 pub mod prompts;
+pub mod refresh;
 pub mod status;
 pub mod transform;
 pub mod tutorial;

--- a/crates/dodot-lib/src/commands/refresh.rs
+++ b/crates/dodot-lib/src/commands/refresh.rs
@@ -1,0 +1,451 @@
+//! `dodot refresh` — touch source mtimes when deployed bytes diverged.
+//!
+//! Walks the per-file baseline cache, hashes each deployed (datastore-
+//! side) file, and copies the deployed file's mtime onto the template
+//! source whenever the hashes differ. Why: git uses stat-cache mtimes
+//! to decide whether to re-read a working-tree file, so without this
+//! step a deployed-side edit never surfaces in `git status` (the
+//! source mtime hasn't changed → git uses the cached hash → no clean-
+//! filter invocation → no diff). Touching the source forces a re-read.
+//!
+//! See `docs/proposals/magic.lex` §"Update Trigger Bit". This command
+//! is the engine the Tier 2 shell alias (`alias git='dodot refresh
+//! --quiet && command git'`) and external file-watcher integrations
+//! call before delegating to git.
+//!
+//! # Modes
+//!
+//! - **default**: writes a short report to stdout (touched / clean
+//!   counts, per-file lines for touched entries).
+//! - **`--quiet`**: silent, exit 0. Intended for the shell alias so a
+//!   no-op refresh doesn't print on every git invocation.
+//! - **`--list-paths`**: prints absolute source paths that need a
+//!   touch (mtime not yet copied), one per line. Intended for editor
+//!   / file-watcher integrations that want to drive the touch
+//!   themselves; we don't write mtimes in this mode.
+//!
+//! Exit code: 0 in all healthy cases. Errors (real I/O failures only)
+//! propagate as `DodotError::Fs`.
+
+use serde::Serialize;
+
+use crate::packs::orchestration::ExecutionContext;
+use crate::preprocessing::baseline::hex_sha256;
+use crate::preprocessing::divergence::collect_baselines;
+use crate::Result;
+
+/// What `refresh` did to a single processed file.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefreshAction {
+    /// Deployed file's hash matches the baseline; nothing to do.
+    Clean,
+    /// Source mtime was copied from the deployed file (default mode)
+    /// or would be (`--list-paths` mode).
+    Touched,
+    /// Deployed file is missing from the datastore (e.g. user removed
+    /// it). Reported but not actioned.
+    MissingDeployed,
+    /// Cached source path no longer exists on disk. Reported.
+    MissingSource,
+}
+
+/// One row in the refresh report.
+#[derive(Debug, Clone, Serialize)]
+pub struct RefreshEntry {
+    pub pack: String,
+    pub handler: String,
+    pub filename: String,
+    /// Absolute source path. The CLI renderer trims to `~/...` when
+    /// possible; the JSON output keeps the absolute form.
+    pub source_path: String,
+    pub action: RefreshAction,
+}
+
+/// Aggregate result of a refresh invocation.
+#[derive(Debug, Clone, Serialize)]
+pub struct RefreshResult {
+    pub entries: Vec<RefreshEntry>,
+    /// True iff at least one entry was Touched. Drives the
+    /// `--list-paths` and report-mode rendering.
+    pub touched_any: bool,
+    /// Operating mode chosen by the caller, surfaced so the renderer
+    /// can pick the right template branch.
+    pub mode: RefreshMode,
+}
+
+/// Refresh invocation mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefreshMode {
+    /// Default: write mtimes, render a short report.
+    Report,
+    /// `--quiet`: write mtimes, render nothing.
+    Quiet,
+    /// `--list-paths`: do NOT write mtimes; render only the source
+    /// paths of divergent entries (one per line).
+    ListPaths,
+}
+
+/// Run `dodot refresh` in the given mode.
+///
+/// Walks every cached baseline. For each:
+///   - read the deployed bytes from `<data_dir>/packs/<pack>/<handler>/<filename>`
+///   - hash them; compare to `baseline.rendered_hash`
+///   - if equal → action `Clean`
+///   - if differ AND mode != ListPaths → copy deployed mtime onto source, action `Touched`
+///   - if differ AND mode == ListPaths → action `Touched` (no write; the source path will be printed)
+///   - if deployed is missing → action `MissingDeployed`
+///   - if source path is empty or missing → action `MissingSource`
+pub fn refresh(ctx: &ExecutionContext, mode: RefreshMode) -> Result<RefreshResult> {
+    let baselines = collect_baselines(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+    let mut entries = Vec::with_capacity(baselines.len());
+    let mut touched_any = false;
+
+    for (pack, handler, filename, baseline) in baselines {
+        let source_path = baseline.source_path.clone();
+        let deployed_path = ctx
+            .paths
+            .data_dir()
+            .join("packs")
+            .join(&pack)
+            .join(&handler)
+            .join(&filename);
+
+        let action = if source_path.as_os_str().is_empty() || !ctx.fs.exists(&source_path) {
+            RefreshAction::MissingSource
+        } else if !ctx.fs.exists(&deployed_path) {
+            RefreshAction::MissingDeployed
+        } else {
+            // Hash the deployed bytes. A read error here surfaces as a
+            // hard error rather than silently logging — refresh is a
+            // small command and we'd rather fail loudly than drop a
+            // sync that the user thinks succeeded.
+            let bytes = ctx.fs.read_file(&deployed_path)?;
+            if hex_sha256(&bytes) == baseline.rendered_hash {
+                RefreshAction::Clean
+            } else {
+                if mode != RefreshMode::ListPaths {
+                    let deployed_mtime = ctx.fs.modified(&deployed_path)?;
+                    ctx.fs.set_modified(&source_path, deployed_mtime)?;
+                }
+                touched_any = true;
+                RefreshAction::Touched
+            }
+        };
+
+        entries.push(RefreshEntry {
+            pack,
+            handler,
+            filename,
+            source_path: source_path.display().to_string(),
+            action,
+        });
+    }
+
+    Ok(RefreshResult {
+        entries,
+        touched_any,
+        mode,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::Fs;
+    use crate::paths::Pather;
+    use crate::preprocessing::baseline::Baseline;
+    use crate::testing::TempEnvironment;
+
+    fn make_ctx(env: &TempEnvironment) -> ExecutionContext {
+        use crate::config::ConfigManager;
+        use crate::datastore::{CommandOutput, CommandRunner, FilesystemDataStore};
+        use std::sync::Arc;
+
+        struct NoopRunner;
+        impl CommandRunner for NoopRunner {
+            fn run(&self, _e: &str, _a: &[String]) -> Result<CommandOutput> {
+                Ok(CommandOutput {
+                    exit_code: 0,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            }
+        }
+        let runner: Arc<dyn CommandRunner> = Arc::new(NoopRunner);
+        let datastore = Arc::new(FilesystemDataStore::new(
+            env.fs.clone(),
+            env.paths.clone(),
+            runner.clone(),
+        ));
+        let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
+        ExecutionContext {
+            fs: env.fs.clone() as Arc<dyn Fs>,
+            datastore,
+            paths: env.paths.clone() as Arc<dyn Pather>,
+            config_manager,
+            syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
+            command_runner: runner,
+            dry_run: false,
+            no_provision: true,
+            provision_rerun: false,
+            force: false,
+            view_mode: crate::commands::ViewMode::Full,
+            group_mode: crate::commands::GroupMode::Name,
+            verbose: false,
+        }
+    }
+
+    fn write_file(env: &TempEnvironment, path: &std::path::Path, body: &[u8]) {
+        env.fs.mkdir_all(path.parent().unwrap()).unwrap();
+        env.fs.write_file(path, body).unwrap();
+    }
+
+    /// Stage a baseline + matching pack source + matching deployed
+    /// file. Returns the absolute source and deployed paths so the
+    /// test can edit either side.
+    fn stage_one(
+        env: &TempEnvironment,
+        pack: &str,
+        template_name: &str,
+        rendered: &[u8],
+        source: &[u8],
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
+        let src = env.dotfiles_root.join(pack).join(template_name);
+        write_file(env, &src, source);
+        let stripped = template_name.strip_suffix(".tmpl").unwrap_or(template_name);
+        let deployed = env
+            .paths
+            .data_dir()
+            .join("packs")
+            .join(pack)
+            .join("preprocessed")
+            .join(stripped);
+        write_file(env, &deployed, rendered);
+        let baseline = Baseline::build(&src, rendered, source, Some(""), None);
+        baseline
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                pack,
+                "preprocessed",
+                stripped,
+            )
+            .unwrap();
+        (src, deployed)
+    }
+
+    #[test]
+    fn empty_cache_yields_empty_report() {
+        let env = TempEnvironment::builder().build();
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        assert!(r.entries.is_empty());
+        assert!(!r.touched_any);
+    }
+
+    #[test]
+    fn clean_state_is_a_noop() {
+        // baseline + source + deployed all line up. No mtime touched.
+        let env = TempEnvironment::builder().build();
+        let (src, _) = stage_one(&env, "app", "cfg.toml.tmpl", b"rendered", b"src");
+        // Capture the source mtime before refresh; a no-op must not
+        // change it.
+        let before = env.fs.modified(&src).unwrap();
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        assert_eq!(r.entries.len(), 1);
+        assert!(matches!(r.entries[0].action, RefreshAction::Clean));
+        assert!(!r.touched_any);
+        assert_eq!(env.fs.modified(&src).unwrap(), before);
+    }
+
+    #[test]
+    fn divergent_deployed_touches_source_mtime() {
+        // The core scenario: user edits the deployed file → source
+        // mtime gets bumped to match.
+        let env = TempEnvironment::builder().build();
+        let (src, deployed) = stage_one(&env, "app", "cfg.toml.tmpl", b"rendered", b"src");
+
+        // Edit the deployed file to a divergent value AFTER the
+        // baseline. Sleep briefly so the deployed mtime is strictly
+        // later than the source's.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        env.fs.write_file(&deployed, b"rendered EDITED").unwrap();
+        let deployed_mtime = env.fs.modified(&deployed).unwrap();
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        assert_eq!(r.entries.len(), 1);
+        assert!(matches!(r.entries[0].action, RefreshAction::Touched));
+        assert!(r.touched_any);
+
+        // Source mtime now equals the deployed mtime.
+        let new_src_mtime = env.fs.modified(&src).unwrap();
+        assert_eq!(new_src_mtime, deployed_mtime);
+    }
+
+    #[test]
+    fn list_paths_mode_does_not_write_mtimes() {
+        // `--list-paths` reports divergent sources but never touches.
+        // Editor / watcher integrations want to drive the touch
+        // themselves so they can sequence it correctly with their own
+        // build steps.
+        let env = TempEnvironment::builder().build();
+        let (src, deployed) = stage_one(&env, "app", "cfg.toml.tmpl", b"rendered", b"src");
+
+        let before_src = env.fs.modified(&src).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        env.fs.write_file(&deployed, b"rendered EDITED").unwrap();
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::ListPaths).unwrap();
+        assert_eq!(r.entries.len(), 1);
+        assert!(matches!(r.entries[0].action, RefreshAction::Touched));
+        assert!(r.touched_any);
+
+        // mtime unchanged.
+        assert_eq!(env.fs.modified(&src).unwrap(), before_src);
+    }
+
+    #[test]
+    fn quiet_mode_still_writes_mtimes() {
+        // `--quiet` is just an output-suppression flag; the work
+        // itself happens. The shell alias depends on this.
+        let env = TempEnvironment::builder().build();
+        let (src, deployed) = stage_one(&env, "app", "cfg.toml.tmpl", b"rendered", b"src");
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        env.fs.write_file(&deployed, b"rendered EDITED").unwrap();
+        let deployed_mtime = env.fs.modified(&deployed).unwrap();
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Quiet).unwrap();
+        assert!(matches!(r.entries[0].action, RefreshAction::Touched));
+        assert_eq!(env.fs.modified(&src).unwrap(), deployed_mtime);
+    }
+
+    #[test]
+    fn missing_source_is_reported_not_an_error() {
+        // The cached source path no longer exists (user renamed /
+        // removed the .tmpl). Refresh keeps going; the entry is
+        // surfaced so the user knows the cache is stale.
+        let env = TempEnvironment::builder().build();
+        // Stage a baseline whose source path doesn't exist on disk.
+        let baseline = Baseline::build(
+            &env.dotfiles_root.join("app/missing.toml.tmpl"),
+            b"rendered",
+            b"src",
+            Some(""),
+            None,
+        );
+        baseline
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "missing.toml",
+            )
+            .unwrap();
+        // Deployed file exists.
+        let deployed = env
+            .paths
+            .data_dir()
+            .join("packs/app/preprocessed/missing.toml");
+        write_file(&env, &deployed, b"rendered");
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        assert_eq!(r.entries.len(), 1);
+        assert!(matches!(r.entries[0].action, RefreshAction::MissingSource));
+        assert!(!r.touched_any);
+    }
+
+    #[test]
+    fn missing_deployed_is_reported_not_an_error() {
+        // The deployed file is gone; refresh has nothing to compare
+        // against. Surface as MissingDeployed.
+        let env = TempEnvironment::builder().build();
+        let src = env.dotfiles_root.join("app/cfg.toml.tmpl");
+        write_file(&env, &src, b"src");
+        let baseline = Baseline::build(&src, b"rendered", b"src", Some(""), None);
+        baseline
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "cfg.toml",
+            )
+            .unwrap();
+        // Don't lay down the deployed file.
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        assert!(matches!(
+            r.entries[0].action,
+            RefreshAction::MissingDeployed
+        ));
+        assert!(!r.touched_any);
+    }
+
+    #[test]
+    fn pure_data_edit_is_still_treated_as_divergent() {
+        // Edge case: the user edited only a variable's *value* in the
+        // deployed file. The deployed bytes diverge from the
+        // baseline, so refresh touches the source. The clean filter
+        // (R6, when installed) will then re-evaluate and decide
+        // whether the change is worth a template-space diff. Refresh
+        // itself is intentionally a coarse hash compare — it errs on
+        // the side of triggering the filter rather than missing a
+        // real edit.
+        let env = TempEnvironment::builder().build();
+        let (_src, deployed) = stage_one(
+            &env,
+            "app",
+            "greet.tmpl",
+            b"hello Alice",
+            b"hello {{ name }}",
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        env.fs.write_file(&deployed, b"hello Bob").unwrap();
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        assert!(matches!(r.entries[0].action, RefreshAction::Touched));
+        assert!(r.touched_any);
+    }
+
+    #[test]
+    fn entries_are_sorted_by_pack_handler_filename() {
+        // Stable display order — the underlying walker is sorted, and
+        // refresh inherits that. Pin it so callers can rely on
+        // deterministic output.
+        let env = TempEnvironment::builder().build();
+        for (pack, name) in [
+            ("zebra", "z.tmpl"),
+            ("alpha", "b.tmpl"),
+            ("alpha", "a.tmpl"),
+        ] {
+            stage_one(&env, pack, name, b"rendered", b"src");
+        }
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        let order: Vec<_> = r
+            .entries
+            .iter()
+            .map(|e| (e.pack.clone(), e.filename.clone()))
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                ("alpha".into(), "a".into()),
+                ("alpha".into(), "b".into()),
+                ("zebra".into(), "z".into()),
+            ]
+        );
+    }
+}

--- a/crates/dodot-lib/src/commands/refresh.rs
+++ b/crates/dodot-lib/src/commands/refresh.rs
@@ -56,8 +56,10 @@ pub struct RefreshEntry {
     pub pack: String,
     pub handler: String,
     pub filename: String,
-    /// Absolute source path. The CLI renderer trims to `~/...` when
-    /// possible; the JSON output keeps the absolute form.
+    /// Absolute source path. The CLI renderer (and the JSON output)
+    /// both surface this verbatim — refresh entries are typically a
+    /// short list, and the absolute path is unambiguous when the
+    /// user wants to plug `--list-paths` output into a watcher.
     pub source_path: String,
     pub action: RefreshAction,
 }
@@ -127,7 +129,26 @@ pub fn refresh(ctx: &ExecutionContext, mode: RefreshMode) -> Result<RefreshResul
             } else {
                 if mode != RefreshMode::ListPaths {
                     let deployed_mtime = ctx.fs.modified(&deployed_path)?;
-                    ctx.fs.set_modified(&source_path, deployed_mtime)?;
+                    let source_mtime = ctx.fs.modified(&source_path)?;
+                    // The whole point of refresh is to invalidate
+                    // git's stat-cache by changing the source mtime.
+                    // If the deployed mtime happens to equal the
+                    // current source mtime — possible on coarse-
+                    // resolution filesystems (FAT, HFS+ at 1s
+                    // granularity) or when a user edits and refreshes
+                    // within the same second — copying it would be a
+                    // no-op and git would not re-read the file. Bump
+                    // by 1s in that case so the mtime strictly
+                    // changes. We don't care that the source mtime
+                    // ends up "ahead of" the deployed mtime; what
+                    // matters is that it differs from the cached
+                    // value git has.
+                    let target = if deployed_mtime == source_mtime {
+                        deployed_mtime + std::time::Duration::from_secs(1)
+                    } else {
+                        deployed_mtime
+                    };
+                    ctx.fs.set_modified(&source_path, target)?;
                 }
                 touched_any = true;
                 RefreshAction::Touched
@@ -417,6 +438,38 @@ mod tests {
         let r = refresh(&ctx, RefreshMode::Report).unwrap();
         assert!(matches!(r.entries[0].action, RefreshAction::Touched));
         assert!(r.touched_any);
+    }
+
+    #[test]
+    fn divergent_with_equal_mtimes_still_bumps_source() {
+        // Edge case from PR review: if the deployed mtime happens to
+        // equal the source mtime (coarse FS, rapid edits within the
+        // same second), `set_modified(source, deployed_mtime)` would
+        // be a no-op — git's stat-cache wouldn't invalidate, and
+        // refresh would silently fail at its core purpose. We bump
+        // by 1s in that case so the source mtime *strictly* changes.
+        let env = TempEnvironment::builder().build();
+        let (src, deployed) = stage_one(&env, "app", "cfg.toml.tmpl", b"rendered", b"src");
+
+        // Force the deployed mtime to exactly match the current
+        // source mtime, then mutate the deployed bytes so refresh
+        // sees a divergence to act on.
+        let pinned = env.fs.modified(&src).unwrap();
+        env.fs.write_file(&deployed, b"rendered EDITED").unwrap();
+        env.fs.set_modified(&deployed, pinned).unwrap();
+        assert_eq!(env.fs.modified(&deployed).unwrap(), pinned);
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        assert!(matches!(r.entries[0].action, RefreshAction::Touched));
+
+        // Source mtime must STRICTLY exceed the original (no-op
+        // behaviour would leave it unchanged).
+        let after = env.fs.modified(&src).unwrap();
+        assert!(
+            after > pinned,
+            "source mtime should strictly increase even when deployed mtime equals source mtime"
+        );
     }
 
     #[test]

--- a/crates/dodot-lib/src/fs/mod.rs
+++ b/crates/dodot-lib/src/fs/mod.rs
@@ -96,4 +96,16 @@ pub trait Fs: Send + Sync {
 
     /// Sets file permissions (Unix mode).
     fn set_permissions(&self, path: &Path, mode: u32) -> Result<()>;
+
+    /// Returns the modification time of `path` (follows symlinks).
+    /// Used by `dodot refresh` to compare deployed-side mtimes against
+    /// source-side mtimes when deciding whether to touch the source.
+    fn modified(&self, path: &Path) -> Result<std::time::SystemTime>;
+
+    /// Sets the modification time of `path` to `time`. Used by
+    /// `dodot refresh` to copy the deployed file's mtime onto the
+    /// template source so git's stat-cache invalidates and the next
+    /// `git status` re-reads the file (invoking the clean filter on
+    /// repos that have it installed).
+    fn set_modified(&self, path: &Path, time: std::time::SystemTime) -> Result<()>;
 }

--- a/crates/dodot-lib/src/fs/mod.rs
+++ b/crates/dodot-lib/src/fs/mod.rs
@@ -100,12 +100,24 @@ pub trait Fs: Send + Sync {
     /// Returns the modification time of `path` (follows symlinks).
     /// Used by `dodot refresh` to compare deployed-side mtimes against
     /// source-side mtimes when deciding whether to touch the source.
-    fn modified(&self, path: &Path) -> Result<std::time::SystemTime>;
+    ///
+    /// **Default implementation panics.** Override in `Fs` impls that
+    /// need mtime support (currently `OsFs`). Provided as a default
+    /// so adding mtime operations doesn't break any existing in-tree
+    /// or downstream `Fs` impl.
+    fn modified(&self, _path: &Path) -> Result<std::time::SystemTime> {
+        unimplemented!("Fs::modified is only implemented by OsFs")
+    }
 
     /// Sets the modification time of `path` to `time`. Used by
     /// `dodot refresh` to copy the deployed file's mtime onto the
     /// template source so git's stat-cache invalidates and the next
     /// `git status` re-reads the file (invoking the clean filter on
     /// repos that have it installed).
-    fn set_modified(&self, path: &Path, time: std::time::SystemTime) -> Result<()>;
+    ///
+    /// **Default implementation panics.** Override in `Fs` impls that
+    /// need mtime support (currently `OsFs`).
+    fn set_modified(&self, _path: &Path, _time: std::time::SystemTime) -> Result<()> {
+        unimplemented!("Fs::set_modified is only implemented by OsFs")
+    }
 }

--- a/crates/dodot-lib/src/fs/os.rs
+++ b/crates/dodot-lib/src/fs/os.rs
@@ -130,9 +130,10 @@ impl Fs for OsFs {
     }
 
     fn set_modified(&self, path: &Path, time: std::time::SystemTime) -> Result<()> {
-        // `File::set_modified` (stable since 1.75) opens-or-truncates;
-        // we want existing-file semantics. Use OpenOptions::write(true)
-        // (no truncate) to get a handle to the existing file.
+        // `File::set_modified` (stable since 1.75) needs an existing
+        // file handle. We deliberately open with `.write(true)` (NOT
+        // `.create(true)`, NOT `.truncate(true)`) so we get a handle
+        // to the existing file without touching its content.
         let file = fs::OpenOptions::new()
             .write(true)
             .open(path)

--- a/crates/dodot-lib/src/fs/os.rs
+++ b/crates/dodot-lib/src/fs/os.rs
@@ -122,6 +122,23 @@ impl Fs for OsFs {
         let perms = fs::Permissions::from_mode(mode);
         fs::set_permissions(path, perms).map_err(|e| fs_err(path, e))
     }
+
+    fn modified(&self, path: &Path) -> Result<std::time::SystemTime> {
+        fs::metadata(path)
+            .and_then(|m| m.modified())
+            .map_err(|e| fs_err(path, e))
+    }
+
+    fn set_modified(&self, path: &Path, time: std::time::SystemTime) -> Result<()> {
+        // `File::set_modified` (stable since 1.75) opens-or-truncates;
+        // we want existing-file semantics. Use OpenOptions::write(true)
+        // (no truncate) to get a handle to the existing file.
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .map_err(|e| fs_err(path, e))?;
+        file.set_modified(time).map_err(|e| fs_err(path, e))
+    }
 }
 
 fn metadata_from_std(meta: &fs::Metadata, is_symlink: bool) -> FsMetadata {

--- a/crates/dodot-lib/src/render/mod.rs
+++ b/crates/dodot-lib/src/render/mod.rs
@@ -158,6 +158,9 @@ pub const TEMPLATE_TRANSFORM_CHECK: &str = include_str!("../templates/transform-
 pub const TEMPLATE_TRANSFORM_INSTALL_HOOK: &str =
     include_str!("../templates/transform-install-hook.jinja");
 
+/// `dodot refresh` per-mode output (default report / quiet / list-paths).
+pub const TEMPLATE_REFRESH: &str = include_str!("../templates/refresh.jinja");
+
 // ── Tutorial step templates ─────────────────────────────────────
 //
 // One per step of the interactive tutorial. The CLI driver renders

--- a/crates/dodot-lib/src/templates/refresh.jinja
+++ b/crates/dodot-lib/src/templates/refresh.jinja
@@ -1,0 +1,24 @@
+{%- if mode == "quiet" -%}
+{%- elif mode == "list_paths" -%}
+{%- for e in entries -%}
+{%- if e.action == "touched" %}{{ e.source_path }}
+{% endif -%}
+{%- endfor -%}
+{%- else -%}
+{%- if entries|length == 0 -%}
+[muted]No template baselines. Run [usage]dodot up[/usage] to deploy templates first.[/muted]
+{%- elif touched_any -%}
+[message]Touched {{ entries|selectattr("action", "equalto", "touched")|list|length }} source file(s) — `git status` will now see deployed-side edits.[/message]
+{% for e in entries -%}
+{%- if e.action == "touched" -%}
+  [success]·[/success] {{ e.source_path }}
+{% elif e.action == "missing_source" -%}
+  [warn]? missing source[/warn] {{ e.source_path }} [muted](baseline stale; next [usage]dodot up[/usage] will refresh)[/muted]
+{% elif e.action == "missing_deployed" -%}
+  [warn]? missing deployed[/warn] {{ e.source_path }} [muted](rendered file gone; next [usage]dodot up[/usage] will recreate)[/muted]
+{% endif -%}
+{%- endfor %}
+{%- else -%}
+[message]All {{ entries|length }} template source(s) already in sync.[/message]
+{%- endif -%}
+{%- endif -%}

--- a/crates/dodot-lib/src/templates/refresh.jinja
+++ b/crates/dodot-lib/src/templates/refresh.jinja
@@ -7,8 +7,15 @@
 {%- else -%}
 {%- if entries|length == 0 -%}
 [muted]No template baselines. Run [usage]dodot up[/usage] to deploy templates first.[/muted]
-{%- elif touched_any -%}
+{%- else -%}
+{%- set missing = entries|rejectattr("action", "equalto", "touched")|rejectattr("action", "equalto", "clean")|list -%}
+{%- if touched_any -%}
 [message]Touched {{ entries|selectattr("action", "equalto", "touched")|list|length }} source file(s) — `git status` will now see deployed-side edits.[/message]
+{%- elif missing|length > 0 -%}
+[message]No edits to touch, but {{ missing|length }} cache entry / entries need attention.[/message]
+{%- else -%}
+[message]All {{ entries|length }} template source(s) already in sync.[/message]
+{%- endif %}
 {% for e in entries -%}
 {%- if e.action == "touched" -%}
   [success]·[/success] {{ e.source_path }}
@@ -17,8 +24,6 @@
 {% elif e.action == "missing_deployed" -%}
   [warn]? missing deployed[/warn] {{ e.source_path }} [muted](rendered file gone; next [usage]dodot up[/usage] will recreate)[/muted]
 {% endif -%}
-{%- endfor %}
-{%- else -%}
-[message]All {{ entries|length }} template source(s) already in sync.[/message]
+{%- endfor -%}
 {%- endif -%}
 {%- endif -%}

--- a/tests/e2e/bats/test_refresh.bats
+++ b/tests/e2e/bats/test_refresh.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# E2E tests for `dodot refresh` (R5 of the template-magic track).
+#
+# `dodot refresh` copies deployed-side mtimes onto template sources
+# whenever the deployed bytes have diverged from the cached baseline.
+# Why: git's stat-cache skips re-reading working-tree files when their
+# mtime is unchanged, so a deployed-side edit to a template won't
+# surface in `git status` until the source mtime is bumped. Refresh
+# is the bump.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+    git -C "$DOTFILES_ROOT" init -q
+    git -C "$DOTFILES_ROOT" config user.email "test@example.com"
+    git -C "$DOTFILES_ROOT" config user.name "Test"
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "refresh on clean state reports in-sync and exits 0" {
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'name = {{ name }}'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    run dodot refresh
+    [ "$status" -eq 0 ]
+    assert_output_contains "in sync"
+}
+
+@test "refresh after editing deployed file touches the source mtime" {
+    # The core scenario: edit the rendered file in the datastore,
+    # then `dodot refresh` should bring the source mtime up to date.
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'name = {{ name }}
+port = 5432'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    src="$DOTFILES_ROOT/app/cfg.toml.tmpl"
+    src_mtime_before=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+
+    # Make sure the deployed mtime will be strictly later than the
+    # current source mtime, even on fast filesystems.
+    sleep 1
+    rendered="$XDG_DATA_HOME/dodot/packs/app/preprocessed/cfg.toml"
+    cat > "$rendered" <<'EOF'
+name = Alice
+port = 9999
+EOF
+
+    run dodot refresh
+    [ "$status" -eq 0 ]
+    assert_output_contains "Touched"
+
+    src_mtime_after=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+    [ "$src_mtime_after" -gt "$src_mtime_before" ]
+}
+
+@test "refresh --list-paths prints divergent sources without writing mtimes" {
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'name = {{ name }}'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    src="$DOTFILES_ROOT/app/cfg.toml.tmpl"
+    src_mtime_before=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+
+    sleep 1
+    rendered="$XDG_DATA_HOME/dodot/packs/app/preprocessed/cfg.toml"
+    echo "name = Edited" > "$rendered"
+
+    run dodot refresh --list-paths
+    [ "$status" -eq 0 ]
+    # Output is the absolute source path, suitable for `xargs touch`
+    # or piping into a watcher integration.
+    assert_output_contains "$src"
+
+    # CRITICAL: --list-paths must NOT have written the mtime.
+    src_mtime_after=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+    [ "$src_mtime_after" = "$src_mtime_before" ]
+}
+
+@test "refresh --quiet emits no output but still updates mtime" {
+    # The Tier 2 shell alias depends on this: a no-op refresh on every
+    # git invocation should be silent, but a real refresh must still
+    # do its work.
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'name = {{ name }}'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    src="$DOTFILES_ROOT/app/cfg.toml.tmpl"
+    sleep 1
+    rendered="$XDG_DATA_HOME/dodot/packs/app/preprocessed/cfg.toml"
+    echo "name = Edited" > "$rendered"
+    src_mtime_before=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+
+    run dodot refresh --quiet
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+
+    src_mtime_after=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+    [ "$src_mtime_after" -gt "$src_mtime_before" ]
+}
+
+@test "refresh on empty cache reports nothing-to-do" {
+    # No `dodot up` ever ran in this sandbox, so the baseline cache is
+    # empty. Refresh must not error out — just say there's nothing.
+    run dodot refresh
+    [ "$status" -eq 0 ]
+    assert_output_contains "No template baselines"
+}

--- a/tests/e2e/bats/test_refresh.bats
+++ b/tests/e2e/bats/test_refresh.bats
@@ -134,6 +134,16 @@ name = "Alice"'
     [ "$src_mtime_after" -gt "$src_mtime_before" ]
 }
 
+@test "refresh rejects --quiet and --list-paths together" {
+    # The two flags are semantically incompatible (one suppresses
+    # output, the other is output-only). clap should reject the
+    # combination explicitly so users see a clear error rather than
+    # silent prioritisation.
+    run dodot refresh --quiet --list-paths
+    [ "$status" -ne 0 ]
+    assert_output_contains "cannot be used"
+}
+
 @test "refresh on empty cache reports nothing-to-do" {
     # No `dodot up` ever ran in this sandbox, so the baseline cache is
     # empty. Refresh must not error out — just say there's nothing.

--- a/tests/e2e/bats/test_refresh.bats
+++ b/tests/e2e/bats/test_refresh.bats
@@ -16,6 +16,21 @@ setup() {
     git -C "$DOTFILES_ROOT" config user.name "Test"
 }
 
+# Portable mtime reader. Different stat invocations on macOS (BSD)
+# vs Linux (GNU coreutils): `-c %Y` is GNU-only, `-f %m` is BSD-only,
+# and `stat -f` on GNU coreutils silently switches to filesystem-info
+# mode (returning the mount point) rather than failing — so a naive
+# `stat -f %m || stat -c %Y` chain works on macOS but produces a
+# non-numeric result on Linux that breaks `[ -gt ]` later. Detect
+# the platform once and pick the right format.
+mtime() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        stat -f %m "$1"
+    else
+        stat -c %Y "$1"
+    fi
+}
+
 teardown() {
     sandbox_teardown
 }
@@ -47,7 +62,7 @@ name = "Alice"'
     [ "$status" -eq 0 ]
 
     src="$DOTFILES_ROOT/app/cfg.toml.tmpl"
-    src_mtime_before=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+    src_mtime_before=$(mtime "$src")
 
     # Make sure the deployed mtime will be strictly later than the
     # current source mtime, even on fast filesystems.
@@ -62,7 +77,7 @@ EOF
     [ "$status" -eq 0 ]
     assert_output_contains "Touched"
 
-    src_mtime_after=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+    src_mtime_after=$(mtime "$src")
     [ "$src_mtime_after" -gt "$src_mtime_before" ]
 }
 
@@ -76,7 +91,7 @@ name = "Alice"'
     [ "$status" -eq 0 ]
 
     src="$DOTFILES_ROOT/app/cfg.toml.tmpl"
-    src_mtime_before=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+    src_mtime_before=$(mtime "$src")
 
     sleep 1
     rendered="$XDG_DATA_HOME/dodot/packs/app/preprocessed/cfg.toml"
@@ -89,7 +104,7 @@ name = "Alice"'
     assert_output_contains "$src"
 
     # CRITICAL: --list-paths must NOT have written the mtime.
-    src_mtime_after=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+    src_mtime_after=$(mtime "$src")
     [ "$src_mtime_after" = "$src_mtime_before" ]
 }
 
@@ -109,13 +124,13 @@ name = "Alice"'
     sleep 1
     rendered="$XDG_DATA_HOME/dodot/packs/app/preprocessed/cfg.toml"
     echo "name = Edited" > "$rendered"
-    src_mtime_before=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+    src_mtime_before=$(mtime "$src")
 
     run dodot refresh --quiet
     [ "$status" -eq 0 ]
     [ -z "$output" ]
 
-    src_mtime_after=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
+    src_mtime_after=$(mtime "$src")
     [ "$src_mtime_after" -gt "$src_mtime_before" ]
 }
 


### PR DESCRIPTION
## Summary

R5 of the template-magic track — the third leg of the magic stack. Closes the gap between commits.

## Why

Without refresh, a deployed-side edit to a template doesn't surface in \`git status\`. Git's stat-cache uses mtimes to skip re-reading working-tree files, and the source \`.tmpl\` mtime hasn't changed. So:

- User edits \`~/.config/app/cfg\` (the deployed file)
- Runs \`git status\` → sees nothing (template source unchanged from git's perspective)
- The divergence is invisible until either \`dodot transform check\` (R3) is run explicitly OR commit time (R4 hook fires)

Refresh fixes that by copying the deployed file's mtime onto the source whenever the bytes have diverged from the cached baseline. Forces git to re-read on the next status / diff / commit. This is also the engine R6's clean filter and R7's Tier 2 shell alias call before delegating to git.

## What ships

- \`dodot refresh\` — walks the baseline cache; for each entry, hashes deployed bytes vs \`baseline.rendered_hash\`; if differ, copies deployed mtime onto source. Short summary on stdout.
- \`dodot refresh --quiet\` — same work, no output. For the Tier 2 shell alias \`alias git='dodot refresh --quiet && command git'\` (a no-op refresh must be silent).
- \`dodot refresh --list-paths\` — prints divergent source paths and exits **without writing mtimes**. For editor / file-watcher integrations that drive the touch themselves.
- New \`Fs::modified\` / \`Fs::set_modified\` trait methods (uses std's \`File::set_modified\`, stable since 1.75; toolchain pinned at 1.94.1).

Exit code 0 in all healthy cases. Errors only on real I/O failures.

## Worth flagging

- **Pure-data edits still trigger Touched.** If the user changed only a variable's value (e.g. \`name = Alice\` → \`name = Bob\`), the deployed bytes diverge from the baseline, so refresh touches the source. The clean filter (R6) will then re-evaluate via burgertocow and decide whether the change is worth a template-space diff. Refresh is intentionally a coarse hash compare — better to trigger the filter unnecessarily than miss a real edit.
- **Missing source / missing deployed** are reported, not errors. The cache may legitimately be stale (user renamed a \`.tmpl\` between \`up\` runs); refresh keeps going.
- **No interaction with the R4 hook.** The hook calls \`transform check --strict\`, which reads bytes directly. Refresh isn't needed there; it's a between-commits thing.

User-facing copy follows the saved style feedback: clear about what each mode does in one short sentence, no flowery framing.

## Test plan

- [x] \`cargo test -p dodot-lib --lib\` — **774 tests pass** (+9 from R4's 765).
- [x] **9 unit tests** in \`commands::refresh\`: empty cache, clean state, divergent → mtime touched, list-paths preserves mtime, quiet mode still writes, missing source / missing deployed reports, pure-data still treated as divergent, sort order.
- [x] **5 new e2e bats tests** in \`test_refresh.bats\`: clean → in-sync, divergent → mtime touched (verified via stat), --list-paths → path printed but mtime unchanged, --quiet → silent + still touches, empty cache → "No template baselines".
- [x] All 18 prior e2e tests still pass (23/23 e2e green total).
- [x] CLI smoke confirms each mode behaves as documented.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.

## Follow-ups

R6 (template clean filter + filter install + hook upgrade to call refresh) is next. R7 (\`transform status\` + Tier 2 alias commands) layers on top. R9 (docs + \`no_reverse\` opt-out) finalises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)