### PR TITLE
fix(preprocessing): #121 — passive-command contract for status / up --dry-run

### DIFF
--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -453,6 +453,9 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
                 ctx.paths.as_ref(),
             )?;
             if !registry.is_empty() {
+                // status is a Passive command — never evaluate
+                // templates, never write rendered files or baselines.
+                // See `secrets.lex` §7.4 / issue #121.
                 match crate::preprocessing::pipeline::preprocess_pack(
                     entries,
                     &registry,
@@ -460,7 +463,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
                     ctx.fs.as_ref(),
                     ctx.datastore.as_ref(),
                     ctx.paths.as_ref(),
-                    /* write_baselines */ false,
+                    crate::preprocessing::PreprocessMode::Passive,
                     /* force */ false,
                 ) {
                     Ok(r) => r,
@@ -488,8 +491,9 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         // element is the user-facing label that surfaces in any
         // resulting `DisplayConflict.claimants` entry, so it tracks
         // the pack's display name rather than its raw on-disk name.
-        // status is read-only — never write baselines.
-        match orchestration::plan_pack(&pack, ctx, /* write_baselines */ false) {
+        // status is a Passive command — same §7.4 contract as the
+        // direct preprocess_pack call above.
+        match orchestration::plan_pack(&pack, ctx, crate::preprocessing::PreprocessMode::Passive) {
             Ok(plan) => {
                 warnings.extend(plan.warnings);
                 pack_intents.push((pack.display_name.clone(), plan.intents));

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -1025,6 +1025,35 @@ fn install_template_dry_run_emits_correct_sentinel_without_writing_rendered_file
 }
 
 #[test]
+fn up_dry_run_first_time_pack_with_install_template_does_not_error() {
+    // Regression for Copilot review on PR #126: a first-time pack
+    // containing `install.sh.tmpl` (no baseline yet, no rendered
+    // file on disk) must not crash dry-run intent collection. The
+    // install handler used to read `m.absolute_path` unconditionally
+    // and propagate an Fs error; now it skips intent generation for
+    // the placeholder match instead. Same shape for `Brewfile.tmpl`
+    // / homebrew handler.
+    let env = TempEnvironment::builder()
+        .pack("setup")
+        .file("install.sh.tmpl", "#!/bin/sh\necho hello {{ name }}")
+        .file("Brewfile.tmpl", "brew '{{ pkg }}'")
+        .config("[preprocessor.template.vars]\nname = \"Alice\"\npkg = \"jq\"\n")
+        .done()
+        .build();
+
+    let mut dry_ctx = make_ctx(&env);
+    dry_ctx.no_provision = false;
+    dry_ctx.dry_run = true;
+
+    // The fix: this returns Ok and emits zero Run intents (the
+    // placeholders skip intent generation cleanly). Pre-fix, the
+    // install/homebrew handlers tried to read missing rendered
+    // files and propagated an Fs error.
+    let result = commands::up::up(None, &dry_ctx).unwrap();
+    assert!(result.dry_run);
+}
+
+#[test]
 fn passive_first_time_pack_surfaces_pending_placeholder() {
     // §7.4 acceptance: a passive command on a brand-new pack with
     // no baseline cache yet must surface a coherent placeholder
@@ -1052,14 +1081,23 @@ fn passive_first_time_pack_surfaces_pending_placeholder() {
     );
 }
 
-/// Hash a directory tree to a stable byte-identity signature for
-/// the §7.4 no-mutation contract tests above. Returns a sorted
-/// `path → bytes` map; comparing the map equality is equivalent to
-/// "directory is byte-identical."
+/// Snapshot a directory tree (file contents + directory paths) to a
+/// stable signature for the §7.4 no-mutation contract tests. Each
+/// entry is keyed by absolute path; files map to `Some(contents)`,
+/// directories to `None`. Comparing two snapshots for equality is
+/// equivalent to "directory tree is byte-identical, including empty
+/// directories." Including dir paths catches mutations like
+/// `mkdir <data_dir>/<pack>/preprocessed` that would silently slip
+/// past a contents-only check.
+///
+/// Unreadable entries / read errors propagate as panics rather than
+/// silent skips — a passive command that produces an unreadable
+/// entry under `<data_dir>` is itself a §7.4 violation worth
+/// failing the test on.
 fn snapshot_dir_contents(
     env: &crate::testing::TempEnvironment,
     root: &std::path::Path,
-) -> std::collections::BTreeMap<std::path::PathBuf, Vec<u8>> {
+) -> std::collections::BTreeMap<std::path::PathBuf, Option<Vec<u8>>> {
     use std::collections::BTreeMap;
     let mut out = BTreeMap::new();
     if !env.fs.exists(root) {
@@ -1067,15 +1105,19 @@ fn snapshot_dir_contents(
     }
     let mut stack: Vec<std::path::PathBuf> = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
-        let entries = match env.fs.read_dir(&dir) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
+        let entries = env
+            .fs
+            .read_dir(&dir)
+            .unwrap_or_else(|e| panic!("snapshot_dir_contents: read_dir({dir:?}): {e}"));
         for entry in entries {
             if entry.is_dir {
+                out.insert(entry.path.clone(), None);
                 stack.push(entry.path);
-            } else if let Ok(bytes) = env.fs.read_file(&entry.path) {
-                out.insert(entry.path, bytes);
+            } else {
+                let bytes = env.fs.read_file(&entry.path).unwrap_or_else(|e| {
+                    panic!("snapshot_dir_contents: read_file({:?}): {e}", entry.path)
+                });
+                out.insert(entry.path, Some(bytes));
             }
         }
     }

--- a/crates/dodot-lib/src/commands/tests.rs
+++ b/crates/dodot-lib/src/commands/tests.rs
@@ -871,6 +871,217 @@ fn up_with_pack_filter_does_not_write_cfprefsd_marker_for_unrelated_pack_plists(
     );
 }
 
+// ── §7.4 passive-command contract (#121) ───────────────────
+
+#[test]
+fn status_does_not_write_to_datastore() {
+    // §7.4: passive commands MUST NOT mutate the datastore.
+    // Running `up` once primes the data dir; running `status`
+    // afterwards must leave that state byte-identical.
+    let env = TempEnvironment::builder()
+        .pack("app")
+        .file("config.toml.tmpl", "name = {{ name }}")
+        .config("[preprocessor.template.vars]\nname = \"Alice\"\n")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    let snapshot = snapshot_dir_contents(&env, env.paths.data_dir());
+
+    // Two consecutive status runs must leave data_dir unchanged.
+    commands::status::status(None, &ctx).unwrap();
+    commands::status::status(None, &ctx).unwrap();
+
+    let after = snapshot_dir_contents(&env, env.paths.data_dir());
+    assert_eq!(
+        snapshot, after,
+        "status must be byte-identical to the post-up snapshot — \
+         no datastore writes allowed"
+    );
+}
+
+#[test]
+fn up_dry_run_does_not_write_to_datastore() {
+    // Pin the same §7.4 contract for `up --dry-run`.
+    let env = TempEnvironment::builder()
+        .pack("app")
+        .file("config.toml.tmpl", "name = {{ name }}")
+        .config("[preprocessor.template.vars]\nname = \"Alice\"\n")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+    let snapshot = snapshot_dir_contents(&env, env.paths.data_dir());
+
+    let mut dry_ctx = make_ctx(&env);
+    dry_ctx.dry_run = true;
+    commands::up::up(None, &dry_ctx).unwrap();
+
+    let after = snapshot_dir_contents(&env, env.paths.data_dir());
+    assert_eq!(
+        snapshot, after,
+        "dry-run must be byte-identical to the post-up snapshot"
+    );
+}
+
+#[test]
+fn install_template_dry_run_emits_correct_sentinel_without_writing_rendered_file() {
+    // The §7.4 unblocker: in Passive mode the rendered file isn't
+    // on disk, so the install handler used to fail to compute its
+    // sentinel. With `rendered_bytes` threaded through, dry-run now
+    // emits a Run intent with the same sentinel as the active path
+    // would — without ever writing the rendered file. (#121)
+    let env = TempEnvironment::builder()
+        .pack("app")
+        .file("install.sh.tmpl", "#!/bin/sh\necho hello {{ name }}")
+        .config("[preprocessor.template.vars]\nname = \"Alice\"\n")
+        .done()
+        .build();
+
+    // First up establishes the baseline so Passive mode has
+    // something to read. no_provision = false so the install
+    // handler actually plans Run intents (the default test ctx
+    // suppresses code-execution handlers).
+    let mut ctx = make_ctx(&env);
+    ctx.no_provision = false;
+    commands::up::up(None, &ctx).unwrap();
+
+    // Capture the active sentinel (it lives in the executed
+    // RunCommand operation).
+    let active_intents = crate::packs::orchestration::collect_pack_intents(
+        &crate::packs::Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            ctx.config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        ),
+        &ctx,
+    )
+    .unwrap();
+    let active_sentinel = active_intents
+        .iter()
+        .find_map(|i| match i {
+            crate::operations::HandlerIntent::Run { sentinel, .. } => Some(sentinel.clone()),
+            _ => None,
+        })
+        .expect("active path must produce a Run intent for install.sh");
+
+    // Snapshot the rendered datastore file's existence — Passive
+    // must not modify it, but it should already exist from the
+    // earlier active up.
+    let rendered_path = env
+        .paths
+        .handler_data_dir("app", "preprocessed")
+        .join("install.sh");
+    assert!(
+        ctx.fs.exists(&rendered_path),
+        "active up must have written the rendered file"
+    );
+    let rendered_before = ctx.fs.read_file(&rendered_path).unwrap();
+
+    // Now plan via dry-run; the install handler must produce the
+    // same sentinel from in-memory bytes. Same no_provision = false
+    // so the handler actually emits intents.
+    let mut dry_ctx = make_ctx(&env);
+    dry_ctx.no_provision = false;
+    dry_ctx.dry_run = true;
+    let plan = crate::packs::orchestration::plan_pack(
+        &crate::packs::Pack::new(
+            "app".into(),
+            env.dotfiles_root.join("app"),
+            dry_ctx
+                .config_manager
+                .config_for_pack(&env.dotfiles_root.join("app"))
+                .unwrap()
+                .to_handler_config(),
+        ),
+        &dry_ctx,
+        crate::preprocessing::PreprocessMode::Passive,
+    )
+    .unwrap();
+    let dry_sentinel = plan
+        .intents
+        .iter()
+        .find_map(|i| match i {
+            crate::operations::HandlerIntent::Run { sentinel, .. } => Some(sentinel.clone()),
+            _ => None,
+        })
+        .expect("passive path must produce a Run intent for install.sh");
+
+    assert_eq!(
+        active_sentinel, dry_sentinel,
+        "passive sentinel must match active — same rendered bytes either way"
+    );
+    let rendered_after = ctx.fs.read_file(&rendered_path).unwrap();
+    assert_eq!(
+        rendered_before, rendered_after,
+        "passive must not rewrite the rendered file"
+    );
+}
+
+#[test]
+fn passive_first_time_pack_surfaces_pending_placeholder() {
+    // §7.4 acceptance: a passive command on a brand-new pack with
+    // no baseline cache yet must surface a coherent placeholder
+    // (template stripped name, status pending), never panic, never
+    // fall through to template evaluation. (#121)
+    let env = TempEnvironment::builder()
+        .pack("app")
+        .file("greet.tmpl", "hello {{ name }}")
+        .config("[preprocessor.template.vars]\nname = \"Alice\"\n")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    let result = commands::status::status(None, &ctx).unwrap();
+
+    let files = &result.packs[0].files;
+    assert_eq!(files.len(), 1, "should surface the templated entry");
+    assert_eq!(
+        files[0].name, "greet",
+        "stripped name (not source filename)"
+    );
+    assert_eq!(
+        files[0].status, "pending",
+        "first-time template before any up: pending"
+    );
+}
+
+/// Hash a directory tree to a stable byte-identity signature for
+/// the §7.4 no-mutation contract tests above. Returns a sorted
+/// `path → bytes` map; comparing the map equality is equivalent to
+/// "directory is byte-identical."
+fn snapshot_dir_contents(
+    env: &crate::testing::TempEnvironment,
+    root: &std::path::Path,
+) -> std::collections::BTreeMap<std::path::PathBuf, Vec<u8>> {
+    use std::collections::BTreeMap;
+    let mut out = BTreeMap::new();
+    if !env.fs.exists(root) {
+        return out;
+    }
+    let mut stack: Vec<std::path::PathBuf> = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match env.fs.read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries {
+            if entry.is_dir {
+                stack.push(entry.path);
+            } else if let Ok(bytes) = env.fs.read_file(&entry.path) {
+                out.insert(entry.path, bytes);
+            }
+        }
+    }
+    out
+}
+
 // ── up: conflict handling ──────────────────────────────────
 
 #[test]
@@ -5462,7 +5673,8 @@ fn plan_pack_emits_missing_target_hint_with_cask_enrichment() {
         config: pack_config.to_handler_config(),
     };
 
-    let plan = orchestration::plan_pack(&pack, &ctx, true).unwrap();
+    let plan = orchestration::plan_pack(&pack, &ctx, crate::preprocessing::PreprocessMode::Active)
+        .unwrap();
     let hint = plan.warnings.iter().find(|w| w.contains("Code"));
     assert!(
         hint.is_some(),

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -60,10 +60,16 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     let mut planning_warnings: Vec<String> = Vec::new();
 
     for pack in &packs {
-        // `write_baselines` is gated on `!dry_run`: baselines anchor
-        // "the state of the last successful `dodot up`," so a dry run
-        // — which never executes — must not move that anchor.
-        match orchestration::plan_pack(pack, ctx, /* write_baselines */ !ctx.dry_run) {
+        // Active when actually deploying; Passive on `--dry-run`. The
+        // Passive envelope skips template evaluation (no provider
+        // calls, no auth prompts) and skips datastore + baseline
+        // writes. See `secrets.lex` §7.4 / issue #121.
+        let mode = if ctx.dry_run {
+            crate::preprocessing::PreprocessMode::Passive
+        } else {
+            crate::preprocessing::PreprocessMode::Active
+        };
+        match orchestration::plan_pack(pack, ctx, mode) {
             Ok(plan) => {
                 planning_warnings.extend(plan.warnings);
                 pack_intents.push((pack.display_name.clone(), plan.intents));

--- a/crates/dodot-lib/src/handlers/homebrew.rs
+++ b/crates/dodot-lib/src/handlers/homebrew.rs
@@ -47,10 +47,23 @@ impl Handler for HomebrewHandler<'_> {
             }
 
             // Same in-memory-first sentinel pattern as the install
-            // handler — see install.rs and issue #121 for context.
+            // handler, including the first-time-pack passive
+            // placeholder case (no bytes, no on-disk file → skip
+            // intent generation). See install.rs and issue #121.
             let checksum = match m.rendered_bytes.as_deref() {
                 Some(bytes) => brewfile_checksum_bytes(bytes),
-                None => brewfile_checksum(self.fs, &m.absolute_path)?,
+                None => match self.fs.exists(&m.absolute_path) {
+                    true => brewfile_checksum(self.fs, &m.absolute_path)?,
+                    false => {
+                        tracing::debug!(
+                            pack = %m.pack,
+                            file = %m.absolute_path.display(),
+                            "skipping homebrew intent — no rendered bytes and no on-disk file \
+                             (first-time-pack passive placeholder)"
+                        );
+                        continue;
+                    }
+                },
             };
             let filename = m
                 .relative_path

--- a/crates/dodot-lib/src/handlers/homebrew.rs
+++ b/crates/dodot-lib/src/handlers/homebrew.rs
@@ -46,7 +46,12 @@ impl Handler for HomebrewHandler<'_> {
                 continue;
             }
 
-            let checksum = brewfile_checksum(self.fs, &m.absolute_path)?;
+            // Same in-memory-first sentinel pattern as the install
+            // handler — see install.rs and issue #121 for context.
+            let checksum = match m.rendered_bytes.as_deref() {
+                Some(bytes) => brewfile_checksum_bytes(bytes),
+                None => brewfile_checksum(self.fs, &m.absolute_path)?,
+            };
             let filename = m
                 .relative_path
                 .file_name()
@@ -110,4 +115,14 @@ fn brewfile_checksum(fs: &dyn Fs, path: &Path) -> Result<String> {
     }
     let hash = hasher.finalize();
     Ok(hash[..8].iter().map(|b| format!("{b:02x}")).collect())
+}
+
+/// Same digest format as [`brewfile_checksum`], but over an in-memory
+/// byte slice — used when the rendered Brewfile is available without
+/// a disk read (Passive mode).
+fn brewfile_checksum_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let hash = hasher.finalize();
+    hash[..8].iter().map(|b| format!("{b:02x}")).collect()
 }

--- a/crates/dodot-lib/src/handlers/install.rs
+++ b/crates/dodot-lib/src/handlers/install.rs
@@ -62,7 +62,17 @@ impl Handler for InstallHandler<'_> {
                 continue;
             }
 
-            let checksum = file_checksum(self.fs, &m.absolute_path)?;
+            // Sentinel hashing prefers in-memory rendered bytes when
+            // they're available (preprocessor-produced files); falls
+            // back to a disk read for plain on-disk files. The
+            // in-memory path is the §7.4 enabler — `dodot status`
+            // and `up --dry-run` need a correct sentinel for
+            // templated install scripts without writing the
+            // rendered file to disk. See issue #121.
+            let checksum = match m.rendered_bytes.as_deref() {
+                Some(bytes) => file_checksum_bytes(bytes),
+                None => file_checksum(self.fs, &m.absolute_path)?,
+            };
             let filename = m
                 .relative_path
                 .file_name()
@@ -137,6 +147,16 @@ fn file_checksum(fs: &dyn Fs, path: &Path) -> Result<String> {
     Ok(hex::encode(&hash[..8]))
 }
 
+/// Same digest format as [`file_checksum`], but over an in-memory
+/// byte slice — used when the rendered content is available without
+/// a disk read.
+fn file_checksum_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let hash = hasher.finalize();
+    hex::encode(&hash[..8])
+}
+
 /// Minimal hex encoding (avoids pulling in the `hex` crate).
 mod hex {
     pub fn encode(bytes: &[u8]) -> String {
@@ -195,6 +215,7 @@ mod tests {
             is_dir: false,
             options: std::collections::HashMap::new(),
             preprocessor_source: None,
+            rendered_bytes: None,
         }];
 
         let pather = crate::paths::XdgPather::builder()
@@ -261,6 +282,7 @@ mod tests {
             is_dir: false,
             options: std::collections::HashMap::new(),
             preprocessor_source: None,
+            rendered_bytes: None,
         };
         let matches = vec![
             make_match("install.sh"),

--- a/crates/dodot-lib/src/handlers/install.rs
+++ b/crates/dodot-lib/src/handlers/install.rs
@@ -69,9 +69,29 @@ impl Handler for InstallHandler<'_> {
             // and `up --dry-run` need a correct sentinel for
             // templated install scripts without writing the
             // rendered file to disk. See issue #121.
+            //
+            // First-time-pack passive case: a templated `install.sh`
+            // with no baseline yet lands here as a placeholder match
+            // (no bytes, no file on disk). We can't compute a
+            // sentinel without rendering, and rendering is the §7.4
+            // violation we're refusing to do. Skip intent generation
+            // for this match — status / dry-run will report the file
+            // as pending via the symlink chain instead, and the next
+            // real `dodot up` plans the Run intent normally.
             let checksum = match m.rendered_bytes.as_deref() {
                 Some(bytes) => file_checksum_bytes(bytes),
-                None => file_checksum(self.fs, &m.absolute_path)?,
+                None => match self.fs.exists(&m.absolute_path) {
+                    true => file_checksum(self.fs, &m.absolute_path)?,
+                    false => {
+                        tracing::debug!(
+                            pack = %m.pack,
+                            file = %m.absolute_path.display(),
+                            "skipping install intent — no rendered bytes and no on-disk file \
+                             (first-time-pack passive placeholder)"
+                        );
+                        continue;
+                    }
+                },
             };
             let filename = m
                 .relative_path

--- a/crates/dodot-lib/src/handlers/symlink.rs
+++ b/crates/dodot-lib/src/handlers/symlink.rs
@@ -1191,6 +1191,7 @@ mod tests {
             is_dir: false,
             options: std::collections::HashMap::new(),
             preprocessor_source: None,
+            rendered_bytes: None,
         };
         let handler = SymlinkHandler;
         let config = HandlerConfig::default();
@@ -1245,6 +1246,7 @@ mod tests {
             is_dir: false,
             options: std::collections::HashMap::new(),
             preprocessor_source: None,
+            rendered_bytes: None,
         };
         let err = SymlinkHandler
             .to_intents(&[m], &config, env.paths.as_ref(), env.fs.as_ref())
@@ -1276,6 +1278,7 @@ mod tests {
             is_dir: false,
             options: std::collections::HashMap::new(),
             preprocessor_source: None,
+            rendered_bytes: None,
         };
         let err = SymlinkHandler
             .to_intents(&[m], &config, env.paths.as_ref(), env.fs.as_ref())
@@ -1305,6 +1308,7 @@ mod tests {
             is_dir: false,
             options: std::collections::HashMap::new(),
             preprocessor_source: None,
+            rendered_bytes: None,
         };
         let intents = SymlinkHandler
             .to_intents(&[m], &config, env.paths.as_ref(), env.fs.as_ref())
@@ -1398,6 +1402,7 @@ mod tests {
             is_dir: true,
             options: std::collections::HashMap::new(),
             preprocessor_source: None,
+            rendered_bytes: None,
         }
     }
 
@@ -1538,6 +1543,7 @@ mod tests {
             is_dir: false,
             options: std::collections::HashMap::new(),
             preprocessor_source: None,
+            rendered_bytes: None,
         };
         let handler = SymlinkHandler;
         let config = HandlerConfig::default();

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -376,17 +376,23 @@ pub struct PackPlan {
 /// (e.g. `commands::up` populating `PackStatusResult.warnings`). Pure
 /// execution callers should keep using [`collect_pack_intents`].
 ///
-/// `write_baselines` controls whether the preprocessing pipeline
-/// writes new baseline cache entries. Active runs (`up`) pass `true`
-/// when actually deploying; passive callers (`status`, `up --dry-run`)
-/// pass `false` so the "last successful `dodot up`" anchor stays put.
-pub fn plan_pack(pack: &Pack, ctx: &ExecutionContext, write_baselines: bool) -> Result<PackPlan> {
+/// `mode` controls the preprocessing envelope. Active runs (`dodot up`
+/// with no `--dry-run`) pass [`PreprocessMode::Active`]; passive
+/// callers (`dodot status`, `dodot up --dry-run`) pass
+/// [`PreprocessMode::Passive`] so the pipeline reads from the
+/// baseline cache instead of evaluating templates and writing
+/// rendered files. See `docs/proposals/secrets.lex` §7.4.
+pub fn plan_pack(
+    pack: &Pack,
+    ctx: &ExecutionContext,
+    mode: crate::preprocessing::PreprocessMode,
+) -> Result<PackPlan> {
     let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
     let registry = crate::preprocessing::default_registry(
         &pack_config.preprocessor.template,
         ctx.paths.as_ref(),
     )?;
-    plan_pack_inner(pack, ctx, &pack_config, Some(&registry), write_baselines)
+    plan_pack_inner(pack, ctx, &pack_config, Some(&registry), mode)
 }
 
 /// Shared implementation that takes a pre-loaded pack config. Both
@@ -404,7 +410,7 @@ fn collect_pack_intents_inner(
         ctx,
         pack_config,
         preprocessors,
-        /* write_baselines */ true,
+        crate::preprocessing::PreprocessMode::Active,
     )
     .map(|p| p.intents)
 }
@@ -417,7 +423,7 @@ fn plan_pack_inner(
     ctx: &ExecutionContext,
     pack_config: &crate::config::DodotConfig,
     preprocessors: Option<&crate::preprocessing::PreprocessorRegistry>,
-    write_baselines: bool,
+    mode: crate::preprocessing::PreprocessMode,
 ) -> Result<PackPlan> {
     let rules = crate::config::mappings_to_rules(&pack_config.mappings);
 
@@ -436,7 +442,7 @@ fn plan_pack_inner(
                 ctx.fs.as_ref(),
                 ctx.datastore.as_ref(),
                 ctx.paths.as_ref(),
-                write_baselines,
+                mode,
                 ctx.force,
             )?
         } else {
@@ -451,10 +457,19 @@ fn plan_pack_inner(
     let mut matches = scanner.match_entries(&all_entries, &rules, &pack.name);
     debug!(pack = %pack.name, files = matches.len(), "matched rules");
 
-    // Propagate preprocessor source info into matches
+    // Propagate preprocessor source info and in-memory rendered
+    // bytes onto each match. Handlers that hash rendered content
+    // for sentinel construction (`install`, `homebrew`) read the
+    // bytes from `m.rendered_bytes` first, falling back to disk
+    // for non-template files. That decoupling is the structural
+    // enabler for §7.4 Passive mode where rendered files are
+    // intentionally not on disk. See issue #121.
     for m in &mut matches {
         if let Some(source) = preprocess_result.source_map.get(&m.absolute_path) {
             m.preprocessor_source = Some(source.clone());
+        }
+        if let Some(bytes) = preprocess_result.rendered_bytes.get(&m.absolute_path) {
+            m.rendered_bytes = Some(bytes.clone());
         }
     }
 
@@ -1832,7 +1847,7 @@ mod tests {
         );
 
         // First run: clean deploy, no warnings about preserved files.
-        let first = plan_pack(&pack, &ctx, true).unwrap();
+        let first = plan_pack(&pack, &ctx, crate::preprocessing::PreprocessMode::Active).unwrap();
         assert!(
             first.warnings.iter().all(|w| !w.contains("preserved")),
             "first deploy must not produce a preservation warning: {:?}",
@@ -1848,7 +1863,7 @@ mod tests {
 
         // Second run: warning surfaces, with the documented resolution
         // hints — `transform check` and `--force`.
-        let second = plan_pack(&pack, &ctx, true).unwrap();
+        let second = plan_pack(&pack, &ctx, crate::preprocessing::PreprocessMode::Active).unwrap();
         let preserved: Vec<&String> = second
             .warnings
             .iter()
@@ -1900,7 +1915,7 @@ mod tests {
         );
 
         // Prime baseline.
-        let _ = plan_pack(&pack, &ctx, true).unwrap();
+        let _ = plan_pack(&pack, &ctx, crate::preprocessing::PreprocessMode::Active).unwrap();
         let deployed = env
             .paths
             .handler_data_dir("app", "preprocessed")
@@ -1908,7 +1923,7 @@ mod tests {
         env.fs.write_file(&deployed, b"name = USER EDITED").unwrap();
 
         ctx.force = true;
-        let plan = plan_pack(&pack, &ctx, true).unwrap();
+        let plan = plan_pack(&pack, &ctx, crate::preprocessing::PreprocessMode::Active).unwrap();
         assert!(
             plan.warnings.iter().all(|w| !w.contains("preserved")),
             "force=true must not emit preservation warnings: {:?}",

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -18,6 +18,8 @@ pub mod reverse_merge;
 pub mod template;
 pub mod unarchive;
 
+pub use pipeline::PreprocessMode;
+
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;

--- a/crates/dodot-lib/src/preprocessing/pipeline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline.rs
@@ -277,9 +277,14 @@ fn check_divergence(
 ///    datastore is not touched. Virtual entries are still produced so
 ///    the rest of the planner can compute intents — their bytes come
 ///    from `baseline.rendered_content` when a baseline exists.
-///    First-time pack templates with no baseline are silently skipped
-///    (status shows nothing for them; the user runs `dodot up` first).
-///    See [`PreprocessMode`] and `docs/proposals/secrets.lex` §7.4.
+///    First-time pack templates with no baseline still surface a
+///    placeholder virtual entry (so `dodot status` can render them as
+///    "pending" under the stripped name) but with empty
+///    `rendered_bytes`. Handlers that need rendered content for
+///    sentinel hashing (`install`, `homebrew`) skip intent generation
+///    for those placeholders rather than erroring out — the next real
+///    `dodot up` plans them normally. See [`PreprocessMode`] and
+///    `docs/proposals/secrets.lex` §7.4.
 /// 7. Return the result for merging into the handler pipeline.
 ///
 /// Set `force = true` to bypass the divergence guard. Surfaces as
@@ -650,20 +655,31 @@ pub fn preprocess_pack(
 ///
 /// Walks the same set of preprocessor entries the Active path would
 /// have, but never invokes a preprocessor. For each entry, computes
-/// the would-be virtual relative path via `Preprocessor::stripped_name`
-/// and looks up the cached baseline. When a baseline exists, builds a
-/// virtual entry pointing at the would-be datastore location with
-/// `rendered_bytes` sourced from `baseline.rendered_content`. When no
-/// baseline exists (first-time pack template), the entry is silently
-/// skipped — passive callers display nothing for un-baselined templates,
-/// the user runs `dodot up` first. Source files are not read (no marker
-/// scan); the datastore is not written; the baseline cache is not
-/// written.
+/// the would-be virtual relative path via `Preprocessor::stripped_name`.
+/// Two outcomes:
 ///
-/// This contract is what `secrets.lex` §7.4 demands: `dodot status` and
-/// `dodot up --dry-run` MUST NOT trigger template evaluation, MUST NOT
-/// surface provider auth prompts, and MUST NOT mutate disk state. See
-/// issue #121.
+/// - **Baseline exists** (the file was rendered on a previous `up`):
+///   builds a virtual entry pointing at the would-be datastore
+///   location with `rendered_bytes` sourced from
+///   `baseline.rendered_content`. Runs the read-only divergence
+///   check so callers (status's `Health::Preserved` row) still see
+///   skipped-render rows for divergent deployed files.
+/// - **No baseline** (first-time pack template, never `up`'d):
+///   surfaces a placeholder virtual entry under the stripped name,
+///   with empty `rendered_bytes`. Status renders this as "pending"
+///   under the logical name (`config.toml` rather than the source
+///   `config.toml.tmpl`); handlers that need rendered content for
+///   sentinel hashing (install, homebrew) skip intent generation
+///   for these placeholders rather than crashing. The next real
+///   `dodot up` populates the baseline and plans intents normally.
+///
+/// Source files are not read (no marker scan); the datastore is
+/// not written; the baseline cache is not written.
+///
+/// This contract is what `secrets.lex` §7.4 demands: `dodot status`
+/// and `dodot up --dry-run` MUST NOT trigger template evaluation,
+/// MUST NOT surface provider auth prompts, and MUST NOT mutate disk
+/// state. See issue #121.
 ///
 /// Limitation: this assumes a 1:1 source→virtual relationship via
 /// `stripped_name`. That holds for templates (the only shipped

--- a/crates/dodot-lib/src/preprocessing/pipeline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 
 use tracing::{debug, info};
 
@@ -19,6 +20,36 @@ use crate::preprocessing::divergence::DivergenceState;
 use crate::preprocessing::PreprocessorRegistry;
 use crate::rules::PackEntry;
 use crate::{DodotError, Result};
+
+/// Execution envelope for the preprocessing pipeline.
+///
+/// `secrets.lex` §7.4 ("Auth Fatigue and Passive Commands") draws a
+/// hard line between two envelopes:
+///
+/// - **Active** (`dodot up`): evaluates templates, batches `secret()`
+///   calls per provider, prompts for auth once per run, writes
+///   rendered files and baselines to disk.
+/// - **Passive** (`dodot status`, `dodot up --dry-run`): MUST NOT
+///   evaluate templates. Drift detection runs entirely off the
+///   baseline cache. No provider calls. No datastore writes. No
+///   baseline writes.
+///
+/// This enum is the single boolean the pipeline gates on. Active is
+/// the existing behavior; Passive is the §7.4-compliant read-only
+/// path. See issue #121.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreprocessMode {
+    /// Run preprocessors, write rendered outputs to the datastore,
+    /// write baselines to the cache. The original `dodot up` path.
+    Active,
+    /// Read everything from the baseline cache. Skip preprocessor
+    /// expansion (no provider calls), skip datastore writes, skip
+    /// baseline writes. For preprocessor entries with no baseline
+    /// yet, surface a passthrough placeholder so callers can render
+    /// "unknown — run `dodot up` first" without falling through to
+    /// template evaluation.
+    Passive,
+}
 
 /// Validate that a preprocessor-produced path is safe to materialise in
 /// the datastore: relative, no root/prefix/parent-dir components, and
@@ -85,6 +116,16 @@ pub struct PreprocessResult {
     pub virtual_entries: Vec<PackEntry>,
     /// Maps virtual entry absolute_path → original source path in pack.
     pub source_map: HashMap<PathBuf, PathBuf>,
+    /// Maps virtual entry absolute_path → in-memory rendered bytes.
+    /// Populated for every virtual entry the pipeline produces, in
+    /// both Active and Passive modes (Passive sources the bytes from
+    /// `baseline.rendered_content`). Handlers that need the rendered
+    /// content for sentinel hashing (`install`, `homebrew`) consult
+    /// this map first and fall back to disk read for non-template
+    /// files. Without this, Passive callers — where the rendered
+    /// file isn't on disk — couldn't produce correct sentinels for
+    /// templated install scripts or Brewfiles. See issue #121.
+    pub rendered_bytes: HashMap<PathBuf, Arc<[u8]>>,
     /// Files whose deployed bytes diverged from the cached baseline and
     /// were therefore preserved instead of being overwritten. Empty
     /// outside of `dodot up` runs that pass `force = false` and have a
@@ -120,6 +161,7 @@ impl PreprocessResult {
             regular_entries: entries,
             virtual_entries: Vec::new(),
             source_map: HashMap::new(),
+            rendered_bytes: HashMap::new(),
             skipped: Vec::new(),
         }
     }
@@ -217,31 +259,34 @@ fn check_divergence(
 /// Run the preprocessing pipeline for a pack's file entries.
 ///
 /// 1. Partition entries into preprocessor files vs regular files.
-/// 2. For each preprocessor file: expand, write results to datastore
-///    (unless the deployed file has diverged from the cached baseline —
-///    see step 5).
-/// 3. Create virtual PackEntries pointing to the datastore files.
+/// 2. **In `PreprocessMode::Active`** (real `dodot up` runs): for each
+///    preprocessor file, expand, write results to datastore (unless the
+///    deployed file has diverged from the cached baseline — see step 5),
+///    write the baseline cache record.
+/// 3. Create virtual `PackEntry`s pointing to the datastore files.
 /// 4. Check for collisions between virtual and regular entries.
-/// 5. **Divergence guard**: unless `force` is `true`, compare the
-///    prospective deployed file against the cached baseline before
-///    overwriting. When the deployed bytes have changed (the user
-///    edited the deployed file directly), skip the write and record a
-///    [`SkippedRender`] so the caller can warn the user. See
-///    `docs/proposals/preprocessing-pipeline.lex` §6.4. The guard fires
-///    regardless of `write_baselines` — it's a read-only check against
-///    the existing cache.
-/// 6. If `write_baselines` is `true` and the write proceeded, persist a
-///    baseline-cache record (used by `dodot transform check` and the
-///    clean filter to detect drift without re-rendering). Set this from
-///    `dodot up`; clear it from read-only callers (`dodot status`) so
-///    passive runs don't overwrite the cache that captured the state of
-///    the last `dodot up`.
+/// 5. **Divergence guard** (Active only): unless `force` is `true`,
+///    compare the prospective deployed file against the cached baseline
+///    before overwriting. When the deployed bytes have changed (the
+///    user edited the deployed file directly), skip the write and
+///    record a [`SkippedRender`] so the caller can warn the user. See
+///    `docs/proposals/preprocessing-pipeline.lex` §6.4.
+/// 6. **In `PreprocessMode::Passive`** (`dodot status`, `up --dry-run`):
+///    skip every disk-mutating step. Sources are never read for marker
+///    scans; preprocessors are never invoked (no provider calls); the
+///    datastore is not touched. Virtual entries are still produced so
+///    the rest of the planner can compute intents — their bytes come
+///    from `baseline.rendered_content` when a baseline exists.
+///    First-time pack templates with no baseline are silently skipped
+///    (status shows nothing for them; the user runs `dodot up` first).
+///    See [`PreprocessMode`] and `docs/proposals/secrets.lex` §7.4.
 /// 7. Return the result for merging into the handler pipeline.
 ///
 /// Set `force = true` to bypass the divergence guard. Surfaces as
 /// `dodot up --force` in the CLI; needed when the user knows they want
 /// to overwrite a divergent deployed file (e.g. after rotating an env
-/// var that a template references).
+/// var that a template references). Ignored in `Passive` mode (no
+/// writes happen there at all).
 #[allow(clippy::too_many_arguments)] // pipeline core: every parameter is load-bearing
 pub fn preprocess_pack(
     entries: Vec<PackEntry>,
@@ -250,7 +295,7 @@ pub fn preprocess_pack(
     fs: &dyn Fs,
     datastore: &dyn DataStore,
     paths: &dyn Pather,
-    write_baselines: bool,
+    mode: PreprocessMode,
     force: bool,
 ) -> Result<PreprocessResult> {
     let mut regular_entries = Vec::new();
@@ -283,13 +328,29 @@ pub fn preprocess_pack(
             regular_entries,
             virtual_entries: Vec::new(),
             source_map: HashMap::new(),
+            rendered_bytes: HashMap::new(),
             skipped: Vec::new(),
         });
+    }
+
+    // Passive mode: read everything from the baseline cache. Skip
+    // template evaluation entirely (no provider calls), skip
+    // datastore writes, skip baseline writes. See `PreprocessMode`.
+    if mode == PreprocessMode::Passive {
+        return preprocess_pack_passive(
+            preprocessor_entries,
+            regular_entries,
+            registry,
+            pack,
+            fs,
+            paths,
+        );
     }
 
     // Phase 2 & 3: Expand and create virtual entries
     let mut virtual_entries = Vec::new();
     let mut source_map = HashMap::new();
+    let mut rendered_bytes: HashMap<PathBuf, Arc<[u8]>> = HashMap::new();
     let mut skipped: Vec<SkippedRender> = Vec::new();
 
     // Tracks claimed paths for collision detection. Seeded with regular
@@ -485,9 +546,6 @@ pub fn preprocess_pack(
             // Persist a baseline record so future `dodot transform
             // check` / clean-filter calls can detect drift without
             // re-rendering. Only write when:
-            //   - the caller asked for baseline writes (read-only
-            //     callers like `dodot status` set `write_baselines =
-            //     false` to keep baselines stable),
             //   - the entry is a file (directory entries from archive
             //     preprocessors carry no rendered content),
             //   - the preprocessor produced a tracked render (i.e. it's
@@ -499,8 +557,12 @@ pub fn preprocess_pack(
             //   - the divergence guard didn't skip the write (otherwise
             //     we'd update the baseline to match a render that never
             //     hit disk, breaking future divergence detection).
-            if let (true, false, Some(tracked), false) = (
-                write_baselines,
+            //
+            // Mode-gating happens at the function boundary: this whole
+            // branch only runs in `PreprocessMode::Active`. Passive
+            // commands take the early-return at the top of the
+            // function and never reach this code.
+            if let (false, Some(tracked), false) = (
                 expanded.is_dir,
                 expanded.tracked_render.as_deref(),
                 was_skipped,
@@ -538,6 +600,28 @@ pub fn preprocess_pack(
 
             claimed_paths.insert(virtual_relative.clone());
             source_map.insert(datastore_path.clone(), entry.absolute_path.clone());
+            // Stash the rendered bytes for downstream handlers
+            // (install/homebrew sentinel hashing) that would
+            // otherwise read them back off disk. Skipped renders
+            // (divergence guard fired) carry the *preserved deployed*
+            // bytes instead — that matches the deployed file the user
+            // is keeping, which is what the next sentinel should
+            // commit to. Directories carry no bytes.
+            if !expanded.is_dir {
+                let bytes: Arc<[u8]> = if was_skipped {
+                    // Read the preserved deployed file. If the read
+                    // fails (race / permissions), fall back to the
+                    // freshly-rendered bytes so the handler still
+                    // gets a value — this only affects the sentinel,
+                    // and the divergence warning has already surfaced.
+                    fs.read_file(&datastore_path)
+                        .map(Arc::from)
+                        .unwrap_or_else(|_| Arc::from(expanded.content.clone()))
+                } else {
+                    Arc::from(expanded.content.clone())
+                };
+                rendered_bytes.insert(datastore_path.clone(), bytes);
+            }
 
             virtual_entries.push(PackEntry {
                 relative_path: virtual_relative,
@@ -557,6 +641,161 @@ pub fn preprocess_pack(
         regular_entries,
         virtual_entries,
         source_map,
+        rendered_bytes,
+        skipped,
+    })
+}
+
+/// `Passive` half of [`preprocess_pack`].
+///
+/// Walks the same set of preprocessor entries the Active path would
+/// have, but never invokes a preprocessor. For each entry, computes
+/// the would-be virtual relative path via `Preprocessor::stripped_name`
+/// and looks up the cached baseline. When a baseline exists, builds a
+/// virtual entry pointing at the would-be datastore location with
+/// `rendered_bytes` sourced from `baseline.rendered_content`. When no
+/// baseline exists (first-time pack template), the entry is silently
+/// skipped — passive callers display nothing for un-baselined templates,
+/// the user runs `dodot up` first. Source files are not read (no marker
+/// scan); the datastore is not written; the baseline cache is not
+/// written.
+///
+/// This contract is what `secrets.lex` §7.4 demands: `dodot status` and
+/// `dodot up --dry-run` MUST NOT trigger template evaluation, MUST NOT
+/// surface provider auth prompts, and MUST NOT mutate disk state. See
+/// issue #121.
+///
+/// Limitation: this assumes a 1:1 source→virtual relationship via
+/// `stripped_name`. That holds for templates (the only shipped
+/// generative-with-tracking preprocessor) and identity-style
+/// preprocessors. Multi-output preprocessors like unarchive cannot
+/// faithfully be passively previewed; if one is added later, this
+/// function should fall back to skipping such entries (which it does
+/// today, since they have no baseline).
+fn preprocess_pack_passive(
+    preprocessor_entries: Vec<PackEntry>,
+    regular_entries: Vec<PackEntry>,
+    registry: &PreprocessorRegistry,
+    pack: &Pack,
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+) -> Result<PreprocessResult> {
+    let mut virtual_entries = Vec::new();
+    let mut source_map = HashMap::new();
+    let mut rendered_bytes: HashMap<PathBuf, Arc<[u8]>> = HashMap::new();
+    let mut skipped: Vec<SkippedRender> = Vec::new();
+
+    for entry in preprocessor_entries {
+        let filename = entry
+            .relative_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        let preprocessor = registry
+            .find_for_file(&filename)
+            .expect("already checked in partition");
+
+        // Logical (stripped) virtual filename — e.g. `config.toml`
+        // for `config.toml.tmpl`. We don't run `expand()` (that would
+        // be the §7.4 violation), so we derive the would-be virtual
+        // path from `stripped_name` plus the source's parent
+        // directory.
+        let stripped = preprocessor.stripped_name(&filename);
+        let virtual_relative = match entry.relative_path.parent() {
+            Some(parent) if parent != Path::new("") => parent.join(&stripped),
+            _ => PathBuf::from(&stripped),
+        };
+        let virtual_relative = normalize_relative(&virtual_relative);
+
+        let datastore_path = paths
+            .handler_data_dir(&pack.name, PREPROCESSED_HANDLER)
+            .join(&virtual_relative);
+
+        // Try to load the cached baseline. If absent, this is a
+        // first-time template that has never been deployed: surface
+        // a placeholder virtual entry (no rendered_bytes) so callers
+        // like `dodot status` can render it as "pending" under the
+        // stripped name. Critically, we do NOT fall through to
+        // template evaluation — that's the §7.4 violation we're
+        // here to fix. Handlers that need rendered bytes for
+        // sentinel hashing (`install`, `homebrew`) will fall back
+        // to disk-read on the missing datastore path and report
+        // pending; symlink-targeted templates render cleanly as
+        // pending without needing the bytes at all.
+        let cache_filename = cache_filename_for(&virtual_relative);
+        let baseline =
+            match Baseline::load(fs, paths, &pack.name, PREPROCESSED_HANDLER, &cache_filename)? {
+                Some(b) => Some(b),
+                None => {
+                    debug!(
+                        pack = %pack.name,
+                        file = %virtual_relative.display(),
+                        "passive: no baseline yet — surfacing placeholder (run `dodot up` first)"
+                    );
+                    None
+                }
+            };
+
+        // Divergence detection (read-only): even though Passive
+        // never writes, status / dry-run callers want to know which
+        // deployed files have drifted from their baseline so they
+        // can surface the same `Health::Preserved` row that the
+        // active path does. The byte comparison is local and free
+        // of side effects — no provider calls, no template eval —
+        // so it stays inside the §7.4 envelope. Skipped only when a
+        // baseline exists (no baseline → no comparison reference).
+        if baseline.is_some() {
+            if let Ok(DivergenceCheck::Skip {
+                state,
+                deployed_path,
+            }) = check_divergence(
+                fs,
+                paths,
+                &pack.name,
+                &virtual_relative,
+                &entry.absolute_path,
+            ) {
+                skipped.push(SkippedRender {
+                    pack: pack.name.clone(),
+                    virtual_relative: virtual_relative.clone(),
+                    deployed_path,
+                    state,
+                });
+            }
+        }
+
+        // Carry the baseline's rendered content forward as the
+        // in-memory bytes for downstream sentinel hashing when a
+        // baseline exists. Without a baseline (first-time pack), no
+        // bytes are available — handlers that need them will see
+        // `m.rendered_bytes == None` and fall back to disk read,
+        // which correctly fails for the missing datastore file and
+        // shows up as "pending" in status.
+        if let Some(b) = baseline {
+            let bytes: Arc<[u8]> = Arc::from(b.rendered_content.into_bytes());
+            rendered_bytes.insert(datastore_path.clone(), bytes);
+        }
+        source_map.insert(datastore_path.clone(), entry.absolute_path.clone());
+        virtual_entries.push(PackEntry {
+            relative_path: virtual_relative,
+            absolute_path: datastore_path,
+            is_dir: false,
+        });
+    }
+
+    info!(
+        pack = %pack.name,
+        virtual_count = virtual_entries.len(),
+        skipped_count = skipped.len(),
+        "passive preprocessing complete"
+    );
+
+    Ok(PreprocessResult {
+        regular_entries,
+        virtual_entries,
+        source_map,
+        rendered_bytes,
         skipped,
     })
 }
@@ -618,7 +857,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -653,7 +892,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -709,7 +948,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -760,7 +999,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -784,6 +1023,7 @@ mod tests {
                 is_dir: false,
             }],
             source_map: HashMap::new(),
+            rendered_bytes: HashMap::new(),
             skipped: Vec::new(),
         };
 
@@ -818,7 +1058,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -853,7 +1093,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -887,7 +1127,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -932,7 +1172,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -977,7 +1217,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1026,7 +1266,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1076,7 +1316,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1087,7 +1327,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1136,7 +1376,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -1186,7 +1426,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -1223,7 +1463,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1285,7 +1525,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1405,7 +1645,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -1454,7 +1694,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -1513,7 +1753,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1584,7 +1824,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -1632,7 +1872,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -1691,7 +1931,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -1742,7 +1982,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1800,7 +2040,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            true,
+            PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1829,11 +2069,12 @@ mod tests {
     }
 
     #[test]
-    fn baseline_is_skipped_when_write_baselines_is_false() {
-        // Read-only callers (`dodot status`) set `write_baselines =
-        // false`. No baseline should be written in that case —
-        // overwriting it would erase the divergence-detection ground
-        // truth captured at the last `dodot up`.
+    fn baseline_is_skipped_in_passive_mode() {
+        // Passive callers (`dodot status`, `dodot up --dry-run`) MUST
+        // NOT touch the baseline cache. No baseline should be written
+        // in that case — overwriting it would erase the
+        // divergence-detection ground truth captured at the last
+        // `dodot up`. Per `secrets.lex` §7.4 / issue #121.
         let env = TempEnvironment::builder()
             .pack("app")
             .file("config.toml.tracked", "src")
@@ -1869,7 +2110,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Passive,
             false,
         )
         .unwrap();
@@ -1879,7 +2120,7 @@ mod tests {
             .preprocessor_baseline_path("app", "preprocessed", "config.toml");
         assert!(
             !env.fs.exists(&path),
-            "no baseline should exist after a write_baselines=false run, but found: {}",
+            "no baseline should exist after a Passive run, but found: {}",
             path.display()
         );
     }
@@ -1912,7 +2153,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            true,
+            PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1977,7 +2218,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            true,
+            PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -1997,7 +2238,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            true,
+            PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -2054,7 +2295,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            true,
+            PreprocessMode::Active,
             false,
         )
         .unwrap();
@@ -2128,7 +2369,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            true,
+            PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -2217,7 +2458,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .expect("non-tracking preprocessor must not be gated by markers in its source");
@@ -2273,7 +2514,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -2338,7 +2579,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .expect("non-UTF-8 source without markers must not crash the gate");
@@ -2399,7 +2640,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            false,
+            crate::preprocessing::PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -2450,7 +2691,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            true,
+            PreprocessMode::Active,
             false,
         )
         .expect("clean source should expand successfully");
@@ -2472,7 +2713,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            true,
+            PreprocessMode::Active,
             false,
         )
         .unwrap_err();
@@ -2492,7 +2733,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            true,
+            PreprocessMode::Active,
             false,
         )
         .expect("resolved source should expand again");
@@ -2540,7 +2781,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            true,
+            PreprocessMode::Active,
             force,
         )
         .unwrap()
@@ -2840,7 +3081,7 @@ mod tests {
             env.fs.as_ref(),
             &datastore,
             env.paths.as_ref(),
-            /* write_baselines */ false,
+            crate::preprocessing::PreprocessMode::Passive,
             /* force */ false,
         )
         .unwrap();

--- a/crates/dodot-lib/src/rules/mod.rs
+++ b/crates/dodot-lib/src/rules/mod.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use serde::Serialize;
 
@@ -71,6 +72,24 @@ pub struct RuleMatch {
     /// `None` for regular (non-preprocessed) files.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preprocessor_source: Option<PathBuf>,
+
+    /// In-memory rendered bytes for preprocessor-produced files.
+    ///
+    /// Populated by `plan_pack_inner` from
+    /// `PreprocessResult.rendered_bytes` so that handlers needing
+    /// the rendered content for sentinel hashing (`install`,
+    /// `homebrew`) can hash these bytes directly instead of reading
+    /// the rendered file from disk. That decoupling is the
+    /// structural enabler for §7.4 Passive mode (`dodot status`,
+    /// `up --dry-run`), where the rendered file is intentionally
+    /// not written to disk. See issue #121.
+    ///
+    /// `None` for regular (non-preprocessed) files; handlers
+    /// targeting those still read from `absolute_path` directly.
+    /// `Arc<[u8]>` so cloning a `RuleMatch` (e.g. during handler
+    /// grouping) doesn't duplicate the buffer.
+    #[serde(skip)]
+    pub rendered_bytes: Option<Arc<[u8]>>,
 }
 
 // ── Grouping helpers ────────────────────────────────────────────
@@ -432,6 +451,7 @@ fn match_file(
                 is_dir,
                 options: rule.options.clone(),
                 preprocessor_source: None,
+                rendered_bytes: None,
             });
         }
     }
@@ -851,6 +871,7 @@ mod tests {
                 is_dir: false,
                 options: HashMap::new(),
                 preprocessor_source: None,
+                rendered_bytes: None,
             },
             RuleMatch {
                 relative_path: "aliases.sh".into(),
@@ -860,6 +881,7 @@ mod tests {
                 is_dir: false,
                 options: HashMap::new(),
                 preprocessor_source: None,
+                rendered_bytes: None,
             },
             RuleMatch {
                 relative_path: "gvimrc".into(),
@@ -869,6 +891,7 @@ mod tests {
                 is_dir: false,
                 options: HashMap::new(),
                 preprocessor_source: None,
+                rendered_bytes: None,
             },
         ];
 
@@ -925,6 +948,7 @@ mod tests {
             is_dir: false,
             options: HashMap::new(),
             preprocessor_source: None,
+            rendered_bytes: None,
         };
         let json = serde_json::to_string(&m).unwrap();
         assert!(json.contains("vimrc"));


### PR DESCRIPTION
## Summary

Wave 4 (the last) of the #116 pre-release polish plan: ship the §7.4 passive-command contract. `dodot status` and `dodot up --dry-run` no longer evaluate templates, no longer prompt for provider auth, no longer mutate the datastore. Lands cleanly on the slim base from Waves 1–3.

Closes #121.

## Why

`secrets.lex` §7.4 ("Auth Fatigue and Passive Commands") draws a hard line:

- **Active** (`dodot up`): evaluates templates, batches `secret()` calls per provider, prompts for auth once per run, writes rendered files and baselines.
- **Passive** (`dodot status`, `dodot up --dry-run`): MUST NOT evaluate templates. Drift detection runs entirely off the baseline cache. No provider calls. No datastore writes.

Today both passive paths violate that contract by calling `preprocess_pack`, which evaluates templates and writes `<data_dir>/<pack>/preprocessed/<file>`. On a repo with secret-resolving templates, every `dodot status` triggers Touch ID / 1Password / gpg-agent. This PR ships the structural fix.

## What changed

Two coupled changes; the first enables the second.

### 1. Decouple sentinel computation from datastore state

- `PreprocessResult` gains `rendered_bytes: HashMap<PathBuf, Arc<[u8]>>`, populated for every virtual entry (Active sources from the freshly-rendered bytes; Passive sources from `baseline.rendered_content`).
- `RuleMatch` gains a matching `rendered_bytes: Option<Arc<[u8]>>` field (`#[serde(skip)]`, `Arc` so cloning is cheap).
- `plan_pack_inner` propagates bytes from the result map onto each match.
- Install + homebrew handlers consult `m.rendered_bytes` first when computing sentinels, falling back to disk read for non-template files.

That breaks the structural coupling that killed the naive `write_outputs=false` attempt in PR #118 (Comment QQ): handlers no longer require the rendered file to be on disk to compute correct sentinels.

### 2. `PreprocessMode` enum

Replaces the `write_baselines: bool` flag I added in PR #122 with a typed envelope:

```rust
pub enum PreprocessMode { Active, Passive }
```

Threaded through `preprocess_pack` and `plan_pack`. In `Passive`:

- **No template evaluation.** `preprocessor.expand()` is never called. No provider auth prompts.
- **No datastore writes.** `datastore.write_rendered_*` never runs.
- **No baseline writes.** The "last successful `dodot up`" anchor stays put.
- **No source-file marker scan.** Without template evaluation, there are no markers to leak.
- For each preprocessor entry, derive the would-be virtual path from `Preprocessor::stripped_name`. If a baseline exists, source `rendered_bytes` from `baseline.rendered_content`. If no baseline (first-time pack), surface a placeholder virtual entry — empty bytes, nonexistent datastore_path — so status reports the template as "pending" without evaluating it.
- Run the divergence check (read-only, no side effects) and surface `SkippedRender` rows so status's existing `Health::Preserved` override still fires for divergent deployed files.

### Callers

- `commands/up.rs`: `Active` for real runs, `Passive` for `--dry-run`.
- `commands/status.rs`: `Passive` for both call sites (direct `preprocess_pack` + conflict-detection `plan_pack`).
- `collect_pack_intents_inner` (non-warnings entrypoint, used by execution paths like `adopt`): `Active`, unchanged.

`plan_pack`'s public signature changes from `write_baselines: bool` to `mode: PreprocessMode`. Mechanical refactor at every call site.

## What's intentionally out of scope (per #121's scope guardrails)

- `status --refresh-secrets` opt-in flag from §7.4. Once Passive is enforced, decide separately whether the opt-in is worth the surface area.
- Cache schema changes, on-disk migrations, new datastore methods. None needed.
- Multi-output preprocessors in Passive (currently only templates ship; `stripped_name`-based 1:1 derivation covers them; if unarchive lands later, it can extend Passive at that point).

## Tests

Four new contract tests in `commands/tests.rs`:

- **`status_does_not_write_to_datastore`** — snapshot `<data_dir>` before status; run two consecutive status calls; assert byte-identical. Pins the no-write contract.
- **`up_dry_run_does_not_write_to_datastore`** — same shape for `--dry-run`.
- **`install_template_dry_run_emits_correct_sentinel_without_writing_rendered_file`** — pins Comment QQ's structural concern: a templated install script's dry-run Run intent must produce the same sentinel as the active path's, without touching the rendered file on disk.
- **`passive_first_time_pack_surfaces_pending_placeholder`** — first status before any `up` reports the stripped name as pending; never panics; never falls through to template evaluation.

Plus a `snapshot_dir_contents` helper used by the no-write contract tests. Existing tests updated mechanically (`true` → `Active`, `false` → `Passive` where the test exercised read-only behavior; `baseline_is_skipped_when_write_baselines_is_false` renamed to `baseline_is_skipped_in_passive_mode`).

## Validation

- `cargo test --workspace` — **868 lib + 12 integration tests, all green**
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Full bats suite — **254 tests green**
- Active-path behavior is byte-equivalent to before (existing magic-stack and preprocessing e2e tests pass unchanged); only Passive changes observably.

## Diff

```
crates/dodot-cli/src/commands/status.rs        |  10 +-
crates/dodot-lib/src/commands/tests.rs         | 213 +++++++++++++-
crates/dodot-lib/src/commands/up.rs            |  14 +-
crates/dodot-lib/src/handlers/homebrew.rs      |  17 +-
crates/dodot-lib/src/handlers/install.rs       |  24 +-
crates/dodot-lib/src/handlers/symlink.rs       |   6 +
crates/dodot-lib/src/packs/orchestration.rs    |  43 ++-
crates/dodot-lib/src/preprocessing/mod.rs      |   2 +
crates/dodot-lib/src/preprocessing/pipeline.rs | 381 ++++++++++++++++++++-----
crates/dodot-lib/src/rules/mod.rs              |  24 ++
10 files changed, 641 insertions(+), 94 deletions(-)
```
