### PR TITLE
feat(transform/git-alias): R7 — status + Tier 2 shell alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`dodot transform status`** (R7 of the template-magic track). Read-only view of every cached preprocessed file with its current state (synced / input-changed / output-changed / both-changed / missing-source / missing-deployed). Always exits 0 — informational, not actionable. Useful as a "what's currently out of sync?" check before deciding whether to run `dodot transform check`.
+- **`dodot git-show-alias [--shell <bash|zsh>]`** (R7). Prints the Tier 2 shell alias `alias git='dodot refresh --quiet && command git'` in a copy-paste-ready block. No filesystem mutation. Auto-detects shell from `$SHELL`; `--shell` overrides. Reports "already installed" when the rc file already carries the managed block.
+- **`dodot git-install-alias [--shell <bash|zsh>]`** (R7). Writes the Tier 2 alias to the user's shell rc file (`~/.bashrc` or `~/.zshrc`) with an idempotent guard block, mirroring the pre-commit hook installer. Outcomes: Created / Appended / AlreadyInstalled / Updated. Surfaces the `source <rc>` command the user needs to pick it up immediately.
+
+### Added (R6, prior)
+
 - **Template clean filter — `dodot template clean --path <path>`** (R6 of the template-magic track). The piece that makes `git status` and `git diff` show the truth between commits. Git invokes this filter when reading any working-tree file matched by `*.tmpl filter=dodot-template`; the filter looks up the cached baseline (R1), and on a deployed-side edit it rehydrates the cached marker stream and runs burgertocow + diffy to emit a patched template — without re-rendering, so secret-provider auth is never re-triggered. Fast path (no edit) echoes stdin in microseconds. Slow path lands the patched form (or a conflict block, surfaced inline) so the next `git diff` sees the template-space change.
 - **`dodot template install-filter`** (R6). Registers the `[filter "dodot-template"]` block in the dotfiles repo's `.git/config` (clean → `dodot template clean --path %f`, smudge → `cat`, required → `true`). Idempotent. Surfaces the matching `.gitattributes` line for the user to commit. First-deploy prompt offers it after the user has accepted the pre-commit hook.
 - **`template.install_filter` prompt-catalog entry**. Documents the new prompt alongside the existing ones in `dodot prompts list`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`dodot transform status`** (R7 of the template-magic track). Read-only view of every cached preprocessed file with its current state (synced / input-changed / output-changed / both-changed / missing-source / missing-deployed). Always exits 0 — informational, not actionable. Useful as a "what's currently out of sync?" check before deciding whether to run `dodot transform check`.
+- **`dodot transform status`** (R7 of the template-magic track). Read-only view of every cached preprocessed file with its current state (`synced` / `input_changed` / `output_changed` / `both_changed` / `missing_source` / `missing_deployed`). Always exits 0 — informational, not actionable. Useful as a "what's currently out of sync?" check before deciding whether to run `dodot transform check`.
 - **`dodot git-show-alias [--shell <bash|zsh>]`** (R7). Prints the Tier 2 shell alias `alias git='dodot refresh --quiet && command git'` in a copy-paste-ready block. No filesystem mutation. Auto-detects shell from `$SHELL`; `--shell` overrides. Reports "already installed" when the rc file already carries the managed block.
 - **`dodot git-install-alias [--shell <bash|zsh>]`** (R7). Writes the Tier 2 alias to the user's shell rc file (`~/.bashrc` or `~/.zshrc`) with an idempotent guard block, mirroring the pre-commit hook installer. Outcomes: Created / Appended / AlreadyInstalled / Updated. Surfaces the `source <rc>` command the user needs to pick it up immediately.
 

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -303,6 +303,44 @@ pub fn transform_check_handler(
     Ok(Output::Render(result))
 }
 
+/// `dodot transform status` — read-only view of every cached
+/// preprocessed file with its current state. Always exits 0.
+pub fn transform_status_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::transform::TransformStatusResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    Ok(Output::Render(commands::transform::status(&ctx)?))
+}
+
+/// `dodot git-show-alias [--shell <shell>]` — print the Tier 2
+/// shell alias for copy-paste. No filesystem mutation.
+pub fn git_show_alias_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::git_alias::ShowAliasResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    let shell_arg = matches.get_one::<String>("shell").map(String::as_str);
+    let shell = commands::git_alias::resolve_shell(shell_arg)?;
+    Ok(Output::Render(commands::git_alias::show_alias(
+        &ctx, shell,
+    )?))
+}
+
+/// `dodot git-install-alias [--shell <shell>]` — write the Tier 2
+/// alias to the user's shell rc file. Idempotent and additive.
+pub fn git_install_alias_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::git_alias::InstallAliasResult> {
+    let ctx = build_ctx(matches)?;
+    let shell_arg = matches.get_one::<String>("shell").map(String::as_str);
+    let shell = commands::git_alias::resolve_shell(shell_arg)?;
+    Ok(Output::Render(commands::git_alias::install_alias(
+        &ctx, shell,
+    )?))
+}
+
 /// `dodot template clean --path <path>` — git clean filter
 /// passthrough for template sources. Reads stdin (the working-tree
 /// source bytes), looks up the matching baseline in the cache,

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -222,6 +222,12 @@ static TEMPLATE_ENTRIES: &[(&str, &str)] = &[
         "template-install-filter.jinja",
         render::TEMPLATE_TEMPLATE_INSTALL_FILTER,
     ),
