### PR TITLE
feat(template): R6 — clean filter + install-filter + hook upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Template clean filter — `dodot template clean --path <path>`** (R6 of the template-magic track). The piece that makes `git status` and `git diff` show the truth between commits. Git invokes this filter when reading any working-tree file matched by `*.tmpl filter=dodot-template`; the filter looks up the cached baseline (R1), and on a deployed-side edit it rehydrates the cached marker stream and runs burgertocow + diffy to emit a patched template — without re-rendering, so secret-provider auth is never re-triggered. Fast path (no edit) echoes stdin in microseconds. Slow path lands the patched form (or a conflict block, surfaced inline) so the next `git diff` sees the template-space change.
+- **`dodot template install-filter`** (R6). Registers the `[filter "dodot-template"]` block in the dotfiles repo's `.git/config` (clean → `dodot template clean --path %f`, smudge → `cat`, required → `true`). Idempotent. Surfaces the matching `.gitattributes` line for the user to commit. First-deploy prompt offers it after the user has accepted the pre-commit hook.
+- **`template.install_filter` prompt-catalog entry**. Documents the new prompt alongside the existing ones in `dodot prompts list`.
+- **Hook upgrade path** (R6). The pre-commit hook now runs `dodot refresh --quiet || exit 1` before `dodot transform check --strict || exit 1`. Re-running `dodot transform install-hook` on a repo with the older R4-shape block detects the stale managed block (via the same guard lines) and rewrites it in place, preserving any non-managed user content. New `Updated` outcome distinguishes this from `Created` / `Appended` / `AlreadyInstalled`.
+
+### Added (R5, prior)
+
 - **`dodot refresh [--quiet] [--list-paths]`** (R5 of the template-magic track). Walks the per-file baseline cache, hashes the deployed file at `<data_dir>/packs/<pack>/<handler>/<filename>`, and copies the deployed file's mtime onto the template source when the hashes differ. Why: git's stat-cache skips re-reading working-tree files when their mtime is unchanged, so a deployed-side edit to a template never surfaces in `git status` until the source mtime is bumped — refresh is the bump. `--quiet` suppresses output (for the Tier 2 shell alias `alias git='dodot refresh --quiet && command git'`); `--list-paths` prints out-of-sync source paths and exits without writing (for editor / file-watcher integrations). Exit 0 in all healthy cases. See `docs/proposals/magic.lex` §"Update Trigger Bit".
 - **`Fs::modified` / `Fs::set_modified`** trait methods for reading/writing file mtimes — used by `refresh` to copy mtimes between deployed and source files.
 

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -303,6 +303,55 @@ pub fn transform_check_handler(
     Ok(Output::Render(result))
 }
 
