### PR TITLE
fix(transform): exit 0 on Patched; feat(symlink): plist_extensions config (#113, #114)

### DIFF
--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -662,7 +662,10 @@ fn try_prompt_install_filters() -> Result<(), anyhow::Error> {
             }
             eprintln!();
             eprintln!("Add to .gitattributes (committed in the repo):");
-            eprintln!("    {}", commands::git_filters::gitattributes_line());
+            let extensions = ctx.config_manager.root_config()?.symlink.plist_extensions;
+            for line in commands::git_filters::gitattributes_lines(&extensions) {
+                eprintln!("    {line}");
+            }
             eprintln!();
             eprintln!(
                 "Run `dodot git-install-filters` to install, or `dodot prompts reset {prompt_key}` to skip and ask later."

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -662,7 +662,8 @@ fn try_prompt_install_filters() -> Result<(), anyhow::Error> {
             }
             eprintln!();
             eprintln!("Add to .gitattributes (committed in the repo):");
-            let extensions = ctx.config_manager.root_config()?.symlink.plist_extensions;
+            let raw = ctx.config_manager.root_config()?.symlink.plist_extensions;
+            let extensions = commands::git_filters::normalize_plist_extensions(&raw);
             for line in commands::git_filters::gitattributes_lines(&extensions) {
                 eprintln!("    {line}");
             }

--- a/crates/dodot-lib/src/commands/git_filters.rs
+++ b/crates/dodot-lib/src/commands/git_filters.rs
@@ -34,9 +34,24 @@ pub fn config_block_text() -> String {
     .join("\n")
 }
 
-/// Render the `.gitattributes` line that binds `*.plist` to the filter.
-pub fn gitattributes_line() -> &'static str {
-    "*.plist filter=dodot-plist"
+/// Render the `.gitattributes` lines that bind each configured plist
+/// extension to the `dodot-plist` filter. Default config produces one
+/// line for `*.plist`; users who add e.g. `"binplist"` to the
+/// `[symlink] plist_extensions` config get an additional line.
+pub fn gitattributes_lines(extensions: &[String]) -> Vec<String> {
+    extensions
+        .iter()
+        .map(|ext| format!("*.{ext} filter=dodot-plist"))
+        .collect()
+}
+
+/// Resolve the active `plist_extensions` from the root config. Used by
+/// every code path that needs to render or scan against the configured
+/// extensions; honors the standard root → pack inheritance the
+/// ConfigManager already manages (callers that want pack-scoped
+/// resolution can call `config_for_pack` directly).
+pub(crate) fn root_plist_extensions(ctx: &ExecutionContext) -> Result<Vec<String>> {
+    Ok(ctx.config_manager.root_config()?.symlink.plist_extensions)
 }
 
 /// Install the dodot-plist clean/smudge filter into the dotfiles repo's
@@ -89,19 +104,29 @@ pub fn show_filters(ctx: &ExecutionContext) -> Result<ShowFiltersResult> {
     let runner = ctx.command_runner.as_ref();
     let installed = filter_is_installed(runner, &root)?;
 
-    let attributes_present = ctx
+    let extensions = root_plist_extensions(ctx)?;
+    let expected_lines = gitattributes_lines(&extensions);
+    let attrs_content = ctx
         .fs
         .read_to_string(&root.join(".gitattributes"))
-        .ok()
-        .map(|s| s.lines().any(gitattributes_line_present))
-        .unwrap_or(false);
+        .unwrap_or_default();
+    // "Bound" means *every* configured extension has its line. A
+    // partial bind (e.g. legacy file has `*.plist` but config now
+    // also requires `*.binplist`) reports false so the install hint
+    // surfaces the gap.
+    let attributes_present = !expected_lines.is_empty()
+        && expected_lines.iter().all(|expected| {
+            attrs_content
+                .lines()
+                .any(|existing| gitattributes_line_matches(existing, expected))
+        });
 
     let block = config_block_text();
     let block_lines = block.lines().map(str::to_string).collect();
     Ok(ShowFiltersResult {
         config_block: block,
         config_block_lines: block_lines,
-        gitattributes_line: gitattributes_line().to_string(),
+        gitattributes_lines: expected_lines,
         installed_in_git_config: installed,
         bound_in_gitattributes: attributes_present,
         repo_root: root.display().to_string(),
@@ -116,7 +141,9 @@ pub fn show_filters(ctx: &ExecutionContext) -> Result<ShowFiltersResult> {
 pub struct ShowFiltersResult {
     pub config_block: String,
     pub config_block_lines: Vec<String>,
-    pub gitattributes_line: String,
+    /// One line per configured plist extension (default `["plist"]`).
+    /// Templates iterate to render the full block.
+    pub gitattributes_lines: Vec<String>,
     pub installed_in_git_config: bool,
     pub bound_in_gitattributes: bool,
     pub repo_root: String,
@@ -158,7 +185,10 @@ pub fn detect_plist_files(ctx: &ExecutionContext) -> Result<Vec<std::path::PathB
     let root_config = ctx.config_manager.root_config()?;
     let packs = crate::packs::discover_packs(ctx.fs.as_ref(), root, &root_config.pack.ignore)?;
     for pack in packs {
-        scan_for_plists(ctx.fs.as_ref(), &pack.path, &mut found)?;
+        // Honor pack-level overrides of `[symlink] plist_extensions`.
+        let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
+        let extensions = pack_config.symlink.plist_extensions.clone();
+        scan_for_plists(ctx.fs.as_ref(), &pack.path, &extensions, &mut found)?;
     }
     Ok(found)
 }
@@ -166,6 +196,7 @@ pub fn detect_plist_files(ctx: &ExecutionContext) -> Result<Vec<std::path::PathB
 fn scan_for_plists(
     fs: &dyn crate::fs::Fs,
     dir: &std::path::Path,
+    extensions: &[String],
     found: &mut Vec<std::path::PathBuf>,
 ) -> Result<()> {
     let entries = match fs.read_dir(dir) {
@@ -184,12 +215,16 @@ fn scan_for_plists(
             if name.starts_with('.') {
                 continue;
             }
-            scan_for_plists(fs, &entry.path, found)?;
+            scan_for_plists(fs, &entry.path, extensions, found)?;
         } else if entry
             .path
             .extension()
             .and_then(|e| e.to_str())
-            .map(|s| s.eq_ignore_ascii_case("plist"))
+            .map(|ext| {
+                extensions
+                    .iter()
+                    .any(|configured| configured.eq_ignore_ascii_case(ext))
+            })
             .unwrap_or(false)
         {
             found.push(entry.path);
@@ -219,34 +254,61 @@ fn append_cfprefsd_hint(details: &mut Vec<String>) {
 }
 
 fn append_gitattributes_hint(ctx: &ExecutionContext, details: &mut Vec<String>) {
-    let attrs_path = ctx.paths.dotfiles_root().join(".gitattributes");
-    let already_bound = ctx
+    let extensions = match root_plist_extensions(ctx) {
+        Ok(e) => e,
+        Err(_) => return, // surface elsewhere; don't block the install hint
+    };
+    let lines = gitattributes_lines(&extensions);
+    let attrs_content = ctx
         .fs
-        .read_to_string(&attrs_path)
-        .ok()
-        .map(|s| s.lines().any(gitattributes_line_present))
-        .unwrap_or(false);
-    if !already_bound {
-        details.push(String::new());
-        details.push("Next: ensure your .gitattributes binds *.plist to this filter:".into());
-        details.push(format!(
-            "    echo '{}' >> .gitattributes",
-            gitattributes_line()
-        ));
-        details.push("    git add .gitattributes && git commit -m 'enable plist filters'".into());
+        .read_to_string(&ctx.paths.dotfiles_root().join(".gitattributes"))
+        .unwrap_or_default();
+    let missing: Vec<&str> = lines
+        .iter()
+        .filter(|line| {
+            !attrs_content
+                .lines()
+                .any(|existing| gitattributes_line_matches(existing, line))
+        })
+        .map(String::as_str)
+        .collect();
+    if missing.is_empty() {
+        return;
     }
+    details.push(String::new());
+    let pattern_summary = if missing.len() == 1 {
+        format!("*.{} to this filter", extensions[0])
+    } else {
+        format!("{} extensions to this filter", missing.len())
+    };
+    details.push(format!(
+        "Next: ensure your .gitattributes binds {pattern_summary}:"
+    ));
+    for line in &missing {
+        details.push(format!("    echo '{line}' >> .gitattributes"));
+    }
+    details.push("    git add .gitattributes && git commit -m 'enable plist filters'".into());
 }
 
-/// Match a `.gitattributes` line that binds `*.plist` to the
-/// `dodot-plist` filter. Tolerant of whitespace and comments.
-fn gitattributes_line_present(line: &str) -> bool {
-    let trimmed = line.split('#').next().unwrap_or("").trim();
-    let mut parts = trimmed.split_ascii_whitespace();
-    let pattern = parts.next();
-    if pattern != Some("*.plist") {
-        return false;
+/// True if `existing` (a line from `.gitattributes`) binds the same
+/// `*.<ext> filter=dodot-plist` pattern as `expected`. Tolerant of
+/// whitespace, trailing attributes (e.g. `diff=plist`), and comments.
+fn gitattributes_line_matches(existing: &str, expected: &str) -> bool {
+    let strip = |s: &str| -> Option<String> {
+        let trimmed = s.split('#').next().unwrap_or("").trim();
+        let mut parts = trimmed.split_ascii_whitespace();
+        let pattern = parts.next()?.to_string();
+        let binds_filter = parts.any(|tok| tok == "filter=dodot-plist");
+        if binds_filter {
+            Some(pattern)
+        } else {
+            None
+        }
+    };
+    match (strip(existing), strip(expected)) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
     }
-    parts.any(|tok| tok == "filter=dodot-plist")
 }
 
 fn filter_is_installed(
@@ -416,20 +478,88 @@ mod tests {
 
     #[test]
     fn gitattributes_recogniser_handles_whitespace_and_comments() {
-        assert!(gitattributes_line_present("*.plist filter=dodot-plist"));
-        assert!(gitattributes_line_present(
-            "  *.plist   filter=dodot-plist  "
+        let expected = "*.plist filter=dodot-plist";
+        assert!(gitattributes_line_matches(
+            "*.plist filter=dodot-plist",
+            expected
         ));
-        assert!(gitattributes_line_present(
-            "*.plist filter=dodot-plist diff=plist"
+        assert!(gitattributes_line_matches(
+            "  *.plist   filter=dodot-plist  ",
+            expected
         ));
-        assert!(gitattributes_line_present(
-            "*.plist filter=dodot-plist  # plist filter"
+        assert!(gitattributes_line_matches(
+            "*.plist filter=dodot-plist diff=plist",
+            expected
+        ));
+        assert!(gitattributes_line_matches(
+            "*.plist filter=dodot-plist  # plist filter",
+            expected
         ));
 
-        assert!(!gitattributes_line_present(""));
-        assert!(!gitattributes_line_present("# commented out"));
-        assert!(!gitattributes_line_present("*.plist filter=other"));
-        assert!(!gitattributes_line_present("*.txt filter=dodot-plist"));
+        assert!(!gitattributes_line_matches("", expected));
+        assert!(!gitattributes_line_matches("# commented out", expected));
+        assert!(!gitattributes_line_matches(
+            "*.plist filter=other",
+            expected
+        ));
+        assert!(!gitattributes_line_matches(
+            "*.txt filter=dodot-plist",
+            expected
+        ));
+    }
+
+    #[test]
+    fn gitattributes_lines_emits_one_per_extension() {
+        let lines = gitattributes_lines(&["plist".to_string()]);
+        assert_eq!(lines, vec!["*.plist filter=dodot-plist"]);
+
+        let lines = gitattributes_lines(&[
+            "plist".to_string(),
+            "binplist".to_string(),
+            "savedState".to_string(),
+        ]);
+        assert_eq!(
+            lines,
+            vec![
+                "*.plist filter=dodot-plist",
+                "*.binplist filter=dodot-plist",
+                "*.savedState filter=dodot-plist",
+            ]
+        );
+    }
+
+    #[test]
+    fn detect_plist_files_honors_custom_extension() {
+        // With the default config, only `.plist` is detected. With
+        // `binplist` added to the pack's `[symlink] plist_extensions`,
+        // detection picks it up too. Pack-level inheritance is the
+        // shipped path; root-level overrides the same way.
+        use crate::testing::TempEnvironment;
+        let env = TempEnvironment::builder()
+            .pack("apps")
+            .file("com.app.plist", "binary-or-xml")
+            .file("com.other.binplist", "different ext")
+            .file("README.md", "should be ignored")
+            .config("[symlink]\nplist_extensions = [\"plist\", \"binplist\"]\n")
+            .done()
+            .build();
+        let ctx = make_test_ctx(&env);
+        let found = detect_plist_files(&ctx).expect("detect");
+        let names: Vec<String> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            names.contains(&"com.app.plist".to_string()),
+            "default-extension plist should be found: {names:?}"
+        );
+        assert!(
+            names.contains(&"com.other.binplist".to_string()),
+            "custom-extension plist should be found: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.ends_with(".md")),
+            "non-plist files must not surface: {names:?}"
+        );
     }
 }

--- a/crates/dodot-lib/src/commands/git_filters.rs
+++ b/crates/dodot-lib/src/commands/git_filters.rs
@@ -38,6 +38,13 @@ pub fn config_block_text() -> String {
 /// extension to the `dodot-plist` filter. Default config produces one
 /// line for `*.plist`; users who add e.g. `"binplist"` to the
 /// `[symlink] plist_extensions` config get an additional line.
+///
+/// Callers must pass extensions that have already been normalized by
+/// [`normalize_plist_extensions`]; the rendered patterns are dropped
+/// straight into shell-adjacent contexts (the user's
+/// `.gitattributes`, the install hint), and raw config values can
+/// contain whitespace, quotes, or shell metacharacters that would
+/// produce malformed output.
 pub fn gitattributes_lines(extensions: &[String]) -> Vec<String> {
     extensions
         .iter()
@@ -45,13 +52,56 @@ pub fn gitattributes_lines(extensions: &[String]) -> Vec<String> {
         .collect()
 }
 
-/// Resolve the active `plist_extensions` from the root config. Used by
-/// every code path that needs to render or scan against the configured
+/// Normalize a raw `plist_extensions` config slice into a stable form
+/// suitable for both detection and `.gitattributes` rendering.
+///
+/// For each entry: trim whitespace, strip a single leading `.`,
+/// lowercase. Drop entries that are empty after that or that contain
+/// any character outside `[A-Za-z0-9_+-]` (path separators, glob
+/// metacharacters, quotes, whitespace, anything else that would
+/// either silently fail to match files or turn a `.gitattributes`
+/// line into something unsafe). Dedupe while preserving first-seen
+/// order so user-visible output is stable.
+///
+/// The resulting Vec is what every code path should compare against
+/// or render from. Detection compares case-insensitively; the
+/// rendered glob (`*.<ext>`) is matched by git itself, which on
+/// case-sensitive filesystems would treat `*.Plist` and `*.plist`
+/// as different patterns — lowercasing here makes the contract
+/// uniform regardless of how the user typed the config.
+pub fn normalize_plist_extensions(raw: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(raw.len());
+    for entry in raw {
+        let trimmed = entry.trim();
+        let stripped = trimmed.strip_prefix('.').unwrap_or(trimmed);
+        if stripped.is_empty() {
+            continue;
+        }
+        if !stripped
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '+'))
+        {
+            continue;
+        }
+        let lower = stripped.to_ascii_lowercase();
+        if !out.contains(&lower) {
+            out.push(lower);
+        }
+    }
+    out
+}
+
+/// Resolve the active `plist_extensions` from the root config,
+/// normalized via [`normalize_plist_extensions`]. Used by every code
+/// path that needs to render or scan against the configured
 /// extensions; honors the standard root → pack inheritance the
 /// ConfigManager already manages (callers that want pack-scoped
-/// resolution can call `config_for_pack` directly).
+/// resolution can call `config_for_pack` directly and run the result
+/// through [`normalize_plist_extensions`]).
 pub(crate) fn root_plist_extensions(ctx: &ExecutionContext) -> Result<Vec<String>> {
-    Ok(ctx.config_manager.root_config()?.symlink.plist_extensions)
+    Ok(normalize_plist_extensions(
+        &ctx.config_manager.root_config()?.symlink.plist_extensions,
+    ))
 }
 
 /// Install the dodot-plist clean/smudge filter into the dotfiles repo's
@@ -160,9 +210,15 @@ pub fn is_installed(ctx: &ExecutionContext) -> Result<bool> {
 }
 
 /// Scan every active pack under the dotfiles root and return the
-/// absolute paths of any `*.plist` files within. Used by `dodot up`
-/// to decide whether the user should be offered the filter-install
-/// prompt.
+/// absolute paths of files whose suffix matches any extension in the
+/// pack-resolved `[symlink] plist_extensions` config (default
+/// `["plist"]`). Used by `dodot up` to decide whether to offer the
+/// filter-install prompt.
+///
+/// The configured list is normalized per-pack via
+/// [`normalize_plist_extensions`] (trim, strip leading `.`,
+/// lowercase, drop empty/invalid, dedupe), so `["plist"]`,
+/// `[".Plist"]`, and `["  plist  "]` all behave identically.
 ///
 /// Pack selection goes through [`packs::discover_packs`] so it honours
 /// the same conventions every other command does: `pack.ignore`
@@ -171,9 +227,9 @@ pub fn is_installed(ctx: &ExecutionContext) -> Result<bool> {
 /// nested dot-directories (`.git`, etc.) so we don't recurse into
 /// vendored repos that happen to live inside a pack.
 ///
-/// Detection is "any `*.plist` in any active pack", not "tracked by
-/// git". The looser check is intentional: an untracked plist in a pack
-/// is almost certainly headed for a commit, and a false-positive
+/// Detection is "any matching file in any active pack", not "tracked
+/// by git". The looser check is intentional: an untracked plist in a
+/// pack is almost certainly headed for a commit, and a false-positive
 /// prompt is harmless. A stricter check would require shelling out to
 /// `git ls-files` on every `up`.
 pub fn detect_plist_files(ctx: &ExecutionContext) -> Result<Vec<std::path::PathBuf>> {
@@ -187,7 +243,7 @@ pub fn detect_plist_files(ctx: &ExecutionContext) -> Result<Vec<std::path::PathB
     for pack in packs {
         // Honor pack-level overrides of `[symlink] plist_extensions`.
         let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
-        let extensions = pack_config.symlink.plist_extensions.clone();
+        let extensions = normalize_plist_extensions(&pack_config.symlink.plist_extensions);
         scan_for_plists(ctx.fs.as_ref(), &pack.path, &extensions, &mut found)?;
     }
     Ok(found)
@@ -275,19 +331,25 @@ fn append_gitattributes_hint(ctx: &ExecutionContext, details: &mut Vec<String>) 
     if missing.is_empty() {
         return;
     }
-    details.push(String::new());
-    let pattern_summary = if missing.len() == 1 {
-        format!("*.{} to this filter", extensions[0])
+    // Print lines directly rather than wrapping them in an `echo
+    // '...' >> .gitattributes` snippet. Even though
+    // `normalize_plist_extensions` already filters out shell
+    // metacharacters, emitting copy-pasteable shell that interpolates
+    // config-derived data is the wrong shape on principle: the user
+    // can paste these lines into their editor or run their own append.
+    let label = if missing.len() == 1 {
+        "Next — add this line to .gitattributes:"
     } else {
-        format!("{} extensions to this filter", missing.len())
+        "Next — add these lines to .gitattributes:"
     };
-    details.push(format!(
-        "Next: ensure your .gitattributes binds {pattern_summary}:"
-    ));
+    details.push(String::new());
+    details.push(label.into());
     for line in &missing {
-        details.push(format!("    echo '{line}' >> .gitattributes"));
+        details.push(format!("    {line}"));
     }
-    details.push("    git add .gitattributes && git commit -m 'enable plist filters'".into());
+    details.push(String::new());
+    details
+        .push("Then commit: git add .gitattributes && git commit -m 'enable plist filters'".into());
 }
 
 /// True if `existing` (a line from `.gitattributes`) binds the same
@@ -560,6 +622,59 @@ mod tests {
         assert!(
             !names.iter().any(|n| n.ends_with(".md")),
             "non-plist files must not surface: {names:?}"
+        );
+    }
+
+    #[test]
+    fn normalize_plist_extensions_strips_lowercases_dedupes_and_filters() {
+        // Trims, strips a leading `.`, lowercases.
+        assert_eq!(
+            normalize_plist_extensions(&[
+                "plist".into(),
+                ".plist".into(),
+                "  .Plist  ".into(),
+                "BinPlist".into(),
+            ]),
+            vec!["plist".to_string(), "binplist".to_string()],
+            "leading dot, mixed case, and whitespace must collapse \
+             to a single canonical entry"
+        );
+
+        // Filters empty / whitespace-only.
+        assert!(normalize_plist_extensions(&["".into(), "   ".into(), ".".into()]).is_empty());
+
+        // Rejects shell metacharacters, path separators, glob chars,
+        // quotes — anything that could turn the rendered .gitattributes
+        // line into something unsafe or that would silently fail to
+        // match any file at scan time.
+        let dangerous = [
+            "evil; rm -rf".to_string(),
+            "*.txt".to_string(),
+            "weird path".to_string(),
+            "foo/bar".to_string(),
+            "quote'd".to_string(),
+            "back\\slash".to_string(),
+            "with\nnewline".to_string(),
+        ];
+        assert!(
+            normalize_plist_extensions(&dangerous).is_empty(),
+            "metacharacter-bearing entries must be dropped"
+        );
+
+        // Real-world mix passes through cleanly.
+        assert_eq!(
+            normalize_plist_extensions(&[
+                "plist".into(),
+                "binplist".into(),
+                "savedState".into(),
+                "mobileconfig".into(),
+            ]),
+            vec![
+                "plist".to_string(),
+                "binplist".to_string(),
+                "savedstate".to_string(),
+                "mobileconfig".to_string(),
+            ]
         );
     }
 }

--- a/crates/dodot-lib/src/commands/transform.rs
+++ b/crates/dodot-lib/src/commands/transform.rs
@@ -97,10 +97,19 @@ pub struct TransformCheckResult {
     /// carries unresolved dodot-conflict markers.
     pub unresolved_markers: Vec<UnresolvedMarkerEntry>,
     /// True iff at least one entry has a non-clean state that should
-    /// make the command exit non-zero (Patched, Conflict,
-    /// NeedsRebaseline, MissingSource, MissingDeployed) or `--strict`
-    /// found unresolved markers. CLI uses this to decide the process
-    /// exit code.
+    /// make the command exit non-zero (Conflict, NeedsRebaseline,
+    /// MissingSource, MissingDeployed) or `--strict` found unresolved
+    /// markers. CLI uses this to decide the process exit code.
+    ///
+    /// `Patched` does *not* set this — an unambiguous reverse-merge is
+    /// the auto-merge happy path: burgertocow + diffy produced a clean
+    /// unified patch with no markers, the source has been rewritten
+    /// to match, and there's nothing for the user to review. The
+    /// pre-commit hook lets the original `git commit` proceed; the
+    /// patched source surfaces as modified on the next `git status`,
+    /// at which point the user `git add`s and commits a follow-up
+    /// (or amends) if they want a clean history. Issue #113 walks
+    /// through the rationale.
     pub has_findings: bool,
     pub strict: bool,
 }
@@ -283,7 +292,15 @@ pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResul
                             if !ctx.dry_run {
                                 ctx.fs.write_file(&report.source_path, patched.as_bytes())?;
                             }
-                            has_findings = true;
+                            // `Patched` is the auto-merge happy path:
+                            // burgertocow + diffy produced an
+                            // unambiguous unified patch, the source
+                            // is now in sync with the user's edit.
+                            // Nothing for the user to review →
+                            // `has_findings` stays false. The patched
+                            // source surfaces as modified on the next
+                            // `git status` for a follow-up commit.
+                            // See #113.
                             TransformAction::Patched
                         }
                         ReverseMergeOutcome::Conflict(block) => {
@@ -548,8 +565,11 @@ pub fn hook_is_installed(ctx: &ExecutionContext) -> Result<bool> {
 ///    this, the clean filter (R6) wouldn't fire on the upcoming
 ///    commit, and the commit could include stale template content.
 /// 2. `dodot transform check --strict` — run the 4-state matrix and
-///    refuse the commit on any finding (Patched, Conflict, missing,
-///    unresolved markers).
+///    refuse the commit on any finding (Conflict, missing,
+///    unresolved markers, NeedsRebaseline). `Patched` outcomes don't
+///    refuse — burgertocow's auto-merge already produced a clean
+///    unified patch and rewrote the source; the user `git add`s and
+///    commits the follow-up if they want a clean history.
 ///
 /// Each step short-circuits with `|| exit 1`; a failure in either
 /// aborts the commit (with exit code 1 — the inner command's exit
@@ -761,8 +781,12 @@ mod tests {
             "got: {:?}",
             result.entries[0].action
         );
-        assert!(result.has_findings);
-        assert_eq!(result.exit_code(), 1);
+        // Patched is the auto-merge happy path: clean unified diff,
+        // source rewritten, nothing for the user to review. The
+        // pre-commit hook lets the commit proceed; the user does a
+        // follow-up `git add` + commit on the patched source. See #113.
+        assert!(!result.has_findings);
+        assert_eq!(result.exit_code(), 0);
 
         // Source was rewritten: the static line is updated, the
         // variable-bearing line is preserved verbatim.

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -112,6 +112,19 @@ pub struct SymlinkSection {
     /// `$XDG_CONFIG_HOME`.
     #[config(default = {})]
     pub targets: std::collections::HashMap<String, String>,
+
+    /// Filename suffixes (without leading dot) that should be detected
+    /// as plists for `dodot git-install-filters` adopt hints and the
+    /// `.gitattributes` line. Defaults to `["plist"]`. Some apps store
+    /// plists with non-standard suffixes (`.binplist`, `.savedState`,
+    /// etc.); register additional extensions here to flow them through
+    /// the same clean/smudge pipeline.
+    ///
+    /// Comparison is case-insensitive, matching the existing detection
+    /// behavior. Honors the standard root → pack inheritance.
+    /// See `docs/proposals/plists.lex` §8.1.
+    #[config(default = ["plist"])]
+    pub plist_extensions: Vec<String>,
 }
 
 /// PATH handler settings.

--- a/crates/dodot-lib/src/templates/git-filters.jinja
+++ b/crates/dodot-lib/src/templates/git-filters.jinja
@@ -6,7 +6,8 @@
 {% endfor %}
 [desc]Add to [item].gitattributes[/item] (committed in the repo{% if bound_in_gitattributes %} — [item]already present[/item]{% endif %}):[/desc]
 
-    {{ gitattributes_line }}
+{% for line in gitattributes_lines %}    {{ line }}
+{% endfor %}
 
 [desc]Repo: [item]{{ repo_root }}[/item]
 

--- a/docs/reference/plists.lex
+++ b/docs/reference/plists.lex
@@ -195,9 +195,14 @@ macOS Plists
 
 9. Configuration
 
-    Plist support currently has no configuration knobs. Plist detection (for adopt hints and the up-time prompt) is hard-coded to the `.plist` extension; deployment is governed by the symlink handler and the file's location, the same as any other file. There is no `[preprocessor.plist]` section either — plists do not go through the preprocessing pipeline.
+    Plist support has one config knob: `[symlink] plist_extensions`. It controls which filename suffixes detection treats as plists (for adopt hints, the up-time prompt, and the `.gitattributes` lines emitted by `git-install-filters`). Deployment is still governed by the symlink handler and the file's location, the same as any other file. There is no `[preprocessor.plist]` section — plists do not go through the preprocessing pipeline.
 
-    A configurable `plist_extensions` list was sketched in [./../proposals/plists.lex] §8.1 to cover non-`.plist` suffixes some apps use (`.savedState`, `.mobileconfig`, …). It has not been implemented; if real-world demand surfaces, it would slot in under `[symlink]`.
+        [symlink]
+        plist_extensions = ["plist"]   # default; add "binplist", "savedState", etc. as needed
+
+    :: toml ::
+
+    Honors the standard root → pack inheritance: a pack-level `.dodot.toml` can override the list for that pack only. Comparison is case-insensitive. When more than one extension is configured, `dodot git-install-filters` emits one `.gitattributes` line per extension (`*.plist filter=dodot-plist`, `*.binplist filter=dodot-plist`, …).
 
 10. Commands at a Glance
 

--- a/docs/reference/template-magic.lex
+++ b/docs/reference/template-magic.lex
@@ -127,7 +127,13 @@ Template Magic
 
     4.2. `dodot transform check [--strict] [--dry-run]`
 
-        Active form. Walks the cache, applies reverse-merge diffs back to source on the unambiguous cases, surfaces conflict blocks for the rest, exits non-zero on any finding (so the pre-commit hook can fail the commit). `--dry-run` reports without writing. `--strict` additionally fails on unresolved markers in any source.
+        Active form. Walks the cache and either:
+
+        - Applies a reverse-merge diff back to the source when burgertocow + diffy produce an unambiguous unified patch — `Patched`. Exit 0; nothing for the user to review. The patched source surfaces as modified on the next `git status`; the user runs `git add` and lands a follow-up commit (or amends).
+        - Surfaces a conflict block in the source for the ambiguous cases — `Conflict`. Exit 1; user picks a side and resolves the markers, the same way they would resolve a `git merge` conflict.
+        - Reports `MissingSource` / `MissingDeployed` / `NeedsRebaseline` (cache invariant broken). Exit 1.
+
+        `--dry-run` reports without writing. `--strict` additionally fails on unresolved markers in any source. The pre-commit hook calls `transform check --strict`; the exit-code split above means the hook lets the original commit proceed when reverse-merge succeeds cleanly, and refuses only when human review is genuinely needed.
 
     4.3. `dodot refresh [--quiet] [--list-paths]`
 

--- a/tests/e2e/bats/test_no_reverse.bats
+++ b/tests/e2e/bats/test_no_reverse.bats
@@ -77,10 +77,12 @@ no_reverse = ["*.gen.tmpl"]'
     done
 
     run dodot transform check
-    # `regular.tmpl` falls into reverse-merge (one finding); the two
-    # `*.gen.tmpl` files are skipped. So exit code is 1 (the regular
-    # finding) but the gen sources must be byte-identical.
-    [ "$status" -eq 1 ]
+    # `regular.tmpl` falls into reverse-merge and produces a clean
+    # unified patch (no markers needed) → Patched, exit 0 (per #113:
+    # an unambiguous auto-merge is the happy path). The two
+    # `*.gen.tmpl` files are skipped by the no_reverse opt-out and
+    # remain byte-identical. The regular source IS rewritten.
+    [ "$status" -eq 0 ]
 
     alpha_src=$(cat "$DOTFILES_ROOT/app/alpha.gen.tmpl")
     beta_src=$(cat "$DOTFILES_ROOT/app/beta.gen.tmpl")

--- a/tests/e2e/bats/test_transform_check.bats
+++ b/tests/e2e/bats/test_transform_check.bats
@@ -54,8 +54,13 @@ name = Alice
 port = 9999
 EOF
 
+    # Patched is the auto-merge happy path: clean unified diff, source
+    # rewritten, nothing for the user to review → exit 0. The
+    # pre-commit hook lets the original commit proceed; the patched
+    # source surfaces as modified on the next `git status` for a
+    # follow-up commit. See #113.
     run dodot transform check
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
     assert_output_contains "patched"
     assert_output_contains "config.toml.tmpl"
 
@@ -111,8 +116,11 @@ name = Alice
 port = 9999
 EOF
 
+    # Patched is the auto-merge happy path — exits 0 even with
+    # --dry-run. The would-be patch shows in the report; the source
+    # is untouched on disk because of --dry-run. See #113.
     run dodot transform check --dry-run
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
     assert_output_contains "patched"
 
     # Source unchanged on disk.


### PR DESCRIPTION
## Summary

Wave 2 of the #116 pre-release polish plan: two small isolated bug fixes / additions, parallel-safe (neither touches the post-`up` prompt ladder or the preprocessing pipeline).

Closes #113, closes #114.

## #113 — `dodot transform check` exit 0 on Patched

**Problem.** When a deployed-file edit reverse-merges cleanly (burgertocow + diffy produce an unambiguous unified patch), `transform check` was exiting 1. The pre-commit hook calls `transform check --strict`, so a clean auto-merge refused the user's commit unnecessarily — they had to `git add` the rewritten source and retry.

**Fix.** `Patched` (clean unambiguous reverse-merge) now leaves `has_findings` false → exit 0. The pre-commit hook lets the original `git commit` proceed; the patched source surfaces as modified on the next `git status` for a follow-up commit (or amend).

**What still blocks the commit.** `Conflict`, `MissingSource`, `MissingDeployed`, `NeedsRebaseline`, and `--strict` unresolved markers. Those genuinely require human attention; `Patched` does not.

**Decision on auto-`git add`.** The issue body asked whether the hook should auto-`git add` the patched source so the user's original commit succeeds in one shot. **Not done.** Keeping `transform check` pure of git interaction avoids accidentally widening the user's intended commit when they're staging a partial commit. Follow-up workflow: `git status` → `git add <patched-source>` → commit (or `git commit --amend`).

## #114 — `[symlink] plist_extensions` config

**Problem.** Plist detection was hard-coded to `.plist` only. Some apps store plists with non-standard suffixes (`.binplist`, `.savedState`, `.mobileconfig`, …). The proposal sketched the config knob in `plists.lex` §8.1; the reference doc openly noted it was unimplemented.

**Fix.** New `plist_extensions: Vec<String>` field on `SymlinkSection`, default `["plist"]`. Files with any configured extension flow through the same clean/smudge pipeline. Honors root → pack inheritance. Comparison is case-insensitive.

When more than one extension is configured, `dodot git-install-filters` emits one `.gitattributes` line per extension (`*.plist filter=dodot-plist`, `*.binplist filter=dodot-plist`, …). The `bound_in_gitattributes` flag in `git-show-filters` reports `true` only when *every* configured extension has its line — partial binds surface in the install hint.

## API changes

- `commands::git_filters::gitattributes_line() -> &'static str` is replaced by `gitattributes_lines(extensions: &[String]) -> Vec<String>`.
- `gitattributes_line_present(line)` is replaced by `gitattributes_line_matches(existing, expected)` (matches by pattern).
- `ShowFiltersResult.gitattributes_line: String` becomes `gitattributes_lines: Vec<String>`.
- `git-filters.jinja` template iterates the new list.

These are internal-API changes; no external consumers.

## Test plan

- [x] `cargo test --workspace` — 857 lib + 12 integration tests, all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Full bats suite — 254 tests green
- [x] New unit tests: `gitattributes_lines_emits_one_per_extension`, `detect_plist_files_honors_custom_extension`
- [x] Updated bats: `transform check` static-line case asserts exit 0; `--dry-run` Patched case asserts exit 0; `no_reverse` glob test reflects the new exit-code contract
- [x] Reference docs updated: `template-magic.lex` §4.2 (per-action exit codes), `plists.lex` §9 (drop "not implemented" note, document the shipped knob)

## Out of scope

- The Wave 3 installer-flow consolidation (#112) and Wave 4 passive-command contract (#121) per #116.
- `git-install-alias` / Tier-3 prompt is unchanged.
