### PR TITLE
feat(cli): consolidate post-up install ladder + cfprefsd prompt (#109, #112)

### DIFF
--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -770,26 +770,60 @@ fn install_ladder_yes(
         .iter()
         .any(|r| r.component_key == RUNG_TEMPLATE_FILTER.component_key);
 
+    // Each rung is soft-fail: an error in one installer must not
+    // skip the others. The pre-three-prompts UX let the user
+    // accept/reject each rung independently; the consolidated
+    // ladder needs to preserve that "approved means tried" contract,
+    // because the rungs are operationally unrelated (the plist
+    // filter doesn't care whether the hook installed). Surface each
+    // failure to stderr so the user knows what didn't land, and
+    // only dismiss the catalog key on the success path so a failed
+    // rung re-prompts on the next `up`.
     if install_hook {
-        let r = commands::transform::install_hook(ctx)?;
-        eprintln!("Installed pre-commit hook at {}", r.hook_display_path);
-        registry.dismiss(RUNG_HOOK.component_key);
+        match commands::transform::install_hook(ctx) {
+            Ok(r) => {
+                eprintln!("Installed pre-commit hook at {}", r.hook_display_path);
+                registry.dismiss(RUNG_HOOK.component_key);
+            }
+            Err(e) => {
+                eprintln!("Failed to install pre-commit hook: {e}");
+                eprintln!(
+                    "  Try `dodot transform install-hook` directly for the full error, \
+                     or skip with `dodot prompts reset {}`.",
+                    RUNG_HOOK.component_key
+                );
+            }
+        }
     }
     if install_plist {
-        let r = commands::git_filters::install_filters(ctx)?;
-        eprintln!("{}", r.message);
-        for d in &r.details {
-            eprintln!("  {d}");
+        match commands::git_filters::install_filters(ctx) {
+            Ok(r) => {
+                eprintln!("{}", r.message);
+                for d in &r.details {
+                    eprintln!("  {d}");
+                }
+                registry.dismiss(RUNG_PLIST_FILTER.component_key);
+            }
+            Err(e) => {
+                eprintln!("Failed to install plist filters: {e}");
+                eprintln!("  Try `dodot git-install-filters` directly for the full error.");
+            }
         }
-        registry.dismiss(RUNG_PLIST_FILTER.component_key);
     }
     if install_template_filter {
-        let r = commands::template_install_filter::install_filter(ctx)?;
-        eprintln!("{}", r.message);
-        for d in &r.details {
-            eprintln!("  {d}");
+        match commands::template_install_filter::install_filter(ctx) {
+            Ok(r) => {
+                eprintln!("{}", r.message);
+                for d in &r.details {
+                    eprintln!("  {d}");
+                }
+                registry.dismiss(RUNG_TEMPLATE_FILTER.component_key);
+            }
+            Err(e) => {
+                eprintln!("Failed to install template clean filter: {e}");
+                eprintln!("  Try `dodot template install-filter` directly for the full error.");
+            }
         }
-        registry.dismiss(RUNG_TEMPLATE_FILTER.component_key);
     }
     Ok(())
 }
@@ -855,10 +889,12 @@ fn install_ladder_show(
 /// cfprefsd respawns immediately. See `docs/proposals/plists.lex`
 /// §6.4 and issue #109.
 ///
-/// On every outcome (yes / no / show), the marker is cleared so the
-/// prompt doesn't re-fire on the next `up` unless drift recurs. "No"
-/// additionally dismisses the catalog entry so the prompt never
-/// returns until the user runs `dodot prompts reset`.
+/// On `Yes` (ran killall) and `No` (declined), the marker is cleared
+/// so the prompt doesn't re-fire on the next `up` unless drift recurs.
+/// `No` additionally dismisses the catalog entry so the prompt never
+/// returns until the user runs `dodot prompts reset`. `Show` is
+/// informational — it leaves both the marker and the dismissal alone,
+/// so the user can re-run `up` to answer for real.
 pub fn maybe_prompt_invalidate_cfprefsd() {
     if let Err(e) = try_prompt_invalidate_cfprefsd() {
         tracing::debug!("cfprefsd-invalidate prompt skipped: {e}");
@@ -894,7 +930,9 @@ fn try_prompt_invalidate_cfprefsd() -> Result<(), anyhow::Error> {
     }
 
     let response = crate::interactive::prompt_yes_no_show(&[
-        "dodot detected a plist change on this `up`.",
+        "A plist file in your dotfiles has changed since the previous `dodot up`.",
+        "(That covers two cases: a plist this run just deployed, *or* one a GUI app rewrote",
+        "in between runs — both leave cfprefsd holding a stale value.)",
         "macOS caches plist values via cfprefsd; running apps may show stale values until",
         "cfprefsd is restarted. Run `killall cfprefsd` now? (cfprefsd respawns immediately;",
         "no data loss.) `no` skips and won't ask again.",

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -582,26 +582,73 @@ pub fn git_show_filters_handler(
     Ok(Output::Render(result))
 }
 
-/// Post-`up` hook that offers to install plist filters when:
+/// Post-`up` consolidated installer ladder.
 ///
-/// 1. stdin is a TTY (we're interactive, not in CI/script),
-/// 2. at least one pack contains a `*.plist` file,
-/// 3. the dodot-plist filter is NOT yet registered in `.git/config`,
-/// 4. the user has NOT previously dismissed the prompt.
+/// Replaces three sequential prompts (plist filter, hook, template
+/// filter) with a single Y/n covering whichever rungs apply. Spec:
+/// `docs/proposals/magic.lex` §"What This Costs the User" promises
+/// "one Y/n to install the clean/smudge filters and the pre-commit
+/// hook"; this function is the implementation.
 ///
-/// All four must hold; otherwise the function returns silently. Errors
-/// in any check (e.g. registry corrupt, git missing) go to the dodot
-/// log at debug level — visible with `--debug` or in the log file,
-/// but silent at default verbosity. This is a nudge, not a critical
-/// step, and a noisy stderr line every `up` would be worse UX than
-/// silently skipping the offer.
-pub fn maybe_prompt_install_filters() {
-    if let Err(e) = try_prompt_install_filters() {
-        tracing::debug!("plist install-filters prompt skipped: {e}");
+/// Behavior:
+/// - **Yes** installs every applicable rung whose component dismissal
+///   is not set, in dependency order (hook first; template filter
+///   only after hook installs cleanly). Each successful install
+///   dismisses its component key.
+/// - **Show** walks each rung individually, printing the previewable
+///   block (config, hook script, .gitattributes lines) without
+///   touching the registry. The user can read, then re-run `up` to
+///   answer the prompt for real.
+/// - **No** dismisses every applicable component key so the ladder
+///   never re-prompts on subsequent `up` runs. The user can resurface
+///   any rung individually with `dodot prompts reset <key>`.
+///
+/// Tier-3 alias (`dodot git-install-alias`) is intentionally not in
+/// the ladder per the magic.lex spec — it ships separately.
+///
+/// Soft-fail like every other post-`up` prompt: errors and skips go
+/// to the debug log so a noisy stderr line never appears on routine
+/// runs.
+pub fn maybe_prompt_install_ladder() {
+    if let Err(e) = try_prompt_install_ladder() {
+        tracing::debug!("install-ladder prompt skipped: {e}");
     }
 }
 
-fn try_prompt_install_filters() -> Result<(), anyhow::Error> {
+/// Per-rung gating decision. Each rung answers two questions: is the
+/// rung *applicable* (does the user's repo state make it relevant?),
+/// and is its component dismissal *outstanding* (the user hasn't
+/// previously chosen `no`). A rung shows up in the ladder only when
+/// both are yes; "yes" installs it, "no" dismisses it.
+struct LadderRung {
+    /// Display label for the prompt body and the show output.
+    name: &'static str,
+    /// Catalog key for this rung's component-level dismissal.
+    component_key: &'static str,
+    /// One-liner the prompt body uses to enumerate what would be
+    /// installed.
+    summary: &'static str,
+}
+
+const RUNG_HOOK: LadderRung = LadderRung {
+    name: "pre-commit hook",
+    component_key: "template.install_hook",
+    summary: "pre-commit hook (refreshes templates + safety check on `git commit`)",
+};
+
+const RUNG_PLIST_FILTER: LadderRung = LadderRung {
+    name: "plist clean/smudge filters",
+    component_key: "plist.install_filters",
+    summary: "dodot-plist clean/smudge filters (binary↔XML for plists)",
+};
+
+const RUNG_TEMPLATE_FILTER: LadderRung = LadderRung {
+    name: "template clean filter",
+    component_key: "template.install_filter",
+    summary: "dodot-template clean filter (live diffs in `git status` / `git diff`)",
+};
+
+fn try_prompt_install_ladder() -> Result<(), anyhow::Error> {
     use dodot_lib::prompts::PromptRegistry;
 
     if !crate::interactive::stdin_is_tty() {
@@ -611,199 +658,220 @@ fn try_prompt_install_filters() -> Result<(), anyhow::Error> {
     let dotfiles_root = discover_dotfiles_root()?;
     let ctx = dodot_lib::packs::orchestration::ExecutionContext::production(&dotfiles_root, false)?;
 
-    let plist_files = commands::git_filters::detect_plist_files(&ctx)?;
-    if plist_files.is_empty() {
-        return Ok(());
-    }
-    if commands::git_filters::is_installed(&ctx)? {
-        return Ok(());
-    }
+    // Determine applicability per rung. Each rung is considered iff
+    // the user has state that justifies it AND that state isn't
+    // already wired up.
+    let templates_present = !dodot_lib::preprocessing::divergence::collect_baselines(
+        ctx.fs.as_ref(),
+        ctx.paths.as_ref(),
+    )?
+    .is_empty();
+    let plist_present = !commands::git_filters::detect_plist_files(&ctx)?.is_empty();
+    let in_git_worktree = ctx.fs.is_dir(&ctx.paths.dotfiles_root().join(".git"));
+
+    let hook_applicable =
+        templates_present && in_git_worktree && !commands::transform::hook_is_installed(&ctx)?;
+    let plist_filter_applicable = plist_present && !commands::git_filters::is_installed(&ctx)?;
+    let template_filter_applicable =
+        templates_present && !commands::template_install_filter::is_installed(&ctx)?;
 
     let registry_path = ctx.paths.prompts_path();
     let mut registry = PromptRegistry::load(ctx.fs.as_ref(), registry_path)?;
-    let prompt_key = "plist.install_filters";
-    if registry.is_dismissed(prompt_key) {
+    let ladder_key = "magic.install_ladder";
+    if registry.is_dismissed(ladder_key) {
         return Ok(());
     }
 
-    // Pick a representative pack name for the prompt body — first
-    // file's parent (under dotfiles_root) gives us "<pack>".
-    let example_pack = plist_files
-        .first()
-        .and_then(|p| p.strip_prefix(ctx.paths.dotfiles_root()).ok())
-        .and_then(|rel| rel.components().next())
-        .map(|c| c.as_os_str().to_string_lossy().into_owned())
-        .unwrap_or_else(|| "(unknown)".into());
+    // A rung enters the ladder only when applicable AND its
+    // component dismissal isn't set. The component check lets the
+    // user opt out of a single rung (via `dodot prompts <key>`) while
+    // still hearing about the others.
+    let mut active_rungs: Vec<&LadderRung> = Vec::new();
+    if hook_applicable && !registry.is_dismissed(RUNG_HOOK.component_key) {
+        active_rungs.push(&RUNG_HOOK);
+    }
+    if plist_filter_applicable && !registry.is_dismissed(RUNG_PLIST_FILTER.component_key) {
+        active_rungs.push(&RUNG_PLIST_FILTER);
+    }
+    if template_filter_applicable && !registry.is_dismissed(RUNG_TEMPLATE_FILTER.component_key) {
+        active_rungs.push(&RUNG_TEMPLATE_FILTER);
+    }
+    if active_rungs.is_empty() {
+        return Ok(());
+    }
 
-    let count = plist_files.len();
-    let header = format!("dodot detected {count} .plist file(s) in pack `{example_pack}`.");
-    let response = crate::interactive::prompt_yes_no_show(&[
-        &header,
-        "Plist support uses git clean/smudge filters to keep the source diffable.",
-        "Install filters now? Run `dodot git-show-filters` to inspect first.",
-    ])?;
+    // Build the prompt body. Header summarises detection; bullet list
+    // enumerates what would be installed; closing line frames the
+    // ask.
+    let mut body: Vec<String> = Vec::new();
+    body.push("dodot can wire git up to handle the files in this repo:".into());
+    for rung in &active_rungs {
+        body.push(format!("  - {}", rung.summary));
+    }
+    body.push(String::new());
+    if active_rungs.len() == 1 {
+        body.push("Install it now? `show` previews first; `no` skips and won't ask again.".into());
+    } else {
+        body.push(format!(
+            "Install all {}? `show` previews each; `no` skips and won't ask again.",
+            active_rungs.len()
+        ));
+    }
+    let body_refs: Vec<&str> = body.iter().map(String::as_str).collect();
+    let response = crate::interactive::prompt_yes_no_show(&body_refs)?;
 
     match response {
         crate::interactive::YesNoShow::Yes => {
-            let r = commands::git_filters::install_filters(&ctx)?;
-            eprintln!("{}", r.message);
-            for d in &r.details {
-                eprintln!("  {d}");
-            }
-            registry.dismiss(prompt_key);
+            install_ladder_yes(&ctx, &active_rungs, &mut registry)?;
             registry.save(ctx.fs.as_ref())?;
         }
         crate::interactive::YesNoShow::Show => {
-            eprintln!();
-            eprintln!("Add to .git/config (per clone, per machine):");
-            eprintln!();
-            for line in commands::git_filters::config_block_text().lines() {
-                eprintln!("    {line}");
-            }
-            eprintln!();
-            eprintln!("Add to .gitattributes (committed in the repo):");
-            let raw = ctx.config_manager.root_config()?.symlink.plist_extensions;
-            let extensions = commands::git_filters::normalize_plist_extensions(&raw);
-            for line in commands::git_filters::gitattributes_lines(&extensions) {
-                eprintln!("    {line}");
-            }
-            eprintln!();
-            eprintln!(
-                "Run `dodot git-install-filters` to install, or `dodot prompts reset {prompt_key}` to skip and ask later."
-            );
-            // Don't dismiss — show is informational, the user hasn't
-            // committed to either install or skip.
+            install_ladder_show(&ctx, &active_rungs)?;
+            // Show is informational — no dismissal. Re-running `up`
+            // will offer the same prompt.
         }
         crate::interactive::YesNoShow::No => {
-            // Don't dismiss — re-prompt next up. If the user wants to
-            // permanently silence it, they can run
-            // `dodot prompts reset <key>` later (well, the inverse —
-            // to dismiss it themselves we'd need a `dismiss` CLI verb).
-            //
-            // For now, "no" means "not now"; a future ergonomics pass
-            // can offer "no, and never ask again".
+            // Per #112: "no" dismisses every component key so
+            // subsequent `up` runs don't re-prompt. The umbrella
+            // `magic.install_ladder` key is also dismissed so a
+            // future rung becoming applicable doesn't unilaterally
+            // re-open the ladder against the user's wishes.
+            for rung in &active_rungs {
+                registry.dismiss(rung.component_key);
+            }
+            registry.dismiss(ladder_key);
+            registry.save(ctx.fs.as_ref())?;
+            eprintln!(
+                "Skipped install ladder. Re-run `dodot prompts reset <key>` to surface a \
+                 specific rung again, or `dodot prompts reset {ladder_key}` for the lot."
+            );
         }
     }
     Ok(())
 }
 
-/// Post-`up` hook that offers to install the pre-commit hook when:
-///
-/// 1. stdin is a TTY (interactive — never prompt under CI / pipes),
-/// 2. the dotfiles root is a git working tree,
-/// 3. at least one template baseline exists (i.e. the user just
-///    deployed one or more templates),
-/// 4. the dodot pre-commit block is NOT yet installed,
-/// 5. the user has NOT previously dismissed the prompt.
-///
-/// All five must hold; otherwise the function returns silently.
-/// Symmetric in structure with [`maybe_prompt_install_filters`] — same
-/// "soft nudge" disposition: failures and skips go to the debug log,
-/// not stderr, so a noisy line never appears on routine `up` runs.
-pub fn maybe_prompt_install_template_hook() {
-    if let Err(e) = try_prompt_install_template_hook() {
-        tracing::debug!("template install-hook prompt skipped: {e}");
+fn install_ladder_yes(
+    ctx: &dodot_lib::packs::orchestration::ExecutionContext,
+    rungs: &[&LadderRung],
+    registry: &mut dodot_lib::prompts::PromptRegistry,
+) -> Result<(), anyhow::Error> {
+    // Hook installs first — the template filter rung is only useful
+    // when the hook is also installed (the safety gate against
+    // committing unresolved markers lives in the hook). If the user
+    // accepted both, the hook lands first so the filter's value is
+    // realized immediately.
+    let install_hook = rungs
+        .iter()
+        .any(|r| r.component_key == RUNG_HOOK.component_key);
+    let install_plist = rungs
+        .iter()
+        .any(|r| r.component_key == RUNG_PLIST_FILTER.component_key);
+    let install_template_filter = rungs
+        .iter()
+        .any(|r| r.component_key == RUNG_TEMPLATE_FILTER.component_key);
+
+    if install_hook {
+        let r = commands::transform::install_hook(ctx)?;
+        eprintln!("Installed pre-commit hook at {}", r.hook_display_path);
+        registry.dismiss(RUNG_HOOK.component_key);
     }
-}
-
-fn try_prompt_install_template_hook() -> Result<(), anyhow::Error> {
-    use dodot_lib::prompts::PromptRegistry;
-
-    if !crate::interactive::stdin_is_tty() {
-        return Ok(());
-    }
-
-    let dotfiles_root = discover_dotfiles_root()?;
-    let ctx = dodot_lib::packs::orchestration::ExecutionContext::production(&dotfiles_root, false)?;
-
-    // No templates deployed → nothing to gate on.
-    let baselines = dodot_lib::preprocessing::divergence::collect_baselines(
-        ctx.fs.as_ref(),
-        ctx.paths.as_ref(),
-    )?;
-    if baselines.is_empty() {
-        return Ok(());
-    }
-
-    // Already installed → silent.
-    if commands::transform::hook_is_installed(&ctx)? {
-        return Ok(());
-    }
-
-    // Not a git working tree → installer would error; skip the prompt.
-    if !ctx.fs.is_dir(&ctx.paths.dotfiles_root().join(".git")) {
-        return Ok(());
-    }
-
-    let registry_path = ctx.paths.prompts_path();
-    let mut registry = PromptRegistry::load(ctx.fs.as_ref(), registry_path)?;
-    let prompt_key = "template.install_hook";
-    if registry.is_dismissed(prompt_key) {
-        return Ok(());
-    }
-
-    let header = format!("dodot deployed {} template file(s).", baselines.len());
-    let response = crate::interactive::prompt_yes_no_show(&[
-        &header,
-        "A pre-commit hook can keep template sources in sync with deployed-side edits",
-        "by running `dodot transform check --strict` automatically on every `git commit`.",
-        "Install the hook now? Pick `show` to see the block first, or run `dodot transform install-hook` later.",
-    ])?;
-
-    match response {
-        crate::interactive::YesNoShow::Yes => {
-            let r = commands::transform::install_hook(&ctx)?;
-            eprintln!("Installed pre-commit hook at {}", r.hook_display_path);
-            registry.dismiss(prompt_key);
-            registry.save(ctx.fs.as_ref())?;
+    if install_plist {
+        let r = commands::git_filters::install_filters(ctx)?;
+        eprintln!("{}", r.message);
+        for d in &r.details {
+            eprintln!("  {d}");
         }
-        crate::interactive::YesNoShow::Show => {
-            eprintln!();
-            eprintln!("The hook block that would be added to .git/hooks/pre-commit:");
-            eprintln!();
-            for line in commands::transform::managed_block().lines() {
-                eprintln!("    {line}");
-            }
-            eprintln!();
-            eprintln!(
-                "Run `dodot transform install-hook` to install, \
-                 or `dodot prompts reset {prompt_key}` to skip and ask later."
-            );
-            // Don't dismiss — show is informational. The user has
-            // not committed to install or skip.
+        registry.dismiss(RUNG_PLIST_FILTER.component_key);
+    }
+    if install_template_filter {
+        let r = commands::template_install_filter::install_filter(ctx)?;
+        eprintln!("{}", r.message);
+        for d in &r.details {
+            eprintln!("  {d}");
         }
-        crate::interactive::YesNoShow::No => {
-            // Same convention as the plist prompt: "no" means "not
-            // now"; we'll re-prompt on the next up.
-        }
+        registry.dismiss(RUNG_TEMPLATE_FILTER.component_key);
     }
     Ok(())
 }
 
-/// Post-`up` hook that offers to install the template clean filter
-/// when:
+fn install_ladder_show(
+    ctx: &dodot_lib::packs::orchestration::ExecutionContext,
+    rungs: &[&LadderRung],
+) -> Result<(), anyhow::Error> {
+    for rung in rungs {
+        eprintln!();
+        eprintln!("── {} ──", rung.name);
+        match rung.component_key {
+            "template.install_hook" => {
+                eprintln!("Block to be added to .git/hooks/pre-commit:");
+                eprintln!();
+                for line in commands::transform::managed_block().lines() {
+                    eprintln!("    {line}");
+                }
+            }
+            "plist.install_filters" => {
+                eprintln!("Add to .git/config (per clone, per machine):");
+                eprintln!();
+                for line in commands::git_filters::config_block_text().lines() {
+                    eprintln!("    {line}");
+                }
+                eprintln!();
+                eprintln!("Add to .gitattributes (committed in the repo):");
+                let raw = ctx.config_manager.root_config()?.symlink.plist_extensions;
+                let extensions = commands::git_filters::normalize_plist_extensions(&raw);
+                for line in commands::git_filters::gitattributes_lines(&extensions) {
+                    eprintln!("    {line}");
+                }
+            }
+            "template.install_filter" => {
+                eprintln!("Add to .git/config (per clone, per machine):");
+                eprintln!();
+                for line in commands::template_install_filter::config_block_text().lines() {
+                    eprintln!("    {line}");
+                }
+                eprintln!();
+                eprintln!("Add to .gitattributes (committed in the repo):");
+                eprintln!(
+                    "    {}",
+                    commands::template_install_filter::gitattributes_line()
+                );
+            }
+            _ => unreachable!("unknown rung key"),
+        }
+    }
+    eprintln!();
+    eprintln!("Re-run `dodot up` to answer the prompt, or run the install commands directly.");
+    Ok(())
+}
+
+/// Post-`up` cfprefsd cache-invalidation prompt (macOS only).
 ///
-/// 1. stdin is a TTY,
-/// 2. dotfiles root is a git working tree,
-/// 3. at least one template baseline exists,
-/// 4. the dodot pre-commit hook IS installed (we only prompt for
-///    the filter after the user already accepted the hook — keeps
-///    the install ladder one rung at a time),
-/// 5. the dodot-template filter is NOT yet registered in
-///    `.git/config`,
-/// 6. the user has NOT previously dismissed the prompt.
+/// Fires when the previous `dodot up` (or this one's deploy phase)
+/// dropped the `cfprefsd-needs-invalidation` marker — i.e. some
+/// plist file in an active pack has changed since the prior
+/// successful `up`. macOS's `cfprefsd` aggressively caches plist
+/// values; running apps may continue reading the stale value until
+/// `cfprefsd` is restarted. `killall cfprefsd` clears the cache and
+/// cfprefsd respawns immediately. See `docs/proposals/plists.lex`
+/// §6.4 and issue #109.
 ///
-/// All six must hold; otherwise the function returns silently. Same
-/// soft-failure pattern as the other post-`up` prompts.
-pub fn maybe_prompt_install_template_filter() {
-    if let Err(e) = try_prompt_install_template_filter() {
-        tracing::debug!("template install-filter prompt skipped: {e}");
+/// On every outcome (yes / no / show), the marker is cleared so the
+/// prompt doesn't re-fire on the next `up` unless drift recurs. "No"
+/// additionally dismisses the catalog entry so the prompt never
+/// returns until the user runs `dodot prompts reset`.
+pub fn maybe_prompt_invalidate_cfprefsd() {
+    if let Err(e) = try_prompt_invalidate_cfprefsd() {
+        tracing::debug!("cfprefsd-invalidate prompt skipped: {e}");
     }
 }
 
-fn try_prompt_install_template_filter() -> Result<(), anyhow::Error> {
+fn try_prompt_invalidate_cfprefsd() -> Result<(), anyhow::Error> {
     use dodot_lib::prompts::PromptRegistry;
 
+    // cfprefsd is macOS-only.
+    if !cfg!(target_os = "macos") {
+        return Ok(());
+    }
     if !crate::interactive::stdin_is_tty() {
         return Ok(());
     }
@@ -811,80 +879,70 @@ fn try_prompt_install_template_filter() -> Result<(), anyhow::Error> {
     let dotfiles_root = discover_dotfiles_root()?;
     let ctx = dodot_lib::packs::orchestration::ExecutionContext::production(&dotfiles_root, false)?;
 
-    let baselines = dodot_lib::preprocessing::divergence::collect_baselines(
-        ctx.fs.as_ref(),
-        ctx.paths.as_ref(),
-    )?;
-    if baselines.is_empty() {
-        return Ok(());
-    }
-
-    // is_installed/install_filter both shell out to `git -C <root>
-    // config ...` which handles "not a git repo" semantically (we
-    // detect the resulting failure), so we don't need a manual
-    // .git-exists probe here. Bonus: this skips the gating problem
-    // for worktrees (where .git is a file, not a dir, but `git -C`
-    // still works correctly) and submodules.
-
-    if !commands::transform::hook_is_installed(&ctx)? {
-        // Wait for the user to install the hook first. Filter is
-        // strictly more involved (per-clone setup, .gitattributes
-        // edit), so the install ladder asks for the cheaper one
-        // first.
-        return Ok(());
-    }
-
-    if commands::template_install_filter::is_installed(&ctx)? {
+    if !dodot_lib::probe::cfprefsd_marker_exists(ctx.fs.as_ref(), ctx.paths.as_ref()) {
         return Ok(());
     }
 
     let registry_path = ctx.paths.prompts_path();
     let mut registry = PromptRegistry::load(ctx.fs.as_ref(), registry_path)?;
-    let prompt_key = "template.install_filter";
+    let prompt_key = "plist.cfprefsd_invalidate";
     if registry.is_dismissed(prompt_key) {
+        // User previously chose "no". Clear the marker so it doesn't
+        // accumulate on subsequent ups; respect the dismissal.
+        dodot_lib::probe::clear_cfprefsd_marker(ctx.fs.as_ref(), ctx.paths.as_ref());
         return Ok(());
     }
 
     let response = crate::interactive::prompt_yes_no_show(&[
-        "Install the dodot-template git clean filter?",
-        "It makes `git status` and `git diff` show deployed-side template edits",
-        "between commits, not just at commit time. Adds one block to .git/config",
-        "and a single line to .gitattributes.",
+        "dodot detected a plist change on this `up`.",
+        "macOS caches plist values via cfprefsd; running apps may show stale values until",
+        "cfprefsd is restarted. Run `killall cfprefsd` now? (cfprefsd respawns immediately;",
+        "no data loss.) `no` skips and won't ask again.",
     ])?;
 
     match response {
         crate::interactive::YesNoShow::Yes => {
-            let r = commands::template_install_filter::install_filter(&ctx)?;
-            eprintln!("{}", r.message);
-            for d in &r.details {
-                eprintln!("  {d}");
+            // Use the same CommandRunner the rest of dodot uses so
+            // tests can stub it. `killall` returns 1 if no matching
+            // process — that's fine, treat any exit as success for
+            // prompt purposes (the cache is cleared either way: an
+            // empty cache is the desired end state).
+            let runner = ctx.command_runner.as_ref();
+            let result = runner.run("killall", &["cfprefsd".into()]);
+            match result {
+                Ok(_) => eprintln!("Ran `killall cfprefsd`."),
+                Err(e) => eprintln!(
+                    "Tried to run `killall cfprefsd` but failed: {e}. \
+                     You can run it yourself if running apps still show stale plist values."
+                ),
             }
             registry.dismiss(prompt_key);
             registry.save(ctx.fs.as_ref())?;
         }
+        crate::interactive::YesNoShow::No => {
+            registry.dismiss(prompt_key);
+            registry.save(ctx.fs.as_ref())?;
+            eprintln!(
+                "Skipped. Re-run `dodot prompts reset {prompt_key}` to surface this prompt again."
+            );
+        }
         crate::interactive::YesNoShow::Show => {
             eprintln!();
-            eprintln!("Add to .git/config (per clone, per machine):");
+            eprintln!("Would run:");
+            eprintln!("    killall cfprefsd");
             eprintln!();
-            for line in commands::template_install_filter::config_block_text().lines() {
-                eprintln!("    {line}");
-            }
-            eprintln!();
-            eprintln!("Add to .gitattributes (committed in the repo):");
+            eprintln!("That tells macOS to drop its cached plist values; the daemon respawns");
             eprintln!(
-                "    {}",
-                commands::template_install_filter::gitattributes_line()
+                "automatically. No data loss; running apps re-read the plist on next access."
             );
-            eprintln!();
-            eprintln!(
-                "Run `dodot template install-filter` to install, \
-                 or `dodot prompts reset {prompt_key}` to skip and ask later."
-            );
-        }
-        crate::interactive::YesNoShow::No => {
-            // Same convention as the other prompts: "no" defers.
+            // Show doesn't clear or dismiss — re-running `up`
+            // re-prompts.
+            return Ok(());
         }
     }
+
+    // Yes/No: marker handled, clear it.
+    dodot_lib::probe::clear_cfprefsd_marker(ctx.fs.as_ref(), ctx.paths.as_ref());
     Ok(())
 }
 

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -141,19 +141,24 @@ fn main() {
     match app.dispatch(matches, output_mode) {
         standout::cli::RunResult::Handled(output) => {
             println!("{output}");
-            // Post-up nudges. All fire only after a successful `up`
-            // and all are soft (failures land in the debug log,
-            // never stderr). They form an install ladder:
-            //   1. plist filters (when plist files exist)
-            //   2. template hook (when template baselines exist)
-            //   3. template clean filter (when hook is already
-            //      installed AND filter isn't yet)
-            // The user moves up one rung per `up` until they've
-            // accepted or dismissed each — never spammed all at once.
+            // Post-up nudges. Both fire only after a successful `up`
+            // and are soft (failures land in the debug log, never
+            // stderr).
+            //
+            // - `maybe_prompt_install_ladder`: single Y/n covering
+            //   the pre-commit hook + plist filter + template filter
+            //   (whichever apply). Replaces the earlier three
+            //   sequential prompts. See magic.lex §"What This Costs
+            //   the User" and #112.
+            //
+            // - `maybe_prompt_invalidate_cfprefsd` (macOS only):
+            //   fires when `up` detected a plist change relative to
+            //   the previous run. Offers `killall cfprefsd` so
+            //   running apps re-read the new values. See plists.lex
+            //   §6.4 and #109.
             if subcommand.as_deref() == Some("up") {
-                handlers::maybe_prompt_install_filters();
-                handlers::maybe_prompt_install_template_hook();
-                handlers::maybe_prompt_install_template_filter();
+                handlers::maybe_prompt_install_ladder();
+                handlers::maybe_prompt_invalidate_cfprefsd();
             }
             // `dodot transform check` may have set a non-zero exit code
             // via PENDING_EXIT_CODE: the report still rendered above,

--- a/crates/dodot-lib/src/commands/git_filters.rs
+++ b/crates/dodot-lib/src/commands/git_filters.rs
@@ -233,13 +233,25 @@ pub fn is_installed(ctx: &ExecutionContext) -> Result<bool> {
 /// prompt is harmless. A stricter check would require shelling out to
 /// `git ls-files` on every `up`.
 pub fn detect_plist_files(ctx: &ExecutionContext) -> Result<Vec<std::path::PathBuf>> {
-    let mut found = Vec::new();
     let root = ctx.paths.dotfiles_root();
     if !ctx.fs.is_dir(root) {
-        return Ok(found);
+        return Ok(Vec::new());
     }
     let root_config = ctx.config_manager.root_config()?;
     let packs = crate::packs::discover_packs(ctx.fs.as_ref(), root, &root_config.pack.ignore)?;
+    detect_plist_files_in(ctx, &packs)
+}
+
+/// Like [`detect_plist_files`], but scoped to a caller-supplied pack
+/// list. Used by callers that already discovered packs (e.g.
+/// `commands::up`, which scopes drift detection to only the packs
+/// the current run actually deployed) to avoid re-walking the
+/// dotfiles tree and to honor `--pack` filters.
+pub fn detect_plist_files_in(
+    ctx: &ExecutionContext,
+    packs: &[crate::packs::Pack],
+) -> Result<Vec<std::path::PathBuf>> {
+    let mut found = Vec::new();
     for pack in packs {
         // Honor pack-level overrides of `[symlink] plist_extensions`.
         let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -802,6 +802,49 @@ fn up_dry_run_does_not_write_preprocessing_baselines() {
     );
 }
 
+// ── cfprefsd drift marker (#109) ────────────────────────────
+
+#[cfg(target_os = "macos")]
+#[test]
+fn up_writes_cfprefsd_marker_on_first_run_with_plists() {
+    // First-ever `up`: no previous last-up marker, so any plist
+    // file in an active pack counts as "drifted." The marker
+    // must land for the post-up prompt to fire.
+    let env = TempEnvironment::builder()
+        .pack("mac-defaults")
+        .file("com.example.app.plist", "<?xml?><plist></plist>")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    let marker = ctx.paths.data_dir().join("cfprefsd-needs-invalidation");
+    assert!(
+        ctx.fs.exists(&marker),
+        "marker should land on the first up that deploys a plist"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn up_does_not_write_cfprefsd_marker_when_pack_has_no_plists() {
+    // Pack contains no plist files → the cfprefsd prompt has
+    // nothing to invalidate; the marker must stay absent.
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    let marker = ctx.paths.data_dir().join("cfprefsd-needs-invalidation");
+    assert!(
+        !ctx.fs.exists(&marker),
+        "marker must not appear when no plists are present"
+    );
+}
+
 // ── up: conflict handling ──────────────────────────────────
 
 #[test]

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -845,6 +845,32 @@ fn up_does_not_write_cfprefsd_marker_when_pack_has_no_plists() {
     );
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn up_with_pack_filter_does_not_write_cfprefsd_marker_for_unrelated_pack_plists() {
+    // Pack A contains a plist; pack B has only non-plist files.
+    // Running `dodot up` filtered to pack B must NOT drop the
+    // cfprefsd marker — the user's command didn't touch any plist.
+    let env = TempEnvironment::builder()
+        .pack("mac-defaults")
+        .file("com.example.app.plist", "<?xml?><plist></plist>")
+        .done()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+    let filter = vec!["vim".to_string()];
+    commands::up::up(Some(&filter), &ctx).unwrap();
+
+    let marker = ctx.paths.data_dir().join("cfprefsd-needs-invalidation");
+    assert!(
+        !ctx.fs.exists(&marker),
+        "drift detection must respect the pack filter — \
+         a plist in an unrelated pack should not trigger the marker"
+    );
+}
+
 // ── up: conflict handling ──────────────────────────────────
 
 #[test]

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -181,7 +181,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         // No-op on non-macOS hosts (cfprefsd doesn't exist there).
         if cfg!(target_os = "macos") {
             let prev_last_up = probe::read_last_up_marker(ctx.fs.as_ref(), ctx.paths.as_ref());
-            if let Err(e) = maybe_record_cfprefsd_drift(ctx, prev_last_up) {
+            if let Err(e) = maybe_record_cfprefsd_drift(ctx, &packs, prev_last_up) {
                 debug!(error = %e, "cfprefsd drift check skipped");
             }
         }
@@ -322,7 +322,9 @@ pub fn up_or_status_for_conflict(
 
 /// macOS cfprefsd drift detection.
 ///
-/// Walks every active pack for files whose suffix matches the
+/// Walks the packs that this `up` actually targeted (so a
+/// `dodot up <one-pack>` run never fires cfprefsd because of a plist
+/// in some unrelated pack) for files whose suffix matches the
 /// pack-resolved `[symlink] plist_extensions` list. If any plist's
 /// mtime is newer than `prev_last_up_ts` (or the marker is missing —
 /// first `up` on this machine), drop the cfprefsd-needs-invalidation
@@ -333,10 +335,14 @@ pub fn up_or_status_for_conflict(
 /// drift (the GUI app rewrote the plist between yesterday's `up` and
 /// today's). cfprefsd's cache may be stale either way; the prompt is
 /// what gives the user a single chance to clear it.
-fn maybe_record_cfprefsd_drift(ctx: &ExecutionContext, prev_last_up_ts: Option<u64>) -> Result<()> {
+fn maybe_record_cfprefsd_drift(
+    ctx: &ExecutionContext,
+    packs: &[Pack],
+    prev_last_up_ts: Option<u64>,
+) -> Result<()> {
     use std::time::UNIX_EPOCH;
 
-    let plist_files = crate::commands::git_filters::detect_plist_files(ctx)?;
+    let plist_files = crate::commands::git_filters::detect_plist_files_in(ctx, packs)?;
     if plist_files.is_empty() {
         return Ok(());
     }

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -171,6 +171,20 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         )?;
         info!("writing deployment map");
         probe::write_deployment_map(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+        // cfprefsd cache-invalidation hint (macOS): if any plist file
+        // in any active pack has drifted since the previous successful
+        // `up`, drop a marker so the CLI's post-`up` prompt can offer
+        // `killall cfprefsd`. The previous-up timestamp must be
+        // captured BEFORE the new last-up marker is written below;
+        // afterwards every plist's mtime would be older than the new
+        // marker and the detector would always report "no drift".
+        // No-op on non-macOS hosts (cfprefsd doesn't exist there).
+        if cfg!(target_os = "macos") {
+            let prev_last_up = probe::read_last_up_marker(ctx.fs.as_ref(), ctx.paths.as_ref());
+            if let Err(e) = maybe_record_cfprefsd_drift(ctx, prev_last_up) {
+                debug!(error = %e, "cfprefsd drift check skipped");
+            }
+        }
         // Record the unix timestamp of this up so `dodot probe shell-init`
         // can flag profiles captured before it as stale. Best effort —
         // a clock skip would only affect the staleness banner, never the
@@ -304,6 +318,50 @@ pub fn up_or_status_for_conflict(
         }
         Err(e) => Err(e),
     }
+}
+
+/// macOS cfprefsd drift detection.
+///
+/// Walks every active pack for files whose suffix matches the
+/// pack-resolved `[symlink] plist_extensions` list. If any plist's
+/// mtime is newer than `prev_last_up_ts` (or the marker is missing —
+/// first `up` on this machine), drop the cfprefsd-needs-invalidation
+/// marker so the CLI's post-`up` prompt fires.
+///
+/// "Drift" here is intentionally loose: it captures both
+/// deploy-time changes (a new plist landed) and between-`up` app
+/// drift (the GUI app rewrote the plist between yesterday's `up` and
+/// today's). cfprefsd's cache may be stale either way; the prompt is
+/// what gives the user a single chance to clear it.
+fn maybe_record_cfprefsd_drift(ctx: &ExecutionContext, prev_last_up_ts: Option<u64>) -> Result<()> {
+    use std::time::UNIX_EPOCH;
+
+    let plist_files = crate::commands::git_filters::detect_plist_files(ctx)?;
+    if plist_files.is_empty() {
+        return Ok(());
+    }
+    let drifted = plist_files.iter().any(|p| {
+        let mtime_secs = ctx
+            .fs
+            .modified(p)
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_secs());
+        match (mtime_secs, prev_last_up_ts) {
+            // No previous up marker (first run on this machine):
+            // every plist counts as fresh.
+            (Some(_), None) => true,
+            // Strict newer-than: equal timestamps (same-second `up`
+            // run) don't fire the prompt — the file was just written
+            // by us, no app-side drift to invalidate.
+            (Some(m), Some(prev)) => m > prev,
+            (None, _) => false,
+        }
+    });
+    if drifted {
+        probe::write_cfprefsd_marker(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+    }
+    Ok(())
 }
 
 /// Remove datastore state for a pack across the given configuration

--- a/crates/dodot-lib/src/probe/cfprefsd_marker.rs
+++ b/crates/dodot-lib/src/probe/cfprefsd_marker.rs
@@ -1,0 +1,92 @@
+//! cfprefsd cache-invalidation marker.
+//!
+//! macOS aggressively caches plist values in `cfprefsd`, so a plist
+//! file the user just deployed (or that an app rewrote between
+//! `dodot up` runs) may not be visible to the running app until
+//! cfprefsd is restarted. A `killall cfprefsd` clears the cache and
+//! cfprefsd respawns immediately — no data loss.
+//!
+//! `dodot up` decides whether to prompt the user for cfprefsd
+//! invalidation. It writes this marker file when it observes plist
+//! drift (any plist file in any active pack with mtime newer than the
+//! previous `last-up-at`). The CLI's post-`up` prompt reads the
+//! marker, asks the user once, and clears it on yes/no.
+//!
+//! Format: presence of the file is the entire signal. The contents
+//! are unused; we write a one-line note to make the file
+//! self-documenting if someone discovers it.
+//!
+//! See [`docs/proposals/plists.lex`] §6.4 (cfprefsd caching) and
+//! issue #109.
+//!
+//! Lives under `data_dir` (not `cache_dir`) because clearing the
+//! cache should not silently drop a pending user prompt.
+
+use std::path::PathBuf;
+
+use crate::fs::Fs;
+use crate::paths::Pather;
+use crate::Result;
+
+const MARKER_FILENAME: &str = "cfprefsd-needs-invalidation";
+const MARKER_NOTE: &[u8] =
+    b"dodot detected plist drift on the last `up`; the CLI prompt clears this file.\n";
+
+/// On-disk path of the marker.
+pub fn cfprefsd_marker_path(paths: &dyn Pather) -> PathBuf {
+    paths.data_dir().join(MARKER_FILENAME)
+}
+
+/// True if the marker is present on disk.
+pub fn cfprefsd_marker_exists(fs: &dyn Fs, paths: &dyn Pather) -> bool {
+    fs.exists(&cfprefsd_marker_path(paths))
+}
+
+/// Write the marker. Idempotent: re-writing is a no-op.
+pub fn write_cfprefsd_marker(fs: &dyn Fs, paths: &dyn Pather) -> Result<()> {
+    let path = cfprefsd_marker_path(paths);
+    fs.mkdir_all(paths.data_dir())?;
+    fs.write_file(&path, MARKER_NOTE)
+}
+
+/// Remove the marker if it exists. Best-effort: failures are not
+/// surfaced — the marker's only consumer is the prompt, which would
+/// re-fire on a subsequent `up` if removal silently failed (and the
+/// user can re-dismiss).
+pub fn clear_cfprefsd_marker(fs: &dyn Fs, paths: &dyn Pather) {
+    let path = cfprefsd_marker_path(paths);
+    if fs.exists(&path) {
+        let _ = fs.remove_file(&path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TempEnvironment;
+
+    #[test]
+    fn marker_round_trip() {
+        let env = TempEnvironment::builder().build();
+        assert!(!cfprefsd_marker_exists(env.fs.as_ref(), env.paths.as_ref()));
+        write_cfprefsd_marker(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        assert!(cfprefsd_marker_exists(env.fs.as_ref(), env.paths.as_ref()));
+        clear_cfprefsd_marker(env.fs.as_ref(), env.paths.as_ref());
+        assert!(!cfprefsd_marker_exists(env.fs.as_ref(), env.paths.as_ref()));
+    }
+
+    #[test]
+    fn write_is_idempotent() {
+        let env = TempEnvironment::builder().build();
+        write_cfprefsd_marker(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        write_cfprefsd_marker(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+        assert!(cfprefsd_marker_exists(env.fs.as_ref(), env.paths.as_ref()));
+    }
+
+    #[test]
+    fn clear_is_idempotent_when_missing() {
+        let env = TempEnvironment::builder().build();
+        clear_cfprefsd_marker(env.fs.as_ref(), env.paths.as_ref());
+        assert!(!cfprefsd_marker_exists(env.fs.as_ref(), env.paths.as_ref()));
+    }
+}

--- a/crates/dodot-lib/src/probe/mod.rs
+++ b/crates/dodot-lib/src/probe/mod.rs
@@ -15,12 +15,16 @@
 //! submodule when it lands.
 
 pub mod brew;
+pub mod cfprefsd_marker;
 pub mod data_dir_tree;
 pub mod deployment_map;
 pub mod last_up;
 pub mod macos_native;
 pub mod shell_init;
 
+pub use cfprefsd_marker::{
+    cfprefsd_marker_exists, cfprefsd_marker_path, clear_cfprefsd_marker, write_cfprefsd_marker,
+};
 pub use data_dir_tree::{collect_data_dir_tree, TreeNode};
 pub use deployment_map::{
     collect_deployment_map, read_deployment_map, write_deployment_map, DeploymentKind,

--- a/crates/dodot-lib/src/prompts/catalog.rs
+++ b/crates/dodot-lib/src/prompts/catalog.rs
@@ -23,21 +23,37 @@ pub struct PromptDescriptor {
 /// `dodot prompts list` output is stable across edits.
 pub const KNOWN_PROMPTS: &[PromptDescriptor] = &[
     PromptDescriptor {
+        key: "magic.install_ladder",
+        description:
+            "Single Y/n covering the post-`up` install ladder (pre-commit hook + plist filter \
+             + template filter, whichever apply). Replaces the three sequential prompts that \
+             were dismissed independently.",
+    },
+    PromptDescriptor {
+        key: "plist.cfprefsd_invalidate",
+        description:
+            "macOS only: offer to run `killall cfprefsd` after a `dodot up` that touched plist \
+             files, so running GUI apps re-read the new values from disk.",
+    },
+    PromptDescriptor {
         key: "plist.install_filters",
         description:
-            "Offer to install git clean/smudge filters when a pack contains tracked .plist files",
+            "Per-component dismissal target for the plist clean/smudge filter rung of the \
+             install ladder. The user-facing prompt is `magic.install_ladder`; this key tracks \
+             whether that ladder rung has been dismissed.",
     },
     PromptDescriptor {
         key: "template.install_filter",
         description:
-            "Offer to install the dodot-template git clean filter after the first successful \
-             template deployment with the pre-commit hook already in place",
+            "Per-component dismissal target for the template clean filter rung of the install \
+             ladder. The user-facing prompt is `magic.install_ladder`; this key tracks whether \
+             that ladder rung has been dismissed.",
     },
     PromptDescriptor {
         key: "template.install_hook",
-        description:
-            "Offer to install the pre-commit hook running `dodot transform check --strict` after \
-             the first successful template deployment",
+        description: "Per-component dismissal target for the pre-commit hook rung of the install \
+             ladder. The user-facing prompt is `magic.install_ladder`; this key tracks whether \
+             that ladder rung has been dismissed.",
     },
 ];
 

--- a/docs/proposals/magic.lex
+++ b/docs/proposals/magic.lex
@@ -198,3 +198,11 @@ The User Experience
     6.5. Per-file `no_reverse` opt-out
 
         Not in the original spec. R9 added `[preprocessor.template] no_reverse = ["pattern", ...]` for templates whose content is mostly dynamic — burgertocow's heuristic produces more conflict markers than usable diffs on those, so the user opts the file out of reverse-merge while keeping divergence detection. Per-file glob patterns; pack-level `.dodot.toml` overrides root.
+
+    6.6. Consolidated post-`up` install ladder
+
+        The original R4 / R6 install paths shipped as three sequential post-`up` prompts (plist filter, hook, template filter), each with its own Y/n. That violated the §4 promise of "one Y/n to install the clean/smudge filters and the pre-commit hook." Issue #112 tracked the reconciliation; the shipped form is a single Y/n covering whichever rungs apply, with `show` walking each component's preview block individually and `no` dismissing every applicable component at once. Each rung still has its own catalog dismissal key (`template.install_hook`, `plist.install_filters`, `template.install_filter`) so users can resurface a single rung via `dodot prompts reset <key>` after a global "no". The umbrella prompt is `magic.install_ladder`.
+
+    6.7. cfprefsd cache-invalidation prompt
+
+        Not in the original spec. Issue #109 added a separate post-`up` prompt that fires (macOS only) when `dodot up` detects a plist file in any active pack with mtime newer than the previous successful `up`. Offers `killall cfprefsd` so running GUI apps re-read fresh plist values. The detection is mtime-based via a marker file (`<data_dir>/cfprefsd-needs-invalidation`) written by `up` and consumed by the prompt. Catalog key: `plist.cfprefsd_invalidate`. cfprefsd respawns immediately so there's no data-loss window.


### PR DESCRIPTION
## Summary

Wave 3 of the #116 pre-release polish plan: UX consolidation. Replaces the three sequential post-`up` install prompts with one Y/n covering whichever rungs apply, and adds a separate cfprefsd cache-invalidation prompt that fires (macOS only) when `up` actually changed plist files since the previous run.

Closes #112, closes #109.

## #112 — Consolidated install ladder

Restores the `magic.lex` §"What This Costs the User" promise: "one Y/n to install the clean/smudge filters and the pre-commit hook." Today the user sees three sequential Y/n prompts after `up`; this PR collapses them.

**Behavior:**

- **Yes**: installs every applicable rung in dependency order — pre-commit hook first, plist filter, template clean filter. Each successful install dismisses its component key.
- **Show**: walks each rung's preview block individually (config block, hook script, `.gitattributes` lines) without touching the registry. The user reads, then re-runs `up` to answer for real.
- **No**: dismisses every applicable component key plus the umbrella `magic.install_ladder` key. Subsequent `up` runs don't re-prompt. Resurface a single rung via `dodot prompts reset <key>` later.

**Rung detection:**

A rung enters the ladder only when (a) its trigger condition holds (templates exist for hook/template-filter; plists exist for plist-filter; and the corresponding installer hasn't run), AND (b) its component dismissal isn't set. So a user who said "no" to template-filter once still gets prompted about a hook + plist-filter ladder if they add new packs later.

**Tier-3 alias** (`git-install-alias`) intentionally stays separate per the original spec — not in the ladder.

**Existing CLI primitives** (`git-install-filters`, `template install-filter`, `transform install-hook`) are unchanged. The ladder calls them; users can still invoke them directly.

## #109 — cfprefsd cache-invalidation prompt (macOS only)

After `dodot up` deploys plist file(s), offer `killall cfprefsd` so running GUI apps re-read the new values. cfprefsd respawns immediately — no data loss window.

**Detection:** `commands::up::up` reads the previous `last-up-at` marker BEFORE writing the new one, walks active packs for plist files (using existing `git_filters::detect_plist_files`, which honours `[symlink] plist_extensions`), and drops a marker file at `<data_dir>/cfprefsd-needs-invalidation` if any plist's mtime is newer than the previous up (or no previous up exists). The CLI's post-`up` `maybe_prompt_invalidate_cfprefsd` reads + clears the marker.

The mtime-based marker is a deliberate choice over piping operation results through standout's render-only dispatch: it captures **both** deploy-time changes AND between-up app drift (apps rewrite plists silently on settings changes), which is the actual user-visible failure mode the prompt addresses.

**Outcomes:**

- **Yes**: runs `killall cfprefsd` via the injected `CommandRunner`; clears the marker; dismisses the catalog entry.
- **No**: clears the marker; dismisses the catalog entry. (Use `dodot prompts reset plist.cfprefsd_invalidate` to surface again.)
- **Show**: prints what would run; leaves the marker so re-running `up` re-prompts.

## What's in the diff

```
crates/dodot-cli/src/handlers.rs              | 496 ++++++++++++++++--------
crates/dodot-cli/src/main.rs                  |  29 +-
crates/dodot-lib/src/commands/tests.rs        |  43 +++
crates/dodot-lib/src/commands/up.rs           |  61 ++++
crates/dodot-lib/src/probe/cfprefsd_marker.rs |  92 +++++
crates/dodot-lib/src/probe/mod.rs             |   4 +
crates/dodot-lib/src/prompts/catalog.rs       |  27 +-
docs/proposals/magic.lex                      |   8 +
8 files changed, 522 insertions(+), 238 deletions(-)
```

## Test plan

- [x] `cargo test --workspace` — 863 lib + 12 integration tests, all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Full bats suite — 254 tests green
- [x] 5 new unit tests on the cfprefsd machinery: marker round-trip, idempotent write/clear, drift detection on first run with plists, no marker when pack has no plists, drift module idempotent-clear-when-missing

## Out of scope (Wave 4 per #116)

- #121 — passive-command contract (`status` and `up --dry-run` still call `preprocess_pack`, which evaluates templates). Structural fix tracked separately.