+/// `dodot template clean --path <path>` — git clean filter
+/// passthrough for template sources. Reads stdin (the working-tree
+/// source bytes), looks up the matching baseline in the cache,
+/// applies the cached reverse-merge if the deployed file has
+/// drifted, and writes the result to stdout. Mirrors the
+/// `plist clean/smudge` passthrough shape — no standout rendering,
+/// just stdin → stdout.
+pub fn template_clean_passthrough(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> {
+    use dodot_lib::commands::template_clean;
+    let dotfiles_root = discover_dotfiles_root()?;
+    let ctx = ExecutionContext::production(&dotfiles_root, false)?;
+
+    let path = matches
+        .get_one::<String>("path")
+        .ok_or_else(|| anyhow::anyhow!("missing required argument: --path"))?;
+    let path = std::path::PathBuf::from(path);
+
+    // Path may be relative (git's `%f`) — resolve against the
+    // dotfiles root (the working tree git is operating on).
+    let path = if path.is_absolute() {
+        path
+    } else {
+        ctx.paths.dotfiles_root().join(path)
+    };
+
+    let mut stdin = std::io::stdin().lock();
+    let mut stdout = std::io::stdout().lock();
+    template_clean::template_clean_stdio(
+        ctx.fs.as_ref(),
+        ctx.paths.as_ref(),
+        &path,
+        &mut stdin,
+        &mut stdout,
+    )?;
+    Ok(())
+}
+
+/// `dodot template install-filter` — register the dodot-template
+/// clean filter in `.git/config`. Idempotent.
+pub fn template_install_filter_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::template_install_filter::InstallFilterResult> {
+    let ctx = build_ctx(matches)?;
+    Ok(Output::Render(
+        commands::template_install_filter::install_filter(&ctx)?,
+    ))
+}
+
 /// `dodot refresh [--quiet] [--list-paths]` — copy deployed mtimes
 /// onto template sources where they've drifted from the baseline.
 /// Used by the Tier 2 shell alias and by the upcoming clean filter
@@ -665,6 +714,111 @@ fn try_prompt_install_template_hook() -> Result<(), anyhow::Error> {
         crate::interactive::YesNoShow::No => {
             // Same convention as the plist prompt: "no" means "not
             // now"; we'll re-prompt on the next up.
+        }
+    }
+    Ok(())
+}
+
+/// Post-`up` hook that offers to install the template clean filter
+/// when:
+///
+/// 1. stdin is a TTY,
+/// 2. dotfiles root is a git working tree,
+/// 3. at least one template baseline exists,
+/// 4. the dodot pre-commit hook IS installed (we only prompt for
+///    the filter after the user already accepted the hook — keeps
+///    the install ladder one rung at a time),
+/// 5. the dodot-template filter is NOT yet registered in
+///    `.git/config`,
+/// 6. the user has NOT previously dismissed the prompt.
+///
+/// All six must hold; otherwise the function returns silently. Same
+/// soft-failure pattern as the other post-`up` prompts.
+pub fn maybe_prompt_install_template_filter() {
+    if let Err(e) = try_prompt_install_template_filter() {
+        tracing::debug!("template install-filter prompt skipped: {e}");
+    }
+}
+
+fn try_prompt_install_template_filter() -> Result<(), anyhow::Error> {
+    use dodot_lib::prompts::PromptRegistry;
+
+    if !crate::interactive::stdin_is_tty() {
+        return Ok(());
+    }
+
+    let dotfiles_root = discover_dotfiles_root()?;
+    let ctx = dodot_lib::packs::orchestration::ExecutionContext::production(&dotfiles_root, false)?;
+
+    let baselines = dodot_lib::preprocessing::divergence::collect_baselines(
+        ctx.fs.as_ref(),
+        ctx.paths.as_ref(),
+    )?;
+    if baselines.is_empty() {
+        return Ok(());
+    }
+
+    if !ctx.fs.is_dir(&ctx.paths.dotfiles_root().join(".git")) {
+        return Ok(());
+    }
+
+    if !commands::transform::hook_is_installed(&ctx)? {
+        // Wait for the user to install the hook first. Filter is
+        // strictly more involved (per-clone setup, .gitattributes
+        // edit), so the install ladder asks for the cheaper one
+        // first.
+        return Ok(());
+    }
+
+    if commands::template_install_filter::is_installed(&ctx)? {
+        return Ok(());
+    }
+
+    let registry_path = ctx.paths.prompts_path();
+    let mut registry = PromptRegistry::load(ctx.fs.as_ref(), registry_path)?;
+    let prompt_key = "template.install_filter";
+    if registry.is_dismissed(prompt_key) {
+        return Ok(());
+    }
+
+    let response = crate::interactive::prompt_yes_no_show(&[
+        "Install the dodot-template git clean filter?",
+        "It makes `git status` and `git diff` show deployed-side template edits",
+        "between commits, not just at commit time. Adds one block to .git/config",
+        "and a single line to .gitattributes.",
+    ])?;
+
+    match response {
+        crate::interactive::YesNoShow::Yes => {
+            let r = commands::template_install_filter::install_filter(&ctx)?;
+            eprintln!("{}", r.message);
+            for d in &r.details {
+                eprintln!("  {d}");
+            }
+            registry.dismiss(prompt_key);
+            registry.save(ctx.fs.as_ref())?;
+        }
+        crate::interactive::YesNoShow::Show => {
+            eprintln!();
+            eprintln!("Add to .git/config (per clone, per machine):");
+            eprintln!();
+            for line in commands::template_install_filter::config_block_text().lines() {
+                eprintln!("    {line}");
+            }
+            eprintln!();
+            eprintln!("Add to .gitattributes (committed in the repo):");
+            eprintln!(
+                "    {}",
+                commands::template_install_filter::gitattributes_line()
+            );
+            eprintln!();
+            eprintln!(
+                "Run `dodot template install-filter` to install, \
+                 or `dodot prompts reset {prompt_key}` to skip and ask later."
+            );
+        }
+        crate::interactive::YesNoShow::No => {
+            // Same convention as the other prompts: "no" defers.
         }
     }
     Ok(())

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -758,9 +758,12 @@ fn try_prompt_install_template_filter() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    if !ctx.fs.is_dir(&ctx.paths.dotfiles_root().join(".git")) {
-        return Ok(());
-    }
+    // is_installed/install_filter both shell out to `git -C <root>
+    // config ...` which handles "not a git repo" semantically (we
+    // detect the resulting failure), so we don't need a manual
+    // .git-exists probe here. Bonus: this skips the gating problem
+    // for worktrees (where .git is a file, not a dir, but `git -C`
+    // still works correctly) and submodules.
 
     if !commands::transform::hook_is_installed(&ctx)? {
         // Wait for the user to install the hook first. Filter is

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -57,6 +57,20 @@ fn main() {
         return;
     }
 
+    // Passthrough: `template clean` (git clean filter — stdin/stdout
+    // bytes, must bypass standout for the same reasons as plist's
+    // filter passthroughs). `template install-filter` is NOT
+    // passthrough — it goes through standout dispatch normally.
+    if let Some(("template", sub)) = matches.subcommand() {
+        if let Some(("clean", clean_matches)) = sub.subcommand() {
+            if let Err(e) = handlers::template_clean_passthrough(clean_matches) {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+            return;
+        }
+    }
+
     // Initialize logging based on CLI flags
     let verbosity = if matches.get_flag("debug") {
         logging::Verbosity::Debug
@@ -127,13 +141,19 @@ fn main() {
     match app.dispatch(matches, output_mode) {
         standout::cli::RunResult::Handled(output) => {
             println!("{output}");
-            // Post-up nudges. Both fire only after a successful
-            // `up` and both are soft (failures land in the debug log,
-            // never stderr). The two prompts are independent: the
-            // user might hit either, both, or neither in a session.
+            // Post-up nudges. All fire only after a successful `up`
+            // and all are soft (failures land in the debug log,
+            // never stderr). They form an install ladder:
+            //   1. plist filters (when plist files exist)
+            //   2. template hook (when template baselines exist)
+            //   3. template clean filter (when hook is already
+            //      installed AND filter isn't yet)
+            // The user moves up one rung per `up` until they've
+            // accepted or dismissed each — never spammed all at once.
             if subcommand.as_deref() == Some("up") {
                 handlers::maybe_prompt_install_filters();
                 handlers::maybe_prompt_install_template_hook();
+                handlers::maybe_prompt_install_template_filter();
             }
             // `dodot transform check` may have set a non-zero exit code
             // via PENDING_EXIT_CODE: the report still rendered above,
@@ -198,6 +218,10 @@ static TEMPLATE_ENTRIES: &[(&str, &str)] = &[
         render::TEMPLATE_TRANSFORM_INSTALL_HOOK,
     ),
     ("refresh.jinja", render::TEMPLATE_REFRESH),
+    (
+        "template-install-filter.jinja",
+        render::TEMPLATE_TEMPLATE_INSTALL_FILTER,
+    ),
 ];
 
 fn build_app() -> App {
@@ -278,6 +302,12 @@ fn build_app() -> App {
         .expect("register transform.install-hook")
         .command("refresh", handlers::refresh_handler, "refresh")
         .expect("register refresh")
+        .command(
+            "template.install-filter",
+            handlers::template_install_filter_handler,
+            "template-install-filter",
+        )
+        .expect("register template.install-filter")
         .command_groups(vec![
             CommandGroup {
                 title: "Core".into(),
@@ -305,12 +335,13 @@ fn build_app() -> App {
                 commands: vec![Some("probe".into())],
             },
             CommandGroup {
-                title: "Plist filters".into(),
+                title: "Git filters".into(),
                 help: None,
                 commands: vec![
                     Some("git-install-filters".into()),
                     Some("git-show-filters".into()),
                     Some("plist".into()),
+                    Some("template".into()),
                 ],
             },
             CommandGroup {
@@ -503,6 +534,36 @@ fn build_clap_command() -> ClapCommand {
         )
         .subcommand(
             ClapCommand::new("init-sh").about("Print shell init script for eval in .zshrc/.bashrc"),
+        )
+        .subcommand(
+            ClapCommand::new("template")
+                .about(
+                    "Template-source git integration: the clean filter (passthrough) and \
+                     filter installer.",
+                )
+                .subcommand_required(true)
+                .arg_required_else_help(true)
+                .subcommand(
+                    ClapCommand::new("clean")
+                        .about(
+                            "git clean filter for templates — reads source on stdin, writes \
+                             patched form on stdout. Invoked by git when reading a template.",
+                        )
+                        .arg(
+                            Arg::new("path")
+                                .long("path")
+                                .help("Working-tree path of the file being filtered (git's `%f`).")
+                                .value_name("PATH")
+                                .required(true)
+                                .num_args(1),
+                        ),
+                )
+                .subcommand(
+                    ClapCommand::new("install-filter").about(
+                        "Register the dodot-template clean filter in the dotfiles repo's \
+                         .git/config (idempotent, per-clone, per-machine).",
+                    ),
+                ),
         )
         .subcommand(
             ClapCommand::new("plist")

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -16,6 +16,8 @@ pub mod probe;
 pub mod prompts;
 pub mod refresh;
 pub mod status;
+pub mod template_clean;
+pub mod template_install_filter;
 pub mod transform;
 pub mod tutorial;
 pub mod up;

--- a/crates/dodot-lib/src/commands/template_clean.rs
+++ b/crates/dodot-lib/src/commands/template_clean.rs
@@ -124,15 +124,15 @@ pub fn template_clean(
 
     if diff.starts_with(MARKER_START) {
         // Conflict block: burgertocow couldn't safely auto-merge.
-        // The block IS the patched template content (it carries the
-        // marker text as plain bytes that git will surface via
-        // `git diff`). Splice it onto the original source so the
-        // user sees both the original and the marker block.
-        //
-        // Simplest approach: prepend a comment-style banner +
-        // append the conflict block. The exact placement doesn't
-        // matter for git's purposes (any change shows up as a
-        // diff); the user's editor handles the marker resolution.
+        // The block carries the marker text as plain bytes that git
+        // will surface via `git diff`. We splice it AFTER the
+        // original source — exact placement doesn't matter for
+        // git's purposes (any change shows up as a diff), and
+        // appending leaves the user's editor view of the source
+        // mostly intact, with the conflict block to resolve at the
+        // bottom. We add a leading newline if needed so the block
+        // sits on its own lines rather than concatenating with the
+        // last line of the source.
         let mut out = template_src.to_string();
         if !out.ends_with('\n') {
             out.push('\n');
@@ -155,8 +155,15 @@ pub fn template_clean(
 /// Drive the clean filter as a stdin/stdout passthrough — what git
 /// invokes when running the registered filter. Reads `stdin` to
 /// `template_src`, calls [`template_clean`], writes the result to
-/// `stdout`. Any I/O error here propagates up; the inner
-/// reverse-merge soft-fails (echoes stdin on hiccups).
+/// `stdout`.
+///
+/// Per the module's failure model: any error from the inner
+/// reverse-merge (cache read failure, hash mismatch, malformed
+/// baseline) is caught here and we fall back to writing the
+/// original stdin bytes to stdout, with a stderr warning so the
+/// user sees the issue without git aborting. `Err` is reserved
+/// strictly for stdin/stdout I/O failures, which are real
+/// "filter genuinely cannot run" cases.
 pub fn template_clean_stdio(
     fs: &dyn Fs,
     paths: &dyn Pather,
@@ -169,7 +176,19 @@ pub fn template_clean_stdio(
         .read_to_end(&mut buf)
         .map_err(|e| crate::DodotError::Other(format!("template clean: stdin read: {e}")))?;
     let src = String::from_utf8_lossy(&buf).into_owned();
-    let out = template_clean(fs, paths, &src, source_path)?;
+    let out = match template_clean(fs, paths, &src, source_path) {
+        Ok(o) => o,
+        Err(e) => {
+            // Soft-fail: log to stderr (visible when the user runs
+            // `git status` interactively, captured by CI logs) and
+            // echo stdin so git doesn't abort the working-tree read.
+            eprintln!(
+                "dodot template clean: degraded to echo for {}: {e}",
+                source_path.display()
+            );
+            src
+        }
+    };
     stdout
         .write_all(out.as_bytes())
         .map_err(|e| crate::DodotError::Other(format!("template clean: stdout write: {e}")))?;
@@ -443,6 +462,48 @@ mod tests {
             &mut stdout,
         )
         .unwrap();
+        assert_eq!(stdout, template.as_bytes());
+    }
+
+    #[test]
+    fn stdio_soft_fails_when_inner_clean_errors() {
+        // Pin the documented failure model: if the inner
+        // template_clean returns an Err, the stdio wrapper must
+        // catch it and echo stdin rather than propagate. Git
+        // treats filter exit != 0 as fatal — a template-source
+        // anywhere in the repo with a transient cache I/O error
+        // would otherwise brick `git status`.
+        //
+        // We force the error path by pointing at a baseline whose
+        // backing JSON is corrupt — Baseline::load returns Err on
+        // parse failure, which collect_baselines surfaces, which
+        // find_baseline_for_source propagates. With the soft-fail
+        // wrapper, the user gets stdin echoed instead.
+        let env = TempEnvironment::builder().build();
+        let src = env.dotfiles_root.join("app/cfg.tmpl");
+        env.fs.mkdir_all(src.parent().unwrap()).unwrap();
+        let template = "name = {{ name }}\n";
+        env.fs.write_file(&src, template.as_bytes()).unwrap();
+
+        // Lay down a corrupt baseline JSON (parse failure on load).
+        let cache_path = env
+            .paths
+            .preprocessor_baseline_path("app", "preprocessed", "cfg");
+        env.fs.mkdir_all(cache_path.parent().unwrap()).unwrap();
+        env.fs.write_file(&cache_path, b"{not json").unwrap();
+
+        let mut stdin = std::io::Cursor::new(template.as_bytes().to_vec());
+        let mut stdout: Vec<u8> = Vec::new();
+        // Must succeed — the inner Err is swallowed.
+        template_clean_stdio(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            &src,
+            &mut stdin,
+            &mut stdout,
+        )
+        .expect("stdio must soft-fail to echo, not propagate Err");
+        // And the echoed bytes must equal the input verbatim.
         assert_eq!(stdout, template.as_bytes());
     }
 

--- a/crates/dodot-lib/src/commands/template_clean.rs
+++ b/crates/dodot-lib/src/commands/template_clean.rs
@@ -1,0 +1,497 @@
+//! `dodot template clean --path <path>` — git clean filter for
+//! template sources.
+//!
+//! This is what makes `git status` / `git diff` / `git log -p` show
+//! the truth between commits, even when the user has only edited the
+//! deployed file. Git invokes us when reading a working-tree file
+//! whose mtime suggests it might have changed (refresh — R5 — is the
+//! thing that nudges those mtimes); we look up the cached baseline,
+//! compare the deployed bytes to the baseline's rendered hash, and:
+//!
+//! 1. **Fast path**: if the deployed file matches the baseline
+//!    exactly, echo stdin unchanged. No reverse-merge work, no
+//!    burgertocow call, no provider invocations. Microseconds. The
+//!    common case — most git operations don't follow a deployed-side
+//!    edit.
+//!
+//! 2. **Slow path**: if the deployed file diverges, rehydrate the
+//!    cached `TrackedRender::from_tracked_string` and run
+//!    `burgertocow::generate_diff_with_markers` (with our
+//!    `MARKER_*` constants from R2) against the deployed bytes.
+//!    Apply the resulting diff to the template via diffy and emit
+//!    the patched form. Conflict blocks land inline.
+//!
+//! No provider calls, ever. The whole point of caching
+//! `tracked_render` in R1 is so this filter never re-renders — that
+//! would re-trigger any `secret(...)` provider auth on every
+//! `git status`, the auth-fatigue scenario magic.lex specifically
+//! rules out.
+//!
+//! # Failure model
+//!
+//! Git treats filter exit codes other than 0 as fatal (the working-
+//! tree read fails, blocking `git status` etc). We refuse to fail
+//! the filter for anything except a hard I/O error: missing
+//! baselines, decoding hiccups, and even malformed cached bytes
+//! degrade to "echo stdin" with a stderr warning. Better the user
+//! sees the unmodified template through git than their entire repo
+//! becomes unreadable.
+
+use burgertocow::{generate_diff_with_markers, ConflictMarkers, TrackedRender};
+use diffy::Patch;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use crate::fs::Fs;
+use crate::paths::Pather;
+use crate::preprocessing::baseline::hex_sha256;
+use crate::preprocessing::conflict::{MARKER_END, MARKER_MID, MARKER_START};
+use crate::preprocessing::divergence::find_baseline_for_source;
+use crate::Result;
+
+/// Produce the patched template content for one filter invocation.
+///
+/// `template_src` is the working-tree source bytes (what git passed
+/// us on stdin). `source_path` is the absolute path of that file
+/// (what git passed via `%f` and the CLI surfaced via `--path`).
+/// Returns the bytes the filter should write to stdout.
+///
+/// On any non-fatal hiccup (no baseline, hash mismatch, malformed
+/// tracked render, diff parse failure, diff apply failure) returns
+/// `template_src` unchanged. The caller (`template_clean_passthrough`
+/// in the CLI) writes a stderr warning so the user sees the issue
+/// without the filter aborting.
+pub fn template_clean(
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+    template_src: &str,
+    source_path: &Path,
+) -> Result<String> {
+    let Some((_pack, _handler, _filename, baseline)) =
+        find_baseline_for_source(fs, paths, source_path)?
+    else {
+        // Source isn't tracked by dodot's preprocessing pipeline.
+        // Echo unchanged. (git registered our filter for *.tmpl, but
+        // a `.tmpl` file outside any pack would still hit us.)
+        return Ok(template_src.to_string());
+    };
+
+    // Build the deployed path from the cache layout. find_baseline
+    // already gave us the (pack, handler, filename) triple; we
+    // re-derive the path here rather than hauling it through the
+    // tuple destructure for clarity.
+    let (pack, handler, filename, baseline) = (_pack, _handler, _filename, baseline);
+    let deployed_path = paths
+        .data_dir()
+        .join("packs")
+        .join(&pack)
+        .join(&handler)
+        .join(&filename);
+
+    if !fs.exists(&deployed_path) {
+        // Deployed file gone. Nothing to compare against → echo.
+        return Ok(template_src.to_string());
+    }
+    let deployed_bytes = fs.read_file(&deployed_path)?;
+
+    // ── Fast path ───────────────────────────────────────────────
+    if hex_sha256(&deployed_bytes) == baseline.rendered_hash {
+        return Ok(template_src.to_string());
+    }
+
+    // ── Slow path ───────────────────────────────────────────────
+    if baseline.tracked_render.is_empty() {
+        // Forward-compat: a baseline written before tracked_render
+        // existed (or by a non-tracking preprocessor). We can't drive
+        // burgertocow without the marker stream — echo and let
+        // `dodot transform check` flag this on the next run.
+        return Ok(template_src.to_string());
+    }
+
+    let tracked = TrackedRender::from_tracked_string(baseline.tracked_render.clone());
+    let deployed_str = String::from_utf8_lossy(&deployed_bytes);
+    let start = format!("{MARKER_START}\n");
+    let mid = format!("\n{MARKER_MID}\n");
+    let end = format!("\n{MARKER_END}\n");
+    let markers = ConflictMarkers::new(&start, &mid, &end);
+    let diff = generate_diff_with_markers(template_src, &tracked, &deployed_str, &markers);
+
+    if diff.is_empty() {
+        // Pure-data edit (only variable values changed) — no
+        // template-space change needed.
+        return Ok(template_src.to_string());
+    }
+
+    if diff.starts_with(MARKER_START) {
+        // Conflict block: burgertocow couldn't safely auto-merge.
+        // The block IS the patched template content (it carries the
+        // marker text as plain bytes that git will surface via
+        // `git diff`). Splice it onto the original source so the
+        // user sees both the original and the marker block.
+        //
+        // Simplest approach: prepend a comment-style banner +
+        // append the conflict block. The exact placement doesn't
+        // matter for git's purposes (any change shows up as a
+        // diff); the user's editor handles the marker resolution.
+        let mut out = template_src.to_string();
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str(&diff);
+        return Ok(out);
+    }
+
+    // Unified diff: apply via diffy.
+    let patch = match Patch::from_str(&diff) {
+        Ok(p) => p,
+        Err(_) => return Ok(template_src.to_string()),
+    };
+    match diffy::apply(template_src, &patch) {
+        Ok(patched) => Ok(patched),
+        Err(_) => Ok(template_src.to_string()),
+    }
+}
+
+/// Drive the clean filter as a stdin/stdout passthrough — what git
+/// invokes when running the registered filter. Reads `stdin` to
+/// `template_src`, calls [`template_clean`], writes the result to
+/// `stdout`. Any I/O error here propagates up; the inner
+/// reverse-merge soft-fails (echoes stdin on hiccups).
+pub fn template_clean_stdio(
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+    source_path: &Path,
+    stdin: &mut dyn Read,
+    stdout: &mut dyn Write,
+) -> Result<()> {
+    let mut buf = Vec::new();
+    stdin
+        .read_to_end(&mut buf)
+        .map_err(|e| crate::DodotError::Other(format!("template clean: stdin read: {e}")))?;
+    let src = String::from_utf8_lossy(&buf).into_owned();
+    let out = template_clean(fs, paths, &src, source_path)?;
+    stdout
+        .write_all(out.as_bytes())
+        .map_err(|e| crate::DodotError::Other(format!("template clean: stdout write: {e}")))?;
+    stdout
+        .flush()
+        .map_err(|e| crate::DodotError::Other(format!("template clean: stdout flush: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preprocessing::baseline::Baseline;
+    use crate::testing::TempEnvironment;
+    use burgertocow::Tracker;
+
+    /// Render a template through burgertocow the way R1's pipeline
+    /// does, so we get a tracked-render string that the filter will
+    /// be able to rehydrate. Mirrors the test helper in the
+    /// reverse_merge module.
+    fn render(src: &str, ctx: serde_json::Value) -> (String, String) {
+        let mut tracker = Tracker::new();
+        tracker.add_template("t", src).unwrap();
+        let tracked = tracker.render("t", &ctx).unwrap();
+        (tracked.output().to_string(), tracked.tracked().to_string())
+    }
+
+    /// Stage a baseline + matching pack source + matching deployed
+    /// file. Returns the absolute paths so the test can edit either
+    /// side. Same shape as the helper in `commands::refresh::tests`.
+    fn stage(
+        env: &TempEnvironment,
+        pack: &str,
+        template_name: &str,
+        template_body: &str,
+        ctx: serde_json::Value,
+    ) -> (std::path::PathBuf, std::path::PathBuf, String) {
+        let src = env.dotfiles_root.join(pack).join(template_name);
+        env.fs.mkdir_all(src.parent().unwrap()).unwrap();
+        env.fs.write_file(&src, template_body.as_bytes()).unwrap();
+
+        let stripped = template_name.strip_suffix(".tmpl").unwrap_or(template_name);
+        let deployed = env
+            .paths
+            .data_dir()
+            .join("packs")
+            .join(pack)
+            .join("preprocessed")
+            .join(stripped);
+        env.fs.mkdir_all(deployed.parent().unwrap()).unwrap();
+
+        let (rendered, tracked) = render(template_body, ctx);
+        env.fs.write_file(&deployed, rendered.as_bytes()).unwrap();
+
+        let baseline = Baseline::build(
+            &src,
+            rendered.as_bytes(),
+            template_body.as_bytes(),
+            Some(&tracked),
+            None,
+        );
+        baseline
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                pack,
+                "preprocessed",
+                stripped,
+            )
+            .unwrap();
+
+        (src, deployed, rendered)
+    }
+
+    #[test]
+    fn fast_path_echoes_stdin_when_deployed_matches_baseline() {
+        // No edit on either side → deployed bytes hash to
+        // baseline.rendered_hash → fast path hits → output equals
+        // input verbatim. This is the common case (most git
+        // operations don't follow a deployed-side edit).
+        let env = TempEnvironment::builder().build();
+        let template = "name = {{ name }}\nport = 5432\n";
+        let (src, _deployed, _) = stage(
+            &env,
+            "app",
+            "cfg.tmpl",
+            template,
+            serde_json::json!({"name": "Alice"}),
+        );
+
+        let out = template_clean(env.fs.as_ref(), env.paths.as_ref(), template, &src).unwrap();
+        assert_eq!(out, template, "fast path must echo stdin verbatim");
+    }
+
+    #[test]
+    fn slow_path_patches_static_line_edit() {
+        // The user edited a static line in the deployed file. Slow
+        // path runs burgertocow + diffy and produces the patched
+        // template (var preserved, static line propagated).
+        let env = TempEnvironment::builder().build();
+        let template = "name = {{ name }}\nport = 5432\n";
+        let (src, deployed, _) = stage(
+            &env,
+            "app",
+            "cfg.tmpl",
+            template,
+            serde_json::json!({"name": "Alice"}),
+        );
+
+        env.fs
+            .write_file(&deployed, b"name = Alice\nport = 9999\n")
+            .unwrap();
+
+        let out = template_clean(env.fs.as_ref(), env.paths.as_ref(), template, &src).unwrap();
+        assert!(
+            out.contains("port = 9999"),
+            "expected patched static line, got: {out:?}"
+        );
+        assert!(
+            out.contains("name = {{ name }}"),
+            "var must survive, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn slow_path_pure_data_edit_echoes_stdin() {
+        // The user changed only a variable value in the deployed
+        // file. burgertocow returns an empty diff (pure-data edit);
+        // we echo stdin unchanged.
+        let env = TempEnvironment::builder().build();
+        let template = "name = {{ name }}\n";
+        let (src, deployed, _) = stage(
+            &env,
+            "app",
+            "cfg.tmpl",
+            template,
+            serde_json::json!({"name": "Alice"}),
+        );
+
+        env.fs.write_file(&deployed, b"name = Bob\n").unwrap();
+
+        let out = template_clean(env.fs.as_ref(), env.paths.as_ref(), template, &src).unwrap();
+        assert_eq!(out, template);
+    }
+
+    #[test]
+    fn slow_path_conflict_appends_marker_block_to_template() {
+        // Inconsistent loop edits → burgertocow returns a conflict
+        // block (starting with our MARKER_START). The filter splices
+        // it after the original template so `git diff` shows both
+        // the unchanged template and the conflict block.
+        let env = TempEnvironment::builder().build();
+        let template = "{% for i in items %}- {{ i }}\n{% endfor %}";
+        let (src, deployed, _) = stage(
+            &env,
+            "app",
+            "list.tmpl",
+            template,
+            serde_json::json!({"items": ["a", "b", "c"]}),
+        );
+        env.fs.write_file(&deployed, b"* a\n+ b\n- c\n").unwrap();
+
+        let out = template_clean(env.fs.as_ref(), env.paths.as_ref(), template, &src).unwrap();
+        // Original template still present.
+        assert!(
+            out.contains("{% for i in items %}"),
+            "original template must be retained: {out:?}"
+        );
+        // Conflict block appended.
+        assert!(
+            out.contains(MARKER_START),
+            "conflict block missing: {out:?}"
+        );
+        assert!(
+            out.contains(MARKER_END),
+            "conflict block missing end: {out:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_source_path_echoes_stdin() {
+        // Path the cache has never seen → echo. (Defensive: git's
+        // .gitattributes might match a .tmpl file in some sub-tree
+        // that isn't a dodot-managed pack.)
+        let env = TempEnvironment::builder().build();
+        let stranger = env.dotfiles_root.join("not-a-pack/random.tmpl");
+        env.fs.mkdir_all(stranger.parent().unwrap()).unwrap();
+        let body = "hello {{ x }}\n";
+        env.fs.write_file(&stranger, body.as_bytes()).unwrap();
+
+        let out = template_clean(env.fs.as_ref(), env.paths.as_ref(), body, &stranger).unwrap();
+        assert_eq!(out, body);
+    }
+
+    #[test]
+    fn missing_deployed_echoes_stdin() {
+        // Baseline exists but deployed file was deleted. Nothing to
+        // compare against → echo. (`dodot transform check` will
+        // surface the MissingDeployed state on its own pass.)
+        let env = TempEnvironment::builder().build();
+        let template = "name = {{ name }}\n";
+        let (src, deployed, _) = stage(
+            &env,
+            "app",
+            "cfg.tmpl",
+            template,
+            serde_json::json!({"name": "Alice"}),
+        );
+        env.fs.remove_file(&deployed).unwrap();
+
+        let out = template_clean(env.fs.as_ref(), env.paths.as_ref(), template, &src).unwrap();
+        assert_eq!(out, template);
+    }
+
+    #[test]
+    fn empty_tracked_render_falls_back_to_echo() {
+        // Forward-compat: a baseline whose tracked_render is empty
+        // (v1 baseline before the field existed, or future non-
+        // tracking preprocessor) — we can't drive burgertocow.
+        // Echo and let `dodot transform check` surface the issue
+        // when it next runs.
+        let env = TempEnvironment::builder().build();
+        let template = "name = {{ name }}\n";
+        let src = env.dotfiles_root.join("app/cfg.tmpl");
+        env.fs.mkdir_all(src.parent().unwrap()).unwrap();
+        env.fs.write_file(&src, template.as_bytes()).unwrap();
+
+        let deployed = env.paths.data_dir().join("packs/app/preprocessed/cfg");
+        env.fs.mkdir_all(deployed.parent().unwrap()).unwrap();
+        env.fs.write_file(&deployed, b"name = EDITED\n").unwrap();
+
+        // Baseline with an empty tracked_render.
+        let baseline = Baseline::build(&src, b"name = Alice\n", template.as_bytes(), None, None);
+        baseline
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "cfg",
+            )
+            .unwrap();
+
+        let out = template_clean(env.fs.as_ref(), env.paths.as_ref(), template, &src).unwrap();
+        assert_eq!(out, template);
+    }
+
+    #[test]
+    fn stdio_passthrough_writes_filter_output_to_stdout() {
+        // Pin the stdin/stdout wiring: same fast-path scenario as
+        // the first test, but exercised through the I/O surface git
+        // will use. Confirms read_to_end / write_all / flush all
+        // succeed and the output matches.
+        let env = TempEnvironment::builder().build();
+        let template = "name = {{ name }}\n";
+        let (src, _deployed, _) = stage(
+            &env,
+            "app",
+            "cfg.tmpl",
+            template,
+            serde_json::json!({"name": "Alice"}),
+        );
+
+        let mut stdin = std::io::Cursor::new(template.as_bytes().to_vec());
+        let mut stdout: Vec<u8> = Vec::new();
+        template_clean_stdio(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            &src,
+            &mut stdin,
+            &mut stdout,
+        )
+        .unwrap();
+        assert_eq!(stdout, template.as_bytes());
+    }
+
+    #[test]
+    fn filter_never_fails_on_baseline_disagreement() {
+        // Pin the soft-fail contract: the filter must never return
+        // an Err for "logically wrong" inputs (mismatched hashes,
+        // malformed cache, etc) — only for I/O failures. Git treats
+        // any non-zero exit as fatal and the working tree becomes
+        // unreadable.
+        //
+        // Construct a baseline whose rendered_hash claims one thing
+        // but whose tracked_render is internally inconsistent.
+        // burgertocow will produce *something* (probably an empty
+        // diff or a conflict); whatever it does, we must succeed.
+        let env = TempEnvironment::builder().build();
+        let template = "name = {{ name }}\n";
+        let src = env.dotfiles_root.join("app/cfg.tmpl");
+        env.fs.mkdir_all(src.parent().unwrap()).unwrap();
+        env.fs.write_file(&src, template.as_bytes()).unwrap();
+
+        let deployed = env.paths.data_dir().join("packs/app/preprocessed/cfg");
+        env.fs.mkdir_all(deployed.parent().unwrap()).unwrap();
+        env.fs
+            .write_file(&deployed, b"unrelated content\n")
+            .unwrap();
+
+        // Baseline with a tracked_render that doesn't correspond to
+        // the template — burgertocow will see them as totally
+        // different.
+        let baseline = Baseline::build(
+            &src,
+            b"different",
+            template.as_bytes(),
+            Some("\u{1e}wrong\u{1f}"),
+            None,
+        );
+        baseline
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "cfg",
+            )
+            .unwrap();
+
+        // Must succeed (output may be anything; just not a panic or
+        // an Err).
+        let _ = template_clean(env.fs.as_ref(), env.paths.as_ref(), template, &src).unwrap();
+    }
+}

--- a/crates/dodot-lib/src/commands/template_install_filter.rs
+++ b/crates/dodot-lib/src/commands/template_install_filter.rs
@@ -1,0 +1,385 @@
+//! `dodot template install-filter` — register the dodot-template
+//! clean filter in the dotfiles repo's `.git/config`.
+//!
+//! Mirrors the structure of [`crate::commands::git_filters`] (the
+//! plist filter installer). The differences vs plist:
+//!
+//! 1. **Filter name**: `dodot-template` (vs `dodot-plist`).
+//! 2. **Clean command**: `dodot template clean --path %f` (with the
+//!    `%f` placeholder so git passes the path of the file being
+//!    processed; we need it to look up the matching baseline).
+//! 3. **No transforming smudge**: templates must NEVER be re-rendered
+//!    at smudge time (would re-trigger secret-provider auth on every
+//!    `git checkout`, `git stash pop`, etc — exactly the auth-fatigue
+//!    scenario magic.lex rules out). We register `smudge = cat` so
+//!    smudge is an explicit identity rather than implicit; makes the
+//!    intent legible in `.git/config`.
+//!
+//! Per-clone, per-machine: the filter command lives in `.git/config`
+//! which is not carried by the repo. The `.gitattributes` line that
+//! BINDS files to the filter (`*.tmpl filter=dodot-template`) does
+//! travel with the repo but is inert without the matching
+//! `.git/config` entries.
+
+use serde::Serialize;
+
+use crate::commands::MessageResult;
+use crate::packs::orchestration::ExecutionContext;
+use crate::{DodotError, Result};
+
+/// The `.git/config` snippet this command writes. Public so
+/// `dodot template show-filter` (future) can print it for users
+/// who want to install by hand.
+pub fn config_block_text() -> String {
+    [
+        "[filter \"dodot-template\"]",
+        "    clean    = dodot template clean --path %f",
+        "    smudge   = cat",
+        "    required = true",
+    ]
+    .join("\n")
+}
+
+/// The `.gitattributes` line that binds `*.tmpl` files to the filter.
+/// Lives in the repo (committed alongside the templates) so every
+/// clone gets the binding for free; the `.git/config` block makes
+/// it active.
+pub fn gitattributes_line() -> &'static str {
+    "*.tmpl filter=dodot-template"
+}
+
+/// Result returned by `install_filter`. CLI exits 0 in all three
+/// outcomes (every state is a success). Renders through the
+/// `template-install-filter.jinja` template.
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallFilterResult {
+    pub message: String,
+    pub details: Vec<String>,
+    /// True iff `[filter "dodot-template"]` was already in
+    /// `.git/config` — in which case we made no change. Surfaced
+    /// separately from `message` so a JSON consumer can distinguish
+    /// "installed now" from "already there".
+    pub already_installed: bool,
+}
+
+/// Install the dodot-template clean filter into the dotfiles repo's
+/// `.git/config`. Idempotent: re-running when already installed is
+/// a no-op success.
+pub fn install_filter(ctx: &ExecutionContext) -> Result<InstallFilterResult> {
+    let root = ctx.paths.dotfiles_root().to_path_buf();
+    let runner = ctx.command_runner.as_ref();
+
+    if filter_is_installed(runner, &root)? {
+        let mut details = Vec::new();
+        append_gitattributes_hint(ctx, &mut details);
+        return Ok(InstallFilterResult {
+            message: "Template filter already installed in .git/config.".into(),
+            details,
+            already_installed: true,
+        });
+    }
+
+    git_config_set(
+        runner,
+        &root,
+        "filter.dodot-template.clean",
+        "dodot template clean --path %f",
+    )?;
+    git_config_set(runner, &root, "filter.dodot-template.smudge", "cat")?;
+    git_config_set(runner, &root, "filter.dodot-template.required", "true")?;
+
+    let mut details = vec![format!(
+        "Wrote [filter \"dodot-template\"] to {}/.git/config",
+        root.display()
+    )];
+    append_gitattributes_hint(ctx, &mut details);
+    Ok(InstallFilterResult {
+        message: "Installed template clean filter.".into(),
+        details,
+        already_installed: false,
+    })
+}
+
+/// Detect whether the filter is currently registered. Cheap (one
+/// `git config --get`). Used by the post-`up` first-deploy prompt
+/// to decide whether to offer installation.
+pub fn is_installed(ctx: &ExecutionContext) -> Result<bool> {
+    filter_is_installed(ctx.command_runner.as_ref(), ctx.paths.dotfiles_root())
+}
+
+/// Render the install snippet without writing anything. Companion
+/// to `git-show-filters` for plist; callers (the CLI's `show`
+/// branch in the post-`up` prompt) print the block so users can
+/// inspect or install by hand.
+pub fn show_filter(ctx: &ExecutionContext) -> Result<MessageResult> {
+    let installed = is_installed(ctx)?;
+    let block = config_block_text();
+    let mut details: Vec<String> = block.lines().map(|s| format!("    {s}")).collect();
+    details.push(String::new());
+    details.push("Then add this line to .gitattributes (committed in the repo):".to_string());
+    details.push(format!("    {}", gitattributes_line()));
+    Ok(MessageResult {
+        message: if installed {
+            "Template filter is currently installed.".into()
+        } else {
+            "Template filter is NOT installed. To install, add to .git/config:".into()
+        },
+        details,
+    })
+}
+
+fn append_gitattributes_hint(ctx: &ExecutionContext, details: &mut Vec<String>) {
+    let attrs_path = ctx.paths.dotfiles_root().join(".gitattributes");
+    let already_bound = ctx
+        .fs
+        .read_to_string(&attrs_path)
+        .ok()
+        .map(|s| s.lines().any(gitattributes_line_present))
+        .unwrap_or(false);
+    if !already_bound {
+        details.push(String::new());
+        details.push("Next: ensure your .gitattributes binds *.tmpl to this filter:".into());
+        details.push(format!(
+            "    echo '{}' >> .gitattributes",
+            gitattributes_line()
+        ));
+        details.push("    git add .gitattributes && git commit -m 'enable template filter'".into());
+    }
+}
+
+/// Match a `.gitattributes` line that binds `*.tmpl` to
+/// `dodot-template`. Tolerant of whitespace and trailing comments.
+fn gitattributes_line_present(line: &str) -> bool {
+    let trimmed = line.split('#').next().unwrap_or("").trim();
+    let mut parts = trimmed.split_ascii_whitespace();
+    let pattern = parts.next();
+    if pattern != Some("*.tmpl") {
+        return false;
+    }
+    parts.any(|tok| tok == "filter=dodot-template")
+}
+
+fn filter_is_installed(
+    runner: &dyn crate::datastore::CommandRunner,
+    root: &std::path::Path,
+) -> Result<bool> {
+    match runner.run(
+        "git",
+        &[
+            "-C".into(),
+            root.display().to_string(),
+            "config".into(),
+            "--get".into(),
+            "filter.dodot-template.clean".into(),
+        ],
+    ) {
+        Ok(out) => Ok(out.exit_code == 0 && !out.stdout.trim().is_empty()),
+        Err(DodotError::CommandFailed { exit_code: 1, .. }) => Ok(false),
+        Err(DodotError::CommandFailed { stderr, .. })
+            if stderr.contains("not a git repository") =>
+        {
+            Ok(false)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn git_config_set(
+    runner: &dyn crate::datastore::CommandRunner,
+    root: &std::path::Path,
+    key: &str,
+    value: &str,
+) -> Result<()> {
+    let out = runner.run(
+        "git",
+        &[
+            "-C".into(),
+            root.display().to_string(),
+            "config".into(),
+            key.into(),
+            value.into(),
+        ],
+    )?;
+    if out.exit_code != 0 {
+        return Err(DodotError::CommandFailed {
+            command: format!("git -C {} config {} {}", root.display(), key, value),
+            exit_code: out.exit_code,
+            stderr: out.stderr,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_block_carries_required_keys() {
+        let block = config_block_text();
+        assert!(block.contains("[filter \"dodot-template\"]"));
+        assert!(block.contains("clean    = dodot template clean --path %f"));
+        // Identity smudge is explicit, not implicit.
+        assert!(block.contains("smudge   = cat"));
+        // required=true so a missing dodot fails loudly rather than
+        // silently storing/checking out the wrong representation.
+        assert!(block.contains("required = true"));
+    }
+
+    #[test]
+    fn gitattributes_line_recogniser_handles_whitespace_and_comments() {
+        assert!(gitattributes_line_present("*.tmpl filter=dodot-template"));
+        assert!(gitattributes_line_present(
+            "  *.tmpl   filter=dodot-template  "
+        ));
+        assert!(gitattributes_line_present(
+            "*.tmpl filter=dodot-template diff=template"
+        ));
+        assert!(gitattributes_line_present(
+            "*.tmpl filter=dodot-template  # template filter"
+        ));
+
+        assert!(!gitattributes_line_present(""));
+        assert!(!gitattributes_line_present("# commented out"));
+        assert!(!gitattributes_line_present("*.tmpl filter=other"));
+        assert!(!gitattributes_line_present("*.txt filter=dodot-template"));
+        // Plist filter line must NOT match the template recogniser.
+        assert!(!gitattributes_line_present("*.plist filter=dodot-plist"));
+    }
+
+    /// Test-only ExecutionContext that uses a `MockRunner` so we can
+    /// observe the `git config` calls install_filter would issue.
+    fn make_test_ctx(env: &crate::testing::TempEnvironment) -> ExecutionContext {
+        use crate::config::ConfigManager;
+        use crate::datastore::{CommandOutput, CommandRunner, FilesystemDataStore};
+        use crate::fs::Fs;
+        use crate::paths::Pather;
+        use std::sync::{Arc, Mutex};
+
+        // A mock runner that:
+        //   - records every `run` call so tests can assert which
+        //     `git config` keys were touched
+        //   - emulates `git config --get`'s exit-1 for unset keys
+        //     until set, then exit-0 with stdout == value
+        struct MockRunner {
+            store: Mutex<std::collections::HashMap<String, String>>,
+            calls: Mutex<Vec<Vec<String>>>,
+        }
+        impl CommandRunner for MockRunner {
+            fn run(&self, exe: &str, args: &[String]) -> Result<CommandOutput> {
+                self.calls.lock().unwrap().push(
+                    std::iter::once(exe.to_string())
+                        .chain(args.iter().cloned())
+                        .collect(),
+                );
+                if exe != "git" {
+                    return Ok(CommandOutput {
+                        exit_code: 0,
+                        stdout: String::new(),
+                        stderr: String::new(),
+                    });
+                }
+                // args = ["-C", root, "config", ...]
+                let rest: Vec<&str> = args.iter().skip(3).map(String::as_str).collect();
+                if rest.first() == Some(&"--get") {
+                    let key = rest.get(1).copied().unwrap_or("");
+                    let store = self.store.lock().unwrap();
+                    match store.get(key) {
+                        Some(v) => Ok(CommandOutput {
+                            exit_code: 0,
+                            stdout: format!("{v}\n"),
+                            stderr: String::new(),
+                        }),
+                        None => Err(DodotError::CommandFailed {
+                            command: format!("git config --get {key}"),
+                            exit_code: 1,
+                            stderr: String::new(),
+                        }),
+                    }
+                } else {
+                    // Setting: ["config", "<key>", "<value>"]
+                    let key = rest.first().copied().unwrap_or("");
+                    let value = rest.get(1).copied().unwrap_or("");
+                    self.store
+                        .lock()
+                        .unwrap()
+                        .insert(key.to_string(), value.to_string());
+                    Ok(CommandOutput {
+                        exit_code: 0,
+                        stdout: String::new(),
+                        stderr: String::new(),
+                    })
+                }
+            }
+        }
+        let runner = Arc::new(MockRunner {
+            store: Mutex::new(std::collections::HashMap::new()),
+            calls: Mutex::new(Vec::new()),
+        });
+        let runner_dyn: Arc<dyn CommandRunner> = runner.clone();
+        let datastore = Arc::new(FilesystemDataStore::new(
+            env.fs.clone(),
+            env.paths.clone(),
+            runner_dyn.clone(),
+        ));
+        let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
+        ExecutionContext {
+            fs: env.fs.clone() as Arc<dyn Fs>,
+            datastore,
+            paths: env.paths.clone() as Arc<dyn Pather>,
+            config_manager,
+            syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
+            command_runner: runner_dyn,
+            dry_run: false,
+            no_provision: true,
+            provision_rerun: false,
+            force: false,
+            view_mode: crate::commands::ViewMode::Full,
+            group_mode: crate::commands::GroupMode::Name,
+            verbose: false,
+        }
+    }
+
+    #[test]
+    fn install_filter_writes_three_config_keys_first_time() {
+        // First install: `--get` reports unset → set clean / smudge /
+        // required → return success with already_installed=false.
+        let env = crate::testing::TempEnvironment::builder().build();
+        let ctx = make_test_ctx(&env);
+        let r = install_filter(&ctx).unwrap();
+        assert!(!r.already_installed);
+        assert!(r.message.starts_with("Installed"));
+    }
+
+    #[test]
+    fn install_filter_is_idempotent() {
+        let env = crate::testing::TempEnvironment::builder().build();
+        let ctx = make_test_ctx(&env);
+        install_filter(&ctx).unwrap();
+        let second = install_filter(&ctx).unwrap();
+        assert!(second.already_installed);
+        assert!(second.message.contains("already installed"));
+    }
+
+    #[test]
+    fn is_installed_reflects_state_correctly() {
+        let env = crate::testing::TempEnvironment::builder().build();
+        let ctx = make_test_ctx(&env);
+        assert!(!is_installed(&ctx).unwrap());
+        install_filter(&ctx).unwrap();
+        assert!(is_installed(&ctx).unwrap());
+    }
+
+    #[test]
+    fn show_filter_renders_block_and_attributes_line() {
+        let env = crate::testing::TempEnvironment::builder().build();
+        let ctx = make_test_ctx(&env);
+        let r = show_filter(&ctx).unwrap();
+        // Block lines + the gitattributes hint must both be present
+        // in `details` so the user can copy them.
+        let joined = r.details.join("\n");
+        assert!(joined.contains("[filter \"dodot-template\"]"));
+        assert!(joined.contains("clean    = dodot template clean --path %f"));
+        assert!(joined.contains(gitattributes_line()));
+    }
+}

--- a/crates/dodot-lib/src/commands/transform.rs
+++ b/crates/dodot-lib/src/commands/transform.rs
@@ -424,7 +424,9 @@ pub fn hook_is_installed(ctx: &ExecutionContext) -> Result<bool> {
 ///    unresolved markers).
 ///
 /// Each step short-circuits with `|| exit 1`; a failure in either
-/// aborts the commit with the matching exit code.
+/// aborts the commit (with exit code 1 — the inner command's exit
+/// status is intentionally not preserved, since for git's purposes
+/// "any non-zero" is what blocks the commit).
 pub fn managed_block() -> String {
     format!(
         "{guard_start}\n\

--- a/crates/dodot-lib/src/commands/transform.rs
+++ b/crates/dodot-lib/src/commands/transform.rs
@@ -284,8 +284,14 @@ pub enum InstallHookOutcome {
     /// Hook file existed; we appended our block to it. Existing content
     /// is preserved.
     Appended,
-    /// Hook was already installed (guard line found) — no change.
+    /// Hook was already installed and matches the current managed
+    /// block exactly — no change.
     AlreadyInstalled,
+    /// Hook was installed but the managed block was an older version
+    /// (e.g. didn't yet call `dodot refresh`). We replaced the
+    /// outdated block in place. Existing non-managed content in the
+    /// hook file is preserved.
+    Updated,
 }
 
 /// Result returned by [`install_hook`]. Renders through the
@@ -339,12 +345,27 @@ pub fn install_hook(ctx: &ExecutionContext) -> Result<InstallHookResult> {
 
     let outcome = if ctx.fs.exists(&hook_path) {
         let existing = ctx.fs.read_to_string(&hook_path)?;
-        if existing.contains(HOOK_GUARD_START) {
-            InstallHookOutcome::AlreadyInstalled
+        if let Some((start_byte, end_byte)) = find_managed_block(&existing) {
+            // A managed block exists. Decide whether it matches the
+            // current `block` exactly (no-op) or is stale and needs
+            // replacing.
+            let current_block = &existing[start_byte..end_byte];
+            if current_block == block {
+                InstallHookOutcome::AlreadyInstalled
+            } else {
+                // Stale block — rewrite it in place. Anything outside
+                // the marker pair is preserved.
+                let mut new_content = String::with_capacity(existing.len() + block.len());
+                new_content.push_str(&existing[..start_byte]);
+                new_content.push_str(&block);
+                new_content.push_str(&existing[end_byte..]);
+                ctx.fs.write_file(&hook_path, new_content.as_bytes())?;
+                ctx.fs.set_permissions(&hook_path, 0o755)?;
+                InstallHookOutcome::Updated
+            }
         } else {
-            // Append the block, preserving the existing hook. Add a
-            // leading blank line if the existing content doesn't end
-            // in one — readability when the hook is opened by hand.
+            // No managed block at all — append. Preserves existing
+            // hook content (user-written or installed by another tool).
             let mut new_content = existing.clone();
             if !new_content.ends_with('\n') {
                 new_content.push('\n');
@@ -391,24 +412,74 @@ pub fn hook_is_installed(ctx: &ExecutionContext) -> Result<bool> {
 /// onboarding prompt in `commands::up` to surface what would be
 /// installed. Includes the guard lines so callers can grep-detect
 /// the block in arbitrary contexts.
+///
+/// The block runs two commands:
+///
+/// 1. `dodot refresh --quiet` — touch source mtimes for any
+///    deployed-side edits so git's stat-cache invalidates. Without
+///    this, the clean filter (R6) wouldn't fire on the upcoming
+///    commit, and the commit could include stale template content.
+/// 2. `dodot transform check --strict` — run the 4-state matrix and
+///    refuse the commit on any finding (Patched, Conflict, missing,
+///    unresolved markers).
+///
+/// Each step short-circuits with `|| exit 1`; a failure in either
+/// aborts the commit with the matching exit code.
 pub fn managed_block() -> String {
     format!(
         "{guard_start}\n\
-         # Aborts the commit if `dodot transform check --strict` reports findings —\n\
-         # template files whose deployed sides drifted, or unresolved dodot-conflict\n\
-         # markers. Remove this block to opt out.\n\
-         {command}\n\
+         # Aborts the commit if any template-source has drift that needs review —\n\
+         # divergent deployed file or unresolved dodot-conflict markers. Remove\n\
+         # this block to opt out.\n\
+         {refresh}\n\
+         {check}\n\
          {guard_end}\n",
         guard_start = HOOK_GUARD_START,
         guard_end = HOOK_GUARD_END,
-        command = HOOK_COMMAND,
+        refresh = HOOK_COMMAND_REFRESH,
+        check = HOOK_COMMAND_CHECK,
     )
 }
 
-/// The exact shell line our hook block runs. Pulled out as a
-/// constant so the install path and the renderer surface the same
-/// string verbatim.
-pub(crate) const HOOK_COMMAND: &str = "dodot transform check --strict || exit 1";
+/// First shell line of the managed block: invalidate git's
+/// stat-cache for any deployed-side edits. `--quiet` so a no-op
+/// refresh doesn't print on every commit.
+pub(crate) const HOOK_COMMAND_REFRESH: &str = "dodot refresh --quiet || exit 1";
+
+/// Second shell line: run the strict check. Splits across two lines
+/// in the hook so each step can be diagnosed independently.
+pub(crate) const HOOK_COMMAND_CHECK: &str = "dodot transform check --strict || exit 1";
+
+/// Combined "what the hook runs" string for display purposes
+/// (shown by the install message + the post-up prompt). The actual
+/// hook file uses the two-line form from [`managed_block`].
+pub(crate) const HOOK_COMMAND: &str = "dodot refresh --quiet && dodot transform check --strict";
+
+/// Locate the byte range of our managed block inside `text` —
+/// from the first character of `HOOK_GUARD_START` through the
+/// trailing newline after `HOOK_GUARD_END`. Returns `None` if either
+/// guard is missing or if the end guard doesn't appear after the
+/// start guard.
+///
+/// Used by the install path to detect stale managed blocks (and
+/// rewrite them to the current shape) without disturbing any
+/// non-managed content the user has in their hook.
+fn find_managed_block(text: &str) -> Option<(usize, usize)> {
+    let start = text.find(HOOK_GUARD_START)?;
+    // Find the end guard after `start`.
+    let after_start = start + HOOK_GUARD_START.len();
+    let end_rel = text[after_start..].find(HOOK_GUARD_END)?;
+    let end_guard_start = after_start + end_rel;
+    let end_byte = end_guard_start + HOOK_GUARD_END.len();
+    // Include the trailing newline (if any) so re-inserting the new
+    // block doesn't double-up the line break.
+    let end_byte = if text.as_bytes().get(end_byte) == Some(&b'\n') {
+        end_byte + 1
+    } else {
+        end_byte
+    };
+    Some((start, end_byte))
+}
 
 #[cfg(test)]
 mod tests {
@@ -829,7 +900,8 @@ mod tests {
         let body = env.fs.read_to_string(&hook_path).unwrap();
         assert!(body.starts_with("#!/bin/sh\n"), "body: {body:?}");
         assert!(body.contains(HOOK_GUARD_START), "body: {body:?}");
-        assert!(body.contains(HOOK_COMMAND), "body: {body:?}");
+        assert!(body.contains(HOOK_COMMAND_REFRESH), "body: {body:?}");
+        assert!(body.contains(HOOK_COMMAND_CHECK), "body: {body:?}");
         assert!(body.contains(HOOK_GUARD_END), "body: {body:?}");
     }
 
@@ -851,7 +923,8 @@ mod tests {
         let body = env.fs.read_to_string(&hook_path).unwrap();
         assert!(body.starts_with(existing), "user content lost: {body:?}");
         assert!(body.contains(HOOK_GUARD_START));
-        assert!(body.contains(HOOK_COMMAND));
+        assert!(body.contains(HOOK_COMMAND_REFRESH));
+        assert!(body.contains(HOOK_COMMAND_CHECK));
     }
 
     #[test]
@@ -952,6 +1025,108 @@ mod tests {
         let block = managed_block();
         assert!(block.starts_with(HOOK_GUARD_START));
         assert!(block.trim_end().ends_with(HOOK_GUARD_END));
-        assert!(block.contains(HOOK_COMMAND));
+        // Both shell lines (refresh + check) must appear in the
+        // block — the hook runs them as two independent steps.
+        assert!(block.contains(HOOK_COMMAND_REFRESH));
+        assert!(block.contains(HOOK_COMMAND_CHECK));
+    }
+
+    // ── hook upgrade (managed-block detection + replacement) ────
+
+    #[test]
+    fn install_hook_replaces_a_stale_managed_block() {
+        // An older R4-shape block (single check command, no refresh
+        // line) must be detected and rewritten to the new two-line
+        // form when `install-hook` runs again. Existing non-managed
+        // content is preserved.
+        let env = TempEnvironment::builder().build();
+        fake_git_dir(&env);
+
+        // Stage an old-style block manually. This is what an R4-era
+        // install-hook would have produced: the same guards, but the
+        // single old `dodot transform check --strict || exit 1`
+        // command line and the older comment.
+        let stale = format!(
+            "#!/bin/sh\n\
+             echo 'user-installed pre-commit step'\n\
+             \n\
+             {start}\n\
+             # Old-style block from R4. Still works, but doesn't run\n\
+             # `dodot refresh` first, so deployed-side edits between\n\
+             # commits aren't always picked up.\n\
+             dodot transform check --strict || exit 1\n\
+             {end}\n\
+             # User content after the block.\n\
+             echo 'trailing user step'\n",
+            start = HOOK_GUARD_START,
+            end = HOOK_GUARD_END,
+        );
+        let hook_path = env.dotfiles_root.join(".git/hooks/pre-commit");
+        env.fs.write_file(&hook_path, stale.as_bytes()).unwrap();
+
+        let ctx = make_ctx(&env);
+        let result = install_hook(&ctx).unwrap();
+        assert!(matches!(result.outcome, InstallHookOutcome::Updated));
+
+        let body = env.fs.read_to_string(&hook_path).unwrap();
+        // New shape: both refresh + check lines, comment matches the
+        // current block.
+        assert!(body.contains(HOOK_COMMAND_REFRESH), "body: {body:?}");
+        assert!(body.contains(HOOK_COMMAND_CHECK), "body: {body:?}");
+        // User content (before AND after the managed block) survived.
+        assert!(body.contains("user-installed pre-commit step"));
+        assert!(body.contains("trailing user step"));
+        // Exactly one managed block — no duplicates.
+        assert_eq!(body.matches(HOOK_GUARD_START).count(), 1);
+        assert_eq!(body.matches(HOOK_GUARD_END).count(), 1);
+    }
+
+    #[test]
+    fn install_hook_no_op_on_current_block() {
+        // The exact opposite of the upgrade test: if the existing
+        // block is already the current shape, install_hook returns
+        // AlreadyInstalled and leaves the file byte-identical.
+        let env = TempEnvironment::builder().build();
+        fake_git_dir(&env);
+        let ctx = make_ctx(&env);
+
+        // Install fresh.
+        let r1 = install_hook(&ctx).unwrap();
+        assert!(matches!(r1.outcome, InstallHookOutcome::Created));
+        let body_after_first = env
+            .fs
+            .read_to_string(&env.dotfiles_root.join(".git/hooks/pre-commit"))
+            .unwrap();
+
+        // Re-install — current block is up to date, no change.
+        let r2 = install_hook(&ctx).unwrap();
+        assert!(matches!(r2.outcome, InstallHookOutcome::AlreadyInstalled));
+        let body_after_second = env
+            .fs
+            .read_to_string(&env.dotfiles_root.join(".git/hooks/pre-commit"))
+            .unwrap();
+        assert_eq!(body_after_first, body_after_second);
+    }
+
+    #[test]
+    fn find_managed_block_locates_byte_range() {
+        // White-box test for the byte-range finder so we don't have
+        // to reverse-engineer it from the splice tests above.
+        let block = managed_block();
+        let prefix = "before\n";
+        let suffix = "after\n";
+        let text = format!("{prefix}{block}{suffix}");
+        let (start, end) = find_managed_block(&text).expect("must find block");
+        assert_eq!(&text[start..end], block);
+    }
+
+    #[test]
+    fn find_managed_block_returns_none_when_absent() {
+        assert!(find_managed_block("nothing here").is_none());
+        // Half-block (start without end) → also None: we treat
+        // partial blocks as "not installed" so install_hook will
+        // append rather than try to splice.
+        let only_start = format!("{HOOK_GUARD_START}\nrandom content\n");
+        assert!(find_managed_block(&only_start).is_none());
     }
 }

--- a/crates/dodot-lib/src/preprocessing/divergence.rs
+++ b/crates/dodot-lib/src/preprocessing/divergence.rs
@@ -218,6 +218,33 @@ pub fn collect_divergences(fs: &dyn Fs, paths: &dyn Pather) -> Result<Vec<Diverg
     Ok(reports)
 }
 
+/// Look up the baseline whose `source_path` matches `target`, plus
+/// the `(pack, handler, filename)` triple that identifies it in the
+/// cache layout.
+///
+/// Used by the clean filter (R6): git invokes the filter with the
+/// source path of the file being processed, and the filter needs the
+/// matching baseline to find the deployed bytes and the cached
+/// tracked render. The lookup is a linear scan of the cache — fast
+/// enough for the realistic per-repo template count (tens to low
+/// hundreds), and avoids the on-disk index file the cache layout
+/// would otherwise need.
+///
+/// Returns `Ok(None)` when no baseline matches; the clean filter
+/// treats that as "echo stdin unchanged" rather than an error.
+pub fn find_baseline_for_source(
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+    target: &std::path::Path,
+) -> Result<Option<(String, String, String, Baseline)>> {
+    for (pack, handler, filename, baseline) in collect_baselines(fs, paths)? {
+        if baseline.source_path == target {
+            return Ok(Some((pack, handler, filename, baseline)));
+        }
+    }
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -453,5 +480,69 @@ mod tests {
 
         let reports = collect_divergences(env.fs.as_ref(), env.paths.as_ref()).unwrap();
         assert_eq!(reports[0].state, DivergenceState::MissingSource);
+    }
+
+    // ── find_baseline_for_source ────────────────────────────────
+
+    #[test]
+    fn find_baseline_for_source_returns_match() {
+        // Stage two baselines with distinct source paths; the lookup
+        // must return only the one whose `source_path` matches.
+        let env = TempEnvironment::builder().build();
+        let src_a = env.dotfiles_root.join("app/a.toml.tmpl");
+        write_pack_template(&env, "app", "a.toml.tmpl", "src-a");
+        write_deployed(&env, "app", "preprocessed", "a.toml", "rendered-a");
+        baseline_for(&src_a, b"rendered-a", b"src-a")
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "a.toml",
+            )
+            .unwrap();
+
+        let src_b = env.dotfiles_root.join("app/b.toml.tmpl");
+        write_pack_template(&env, "app", "b.toml.tmpl", "src-b");
+        write_deployed(&env, "app", "preprocessed", "b.toml", "rendered-b");
+        baseline_for(&src_b, b"rendered-b", b"src-b")
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "b.toml",
+            )
+            .unwrap();
+
+        let hit = find_baseline_for_source(env.fs.as_ref(), env.paths.as_ref(), &src_a).unwrap();
+        let (pack, handler, filename, baseline) = hit.expect("baseline must be found");
+        assert_eq!(pack, "app");
+        assert_eq!(handler, "preprocessed");
+        assert_eq!(filename, "a.toml");
+        assert_eq!(baseline.source_path, src_a);
+        assert_eq!(baseline.rendered_content, "rendered-a");
+    }
+
+    #[test]
+    fn find_baseline_for_source_returns_none_when_unknown() {
+        // Path the cache has never seen → Ok(None). The clean
+        // filter treats this as "echo stdin unchanged", so the
+        // None case is part of the normal contract, not an error.
+        let env = TempEnvironment::builder().build();
+        let unknown = env.dotfiles_root.join("never-cached.tmpl");
+        let result =
+            find_baseline_for_source(env.fs.as_ref(), env.paths.as_ref(), &unknown).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn find_baseline_for_source_on_empty_cache_returns_none() {
+        // No baselines on disk at all (e.g. user has never run
+        // `dodot up`) → Ok(None), not an error.
+        let env = TempEnvironment::builder().build();
+        let any = env.dotfiles_root.join("anything.tmpl");
+        let result = find_baseline_for_source(env.fs.as_ref(), env.paths.as_ref(), &any).unwrap();
+        assert!(result.is_none());
     }
 }

--- a/crates/dodot-lib/src/prompts/catalog.rs
+++ b/crates/dodot-lib/src/prompts/catalog.rs
@@ -28,6 +28,12 @@ pub const KNOWN_PROMPTS: &[PromptDescriptor] = &[
             "Offer to install git clean/smudge filters when a pack contains tracked .plist files",
     },
     PromptDescriptor {
+        key: "template.install_filter",
+        description:
+            "Offer to install the dodot-template git clean filter after the first successful \
+             template deployment with the pre-commit hook already in place",
+    },
+    PromptDescriptor {
         key: "template.install_hook",
         description:
             "Offer to install the pre-commit hook running `dodot transform check --strict` after \

--- a/crates/dodot-lib/src/render/mod.rs
+++ b/crates/dodot-lib/src/render/mod.rs
@@ -161,6 +161,10 @@ pub const TEMPLATE_TRANSFORM_INSTALL_HOOK: &str =
 /// `dodot refresh` per-mode output (default report / quiet / list-paths).
 pub const TEMPLATE_REFRESH: &str = include_str!("../templates/refresh.jinja");
 
+/// `dodot template install-filter` outcome message.
+pub const TEMPLATE_TEMPLATE_INSTALL_FILTER: &str =
+    include_str!("../templates/template-install-filter.jinja");
+
 // ── Tutorial step templates ─────────────────────────────────────
 //
 // One per step of the interactive tutorial. The CLI driver renders

--- a/crates/dodot-lib/src/templates/template-install-filter.jinja
+++ b/crates/dodot-lib/src/templates/template-install-filter.jinja
@@ -1,0 +1,8 @@
+{%- if already_installed -%}
+[message]{{ message }}[/message]
+{%- else -%}
+[message]{{ message }}[/message]
+{%- endif %}
+{% for line in details -%}
+  {{ line }}
+{% endfor -%}

--- a/crates/dodot-lib/src/templates/template-install-filter.jinja
+++ b/crates/dodot-lib/src/templates/template-install-filter.jinja
@@ -1,8 +1,4 @@
-{%- if already_installed -%}
 [message]{{ message }}[/message]
-{%- else -%}
-[message]{{ message }}[/message]
-{%- endif %}
 {% for line in details -%}
   {{ line }}
 {% endfor -%}

--- a/tests/e2e/bats/test_template_clean_filter.bats
+++ b/tests/e2e/bats/test_template_clean_filter.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# E2E tests for the template clean filter (R6 of the template-magic
+# track). Exercises the full git-side integration: install the
+# filter, bind it via .gitattributes, edit a deployed template,
+# verify `git diff` shows the template-space change.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+
+    # Initialise the dotfiles root as a git repo so install-filter
+    # accepts it.
+    git -C "$DOTFILES_ROOT" init -q
+    git -C "$DOTFILES_ROOT" config user.email "test@example.com"
+    git -C "$DOTFILES_ROOT" config user.name "Test"
+    git -C "$DOTFILES_ROOT" config commit.gpgsign false
+
+    # Filter subprocess (`git status`, `git diff`) runs in a fresh
+    # shell that doesn't inherit the bats `dodot` function — the
+    # registered clean command is bare `dodot template clean ...`,
+    # so the binary must be on PATH.
+    export PATH="$(dirname "$DODOT_BIN"):$PATH"
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "install-filter writes the dodot-template filter to .git/config" {
+    run dodot template install-filter
+    [ "$status" -eq 0 ]
+    assert_output_contains "Installed template clean filter"
+
+    # Three keys present.
+    [ "$(git -C "$DOTFILES_ROOT" config --get filter.dodot-template.clean)" = "dodot template clean --path %f" ]
+    [ "$(git -C "$DOTFILES_ROOT" config --get filter.dodot-template.smudge)" = "cat" ]
+    [ "$(git -C "$DOTFILES_ROOT" config --get filter.dodot-template.required)" = "true" ]
+}
+
+@test "install-filter is idempotent on re-run" {
+    run dodot template install-filter
+    [ "$status" -eq 0 ]
+    run dodot template install-filter
+    [ "$status" -eq 0 ]
+    assert_output_contains "already installed"
+}
+
+@test "clean filter on clean state echoes stdin verbatim" {
+    # No edit on either side. The filter's fast path hits and the
+    # template content passes through unchanged.
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'name = {{ name }}
+port = 5432'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    src="$DOTFILES_ROOT/app/cfg.toml.tmpl"
+    expected="$(cat "$src")"
+
+    out=$(dodot template clean --path "$src" < "$src")
+    [ "$out" = "$expected" ]
+}
+
+@test "clean filter patches template when deployed file diverges" {
+    # The core scenario: edit the rendered file, run the clean
+    # filter on the source, observe the patched output (var
+    # preserved, static line propagated).
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'name = {{ name }}
+port = 5432'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    rendered="$XDG_DATA_HOME/dodot/packs/app/preprocessed/cfg.toml"
+    cat > "$rendered" <<'EOF'
+name = Alice
+port = 9999
+EOF
+
+    src="$DOTFILES_ROOT/app/cfg.toml.tmpl"
+    out=$(dodot template clean --path "$src" < "$src")
+    [[ "$out" == *"port = 9999"* ]]
+    [[ "$out" == *"name = {{ name }}"* ]]
+}
+
+@test "git status surfaces template-space diff after refresh + filter" {
+    # End-to-end through git: install filter, bind in .gitattributes,
+    # commit the clean state, edit deployed file, refresh source
+    # mtime, run `git status` → source shows as modified, `git diff`
+    # shows the template-space change.
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'name = {{ name }}
+port = 5432'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    # Install + bind.
+    run dodot template install-filter
+    [ "$status" -eq 0 ]
+    echo '*.tmpl filter=dodot-template' > "$DOTFILES_ROOT/.gitattributes"
+
+    # Initial commit so we have a baseline tree to diff against.
+    git -C "$DOTFILES_ROOT" add -A
+    git -C "$DOTFILES_ROOT" commit -q -m "initial"
+
+    # Edit the deployed file.
+    sleep 1
+    rendered="$XDG_DATA_HOME/dodot/packs/app/preprocessed/cfg.toml"
+    cat > "$rendered" <<'EOF'
+name = Alice
+port = 9999
+EOF
+
+    # Without refresh, git's stat-cache won't even invoke the
+    # filter — refresh is the bump.
+    run dodot refresh --quiet
+    [ "$status" -eq 0 ]
+
+    # Now `git status` should see the source as modified.
+    run git -C "$DOTFILES_ROOT" status --porcelain
+    [[ "$output" == *"app/cfg.toml.tmpl"* ]]
+
+    # And `git diff` shows the template-space change.
+    run git -C "$DOTFILES_ROOT" diff app/cfg.toml.tmpl
+    [[ "$output" == *"port = 9999"* ]]
+}
+
+@test "reinstalling the hook upgrades a stale R4-shape block" {
+    # An older R4 hook (no `dodot refresh` line) should be detected
+    # and upgraded to the new two-line form when the user re-runs
+    # `dodot transform install-hook`.
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'name = {{ name }}'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    # Stage an old-style hook by hand: same guards, only the check
+    # command (no refresh).
+    cat > "$DOTFILES_ROOT/.git/hooks/pre-commit" <<'EOF'
+#!/bin/sh
+# >>> dodot transform check --strict (managed by `dodot transform install-hook`) >>>
+# Old R4-style block.
+dodot transform check --strict || exit 1
+# <<< dodot transform check --strict <<<
+EOF
+    chmod +x "$DOTFILES_ROOT/.git/hooks/pre-commit"
+
+    run dodot transform install-hook
+    [ "$status" -eq 0 ]
+    # New block is in place: refresh + check both run.
+    assert_file_contains "$DOTFILES_ROOT/.git/hooks/pre-commit" "dodot refresh --quiet"
+    assert_file_contains "$DOTFILES_ROOT/.git/hooks/pre-commit" "dodot transform check --strict"
+}


### PR DESCRIPTION
## Summary

R6 of the template-magic track. The piece that makes \"git status tells the truth\" actually true.

R3+R4 closed the commit-time gap: \`git commit\` now refuses divergent templates and unresolved markers via the pre-commit hook. R5 added the mtime touch so git's stat-cache invalidates. **R6 ties it together** with the clean filter — once installed, every \`git status\` / \`git diff\` / \`git log -p\` between commits surfaces template-space changes transparently. No new commands in the user's daily flow.

## What ships

- **\`dodot template clean --path <path>\`** — git clean filter for \`*.tmpl filter=dodot-template\`. Reads template source on stdin, writes the cleaned form on stdout.
  - **Fast path**: hash deployed file, compare to \`baseline.rendered_hash\`. Equal → echo stdin verbatim. Microseconds. The common case.
  - **Slow path**: rehydrate \`TrackedRender::from_tracked_string\`, run \`burgertocow::generate_diff_with_markers\` (with our R2 markers), apply via diffy. Conflict blocks splice inline.
  - **Never re-renders.** That's the entire point of caching the tracked render in R1 — keeps secret-provider auth out of \`git status\`.
  - **Failure model**: any non-fatal hiccup degrades to \"echo stdin\". Git treats filter exit != 0 as fatal; better stale-but-readable than brick the repo.
- **\`dodot template install-filter\`** — registers \`[filter \"dodot-template\"]\` in \`.git/config\` (clean / smudge=cat / required=true). Idempotent. Surfaces the matching \`.gitattributes\` line.
- **Hook upgrade** — pre-commit block now runs \`dodot refresh --quiet\` before \`dodot transform check --strict\`. Re-running \`dodot transform install-hook\` detects a stale R4-shape block (via the same guard lines) and rewrites it in place, preserving any non-managed user content. New \`Updated\` outcome.
- **First-deploy prompt** — post-\`up\` ladder: hook (R4) → filter (this PR) → fires only after the hook is already installed. Same Y/n/show shape as the existing prompts.
- **\`template.install_filter\`** prompt-catalog entry.
- **\`divergence::find_baseline_for_source\`** — reverse-lookup helper used by the filter to find the deployed bytes given just the source path git passed via \`%f\`.

## End-to-end demo (the showcase test)

\`\`\`sh
# 1. setup
dodot up                                  # deploy templates
dodot transform install-hook              # commit-time gate
dodot template install-filter             # ambient git-status gate
echo '*.tmpl filter=dodot-template' >> .gitattributes
git add .gitattributes && git commit -m \"enable filter\"

# 2. user edits a deployed config
$EDITOR ~/.config/app/cfg.toml            # change \`port = 5432\` to \`port = 9999\`

# 3. between-commits visibility
dodot refresh --quiet                     # touches source mtime; clean filter fires next
git status                                # → app/cfg.toml.tmpl modified
git diff                                  # → static line edit shown in template space,
                                          #   {{ name }} preserved verbatim
\`\`\`

The \`git status surfaces template-space diff after refresh + filter\` bats test exercises this exact flow and passes.

## Architecture choices worth flagging

- **6-char angle-bracket guards** for the hook-block detection match the convention from R2's conflict markers — distinct from git's own 7-char merge markers.
- **\`smudge = cat\`** is explicit, not implicit. Templates must NEVER re-render at smudge time (would re-trigger secret auth on every \`git checkout\`). Setting smudge to identity \`cat\` makes the don't-re-render contract legible in \`.git/config\`.
- **Clean filter never fails the working-tree read.** Any internal hiccup (missing baseline, bad bytes, diff parse failure) degrades to \"echo stdin\" rather than \`Err\` → exit 1 → git aborts.
- **Linear-scan baseline lookup** rather than maintaining a separate index. Fast enough at realistic dotfile counts; one less moving part to keep coherent with the cache.

## Test plan

- [x] \`cargo test -p dodot-lib --lib\` — **797 tests pass** (+22 from R5's 775).
- [x] **9 \`commands::template_clean\` unit tests**: fast path, slow path Patched, slow path Conflict (inconsistent-loop scenario), pure-data → echo, missing baseline → echo, missing deployed → echo, empty tracked → echo, stdio passthrough wiring, soft-fail on inconsistent baseline.
- [x] **6 \`commands::template_install_filter\` unit tests**: config block has three keys, .gitattributes recogniser handles whitespace + comments, install writes config, idempotent re-run, \`is_installed\` reflects state, \`show_filter\` renders block + line.
- [x] **3 \`commands::transform\` new unit tests**: hook upgrade replaces stale block (preserving surrounding user content), no-op on current block, \`find_managed_block\` byte-range finder + None-on-half-block.
- [x] **3 \`preprocessing::divergence\` new unit tests** for \`find_baseline_for_source\`.
- [x] **6 new e2e bats tests** in \`test_template_clean_filter.bats\` including the full-stack \"git status surfaces template-space diff after refresh + filter\" round trip.
- [x] All 23 prior e2e tests still pass.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.

## Follow-ups

R7 (\`dodot transform status\` + \`dodot git-show-alias\` + \`dodot git-install-alias\` for Tier 2) and R9 (docs + \`no_reverse\` per-file opt-out) round out the track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)