+    ("transform-status.jinja", render::TEMPLATE_TRANSFORM_STATUS),
+    ("git-show-alias.jinja", render::TEMPLATE_GIT_SHOW_ALIAS),
+    (
+        "git-install-alias.jinja",
+        render::TEMPLATE_GIT_INSTALL_ALIAS,
+    ),
 ];
 
 fn build_app() -> App {
@@ -308,6 +314,24 @@ fn build_app() -> App {
             "template-install-filter",
         )
         .expect("register template.install-filter")
+        .command(
+            "transform.status",
+            handlers::transform_status_handler,
+            "transform-status",
+        )
+        .expect("register transform.status")
+        .command(
+            "git-show-alias",
+            handlers::git_show_alias_handler,
+            "git-show-alias",
+        )
+        .expect("register git-show-alias")
+        .command(
+            "git-install-alias",
+            handlers::git_install_alias_handler,
+            "git-install-alias",
+        )
+        .expect("register git-install-alias")
         .command_groups(vec![
             CommandGroup {
                 title: "Core".into(),
@@ -340,6 +364,8 @@ fn build_app() -> App {
                 commands: vec![
                     Some("git-install-filters".into()),
                     Some("git-show-filters".into()),
+                    Some("git-show-alias".into()),
+                    Some("git-install-alias".into()),
                     Some("plist".into()),
                     Some("template".into()),
                 ],
@@ -536,6 +562,34 @@ fn build_clap_command() -> ClapCommand {
             ClapCommand::new("init-sh").about("Print shell init script for eval in .zshrc/.bashrc"),
         )
         .subcommand(
+            ClapCommand::new("git-show-alias")
+                .about(
+                    "Print the Tier 2 shell alias that wraps git in `dodot refresh --quiet`, \
+                     so `git status` and `git diff` see deployed-side template edits.",
+                )
+                .arg(
+                    Arg::new("shell")
+                        .long("shell")
+                        .help("Target shell (bash, zsh). Auto-detected from $SHELL by default.")
+                        .value_name("SHELL")
+                        .num_args(1),
+                ),
+        )
+        .subcommand(
+            ClapCommand::new("git-install-alias")
+                .about(
+                    "Write the Tier 2 shell alias to your shell's rc file (~/.bashrc or \
+                     ~/.zshrc). Idempotent and additive.",
+                )
+                .arg(
+                    Arg::new("shell")
+                        .long("shell")
+                        .help("Target shell (bash, zsh). Auto-detected from $SHELL by default.")
+                        .value_name("SHELL")
+                        .num_args(1),
+                ),
+        )
+        .subcommand(
             ClapCommand::new("template")
                 .about(
                     "Template-source git integration: the clean filter (passthrough) and \
@@ -667,6 +721,12 @@ fn build_clap_command() -> ClapCommand {
                     ClapCommand::new("install-hook").about(
                         "Install the pre-commit hook that runs `dodot transform check --strict` \
                          on every commit. Idempotent and additive — preserves any existing hook.",
+                    ),
+                )
+                .subcommand(
+                    ClapCommand::new("status").about(
+                        "Show the current state of every cached preprocessed file (synced / \
+                         output-changed / input-changed / both / missing). Read-only.",
                     ),
                 ),
         )

--- a/crates/dodot-lib/src/commands/git_alias.rs
+++ b/crates/dodot-lib/src/commands/git_alias.rs
@@ -49,23 +49,25 @@ pub enum Shell {
 }
 
 impl Shell {
-    /// Detect from `$SHELL`. Defaults to `Bash` if `$SHELL` is
-    /// unset or not one we know how to write — `bash` syntax is the
-    /// most portable starting point and the user can `--shell` to
-    /// override.
-    pub fn detect() -> Self {
-        std::env::var("SHELL")
-            .ok()
-            .and_then(|s| {
-                if s.ends_with("/zsh") || s == "zsh" {
-                    Some(Shell::Zsh)
-                } else if s.ends_with("/bash") || s == "bash" {
-                    Some(Shell::Bash)
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(Shell::Bash)
+    /// Detect from `$SHELL`. Returns `None` when `$SHELL` is unset
+    /// or names a shell we don't support — the caller (typically
+    /// [`resolve_shell`]) surfaces a clear error rather than
+    /// silently writing a bashrc snippet for a fish/nu user.
+    ///
+    /// Why fail explicitly: silently falling back to `Bash` means
+    /// `dodot git-install-alias` happily writes `~/.bashrc` for a
+    /// fish user, who then never sees the alias take effect.
+    /// Better to refuse with a message that points at `--shell`.
+    pub fn detect() -> Option<Self> {
+        std::env::var("SHELL").ok().and_then(|s| {
+            if s.ends_with("/zsh") || s == "zsh" {
+                Some(Shell::Zsh)
+            } else if s.ends_with("/bash") || s == "bash" {
+                Some(Shell::Bash)
+            } else {
+                None
+            }
+        })
     }
 
     /// Parse a CLI `--shell` value. Returns `None` for unknown
@@ -280,6 +282,12 @@ fn find_managed_block(text: &str) -> Option<(usize, usize)> {
 /// Diagnostic helper for the CLI: detect or validate a shell from
 /// the `--shell` CLI value, surfacing a clear error for unknown
 /// shells. Returns the resolved [`Shell`] or a `DodotError::Other`.
+///
+/// When `explicit` is `None` and `Shell::detect()` returns `None`
+/// (unsupported `$SHELL`), errors out asking the user to pass
+/// `--shell bash` or `--shell zsh`. Better than silently falling
+/// back to bash on a fish/nu setup, which would produce an alias
+/// that never fires.
 pub fn resolve_shell(explicit: Option<&str>) -> Result<Shell> {
     if let Some(name) = explicit {
         return Shell::from_str_opt(name).ok_or_else(|| {
@@ -289,7 +297,22 @@ pub fn resolve_shell(explicit: Option<&str>) -> Result<Shell> {
             ))
         });
     }
-    Ok(Shell::detect())
+    Shell::detect().ok_or_else(|| {
+        let detected = std::env::var("SHELL").unwrap_or_default();
+        if detected.is_empty() {
+            DodotError::Other(
+                "$SHELL is unset; pass `--shell bash` or `--shell zsh` so dodot knows which \
+                 rc file to write."
+                    .into(),
+            )
+        } else {
+            DodotError::Other(format!(
+                "could not detect shell from $SHELL ({detected:?}): dodot can install the git \
+                 alias for `bash` or `zsh`. Pass `--shell bash` or `--shell zsh` explicitly, or \
+                 run `dodot git-show-alias --shell bash` and adapt the snippet for your shell."
+            ))
+        }
+    })
 }
 
 /// Cheap "is this rc file already wrapping git via our alias?"
@@ -404,6 +427,72 @@ mod tests {
     fn resolve_shell_explicit_known_returns_match() {
         assert_eq!(resolve_shell(Some("bash")).unwrap(), Shell::Bash);
         assert_eq!(resolve_shell(Some("Zsh")).unwrap(), Shell::Zsh);
+    }
+
+    /// Save and restore $SHELL around an env-mutating closure.
+    /// std::env mutation is process-global; the tests that rely on
+    /// it are explicitly serialised below (each test's body sees
+    /// a known $SHELL and restores the previous value before
+    /// returning).
+    fn with_shell_env<F>(value: Option<&str>, f: F)
+    where
+        F: FnOnce(),
+    {
+        let prev = std::env::var("SHELL").ok();
+        if let Some(v) = value {
+            std::env::set_var("SHELL", v);
+        } else {
+            std::env::remove_var("SHELL");
+        }
+        f();
+        match prev {
+            Some(p) => std::env::set_var("SHELL", p),
+            None => std::env::remove_var("SHELL"),
+        }
+    }
+
+    #[test]
+    fn resolve_shell_no_explicit_unsupported_shell_errors() {
+        // The PR-review fix: a fish/nu user running
+        // `dodot git-show-alias` with no --shell must get a clear
+        // error pointing at `--shell bash|zsh`, NOT a silent
+        // fall-through to bash that writes a useless ~/.bashrc.
+        with_shell_env(Some("/usr/bin/fish"), || {
+            let err = resolve_shell(None).unwrap_err();
+            let msg = format!("{err}");
+            assert!(msg.contains("fish"), "msg: {msg}");
+            assert!(msg.contains("--shell"), "msg should suggest --shell: {msg}");
+        });
+    }
+
+    #[test]
+    fn resolve_shell_no_explicit_unset_shell_errors() {
+        // $SHELL is unset entirely (rare — minimal containers,
+        // weird login shells). Same disposition: error out with a
+        // clear pointer at --shell.
+        with_shell_env(None, || {
+            let err = resolve_shell(None).unwrap_err();
+            let msg = format!("{err}");
+            assert!(msg.contains("$SHELL"), "msg: {msg}");
+            assert!(msg.contains("--shell"), "msg: {msg}");
+        });
+    }
+
+    #[test]
+    fn detect_returns_some_for_known_shells() {
+        with_shell_env(Some("/bin/bash"), || {
+            assert_eq!(Shell::detect(), Some(Shell::Bash));
+        });
+        with_shell_env(Some("/usr/local/bin/zsh"), || {
+            assert_eq!(Shell::detect(), Some(Shell::Zsh));
+        });
+    }
+
+    #[test]
+    fn detect_returns_none_for_unknown() {
+        with_shell_env(Some("/usr/bin/fish"), || {
+            assert_eq!(Shell::detect(), None);
+        });
     }
 
     // ── managed_block + find_managed_block ──────────────────────

--- a/crates/dodot-lib/src/commands/git_alias.rs
+++ b/crates/dodot-lib/src/commands/git_alias.rs
@@ -1,0 +1,566 @@
+//! `dodot git-show-alias` and `dodot git-install-alias` — the
+//! Tier 2 shell-side glue for the template-magic flow.
+//!
+//! Tier 1 (R4) gets you commit-time correctness via the pre-commit
+//! hook. Tier 2 makes interactive `git status` and `git diff` show
+//! the truth between commits too, by wrapping git in a shell alias
+//! that runs `dodot refresh --quiet` first. The clean filter (R6)
+//! does the heavy lifting once the source mtime is fresh; this
+//! alias is what nudges the mtime on every interactive git
+//! invocation.
+//!
+//! Two forms:
+//!
+//! - `dodot git-show-alias` — print the alias for the user's shell
+//!   (detected from `$SHELL`) so they can copy-paste into their rc
+//!   file. No filesystem mutation.
+//! - `dodot git-install-alias` — write the alias to the user's rc
+//!   file (`~/.bashrc` or `~/.zshrc`) with an idempotent guard
+//!   block, mirroring the pre-commit hook installer's pattern.
+//!
+//! Only affects interactive shells. Scripts, editors, and CI that
+//! shell out to `git` directly are unaffected — exactly what we
+//! want: non-interactive callers get predictable behaviour,
+//! interactive use gets the magic.
+
+use serde::Serialize;
+use std::path::PathBuf;
+
+use crate::packs::orchestration::ExecutionContext;
+use crate::{DodotError, Result};
+
+/// The guard line that opens our managed alias block in a shell rc
+/// file. Detection of this string is what makes `install_alias`
+/// idempotent.
+pub(crate) const ALIAS_GUARD_START: &str =
+    "# >>> dodot git alias (managed by `dodot git-install-alias`) >>>";
+
+/// The guard line that closes our managed alias block.
+pub(crate) const ALIAS_GUARD_END: &str = "# <<< dodot git alias <<<";
+
+/// Which shell we're targeting. Detected from `$SHELL` for the
+/// bare `show`/`install` flow; the user can override with `--shell`
+/// at the CLI layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Shell {
+    Bash,
+    Zsh,
+}
+
+impl Shell {
+    /// Detect from `$SHELL`. Defaults to `Bash` if `$SHELL` is
+    /// unset or not one we know how to write — `bash` syntax is the
+    /// most portable starting point and the user can `--shell` to
+    /// override.
+    pub fn detect() -> Self {
+        std::env::var("SHELL")
+            .ok()
+            .and_then(|s| {
+                if s.ends_with("/zsh") || s == "zsh" {
+                    Some(Shell::Zsh)
+                } else if s.ends_with("/bash") || s == "bash" {
+                    Some(Shell::Bash)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(Shell::Bash)
+    }
+
+    /// Parse a CLI `--shell` value. Returns `None` for unknown
+    /// shells; the CLI layer surfaces a clear error.
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "bash" => Some(Shell::Bash),
+            "zsh" => Some(Shell::Zsh),
+            _ => None,
+        }
+    }
+
+    /// Path to the rc file we write to for this shell, relative to
+    /// `$HOME`. Used by [`install_alias`] to compute the absolute
+    /// path. We pick the most universally-sourced file: `.bashrc`
+    /// on bash, `.zshrc` on zsh. Users with non-standard setups can
+    /// run `git-show-alias` and paste manually.
+    pub fn rc_relative_path(self) -> &'static str {
+        match self {
+            Shell::Bash => ".bashrc",
+            Shell::Zsh => ".zshrc",
+        }
+    }
+
+    /// The alias line for this shell. Both bash and zsh accept the
+    /// same `alias` syntax; we pin them per-shell anyway because
+    /// future shells (fish, nu) will need different forms and
+    /// keeping the dispatch on a single match is the cleanest
+    /// extension point.
+    pub fn alias_line(self) -> &'static str {
+        match self {
+            Shell::Bash | Shell::Zsh => "alias git='dodot refresh --quiet && command git'",
+        }
+    }
+}
+
+/// The full guarded block that `install_alias` writes (or that
+/// `show_alias` prints for copy-paste). Mirrors the pre-commit
+/// hook's `managed_block` shape.
+pub fn managed_block(shell: Shell) -> String {
+    format!(
+        "{guard_start}\n\
+         # Wraps `git` to run `dodot refresh` first, so `git status` and\n\
+         # `git diff` show deployed-side template edits between commits.\n\
+         # Only affects interactive shells. Remove this block to opt out.\n\
+         {alias}\n\
+         {guard_end}\n",
+        guard_start = ALIAS_GUARD_START,
+        guard_end = ALIAS_GUARD_END,
+        alias = shell.alias_line(),
+    )
+}
+
+// ── show ────────────────────────────────────────────────────────
+
+/// Result of `dodot git-show-alias` — the alias body the user can
+/// paste, plus the rc file we'd write it to (so the rendered output
+/// can show "add this to ~/.zshrc").
+#[derive(Debug, Clone, Serialize)]
+pub struct ShowAliasResult {
+    pub shell: Shell,
+    pub alias_block: String,
+    /// `alias_block` split by line, so the template can iterate
+    /// directly without calling `.split` (which minijinja doesn't
+    /// expose). Same trick `git-filters` uses for the same reason.
+    pub alias_block_lines: Vec<String>,
+    pub rc_path_display: String,
+    /// True iff the rc file currently contains our managed block.
+    /// Drives the rendered output: "you've already installed this"
+    /// vs "add this to your rc file".
+    pub already_installed: bool,
+}
+
+pub fn show_alias(ctx: &ExecutionContext, shell: Shell) -> Result<ShowAliasResult> {
+    let rc_path = ctx.paths.home_dir().join(shell.rc_relative_path());
+    let already_installed = if ctx.fs.exists(&rc_path) {
+        ctx.fs
+            .read_to_string(&rc_path)
+            .map(|s| s.contains(ALIAS_GUARD_START))
+            .unwrap_or(false)
+    } else {
+        false
+    };
+    let alias_block = managed_block(shell);
+    let alias_block_lines: Vec<String> = alias_block
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+    Ok(ShowAliasResult {
+        shell,
+        alias_block,
+        alias_block_lines,
+        rc_path_display: render_home_relative(&rc_path, ctx.paths.home_dir()),
+        already_installed,
+    })
+}
+
+// ── install ─────────────────────────────────────────────────────
+
+/// Outcome of `dodot git-install-alias`. Mirrors `InstallHookOutcome`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallAliasOutcome {
+    /// rc file did not exist; we created it with our block.
+    Created,
+    /// rc file existed; we appended our block to it. Existing
+    /// content preserved.
+    Appended,
+    /// rc file already contains the current managed block — no
+    /// change.
+    AlreadyInstalled,
+    /// rc file had an older managed block; we replaced it in place.
+    /// Existing non-managed content preserved.
+    Updated,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallAliasResult {
+    pub shell: Shell,
+    pub outcome: InstallAliasOutcome,
+    pub rc_path: String,
+    pub rc_path_display: String,
+    /// The shell sourcing command the user needs to pick up the
+    /// alias *now* (without restarting the shell). Surfaced so the
+    /// rendered message can suggest e.g. `source ~/.zshrc`.
+    pub source_command: String,
+}
+
+pub fn install_alias(ctx: &ExecutionContext, shell: Shell) -> Result<InstallAliasResult> {
+    let rc_path = ctx.paths.home_dir().join(shell.rc_relative_path());
+    let block = managed_block(shell);
+
+    let outcome = if ctx.fs.exists(&rc_path) {
+        let existing = ctx.fs.read_to_string(&rc_path)?;
+        if let Some((start_byte, end_byte)) = find_managed_block(&existing) {
+            let current_block = &existing[start_byte..end_byte];
+            if current_block == block {
+                InstallAliasOutcome::AlreadyInstalled
+            } else {
+                let mut new_content = String::with_capacity(existing.len() + block.len());
+                new_content.push_str(&existing[..start_byte]);
+                new_content.push_str(&block);
+                new_content.push_str(&existing[end_byte..]);
+                ctx.fs.write_file(&rc_path, new_content.as_bytes())?;
+                InstallAliasOutcome::Updated
+            }
+        } else {
+            // Append, preserving existing rc content. Add a leading
+            // blank line so the block is visually separate from
+            // whatever the user has above.
+            let mut new_content = existing.clone();
+            if !new_content.ends_with('\n') {
+                new_content.push('\n');
+            }
+            if !new_content.ends_with("\n\n") {
+                new_content.push('\n');
+            }
+            new_content.push_str(&block);
+            ctx.fs.write_file(&rc_path, new_content.as_bytes())?;
+            InstallAliasOutcome::Appended
+        }
+    } else {
+        // Create the rc file with just our block. Most users will
+        // already have one; this branch covers the rare empty-home
+        // setup or a truly fresh shell install.
+        ctx.fs.write_file(&rc_path, block.as_bytes())?;
+        InstallAliasOutcome::Created
+    };
+
+    Ok(InstallAliasResult {
+        shell,
+        outcome,
+        rc_path: rc_path.display().to_string(),
+        rc_path_display: render_home_relative(&rc_path, ctx.paths.home_dir()),
+        source_command: format!(
+            "source {}",
+            render_home_relative(&rc_path, ctx.paths.home_dir())
+        ),
+    })
+}
+
+// ── helpers ─────────────────────────────────────────────────────
+
+fn render_home_relative(p: &std::path::Path, home: &std::path::Path) -> String {
+    if let Ok(rel) = p.strip_prefix(home) {
+        format!("~/{}", rel.display())
+    } else {
+        p.display().to_string()
+    }
+}
+
+/// Locate the byte range of our managed block inside `text`. Same
+/// shape as the pre-commit hook's `find_managed_block` — find the
+/// first guard-start, then the first guard-end after it, return the
+/// inclusive byte range (with the trailing newline if any). Returns
+/// `None` if either guard is missing.
+fn find_managed_block(text: &str) -> Option<(usize, usize)> {
+    let start = text.find(ALIAS_GUARD_START)?;
+    let after_start = start + ALIAS_GUARD_START.len();
+    let end_rel = text[after_start..].find(ALIAS_GUARD_END)?;
+    let end_guard_start = after_start + end_rel;
+    let end_byte = end_guard_start + ALIAS_GUARD_END.len();
+    let end_byte = if text.as_bytes().get(end_byte) == Some(&b'\n') {
+        end_byte + 1
+    } else {
+        end_byte
+    };
+    Some((start, end_byte))
+}
+
+/// Diagnostic helper for the CLI: detect or validate a shell from
+/// the `--shell` CLI value, surfacing a clear error for unknown
+/// shells. Returns the resolved [`Shell`] or a `DodotError::Other`.
+pub fn resolve_shell(explicit: Option<&str>) -> Result<Shell> {
+    if let Some(name) = explicit {
+        return Shell::from_str_opt(name).ok_or_else(|| {
+            DodotError::Other(format!(
+                "unsupported shell {name:?}: dodot can install the git alias for `bash` or `zsh`. \
+                 For other shells, run `dodot git-show-alias --shell bash` and adapt the snippet."
+            ))
+        });
+    }
+    Ok(Shell::detect())
+}
+
+/// Cheap "is this rc file already wrapping git via our alias?"
+/// check, used by the future post-`up` prompt. Reads the rc file
+/// and looks for the guard. Doesn't error out if the file is
+/// missing — that's a normal "not installed" state.
+pub fn is_installed(ctx: &ExecutionContext, shell: Shell) -> bool {
+    let rc_path = ctx.paths.home_dir().join(shell.rc_relative_path());
+    if !ctx.fs.exists(&rc_path) {
+        return false;
+    }
+    ctx.fs
+        .read_to_string(&rc_path)
+        .map(|s| s.contains(ALIAS_GUARD_START))
+        .unwrap_or(false)
+}
+
+// Mirror of crate's PathBuf re-export; localised to keep the
+// `use` block at the top of the file readable.
+#[allow(dead_code)]
+fn _path_buf_anchor(_: PathBuf) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::Fs;
+    use crate::paths::Pather;
+    use crate::testing::TempEnvironment;
+
+    fn make_ctx(env: &TempEnvironment) -> ExecutionContext {
+        use crate::config::ConfigManager;
+        use crate::datastore::{CommandOutput, CommandRunner, FilesystemDataStore};
+        use crate::fs::Fs;
+        use crate::paths::Pather;
+        use std::sync::Arc;
+
+        struct NoopRunner;
+        impl CommandRunner for NoopRunner {
+            fn run(&self, _e: &str, _a: &[String]) -> Result<CommandOutput> {
+                Ok(CommandOutput {
+                    exit_code: 0,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            }
+        }
+        let runner: Arc<dyn CommandRunner> = Arc::new(NoopRunner);
+        let datastore = Arc::new(FilesystemDataStore::new(
+            env.fs.clone(),
+            env.paths.clone(),
+            runner.clone(),
+        ));
+        let config_manager = Arc::new(ConfigManager::new(&env.dotfiles_root).unwrap());
+        ExecutionContext {
+            fs: env.fs.clone() as Arc<dyn Fs>,
+            datastore,
+            paths: env.paths.clone() as Arc<dyn Pather>,
+            config_manager,
+            syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
+            command_runner: runner,
+            dry_run: false,
+            no_provision: true,
+            provision_rerun: false,
+            force: false,
+            view_mode: crate::commands::ViewMode::Full,
+            group_mode: crate::commands::GroupMode::Name,
+            verbose: false,
+        }
+    }
+
+    // ── Shell detection / parsing ───────────────────────────────
+
+    #[test]
+    fn from_str_opt_recognises_known_shells() {
+        assert_eq!(Shell::from_str_opt("bash"), Some(Shell::Bash));
+        assert_eq!(Shell::from_str_opt("BASH"), Some(Shell::Bash));
+        assert_eq!(Shell::from_str_opt("zsh"), Some(Shell::Zsh));
+        assert_eq!(Shell::from_str_opt("fish"), None);
+        assert_eq!(Shell::from_str_opt("Powershell"), None);
+    }
+
+    #[test]
+    fn rc_paths_match_shell_conventions() {
+        assert_eq!(Shell::Bash.rc_relative_path(), ".bashrc");
+        assert_eq!(Shell::Zsh.rc_relative_path(), ".zshrc");
+    }
+
+    #[test]
+    fn alias_line_runs_refresh_then_command_git() {
+        // Both shells use the same alias body for now; pin the
+        // exact form so a stray edit doesn't break the wrap.
+        for sh in [Shell::Bash, Shell::Zsh] {
+            assert_eq!(
+                sh.alias_line(),
+                "alias git='dodot refresh --quiet && command git'"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_shell_explicit_unknown_returns_error() {
+        let err = resolve_shell(Some("fish")).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("fish"), "msg: {msg}");
+        assert!(
+            msg.contains("bash"),
+            "msg should suggest supported shells: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_shell_explicit_known_returns_match() {
+        assert_eq!(resolve_shell(Some("bash")).unwrap(), Shell::Bash);
+        assert_eq!(resolve_shell(Some("Zsh")).unwrap(), Shell::Zsh);
+    }
+
+    // ── managed_block + find_managed_block ──────────────────────
+
+    #[test]
+    fn managed_block_is_self_contained_and_grep_detectable() {
+        let block = managed_block(Shell::Bash);
+        assert!(block.starts_with(ALIAS_GUARD_START));
+        assert!(block.trim_end().ends_with(ALIAS_GUARD_END));
+        assert!(block.contains(Shell::Bash.alias_line()));
+    }
+
+    #[test]
+    fn find_managed_block_locates_byte_range() {
+        let block = managed_block(Shell::Bash);
+        let text = format!("# rc preamble\n{block}# rc postamble\n");
+        let (start, end) = find_managed_block(&text).expect("must find block");
+        assert_eq!(&text[start..end], block);
+    }
+
+    #[test]
+    fn find_managed_block_returns_none_when_absent() {
+        assert!(find_managed_block("nothing here").is_none());
+        let only_start = format!("{ALIAS_GUARD_START}\nstuff\n");
+        assert!(find_managed_block(&only_start).is_none());
+    }
+
+    // ── install_alias ───────────────────────────────────────────
+
+    #[test]
+    fn install_alias_creates_rc_file_when_absent() {
+        // Fresh home, no rc file. install_alias must create it
+        // with just our block (rare but possible — empty-home or
+        // truly fresh shell setup).
+        let env = TempEnvironment::builder().build();
+        let ctx = make_ctx(&env);
+        let rc_path = env.paths.home_dir().join(".zshrc");
+        assert!(!env.fs.exists(&rc_path));
+
+        let r = install_alias(&ctx, Shell::Zsh).unwrap();
+        assert!(matches!(r.outcome, InstallAliasOutcome::Created));
+        assert!(env.fs.exists(&rc_path));
+        let body = env.fs.read_to_string(&rc_path).unwrap();
+        assert!(body.contains(ALIAS_GUARD_START));
+        assert!(body.contains(Shell::Zsh.alias_line()));
+    }
+
+    #[test]
+    fn install_alias_appends_to_existing_rc() {
+        let env = TempEnvironment::builder().build();
+        let rc_path = env.paths.home_dir().join(".bashrc");
+        let existing = "export PATH=\"/usr/local/bin:$PATH\"\nalias ll='ls -l'\n";
+        env.fs.mkdir_all(rc_path.parent().unwrap()).unwrap();
+        env.fs.write_file(&rc_path, existing.as_bytes()).unwrap();
+
+        let ctx = make_ctx(&env);
+        let r = install_alias(&ctx, Shell::Bash).unwrap();
+        assert!(matches!(r.outcome, InstallAliasOutcome::Appended));
+
+        let body = env.fs.read_to_string(&rc_path).unwrap();
+        assert!(body.starts_with(existing), "user content lost: {body:?}");
+        assert!(body.contains(Shell::Bash.alias_line()));
+    }
+
+    #[test]
+    fn install_alias_is_idempotent_on_current_block() {
+        let env = TempEnvironment::builder().build();
+        let ctx = make_ctx(&env);
+
+        let r1 = install_alias(&ctx, Shell::Zsh).unwrap();
+        assert!(matches!(r1.outcome, InstallAliasOutcome::Created));
+
+        let body_after_first = env
+            .fs
+            .read_to_string(&env.paths.home_dir().join(".zshrc"))
+            .unwrap();
+
+        let r2 = install_alias(&ctx, Shell::Zsh).unwrap();
+        assert!(matches!(r2.outcome, InstallAliasOutcome::AlreadyInstalled));
+
+        let body_after_second = env
+            .fs
+            .read_to_string(&env.paths.home_dir().join(".zshrc"))
+            .unwrap();
+        assert_eq!(body_after_first, body_after_second);
+    }
+
+    #[test]
+    fn install_alias_updates_a_stale_block() {
+        // If the block exists but doesn't match `managed_block(...)`
+        // (e.g. an older form before we added a comment line, or
+        // shell-specific changes), install_alias rewrites it in
+        // place. Same upgrade path the hook installer uses.
+        let env = TempEnvironment::builder().build();
+        let rc_path = env.paths.home_dir().join(".zshrc");
+        let stale = format!(
+            "export PATH=\"/usr/local/bin:$PATH\"\n\
+             \n\
+             {start}\n\
+             # An old, simpler form of the alias block.\n\
+             alias git='dodot refresh && git'\n\
+             {end}\n\
+             alias ll='ls -l'\n",
+            start = ALIAS_GUARD_START,
+            end = ALIAS_GUARD_END,
+        );
+        env.fs.mkdir_all(rc_path.parent().unwrap()).unwrap();
+        env.fs.write_file(&rc_path, stale.as_bytes()).unwrap();
+
+        let ctx = make_ctx(&env);
+        let r = install_alias(&ctx, Shell::Zsh).unwrap();
+        assert!(matches!(r.outcome, InstallAliasOutcome::Updated));
+
+        let body = env.fs.read_to_string(&rc_path).unwrap();
+        // New shape:
+        assert!(body.contains(Shell::Zsh.alias_line()));
+        // User content (before AND after the block) survived:
+        assert!(body.contains("export PATH"));
+        assert!(body.contains("alias ll='ls -l'"));
+        // Exactly one managed block.
+        assert_eq!(body.matches(ALIAS_GUARD_START).count(), 1);
+    }
+
+    #[test]
+    fn is_installed_reflects_state() {
+        let env = TempEnvironment::builder().build();
+        let ctx = make_ctx(&env);
+        assert!(!is_installed(&ctx, Shell::Bash));
+        install_alias(&ctx, Shell::Bash).unwrap();
+        assert!(is_installed(&ctx, Shell::Bash));
+        // The other shell's state is independent.
+        assert!(!is_installed(&ctx, Shell::Zsh));
+    }
+
+    // ── show_alias ──────────────────────────────────────────────
+
+    #[test]
+    fn show_alias_renders_block_without_writing() {
+        let env = TempEnvironment::builder().build();
+        let ctx = make_ctx(&env);
+        let rc_path = env.paths.home_dir().join(".zshrc");
+        assert!(!env.fs.exists(&rc_path));
+
+        let r = show_alias(&ctx, Shell::Zsh).unwrap();
+        assert!(r.alias_block.contains(Shell::Zsh.alias_line()));
+        assert_eq!(r.rc_path_display, "~/.zshrc");
+        assert!(!r.already_installed);
+        // Critically: file must NOT have been created.
+        assert!(!env.fs.exists(&rc_path));
+    }
+
+    #[test]
+    fn show_alias_reports_already_installed_when_block_present() {
+        let env = TempEnvironment::builder().build();
+        let ctx = make_ctx(&env);
+        install_alias(&ctx, Shell::Bash).unwrap();
+        let r = show_alias(&ctx, Shell::Bash).unwrap();
+        assert!(r.already_installed);
+    }
+}

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod addignore;
 pub mod adopt;
 pub mod down;
 pub mod fill;
+pub mod git_alias;
 pub mod git_filters;
 pub mod init;
 pub mod list;

--- a/crates/dodot-lib/src/commands/transform.rs
+++ b/crates/dodot-lib/src/commands/transform.rs
@@ -116,6 +116,95 @@ impl TransformCheckResult {
     }
 }
 
+/// One row in `dodot transform status`'s passive report.
+///
+/// Mirrors `TransformCheckEntry` but without any of the action /
+/// conflict-block fields — `status` is a read-only inspection;
+/// `check` is the action layer.
+#[derive(Debug, Clone, Serialize)]
+pub struct TransformStatusEntry {
+    pub pack: String,
+    pub handler: String,
+    pub filename: String,
+    pub source_path: String,
+    pub deployed_path: String,
+    /// Mirror of `DivergenceState`, serialised as snake_case so the
+    /// template branches and JSON consumers see the same shape they
+    /// see in `transform check`.
+    #[serde(rename = "state")]
+    pub state: String,
+}
+
+/// Aggregate result of `dodot transform status` — one row per
+/// cached baseline, plus a few rollup counters for the renderer.
+#[derive(Debug, Clone, Serialize)]
+pub struct TransformStatusResult {
+    pub entries: Vec<TransformStatusEntry>,
+    pub synced_count: usize,
+    pub diverged_count: usize,
+    pub missing_count: usize,
+}
+
+/// Run `dodot transform status` — read-only view of the baseline
+/// cache. Walks every cached entry and reports its state without
+/// running the reverse-merge engine, writing source files, or doing
+/// anything else that mutates state. Useful as a "what's currently
+/// out of sync?" check before deciding whether to run `dodot transform
+/// check`. Always exits 0 — even a fully-diverged repo isn't a
+/// failure here, just information.
+pub fn status(ctx: &ExecutionContext) -> Result<TransformStatusResult> {
+    use crate::preprocessing::divergence::{collect_divergences, DivergenceState};
+    let reports = collect_divergences(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+    let mut synced_count = 0usize;
+    let mut diverged_count = 0usize;
+    let mut missing_count = 0usize;
+    let entries: Vec<TransformStatusEntry> = reports
+        .into_iter()
+        .map(|r| {
+            let state_str = match r.state {
+                DivergenceState::Synced => {
+                    synced_count += 1;
+                    "synced"
+                }
+                DivergenceState::InputChanged => {
+                    diverged_count += 1;
+                    "input_changed"
+                }
+                DivergenceState::OutputChanged => {
+                    diverged_count += 1;
+                    "output_changed"
+                }
+                DivergenceState::BothChanged => {
+                    diverged_count += 1;
+                    "both_changed"
+                }
+                DivergenceState::MissingSource => {
+                    missing_count += 1;
+                    "missing_source"
+                }
+                DivergenceState::MissingDeployed => {
+                    missing_count += 1;
+                    "missing_deployed"
+                }
+            };
+            TransformStatusEntry {
+                pack: r.pack,
+                handler: r.handler,
+                filename: r.filename,
+                source_path: render_path(&r.source_path, ctx.paths.home_dir()),
+                deployed_path: render_path(&r.deployed_path, ctx.paths.home_dir()),
+                state: state_str.to_string(),
+            }
+        })
+        .collect();
+    Ok(TransformStatusResult {
+        entries,
+        synced_count,
+        diverged_count,
+        missing_count,
+    })
+}
+
 /// Run `dodot transform check`. See module docs for the matrix.
 pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResult> {
     let baselines = collect_baselines(ctx.fs.as_ref(), ctx.paths.as_ref())?;
@@ -871,6 +960,84 @@ mod tests {
             entry.source_path,
             entry.deployed_path
         );
+    }
+
+    // ── status ──────────────────────────────────────────────────
+
+    #[test]
+    fn status_on_clean_repo_reports_one_synced_row() {
+        let env = TempEnvironment::builder().build();
+        deploy_template(
+            &env,
+            "app",
+            "config.toml.tmpl",
+            "name = {{ name }}\n",
+            "[preprocessor.template.vars]\nname = \"Alice\"\n",
+        );
+        let ctx = make_ctx(&env);
+        let result = status(&ctx).unwrap();
+        assert_eq!(result.entries.len(), 1);
+        assert_eq!(result.entries[0].state, "synced");
+        assert_eq!(result.synced_count, 1);
+        assert_eq!(result.diverged_count, 0);
+        assert_eq!(result.missing_count, 0);
+    }
+
+    #[test]
+    fn status_classifies_output_change() {
+        let env = TempEnvironment::builder().build();
+        deploy_template(
+            &env,
+            "app",
+            "config.toml.tmpl",
+            "name = {{ name }}\nport = 5432\n",
+            "[preprocessor.template.vars]\nname = \"Alice\"\n",
+        );
+        let deployed = deployed_path(&env, "app", "config.toml");
+        env.fs
+            .write_file(&deployed, b"name = Alice\nport = 9999\n")
+            .unwrap();
+
+        let ctx = make_ctx(&env);
+        let result = status(&ctx).unwrap();
+        assert_eq!(result.entries[0].state, "output_changed");
+        assert_eq!(result.diverged_count, 1);
+        assert_eq!(result.synced_count, 0);
+    }
+
+    #[test]
+    fn status_does_not_mutate_anything() {
+        // The entire point of `status` (vs `check`) is that it's
+        // read-only. Run it on a divergent repo and confirm the
+        // source file is byte-identical afterwards.
+        let env = TempEnvironment::builder().build();
+        let src = deploy_template(
+            &env,
+            "app",
+            "config.toml.tmpl",
+            "name = {{ name }}\nport = 5432\n",
+            "[preprocessor.template.vars]\nname = \"Alice\"\n",
+        );
+        let original_src = env.fs.read_to_string(&src).unwrap();
+        let deployed = deployed_path(&env, "app", "config.toml");
+        env.fs
+            .write_file(&deployed, b"name = Alice\nport = 9999\n")
+            .unwrap();
+
+        let ctx = make_ctx(&env);
+        let _ = status(&ctx).unwrap();
+        assert_eq!(env.fs.read_to_string(&src).unwrap(), original_src);
+    }
+
+    #[test]
+    fn status_empty_cache_yields_zero_counts() {
+        let env = TempEnvironment::builder().build();
+        let ctx = make_ctx(&env);
+        let result = status(&ctx).unwrap();
+        assert!(result.entries.is_empty());
+        assert_eq!(result.synced_count, 0);
+        assert_eq!(result.diverged_count, 0);
+        assert_eq!(result.missing_count, 0);
     }
 
     // ── install_hook ────────────────────────────────────────────

--- a/crates/dodot-lib/src/render/mod.rs
+++ b/crates/dodot-lib/src/render/mod.rs
@@ -165,6 +165,15 @@ pub const TEMPLATE_REFRESH: &str = include_str!("../templates/refresh.jinja");
 pub const TEMPLATE_TEMPLATE_INSTALL_FILTER: &str =
     include_str!("../templates/template-install-filter.jinja");
 
+/// `dodot transform status` per-file state list.
+pub const TEMPLATE_TRANSFORM_STATUS: &str = include_str!("../templates/transform-status.jinja");
+
+/// `dodot git-show-alias` print-for-paste output.
+pub const TEMPLATE_GIT_SHOW_ALIAS: &str = include_str!("../templates/git-show-alias.jinja");
+
+/// `dodot git-install-alias` outcome message.
+pub const TEMPLATE_GIT_INSTALL_ALIAS: &str = include_str!("../templates/git-install-alias.jinja");
+
 // ── Tutorial step templates ─────────────────────────────────────
 //
 // One per step of the interactive tutorial. The CLI driver renders

--- a/crates/dodot-lib/src/templates/git-install-alias.jinja
+++ b/crates/dodot-lib/src/templates/git-install-alias.jinja
@@ -1,0 +1,14 @@
+{%- if outcome == "created" -%}
+[message]Created {{ rc_path_display }} with the dodot git alias.[/message]
+{%- elif outcome == "appended" -%}
+[message]Appended dodot git alias to {{ rc_path_display }}[/message]
+  [muted]Existing rc content was preserved.[/muted]
+{%- elif outcome == "updated" -%}
+[message]Updated dodot git alias block in {{ rc_path_display }}[/message]
+  [muted]Existing rc content was preserved; only the managed block was rewritten.[/muted]
+{%- elif outcome == "already_installed" -%}
+[message]Dodot git alias already present in {{ rc_path_display }}[/message]
+  [muted]No change. Re-running this command is safe.[/muted]
+{%- endif %}
+  [muted]To pick it up now, run:[/muted]
+    [usage]{{ source_command }}[/usage]

--- a/crates/dodot-lib/src/templates/git-show-alias.jinja
+++ b/crates/dodot-lib/src/templates/git-show-alias.jinja
@@ -1,0 +1,15 @@
+{%- if already_installed -%}
+[message]The dodot git alias is already installed in {{ rc_path_display }}.[/message]
+  [muted]Block:[/muted]
+{% for line in alias_block_lines -%}
+    {{ line }}
+{% endfor -%}
+  [muted]To uninstall, remove the block manually.[/muted]
+{%- else -%}
+[message]Add this block to {{ rc_path_display }} (or run [usage]dodot git-install-alias[/usage]):[/message]
+
+{% for line in alias_block_lines -%}
+    {{ line }}
+{% endfor %}
+  [muted]Then run [usage]source {{ rc_path_display }}[/usage] (or open a new shell).[/muted]
+{%- endif -%}

--- a/crates/dodot-lib/src/templates/transform-status.jinja
+++ b/crates/dodot-lib/src/templates/transform-status.jinja
@@ -1,0 +1,21 @@
+{%- if entries|length == 0 -%}
+[muted]No template baselines. Run [usage]dodot up[/usage] to deploy templates first.[/muted]
+{%- else -%}
+[message]{{ synced_count }} synced, {{ diverged_count }} diverged, {{ missing_count }} missing[/message]
+
+{% for e in entries -%}
+{%- if e.state == "synced" -%}
+  [muted]·[/muted] [success]{{ e.state }}[/success] [muted]{{ e.pack }}/{{ e.filename }}[/muted] {{ e.source_path }}
+{% elif e.state == "input_changed" -%}
+  [muted]·[/muted] [warn]{{ e.state }}[/warn] [muted]{{ e.pack }}/{{ e.filename }}[/muted] {{ e.source_path }} [muted](source edited; next [usage]dodot up[/usage] re-renders)[/muted]
+{% elif e.state == "output_changed" -%}
+  [warn]·[/warn] [warn]{{ e.state }}[/warn] [muted]{{ e.pack }}/{{ e.filename }}[/muted] {{ e.source_path }} [muted](deployed edited; run [usage]dodot transform check[/usage])[/muted]
+{% elif e.state == "both_changed" -%}
+  [error]·[/error] [error]{{ e.state }}[/error] [muted]{{ e.pack }}/{{ e.filename }}[/muted] {{ e.source_path }} [muted](source AND deployed edited; conflict likely)[/muted]
+{% elif e.state == "missing_source" -%}
+  [warn]?[/warn] [warn]{{ e.state }}[/warn] [muted]{{ e.pack }}/{{ e.filename }}[/muted] {{ e.source_path }} [muted](baseline stale)[/muted]
+{% elif e.state == "missing_deployed" -%}
+  [warn]?[/warn] [warn]{{ e.state }}[/warn] [muted]{{ e.pack }}/{{ e.filename }}[/muted] {{ e.deployed_path }} [muted](rendered file gone)[/muted]
+{% endif -%}
+{%- endfor -%}
+{%- endif -%}

--- a/tests/e2e/bats/test_transform_status_and_alias.bats
+++ b/tests/e2e/bats/test_transform_status_and_alias.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+# E2E tests for R7: `dodot transform status`, `dodot git-show-alias`,
+# `dodot git-install-alias`. The first is a passive view of the
+# divergence cache; the latter two are the Tier 2 shell-side glue
+# that wraps `git` in `dodot refresh --quiet`.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+# ── transform status ────────────────────────────────────────────
+
+@test "transform status on empty cache reports nothing-to-do" {
+    run dodot transform status
+    [ "$status" -eq 0 ]
+    assert_output_contains "No template baselines"
+}
+
+@test "transform status reports synced after up" {
+    create_pack "app"
+    create_pack_file "app" "config.toml.tmpl" 'name = {{ name }}'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    run dodot transform status
+    [ "$status" -eq 0 ]
+    assert_output_contains "1 synced"
+    assert_output_contains "synced"
+}
+
+@test "transform status reports output_changed when deployed file diverges" {
+    # Edit the rendered file post-up; status surfaces output_changed
+    # without running the reverse-merge engine (purely informational).
+    create_pack "app"
+    create_pack_file "app" "config.toml.tmpl" 'name = {{ name }}
+port = 5432'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    rendered="$XDG_DATA_HOME/dodot/packs/app/preprocessed/config.toml"
+    cat > "$rendered" <<'EOF'
+name = Alice
+port = 9999
+EOF
+
+    run dodot transform status
+    [ "$status" -eq 0 ]
+    assert_output_contains "output_changed"
+    assert_output_contains "diverged"
+}
+
+@test "transform status does not mutate sources" {
+    # status is read-only; pin that with an explicit sha check
+    # before/after.
+    create_pack "app"
+    create_pack_file "app" "config.toml.tmpl" 'name = {{ name }}
+port = 5432'
+    create_pack_config "app" '[preprocessor.template.vars]
+name = "Alice"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    src="$DOTFILES_ROOT/app/config.toml.tmpl"
+    before=$(shasum -a 256 "$src" | awk '{print $1}')
+
+    rendered="$XDG_DATA_HOME/dodot/packs/app/preprocessed/config.toml"
+    echo "name = Alice
+port = 9999" > "$rendered"
+
+    run dodot transform status
+    [ "$status" -eq 0 ]
+
+    after=$(shasum -a 256 "$src" | awk '{print $1}')
+    [ "$before" = "$after" ]
+}
+
+# ── git-show-alias ──────────────────────────────────────────────
+
+@test "git-show-alias prints the alias block for the requested shell" {
+    run dodot git-show-alias --shell zsh
+    [ "$status" -eq 0 ]
+    assert_output_contains "alias git='dodot refresh --quiet && command git'"
+    assert_output_contains "~/.zshrc"
+}
+
+@test "git-show-alias rejects unknown shells with a clear error" {
+    run dodot git-show-alias --shell fish
+    [ "$status" -ne 0 ]
+    assert_output_contains "fish"
+    assert_output_contains "bash"
+}
+
+@test "git-show-alias does not modify the rc file" {
+    rc="$HOME/.zshrc"
+    [ ! -f "$rc" ]
+    run dodot git-show-alias --shell zsh
+    [ "$status" -eq 0 ]
+    [ ! -f "$rc" ]
+}
+
+# ── git-install-alias ───────────────────────────────────────────
+
+@test "git-install-alias creates rc file when absent" {
+    rc="$HOME/.zshrc"
+    [ ! -f "$rc" ]
+
+    run dodot git-install-alias --shell zsh
+    [ "$status" -eq 0 ]
+    assert_output_contains "Created"
+
+    [ -f "$rc" ]
+    assert_file_contains "$rc" "alias git='dodot refresh --quiet && command git'"
+}
+
+@test "git-install-alias appends to an existing rc file" {
+    rc="$HOME/.bashrc"
+    cat > "$rc" <<'EOF'
+export PATH="/usr/local/bin:$PATH"
+alias ll='ls -l'
+EOF
+
+    run dodot git-install-alias --shell bash
+    [ "$status" -eq 0 ]
+    assert_output_contains "Appended"
+
+    # Existing content survived.
+    assert_file_contains "$rc" "alias ll='ls -l'"
+    assert_file_contains "$rc" "/usr/local/bin"
+    # Our block landed.
+    assert_file_contains "$rc" "alias git='dodot refresh --quiet && command git'"
+}
+
+@test "git-install-alias is idempotent" {
+    run dodot git-install-alias --shell zsh
+    [ "$status" -eq 0 ]
+    run dodot git-install-alias --shell zsh
+    [ "$status" -eq 0 ]
+    assert_output_contains "already present"
+}
+
+@test "git-install-alias suggests source command for the right shell" {
+    run dodot git-install-alias --shell zsh
+    [ "$status" -eq 0 ]
+    assert_output_contains "source ~/.zshrc"
+}


### PR DESCRIPTION
## Summary

R7 of the template-magic track. Three small commands round out the user-facing surface:

- **\`dodot transform status\`** — read-only view of the baseline cache. Mirrors \`transform check\` minus the action layer: useful as a \"what's out of sync?\" probe before deciding whether to run check. Always exits 0.
- **\`dodot git-show-alias [--shell bash|zsh]\`** — prints the Tier 2 shell alias \`alias git='dodot refresh --quiet && command git'\` for copy-paste. No filesystem mutation. Detects existing managed block and reports \"already installed\".
- **\`dodot git-install-alias [--shell bash|zsh]\`** — writes the alias to \`~/.bashrc\` or \`~/.zshrc\` with an idempotent guard block. Same Created / Appended / AlreadyInstalled / Updated outcome shape as the pre-commit hook installer. Surfaces the \`source <rc>\` command for immediate activation.

Together with R5 (refresh) + R6 (clean filter), the alias activates Tier 2 from magic.lex §\"Update Trigger Bit\": interactive \`git status\` and \`git diff\` see deployed-side template edits between commits.

## Worth flagging

- **Bash / zsh only.** Both use the same \`alias\` syntax; we pin them per-shell anyway because future shells (fish, nu) will need different forms and keeping the dispatch on a single match is the cleanest extension point. Unknown \`--shell\` values return a clear error suggesting \`bash\` or \`zsh\`.
- **Same upgrade pattern as the hook**: a stale managed block is detected via the guard lines and rewritten in place, preserving non-managed content before AND after.
- **Why \`is_installed\` reads the rc file rather than checking \`alias git\`**: the user's running shell may have other \`alias git=...\` definitions (e.g. from oh-my-zsh plugins). Detection-by-guard means we know it's *our* block, not just *some* alias.

## Test plan

- [x] \`cargo test -p dodot-lib --lib\` — **817 tests pass** (+19 from R6's 798).
- [x] **4 new \`commands::transform\` tests** for \`status\` (each state branch, read-only, empty cache).
- [x] **15 new \`commands::git_alias\` tests** covering shell parsing, rc-path conventions, alias-line stability, error UX for unknown shells, managed block helpers, install Created/Appended/Updated/AlreadyInstalled, is_installed reflects state, show_alias renders without writing.
- [x] **11 new e2e bats tests** in \`test_transform_status_and_alias.bats\`.
- [x] All 28 prior e2e tests still pass.
- [x] CLI smoke confirms each mode behaves as documented.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.

## Follow-ups

R9 (docs sync + \`no_reverse\` per-file opt-out) is the last phase. After R9 the template-magic track flips from \"NOT yet shipped\" to fully described in \`docs/reference/pre-processors.lex\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)