### PR TITLE
feat: Phase S1 secrets — pass + op providers, secret() MiniJinja, preflight UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Phase S1 of the secrets feature** (`docs/proposals/secrets.lex` + `docs/proposals/secrets-testing.lex`). Templates can reference values stored outside the dotfiles repo via a new `secret(...)` MiniJinja function — `{{ secret("pass:test/db_password") }}` — which dispatches to a registered `SecretProvider` impl, resolves the value at render time, and zeroizes the in-memory copy on drop (`SecretString`, no `Debug` / `Display`). Phase S1 ships two providers: `pass` (password-store) and `op` (1Password CLI), both opt-in via `[secret.providers.<scheme>] enabled = true` so a fresh dodot install never shells out to a secret tool unprompted. A run-level preflight runs once per `dodot up`, probes every enabled provider, and aggregates `NotInstalled` / `NotAuthenticated` / `Misconfigured` outcomes into a single user-facing message before any rendering begins — so the user sees every fix-it pointer at once instead of one error per template. Per-render `<baseline>.secret.json` sidecars track the line ranges produced by each `secret(...)` call so downstream consumers (dry-run preview, burgertocow#13 mask integration) can mask resolved values without re-rendering. Multi-line provider returns are refused at render time (security: no whole-file deploys via the value-injection path; use a future whole-file provider instead). `dodot up --dry-run` and `dodot status` honor the `PreprocessMode::Passive` envelope (`secrets.lex` §7.4) — provider `resolve()` is never called from these commands; pinned in tests with a `PanickingProvider` that aborts on call. New `tests/e2e/bats/test_secrets.bats` covers the `pass` happy path, sidecar generation, preflight blocking on missing binaries, missing-reference errors, and the Passive contract end-to-end via a stub `pass` binary; `tests/e2e/bats/helpers/dev-shell.sh secrets-pass` drops developers into an interactive sandbox with the same fixture pre-seeded.
+
 ## [3.0.0] - 2026-05-02
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,20 +2953,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.8.23",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -2941,6 +2942,26 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -24,6 +24,7 @@ tempfile = { version = "3", optional = true }
 thiserror = "2"
 toml = "0.8"
 tracing = "0.1"
+zeroize = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -24,7 +24,7 @@ tempfile = { version = "3", optional = true }
 thiserror = "2"
 toml = "0.8"
 tracing = "0.1"
-zeroize = { version = "1", features = ["derive"] }
+zeroize = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -448,9 +448,11 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         // path (`~/.config.toml.tmpl`) doesn't exist.
         let entries = scanner.walk_pack(&pack.path, &pack_config.pack.ignore)?;
         let preprocess_result = if pack_config.preprocessor.enabled {
-            let registry = crate::preprocessing::default_registry(
+            let (registry, _secret_registry) = crate::preprocessing::default_registry(
                 &pack_config.preprocessor.template,
+                &pack_config.secret,
                 ctx.paths.as_ref(),
+                ctx.command_runner.clone(),
             )?;
             if !registry.is_empty() {
                 // status is a Passive command — never evaluate

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -448,9 +448,11 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         // path (`~/.config.toml.tmpl`) doesn't exist.
         let entries = scanner.walk_pack(&pack.path, &pack_config.pack.ignore)?;
         let preprocess_result = if pack_config.preprocessor.enabled {
+            // [secret] is intentionally root-only — see SecretSection docs.
+            let root_config = ctx.config_manager.root_config()?;
             let (registry, _secret_registry) = crate::preprocessing::default_registry(
                 &pack_config.preprocessor.template,
-                &pack_config.secret,
+                &root_config.secret,
                 ctx.paths.as_ref(),
                 ctx.command_runner.clone(),
             )?;

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -55,6 +55,25 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     // Phase 1: Discover packs and collect intents
     let packs = orchestration::prepare_packs(pack_filter, ctx)?;
 
+    // Preflight secret providers once per active run. Skipped on
+    // `--dry-run` because the Passive envelope (`secrets.lex` §7.4) is
+    // exactly the contract that the secrets layer is not touched at all.
+    // We also skip when no provider is enabled (`build_secret_registry`
+    // returns `None`) — there's nothing to probe and templates that
+    // reference `secret(...)` will fail loudly at render time with a
+    // separate, more specific error.
+    if !ctx.dry_run {
+        let root_config = ctx.config_manager.root_config()?;
+        if root_config.secret.enabled {
+            if let Some(registry) = crate::preprocessing::build_secret_registry(
+                &root_config.secret,
+                ctx.command_runner.clone(),
+            ) {
+                crate::secret::preflight(&registry)?;
+            }
+        }
+    }
+
     let mut pack_intents: Vec<(String, Vec<HandlerIntent>)> = Vec::with_capacity(packs.len());
     let mut intent_errors: Vec<PackResult> = Vec::new();
     let mut planning_warnings: Vec<String> = Vec::new();

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -233,6 +233,17 @@ pub struct ProfilingSection {
 /// section globally (`[secret] enabled = false`) is equivalent to
 /// disabling every provider; templates that call `secret(...)` then
 /// surface a "no providers configured" render error.
+///
+/// **This section is root-only.** Unlike most config sections, the
+/// `[secret]` block is always read from the root `.dodot.toml`;
+/// per-pack overrides are ignored. Secret tooling
+/// (`$PASSWORD_STORE_DIR`, `OP_SERVICE_ACCOUNT_TOKEN`, the binaries
+/// themselves) is a property of the user's environment, not of any
+/// individual pack — a pack-level override would invalidate the
+/// once-per-run preflight contract (`secrets.lex` §5.4) and would
+/// surface as confusing "secret X probed under config A but
+/// resolved under config B" failures. Treat the root section as the
+/// single source of truth.
 #[derive(Config, Debug, Clone, Serialize, Deserialize)]
 pub struct SecretSection {
     /// Master switch. Default true; flip to false to disable all

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -43,6 +43,9 @@ pub struct DodotConfig {
 
     #[config(nested)]
     pub profiling: ProfilingSection,
+
+    #[config(nested)]
+    pub secret: SecretSection,
 }
 
 /// Pack-level settings.
@@ -222,6 +225,62 @@ pub struct ProfilingSection {
     /// 400 KB on disk.
     #[config(default = 100)]
     pub keep_last_runs: usize,
+}
+
+/// Secret-handling settings (`docs/proposals/secrets.lex`).
+///
+/// Top-level kill switch + per-provider blocks. Disabling the
+/// section globally (`[secret] enabled = false`) is equivalent to
+/// disabling every provider; templates that call `secret(...)` then
+/// surface a "no providers configured" render error.
+#[derive(Config, Debug, Clone, Serialize, Deserialize)]
+pub struct SecretSection {
+    /// Master switch. Default true; flip to false to disable all
+    /// secret resolution without removing the per-provider blocks.
+    #[config(default = true)]
+    pub enabled: bool,
+
+    #[config(nested)]
+    pub providers: SecretProvidersSection,
+}
+
+/// Per-provider configuration. Each block has an `enabled` flag plus
+/// any provider-specific knobs (e.g. `pass.store_dir`). Providers
+/// disabled here are not registered in the runtime
+/// `SecretRegistry`; references to their schemes raise
+/// "no provider for scheme" at resolution time.
+#[derive(Config, Debug, Clone, Serialize, Deserialize)]
+pub struct SecretProvidersSection {
+    #[config(nested)]
+    pub pass: SecretProviderPass,
+
+    #[config(nested)]
+    pub op: SecretProviderOp,
+}
+
+/// `pass` (password-store) provider config.
+#[derive(Config, Debug, Clone, Serialize, Deserialize)]
+pub struct SecretProviderPass {
+    /// Whether the `pass:` scheme is registered. Default false —
+    /// users opt in explicitly so a freshly-installed dodot doesn't
+    /// shell out to `pass` on every render.
+    #[config(default = false)]
+    pub enabled: bool,
+
+    /// Override `$PASSWORD_STORE_DIR`. Empty (the default) leaves
+    /// dodot reading the env var, which falls back to
+    /// `$HOME/.password-store`.
+    #[config(default = "")]
+    pub store_dir: String,
+}
+
+/// `op` (1Password CLI) provider config.
+#[derive(Config, Debug, Clone, Serialize, Deserialize)]
+pub struct SecretProviderOp {
+    /// Whether the `op://` scheme is registered. Default false —
+    /// same opt-in posture as `pass`.
+    #[config(default = false)]
+    pub enabled: bool,
 }
 
 /// File-to-handler mapping patterns.

--- a/crates/dodot-lib/src/lib.rs
+++ b/crates/dodot-lib/src/lib.rs
@@ -16,6 +16,7 @@ pub mod probe;
 pub mod prompts;
 pub mod render;
 pub mod rules;
+pub mod secret;
 pub mod shell;
 
 // The testing module is available:

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -334,9 +334,11 @@ pub fn collect_pack_intents(
     ctx: &ExecutionContext,
 ) -> Result<Vec<crate::operations::HandlerIntent>> {
     let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
+    // [secret] is intentionally root-only — see SecretSection docs.
+    let root_config = ctx.config_manager.root_config()?;
     let (registry, _secret_registry) = crate::preprocessing::default_registry(
         &pack_config.preprocessor.template,
-        &pack_config.secret,
+        &root_config.secret,
         ctx.paths.as_ref(),
         ctx.command_runner.clone(),
     )?;
@@ -390,9 +392,11 @@ pub fn plan_pack(
     mode: crate::preprocessing::PreprocessMode,
 ) -> Result<PackPlan> {
     let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
+    // [secret] is intentionally root-only — see SecretSection docs.
+    let root_config = ctx.config_manager.root_config()?;
     let (registry, _secret_registry) = crate::preprocessing::default_registry(
         &pack_config.preprocessor.template,
-        &pack_config.secret,
+        &root_config.secret,
         ctx.paths.as_ref(),
         ctx.command_runner.clone(),
     )?;

--- a/crates/dodot-lib/src/packs/orchestration.rs
+++ b/crates/dodot-lib/src/packs/orchestration.rs
@@ -334,9 +334,11 @@ pub fn collect_pack_intents(
     ctx: &ExecutionContext,
 ) -> Result<Vec<crate::operations::HandlerIntent>> {
     let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
-    let registry = crate::preprocessing::default_registry(
+    let (registry, _secret_registry) = crate::preprocessing::default_registry(
         &pack_config.preprocessor.template,
+        &pack_config.secret,
         ctx.paths.as_ref(),
+        ctx.command_runner.clone(),
     )?;
     collect_pack_intents_inner(pack, ctx, &pack_config, Some(&registry))
 }
@@ -388,9 +390,11 @@ pub fn plan_pack(
     mode: crate::preprocessing::PreprocessMode,
 ) -> Result<PackPlan> {
     let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
-    let registry = crate::preprocessing::default_registry(
+    let (registry, _secret_registry) = crate::preprocessing::default_registry(
         &pack_config.preprocessor.template,
+        &pack_config.secret,
         ctx.paths.as_ref(),
+        ctx.command_runner.clone(),
     )?;
     plan_pack_inner(pack, ctx, &pack_config, Some(&registry), mode)
 }

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -174,6 +174,34 @@ pub trait Pather: Send + Sync {
             .join(format!("{filename}.json"))
     }
 
+    /// Per-file secrets sidecar that lives next to the baseline JSON.
+    ///
+    /// Layout: `<cache_dir>/preprocessor/<pack>/<handler>/<filename>.secret.json`.
+    /// Empty / absent when the file's last render contained no
+    /// `secret(...)` calls; populated otherwise. The sidecar carries
+    /// `secret_line_ranges` (start, end, reference) per the schema in
+    /// `docs/proposals/secrets.lex` §3.3 — burgertocow's mask
+    /// (issue arthur-debert/burgertocow#13) reads the line ranges,
+    /// the dry-run preview reads them to render `[SECRET: <ref>]`
+    /// placeholders.
+    ///
+    /// Same lifecycle as the baseline file: rederivable, lives under
+    /// `cache_dir`. The "no migration" guardrail in §3.3 applies —
+    /// pre-secrets baselines simply have no sidecar (treated as
+    /// empty mask), and adding the file is additive.
+    fn preprocessor_secrets_sidecar_path(
+        &self,
+        pack: &str,
+        handler: &str,
+        filename: &str,
+    ) -> PathBuf {
+        self.cache_dir()
+            .join("preprocessor")
+            .join(pack)
+            .join(handler)
+            .join(format!("{filename}.secret.json"))
+    }
+
     /// Root of the preprocessor baseline cache for a given pack and
     /// handler — mostly useful for cache-cleanup operations like
     /// `dodot down` and tests that want to scan an entire handler's

--- a/crates/dodot-lib/src/preprocessing/baseline.rs
+++ b/crates/dodot-lib/src/preprocessing/baseline.rs
@@ -179,6 +179,119 @@ impl Baseline {
     }
 }
 
+/// Per-file secrets sidecar — the on-disk shape of `secret_line_ranges`.
+///
+/// Schema is intentionally minimal: a version field and the slice of
+/// `SecretLineRange` entries the preprocessor emitted on the last
+/// successful render. Stored next to the baseline as
+/// `<filename>.secret.json`. See secrets.lex §3.3.
+///
+/// **No baseline migration**: this file is purely additive. Pre-secrets
+/// renders simply have no sidecar, which the load path treats as
+/// `secret_line_ranges = []` (empty mask, byte-equivalent to legacy
+/// reverse-merge behaviour).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretsSidecar {
+    /// Schema version. Bumps independently of the baseline schema —
+    /// they're separate files with separate evolution paths.
+    pub version: u32,
+    /// Line ranges produced on the last successful render. Empty when
+    /// the file's template renders without secrets (an explicit
+    /// empty-array sidecar is fine; absence of the file is also
+    /// fine and means the same thing).
+    pub secret_line_ranges: Vec<crate::preprocessing::SecretLineRange>,
+}
+
+/// Current sidecar schema version.
+pub const SECRETS_SIDECAR_VERSION: u32 = 1;
+
+impl SecretsSidecar {
+    /// Build a sidecar from a slice of line ranges.
+    pub fn new(ranges: Vec<crate::preprocessing::SecretLineRange>) -> Self {
+        Self {
+            version: SECRETS_SIDECAR_VERSION,
+            secret_line_ranges: ranges,
+        }
+    }
+
+    /// Persist the sidecar next to its baseline. Path layout matches
+    /// `Pather::preprocessor_secrets_sidecar_path`. Creates parent
+    /// directories as needed (in practice the baseline write that
+    /// runs first has already created them, but write is robust to
+    /// being called in either order). Overwrites any existing file.
+    ///
+    /// When `self.secret_line_ranges` is empty, this is a no-op:
+    /// callers don't need to special-case "no secrets" — they always
+    /// call `write` with whatever the renderer emitted, and the
+    /// no-secrets case skips the disk write rather than dropping a
+    /// `{ "secret_line_ranges": [] }` file. Removes any existing
+    /// sidecar in that case so a previous render's secrets don't
+    /// linger after the user removes them from the template.
+    pub fn write(
+        &self,
+        fs: &dyn Fs,
+        paths: &dyn Pather,
+        pack: &str,
+        handler: &str,
+        filename: &str,
+    ) -> Result<Option<PathBuf>> {
+        let path = paths.preprocessor_secrets_sidecar_path(pack, handler, filename);
+        if self.secret_line_ranges.is_empty() {
+            // No secrets in this render. Remove a stale sidecar from
+            // a prior render if one exists; otherwise no-op.
+            if fs.exists(&path) {
+                fs.remove_file(&path)?;
+            }
+            return Ok(None);
+        }
+        if let Some(parent) = path.parent() {
+            fs.mkdir_all(parent)?;
+        }
+        let body = serde_json::to_string_pretty(self).map_err(|e| {
+            DodotError::Other(format!(
+                "failed to serialise secrets sidecar for {pack}/{handler}/{filename}: {e}"
+            ))
+        })?;
+        fs.write_file(&path, body.as_bytes())?;
+        Ok(Some(path))
+    }
+
+    /// Load the sidecar for a file. Returns `Ok(None)` when no
+    /// sidecar exists — the documented "no secrets" state per §3.3.
+    /// Errors on parse failure or unsupported version so the caller
+    /// can suggest a `dodot up --force` re-render.
+    pub fn load(
+        fs: &dyn Fs,
+        paths: &dyn Pather,
+        pack: &str,
+        handler: &str,
+        filename: &str,
+    ) -> Result<Option<Self>> {
+        let path = paths.preprocessor_secrets_sidecar_path(pack, handler, filename);
+        if !fs.exists(&path) {
+            return Ok(None);
+        }
+        let raw = fs.read_to_string(&path)?;
+        let sidecar: Self = serde_json::from_str(&raw).map_err(|e| {
+            DodotError::Other(format!(
+                "failed to parse secrets sidecar at {}: {e}\n  \
+                 Run `dodot up --force` to re-render and rewrite the sidecar.",
+                path.display()
+            ))
+        })?;
+        if sidecar.version != SECRETS_SIDECAR_VERSION {
+            return Err(DodotError::Other(format!(
+                "secrets sidecar at {} has unsupported schema version {} (expected {}). \
+                 Clear the file and run `dodot up --force` to rebuild.",
+                path.display(),
+                sidecar.version,
+                SECRETS_SIDECAR_VERSION
+            )));
+        }
+        Ok(Some(sidecar))
+    }
+}
+
 /// SHA-256 → 64-char lowercase hex. Used by the baseline cache for
 /// rendered/source content hashing and by the divergence walker for
 /// the same purpose against current on-disk state. `pub(crate)` so
@@ -450,5 +563,181 @@ mod tests {
         assert!(hex_encode_32(&[0xab; 32])
             .chars()
             .all(|c| c == 'a' || c == 'b'));
+    }
+
+    // ── secrets sidecar (Phase S1) ───────────────────────────
+
+    fn range(start: usize, reference: &str) -> crate::preprocessing::SecretLineRange {
+        crate::preprocessing::SecretLineRange {
+            start,
+            end: start + 1,
+            reference: reference.into(),
+        }
+    }
+
+    #[test]
+    fn sidecar_round_trips_through_write_and_load() {
+        let env = TempEnvironment::builder().build();
+        let sidecar = SecretsSidecar::new(vec![
+            range(2, "op://Vault/db/password"),
+            range(5, "pass:api/token"),
+        ]);
+
+        let written = sidecar
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "config.toml",
+            )
+            .unwrap()
+            .expect("non-empty sidecar should write");
+        assert!(env.fs.exists(&written));
+
+        let loaded = SecretsSidecar::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "config.toml",
+        )
+        .unwrap()
+        .expect("written sidecar should load");
+
+        assert_eq!(loaded, sidecar);
+        assert_eq!(loaded.version, SECRETS_SIDECAR_VERSION);
+        assert_eq!(loaded.secret_line_ranges.len(), 2);
+        assert_eq!(
+            loaded.secret_line_ranges[0].reference,
+            "op://Vault/db/password"
+        );
+    }
+
+    #[test]
+    fn sidecar_load_returns_none_when_absent() {
+        let env = TempEnvironment::builder().build();
+        let loaded = SecretsSidecar::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "config.toml",
+        )
+        .unwrap();
+        assert!(
+            loaded.is_none(),
+            "absent sidecar = None (no secrets to mask)"
+        );
+    }
+
+    #[test]
+    fn sidecar_write_with_empty_ranges_does_not_create_file() {
+        // Templates without any `secret(...)` calls should leave NO
+        // sidecar on disk — not even an empty `[]` one. Keeps the
+        // file system clean for the common case (most templates
+        // have no secrets).
+        let env = TempEnvironment::builder().build();
+        let sidecar = SecretsSidecar::new(Vec::new());
+        let written = sidecar
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "c.toml",
+            )
+            .unwrap();
+        assert!(written.is_none(), "empty sidecar should not write");
+        let path = env
+            .paths
+            .preprocessor_secrets_sidecar_path("app", "preprocessed", "c.toml");
+        assert!(!env.fs.exists(&path));
+    }
+
+    #[test]
+    fn sidecar_write_with_empty_ranges_removes_stale_file() {
+        // Previous render had secrets → sidecar on disk. New render
+        // has none → the writer must clean up the stale file so
+        // burgertocow's mask doesn't keep masking lines that
+        // legitimately surface as drift now.
+        let env = TempEnvironment::builder().build();
+        let original = SecretsSidecar::new(vec![range(1, "pass:k")]);
+        original
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "c.toml",
+            )
+            .unwrap()
+            .expect("first write");
+
+        let path = env
+            .paths
+            .preprocessor_secrets_sidecar_path("app", "preprocessed", "c.toml");
+        assert!(env.fs.exists(&path));
+
+        let empty = SecretsSidecar::new(Vec::new());
+        empty
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "c.toml",
+            )
+            .unwrap();
+        assert!(
+            !env.fs.exists(&path),
+            "stale sidecar must be removed when the new render has no secrets"
+        );
+    }
+
+    #[test]
+    fn sidecar_load_rejects_unsupported_version_with_actionable_message() {
+        let env = TempEnvironment::builder().build();
+        let path = env
+            .paths
+            .preprocessor_secrets_sidecar_path("app", "preprocessed", "c.toml");
+        env.fs.mkdir_all(path.parent().unwrap()).unwrap();
+        env.fs
+            .write_file(&path, br#"{"version":99,"secret_line_ranges":[]}"#)
+            .unwrap();
+
+        let err = SecretsSidecar::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "c.toml",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("unsupported schema version 99"));
+        assert!(err.contains("dodot up --force"));
+    }
+
+    #[test]
+    fn sidecar_load_rejects_corrupt_json_with_actionable_message() {
+        let env = TempEnvironment::builder().build();
+        let path = env
+            .paths
+            .preprocessor_secrets_sidecar_path("app", "preprocessed", "c.toml");
+        env.fs.mkdir_all(path.parent().unwrap()).unwrap();
+        env.fs.write_file(&path, b"{not valid json").unwrap();
+
+        let err = SecretsSidecar::load(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "c.toml",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("failed to parse"));
+        assert!(err.contains("dodot up --force"));
     }
 }

--- a/crates/dodot-lib/src/preprocessing/identity.rs
+++ b/crates/dodot-lib/src/preprocessing/identity.rs
@@ -73,6 +73,7 @@ impl Preprocessor for IdentityPreprocessor {
             is_dir: false,
             tracked_render: None,
             context_hash: None,
+            secret_line_ranges: Vec::new(),
         }])
     }
 }

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -38,6 +38,36 @@ pub enum TransformType {
     Opaque,
 }
 
+/// One entry in a per-render secrets sidecar — a span of lines whose
+/// content was produced by a `secret(...)` call, paired with the
+/// reference that produced it.
+///
+/// Lines are 0-indexed and `start..end` is half-open (i.e. `start ==
+/// end` for a single-line secret means an empty range; the secret
+/// occupies line `start`). For Phase S1 this is always a single line:
+/// multi-line secrets are refused at resolution time per
+/// `secrets.lex` §3.4. The `end` field is preserved in the schema for
+/// forward-compatibility but the renderer never produces `end >
+/// start + 1`.
+///
+/// Persisted to disk under `<baseline>.secret.json` (see
+/// `secrets.lex` §3.3); consumed by the dry-run preview rendering
+/// (§7.4) to mask resolved values, and by the burgertocow mask
+/// integration (issue arthur-debert/burgertocow#13) to skip those
+/// lines from the reverse diff.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SecretLineRange {
+    /// First line, 0-indexed, inclusive.
+    pub start: usize,
+    /// One past the last line, 0-indexed, exclusive. `start + 1` for
+    /// a single-line value.
+    pub end: usize,
+    /// The original `secret(...)` argument string, e.g.
+    /// `"op://Personal/DB/password"`. Surfaces in the dry-run
+    /// `[SECRET: <reference>]` placeholder.
+    pub reference: String,
+}
+
 /// A single file produced by a preprocessor's expansion.
 ///
 /// Construct ad-hoc via the struct literal; tests commonly use
@@ -70,6 +100,13 @@ pub struct ExpandedFile {
     /// install/homebrew sentinels both use the context hash to decide
     /// when work is stale.
     pub context_hash: Option<[u8; 32]>,
+    /// Per-render secret-line tracking. Empty when no `secret(...)`
+    /// calls fired (the common case today; will be the common case
+    /// forever for templates that don't use secrets). Populated by
+    /// `TemplatePreprocessor` when a [`crate::secret::SecretRegistry`]
+    /// is wired in. The pipeline persists this as a sidecar JSON
+    /// alongside the baseline.
+    pub secret_line_ranges: Vec<SecretLineRange>,
 }
 
 /// The core preprocessor abstraction.

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -42,13 +42,13 @@ pub enum TransformType {
 /// content was produced by a `secret(...)` call, paired with the
 /// reference that produced it.
 ///
-/// Lines are 0-indexed and `start..end` is half-open (i.e. `start ==
-/// end` for a single-line secret means an empty range; the secret
-/// occupies line `start`). For Phase S1 this is always a single line:
-/// multi-line secrets are refused at resolution time per
-/// `secrets.lex` §3.4. The `end` field is preserved in the schema for
-/// forward-compatibility but the renderer never produces `end >
-/// start + 1`.
+/// Lines are 0-indexed and `start..end` is half-open. A single-line
+/// secret occupies line `start` and is encoded as `end == start + 1`
+/// (`start == end` would be an empty range and is never produced).
+/// For Phase S1 every entry is single-line: multi-line secrets are
+/// refused at resolution time per `secrets.lex` §3.4. The `end` field
+/// is preserved in the schema for forward-compatibility but the
+/// renderer never produces `end > start + 1`.
 ///
 /// Persisted to disk under `<baseline>.secret.json` (see
 /// `secrets.lex` §3.3); consumed by the dry-run preview rendering

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -236,18 +236,97 @@ impl Default for PreprocessorRegistry {
 /// The [`identity`] preprocessor is test-only and is intentionally *not*
 /// registered here (it would match innocuous-looking `.identity` files in
 /// user dotfiles).
+///
+/// `secret_config` controls whether the template preprocessor gets a
+/// [`SecretRegistry`] wired in. When `[secret] enabled = true` and at
+/// least one provider is enabled, this function builds the registry,
+/// wires it onto the template preprocessor, and returns it via
+/// `out_secret_registry` so the caller can run preflight checks
+/// (`crate::secret::preflight`) before any rendering begins. When
+/// secrets are disabled, the template preprocessor is built without a
+/// registry and `secret(...)` calls in templates surface a config-
+/// pointing render error.
 pub fn default_registry(
     template_config: &crate::config::PreprocessorTemplateSection,
+    secret_config: &crate::config::SecretSection,
     pather: &dyn crate::paths::Pather,
-) -> Result<PreprocessorRegistry> {
+    command_runner: std::sync::Arc<dyn crate::datastore::CommandRunner>,
+) -> Result<(
+    PreprocessorRegistry,
+    Option<std::sync::Arc<crate::secret::SecretRegistry>>,
+)> {
+    use std::sync::Arc;
+
     let mut registry = PreprocessorRegistry::new();
     registry.register(Box::new(unarchive::UnarchivePreprocessor::new()));
-    registry.register(Box::new(template::TemplatePreprocessor::new(
+
+    let mut tpl = template::TemplatePreprocessor::new(
         template_config.extensions.clone(),
         template_config.vars.clone(),
         pather,
-    )?));
-    Ok(registry)
+    )?;
+
+    let secret_registry = if secret_config.enabled {
+        build_secret_registry(secret_config, command_runner)
+    } else {
+        None
+    };
+
+    if let Some(sr) = &secret_registry {
+        tpl = tpl.with_secret_registry(Arc::clone(sr));
+    }
+
+    registry.register(Box::new(tpl));
+    Ok((registry, secret_registry))
+}
+
+/// Construct a [`crate::secret::SecretRegistry`] from the per-provider
+/// `[secret.providers.*]` config blocks. Each enabled provider is
+/// constructed with the shared `CommandRunner` (so tests can inject a
+/// mock runner) and registered. Returns `None` if no provider is
+/// enabled — the secrets layer treats that case as "secrets feature
+/// fully off" and templates with `secret(...)` calls fail loudly.
+///
+/// Public so `commands::up` can build a single registry from the root
+/// config to run [`crate::secret::preflight`] once per run, before any
+/// per-pack template rendering begins (`secrets.lex` §5.4).
+pub fn build_secret_registry(
+    config: &crate::config::SecretSection,
+    runner: std::sync::Arc<dyn crate::datastore::CommandRunner>,
+) -> Option<std::sync::Arc<crate::secret::SecretRegistry>> {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    let mut reg = crate::secret::SecretRegistry::new();
+    let mut any_enabled = false;
+
+    if config.providers.pass.enabled {
+        let store_dir = if config.providers.pass.store_dir.is_empty() {
+            // Defer to env / default: PassProvider::from_env reads
+            // $PASSWORD_STORE_DIR or falls back to ~/.password-store.
+            None
+        } else {
+            Some(PathBuf::from(&config.providers.pass.store_dir))
+        };
+        let provider = match store_dir {
+            Some(dir) => crate::secret::PassProvider::new(Arc::clone(&runner), dir),
+            None => crate::secret::PassProvider::from_env(Arc::clone(&runner)),
+        };
+        reg.register(Arc::new(provider));
+        any_enabled = true;
+    }
+
+    if config.providers.op.enabled {
+        let provider = crate::secret::OpProvider::from_env(Arc::clone(&runner));
+        reg.register(Arc::new(provider));
+        any_enabled = true;
+    }
+
+    if any_enabled {
+        Some(Arc::new(reg))
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/crates/dodot-lib/src/preprocessing/pipeline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline.rs
@@ -2036,6 +2036,7 @@ mod tests {
                 is_dir: false,
                 tracked_render: Some("name = \u{1e}rendered\u{1f}".into()),
                 context_hash: Some([0xab; 32]),
+                secret_line_ranges: Vec::new(),
             }],
             ..Default::default()
         }));
@@ -2107,6 +2108,7 @@ mod tests {
                 is_dir: false,
                 tracked_render: Some("x".into()),
                 context_hash: Some([0; 32]),
+                secret_line_ranges: Vec::new(),
             }],
             ..Default::default()
         }));
@@ -2200,6 +2202,7 @@ mod tests {
             is_dir: false,
             tracked_render: Some("FIRST".into()),
             context_hash: Some([1; 32]),
+            secret_line_ranges: Vec::new(),
         }];
         let outputs_second = vec![crate::preprocessing::ExpandedFile {
             relative_path: PathBuf::from("config.toml"),
@@ -2207,6 +2210,7 @@ mod tests {
             is_dir: false,
             tracked_render: Some("SECOND".into()),
             context_hash: Some([2; 32]),
+            secret_line_ranges: Vec::new(),
         }];
 
         let datastore = make_datastore(&env);
@@ -2511,6 +2515,7 @@ mod tests {
                 is_dir: false,
                 tracked_render: Some("x".into()),
                 context_hash: Some([0; 32]),
+                secret_line_ranges: Vec::new(),
             }],
             supports_reverse_merge: true,
         }));
@@ -2574,6 +2579,7 @@ mod tests {
                 is_dir: false,
                 tracked_render: Some("x".into()),
                 context_hash: Some([0; 32]),
+                secret_line_ranges: Vec::new(),
             }],
             supports_reverse_merge: true,
         }));
@@ -2637,6 +2643,7 @@ mod tests {
                 is_dir: false,
                 tracked_render: Some("x".into()),
                 context_hash: Some([0; 32]),
+                secret_line_ranges: Vec::new(),
             }],
             supports_reverse_merge: true,
         }));

--- a/crates/dodot-lib/src/preprocessing/pipeline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline.rs
@@ -601,6 +601,31 @@ pub fn preprocess_pack(
                         "baseline written"
                     );
                 }
+
+                // Secrets sidecar (secrets.lex §3.3). Always called;
+                // the writer no-ops when the render had no
+                // `secret(...)` calls AND removes a stale sidecar
+                // from a prior render that DID, so the on-disk
+                // state always matches the latest render.
+                let sidecar = crate::preprocessing::baseline::SecretsSidecar::new(
+                    expanded.secret_line_ranges.clone(),
+                );
+                if let Err(err) =
+                    sidecar.write(fs, paths, &pack.name, PREPROCESSED_HANDLER, &cache_filename)
+                {
+                    // Same non-fatal disposition as baseline writes:
+                    // a missing sidecar means the next reverse-merge
+                    // sees an empty mask and surfaces the secret
+                    // line as a regular (mask-able) divergence,
+                    // which the user can recover from by re-running
+                    // `dodot up`.
+                    debug!(
+                        pack = %pack.name,
+                        file = %cache_filename,
+                        error = %err,
+                        "secrets sidecar write failed (non-fatal)"
+                    );
+                }
             }
 
             claimed_paths.insert(virtual_relative.clone());

--- a/crates/dodot-lib/src/preprocessing/template.rs
+++ b/crates/dodot-lib/src/preprocessing/template.rs
@@ -30,6 +30,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use burgertocow::Tracker;
@@ -171,11 +172,19 @@ impl TemplatePreprocessor {
     /// because `Tracker::add_template` requires `&mut self`.
     ///
     /// `sidecar` is the per-render secret-tracking accumulator. The
-    /// `secret(...)` MiniJinja function pushes `(reference, value)`
-    /// pairs into it on every successful resolution; the caller (the
-    /// `expand` body) walks the rendered output to convert those
-    /// pairs into [`SecretLineRange`] entries.
-    fn make_tracker(&self, sidecar: Arc<Mutex<Vec<(String, String)>>>) -> Tracker {
+    /// `secret(...)` MiniJinja function returns a unique private-use
+    /// sentinel (rather than the raw secret value) and pushes a
+    /// [`SecretCallEntry`] into the accumulator. The caller (the
+    /// `expand` body) walks the rendered output to find each sentinel,
+    /// records its line position, then substitutes the sentinel back
+    /// to the real value. This avoids the substring-collision failure
+    /// mode where a secret value happens to also appear elsewhere in
+    /// the rendered text.
+    ///
+    /// `render_id` is a per-render monotonic counter used in the
+    /// sentinel format so two concurrent renders can't observe each
+    /// other's sentinels.
+    fn make_tracker(&self, sidecar: Arc<Mutex<Vec<SecretCallEntry>>>, render_id: u64) -> Tracker {
         let mut tracker = Tracker::new();
         let env = tracker.env_mut();
         env.set_undefined_behavior(UndefinedBehavior::Strict);
@@ -233,11 +242,18 @@ impl TemplatePreprocessor {
                             )
                         })?;
                         let owned = s.to_string();
-                        sidecar
-                            .lock()
-                            .unwrap()
-                            .push((reference.to_string(), owned.clone()));
-                        Ok(owned)
+                        let mut entries = sidecar.lock().unwrap();
+                        let sentinel = make_secret_sentinel(render_id, entries.len());
+                        entries.push(SecretCallEntry {
+                            sentinel: sentinel.clone(),
+                            reference: reference.to_string(),
+                            value: owned,
+                        });
+                        // The sentinel is what flows through MiniJinja
+                        // and into the rendered output; `expand()`
+                        // computes line ranges by locating sentinels
+                        // and then substitutes them back to `owned`.
+                        Ok(sentinel)
                     },
                 );
             }
@@ -249,10 +265,10 @@ impl TemplatePreprocessor {
                             MjErrorKind::InvalidOperation,
                             format!(
                                 "secret(`{reference}`) was called but no secret providers \
-                             are configured. Enable a provider via \
-                             `[secret.providers.<scheme>] enabled = true` in your \
-                             .dodot.toml, or remove the `secret(...)` reference from \
-                             the template."
+                             are configured. Either set `[secret] enabled = true` and \
+                             enable a provider via `[secret.providers.<scheme>] enabled = \
+                             true` in your .dodot.toml, or remove the `secret(...)` \
+                             reference from the template."
                             ),
                         ))
                     },
@@ -316,13 +332,15 @@ impl Preprocessor for TemplatePreprocessor {
         // surfaces sensibly in any error MiniJinja produces.
         let template_name = source.to_string_lossy().into_owned();
 
-        // Per-render sidecar accumulator. The `secret(...)` MiniJinja
-        // function pushes `(reference, value)` pairs as they resolve;
-        // we walk the rendered output below to convert into line
-        // ranges.
-        let sidecar_pairs: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(Vec::new()));
+        // Per-render sidecar accumulator. Each `secret(...)` call
+        // pushes a `SecretCallEntry { sentinel, reference, value }`;
+        // the rendered output carries the sentinel (not the value),
+        // and `finalize_secrets` below turns sentinels into line
+        // ranges and then substitutes them back to the real value.
+        let sidecar: Arc<Mutex<Vec<SecretCallEntry>>> = Arc::new(Mutex::new(Vec::new()));
+        let render_id = next_render_id();
 
-        let mut tracker = self.make_tracker(sidecar_pairs.clone());
+        let mut tracker = self.make_tracker(sidecar.clone(), render_id);
         tracker
             .add_template(&template_name, &template_str)
             .map_err(|e| DodotError::TemplateRender {
@@ -346,9 +364,9 @@ impl Preprocessor for TemplatePreprocessor {
         let stripped = self.stripped_name(&filename);
 
         let (rendered, tracked_str) = tracked.into_parts();
-
-        let pairs = std::mem::take(&mut *sidecar_pairs.lock().unwrap());
-        let secret_line_ranges = compute_secret_line_ranges(&rendered, &pairs);
+        let entries = std::mem::take(&mut *sidecar.lock().unwrap());
+        let (rendered, tracked_str, secret_line_ranges) =
+            finalize_secrets(rendered, tracked_str, &entries);
 
         Ok(vec![ExpandedFile {
             relative_path: PathBuf::from(stripped),
@@ -361,45 +379,107 @@ impl Preprocessor for TemplatePreprocessor {
     }
 }
 
-/// Convert a sequence of `(reference, resolved_value)` pairs (in
-/// resolution order) into [`SecretLineRange`] entries by locating
-/// each value's first occurrence in `rendered`.
+/// Per-call accumulator entry for `secret(...)` resolutions. Carries
+/// both the unique private-use sentinel that the MiniJinja function
+/// emitted and the real resolved value, so `finalize_secrets` can
+/// compute line ranges from the sentinel positions and then swap
+/// sentinels for values in the rendered + tracked outputs.
+struct SecretCallEntry {
+    sentinel: String,
+    reference: String,
+    value: String,
+}
+
+/// Process-wide monotonic counter used to make sentinels unique
+/// across concurrent renders. Each `expand()` call gets a fresh id
+/// before installing the `secret()` function.
+static RENDER_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn next_render_id() -> u64 {
+    RENDER_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Sentinel format: `\u{E000}DSEC.<render_id>.<call_idx>\u{E001}`.
 ///
-/// Phase S1 simplification: each value is single-line (multi-line is
-/// refused at resolution time per §3.4), so each entry occupies one
-/// line — `end == start + 1`. Two `secret(...)` calls that resolve
-/// to the same literal value collapse to one range; that's a
-/// degenerate case we accept rather than introduce a marker scheme
-/// that would interact with burgertocow's tracker. The user-visible
-/// failure mode in that case is mild — the sidecar masks one
-/// position but not the duplicate — and rare.
+/// Both bracket characters live in the Unicode Private Use Area
+/// (U+E000–U+F8FF), which by definition has no assigned meaning and
+/// does not appear in normal dotfile content. Combined with the
+/// per-render id, the resulting string is unique within and across
+/// renders, eliminating the substring-collision failure mode of the
+/// previous "search for the resolved value" approach.
+fn make_secret_sentinel(render_id: u64, call_idx: usize) -> String {
+    let mut s = String::with_capacity(20);
+    s.push('\u{E000}');
+    s.push_str("DSEC.");
+    s.push_str(&render_id.to_string());
+    s.push('.');
+    s.push_str(&call_idx.to_string());
+    s.push('\u{E001}');
+    s
+}
+
+/// Walk `rendered` to convert each sentinel into a [`SecretLineRange`]
+/// (single-line per Phase S1 / §3.4), then substitute every sentinel
+/// back to its real value in both `rendered` and `tracked` and return
+/// all three.
 ///
-/// Walks `rendered` line-by-line; for each `(_, value)` pair, finds
-/// the first line containing `value` (left-to-right substring
-/// search) and emits a single-line range. Values that don't appear
-/// at all in `rendered` are dropped (template logic might have
-/// suppressed them, e.g. inside a false `{% if %}` branch — the
-/// `secret()` was called for resolution side effects but the value
-/// didn't make it into the output).
-fn compute_secret_line_ranges(rendered: &str, pairs: &[(String, String)]) -> Vec<SecretLineRange> {
-    let lines: Vec<&str> = rendered.split_inclusive('\n').collect();
-    let mut out = Vec::with_capacity(pairs.len());
-    for (reference, value) in pairs {
-        if value.is_empty() {
-            continue; // empty secret — nothing to mask
-        }
-        for (idx, line) in lines.iter().enumerate() {
-            if line.contains(value.as_str()) {
-                out.push(SecretLineRange {
-                    start: idx,
-                    end: idx + 1,
-                    reference: reference.clone(),
+/// Sentinels that don't appear in the output are dropped from the
+/// range list — the `secret()` was evaluated (for resolution side
+/// effects) but the value never reached the visible output, e.g. a
+/// call inside a false `{% if %}` branch. We still substitute (a
+/// no-op in that case) so callers can rely on the post-call output
+/// containing zero sentinel characters.
+fn finalize_secrets(
+    rendered: String,
+    tracked: String,
+    entries: &[SecretCallEntry],
+) -> (String, String, Vec<SecretLineRange>) {
+    let mut ranges = Vec::with_capacity(entries.len());
+    if !entries.is_empty() {
+        let line_starts = build_line_starts(&rendered);
+        for entry in entries {
+            if let Some(byte_off) = rendered.find(entry.sentinel.as_str()) {
+                let line = byte_offset_to_line(&line_starts, byte_off);
+                ranges.push(SecretLineRange {
+                    start: line,
+                    end: line + 1,
+                    reference: entry.reference.clone(),
                 });
-                break;
             }
         }
     }
-    out
+
+    let mut final_rendered = rendered;
+    let mut final_tracked = tracked;
+    for entry in entries {
+        final_rendered = final_rendered.replace(entry.sentinel.as_str(), &entry.value);
+        final_tracked = final_tracked.replace(entry.sentinel.as_str(), &entry.value);
+    }
+
+    (final_rendered, final_tracked, ranges)
+}
+
+/// Byte offsets where each line begins in `s`. `line_starts[0] == 0`;
+/// `line_starts[i]` for i > 0 is the byte index just past the i-1th
+/// `\n`. Used by [`byte_offset_to_line`] for the sentinel→line lookup.
+fn build_line_starts(s: &str) -> Vec<usize> {
+    let mut v = Vec::with_capacity(s.len() / 32 + 1);
+    v.push(0);
+    for (i, b) in s.bytes().enumerate() {
+        if b == b'\n' {
+            v.push(i + 1);
+        }
+    }
+    v
+}
+
+/// Map a byte offset within the source string to its 0-indexed line
+/// number. Binary search over `line_starts`.
+fn byte_offset_to_line(line_starts: &[usize], offset: usize) -> usize {
+    match line_starts.binary_search(&offset) {
+        Ok(line) => line,
+        Err(insert_pos) => insert_pos.saturating_sub(1),
+    }
 }
 
 /// Produce a deterministic SHA-256 over the rendering context.
@@ -1398,51 +1478,87 @@ mod tests {
         );
     }
 
+    /// Build a `SecretCallEntry` and the rendered text it would
+    /// produce when MiniJinja substitutes the sentinel for the value.
+    /// Tests construct the rendered text with the sentinel in place
+    /// (mimicking `secret()`'s return value) so `finalize_secrets`
+    /// has something to find.
+    fn entry(idx: usize, reference: &str, value: &str) -> (SecretCallEntry, String) {
+        let sentinel = make_secret_sentinel(0, idx);
+        let entry = SecretCallEntry {
+            sentinel: sentinel.clone(),
+            reference: reference.to_string(),
+            value: value.to_string(),
+        };
+        (entry, sentinel)
+    }
+
     #[test]
-    fn compute_secret_line_ranges_finds_value_on_first_matching_line() {
-        let rendered = "header\nuser = alice\npassword = hunter2\nfooter\n";
-        let pairs = vec![("pass:k".to_string(), "hunter2".to_string())];
-        let ranges = compute_secret_line_ranges(rendered, &pairs);
+    fn finalize_secrets_substitutes_sentinels_and_records_line_ranges() {
+        let (e, sentinel) = entry(0, "pass:k", "hunter2");
+        let rendered = format!("header\nuser = alice\npassword = {sentinel}\nfooter\n");
+        let (final_rendered, _, ranges) = finalize_secrets(rendered, String::new(), &[e]);
         assert_eq!(ranges.len(), 1);
-        assert_eq!(ranges[0].start, 2);
-        assert_eq!(ranges[0].end, 3);
+        assert_eq!((ranges[0].start, ranges[0].end), (2, 3));
         assert_eq!(ranges[0].reference, "pass:k");
+        assert_eq!(
+            final_rendered,
+            "header\nuser = alice\npassword = hunter2\nfooter\n"
+        );
+        assert!(!final_rendered.contains('\u{E000}'));
     }
 
     #[test]
-    fn compute_secret_line_ranges_drops_empty_values() {
-        // A `secret()` that resolves to empty string can't be
-        // located in the rendered output; drop it rather than emit
-        // a degenerate range. (The empty value is a degenerate
-        // case; sidecar masking has nothing to mask.)
-        let pairs = vec![("pass:empty".to_string(), String::new())];
-        let ranges = compute_secret_line_ranges("any\noutput\n", &pairs);
-        assert!(ranges.is_empty());
+    fn finalize_secrets_does_not_match_value_substring_outside_sentinel() {
+        // The substring-based predecessor would mark line 0 (the
+        // greeting also contains "hunter2"); the sentinel approach
+        // only matches the exact secret slot.
+        let (e, sentinel) = entry(0, "pass:k", "hunter2");
+        let rendered = format!("greeting = hunter2 hi\npassword = {sentinel}\n");
+        let (final_rendered, _, ranges) = finalize_secrets(rendered, String::new(), &[e]);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!((ranges[0].start, ranges[0].end), (1, 2));
+        assert_eq!(
+            final_rendered,
+            "greeting = hunter2 hi\npassword = hunter2\n"
+        );
     }
 
     #[test]
-    fn compute_secret_line_ranges_drops_values_not_in_output() {
-        // A `secret()` called inside a false `{% if %}` branch
-        // resolves (we have a (ref, value) pair) but its value
-        // never appears in `rendered`. We don't synthesise a fake
-        // line range — the sidecar would mask nothing useful.
-        let pairs = vec![("pass:hidden".to_string(), "never-emitted".to_string())];
-        let ranges = compute_secret_line_ranges("clean output\n", &pairs);
-        assert!(ranges.is_empty());
-    }
-
-    #[test]
-    fn compute_secret_line_ranges_handles_multiple_secrets_in_order() {
-        let rendered = "a = one\nb = two\nc = three\n";
-        let pairs = vec![
-            ("pass:k1".to_string(), "one".to_string()),
-            ("pass:k2".to_string(), "two".to_string()),
-            ("pass:k3".to_string(), "three".to_string()),
-        ];
-        let ranges = compute_secret_line_ranges(rendered, &pairs);
-        assert_eq!(ranges.len(), 3);
+    fn finalize_secrets_handles_two_calls_resolving_to_same_value() {
+        // Two distinct sentinels even when the values are identical;
+        // both lines are masked.
+        let (e1, s1) = entry(0, "pass:a", "shared");
+        let (e2, s2) = entry(1, "pass:b", "shared");
+        let rendered = format!("a = {s1}\nb = {s2}\n");
+        let (final_rendered, _, ranges) = finalize_secrets(rendered, String::new(), &[e1, e2]);
+        assert_eq!(ranges.len(), 2);
         assert_eq!((ranges[0].start, ranges[0].end), (0, 1));
         assert_eq!((ranges[1].start, ranges[1].end), (1, 2));
-        assert_eq!((ranges[2].start, ranges[2].end), (2, 3));
+        assert_eq!(final_rendered, "a = shared\nb = shared\n");
+    }
+
+    #[test]
+    fn finalize_secrets_drops_entries_whose_sentinel_was_not_emitted() {
+        // `secret()` was evaluated (e.g. inside a false `{% if %}`)
+        // but the sentinel never reached the visible output. We
+        // don't synthesise a fake range; we still substitute (a
+        // no-op here) so callers can rely on the post-call output
+        // being sentinel-free.
+        let (e, _sentinel) = entry(0, "pass:hidden", "never-emitted");
+        let rendered = "clean output\n".to_string();
+        let (final_rendered, _, ranges) = finalize_secrets(rendered, String::new(), &[e]);
+        assert!(ranges.is_empty());
+        assert_eq!(final_rendered, "clean output\n");
+    }
+
+    #[test]
+    fn finalize_secrets_substitutes_sentinels_in_tracked_render_too() {
+        // Sentinels must not leak into the baseline cache via the
+        // tracked stream.
+        let (e, sentinel) = entry(0, "pass:k", "hunter2");
+        let tracked = format!("preamble {sentinel} epilogue");
+        let (_, final_tracked, _) = finalize_secrets(String::new(), tracked, &[e]);
+        assert_eq!(final_tracked, "preamble hunter2 epilogue");
     }
 }

--- a/crates/dodot-lib/src/preprocessing/template.rs
+++ b/crates/dodot-lib/src/preprocessing/template.rs
@@ -30,16 +30,17 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use burgertocow::Tracker;
 use minijinja::value::{Enumerator, Object, ObjectRepr, Value};
-use minijinja::UndefinedBehavior;
+use minijinja::{Error as MjError, ErrorKind as MjErrorKind, UndefinedBehavior};
 use sha2::{Digest, Sha256};
 
 use crate::fs::Fs;
 use crate::paths::Pather;
-use crate::preprocessing::{ExpandedFile, Preprocessor, TransformType};
+use crate::preprocessing::{ExpandedFile, Preprocessor, SecretLineRange, TransformType};
+use crate::secret::SecretRegistry;
 use crate::{DodotError, Result};
 
 /// Reserved top-level variable names.
@@ -98,6 +99,12 @@ pub struct TemplatePreprocessor {
     /// invalidation belong in `[preprocessor.template.vars]`
     /// (`user_vars`), not `env.*`.
     context_hash: [u8; 32],
+    /// Optional secret-resolution registry. Populated via
+    /// [`Self::with_secret_registry`] when secrets are configured.
+    /// `None` means `secret(...)` is unavailable in templates and a
+    /// `secret(...)` call surfaces as a render error pointing the
+    /// user at `[secret] enabled = true`. See `secrets.lex` §5.
+    secret_registry: Option<Arc<SecretRegistry>>,
 }
 
 impl std::fmt::Debug for TemplatePreprocessor {
@@ -143,13 +150,32 @@ impl TemplatePreprocessor {
             dodot_ns,
             user_vars,
             context_hash,
+            secret_registry: None,
         })
+    }
+
+    /// Wire a [`SecretRegistry`] into this preprocessor. Templates
+    /// rendered through it can call `{{ secret("op://Vault/Item/Field") }}`
+    /// (and other configured schemes); calls dispatch through the
+    /// registry, populate the per-render sidecar, and refuse
+    /// multi-line values per `secrets.lex` §3.4. Without a registry
+    /// (the default), any `secret(...)` call in a template surfaces
+    /// as a render error.
+    pub fn with_secret_registry(mut self, registry: Arc<SecretRegistry>) -> Self {
+        self.secret_registry = Some(registry);
+        self
     }
 
     /// Build a fresh tracker with this preprocessor's namespaces
     /// installed and `UndefinedBehavior::Strict` set. Called per render
     /// because `Tracker::add_template` requires `&mut self`.
-    fn make_tracker(&self) -> Tracker {
+    ///
+    /// `sidecar` is the per-render secret-tracking accumulator. The
+    /// `secret(...)` MiniJinja function pushes `(reference, value)`
+    /// pairs into it on every successful resolution; the caller (the
+    /// `expand` body) walks the rendered output to convert those
+    /// pairs into [`SecretLineRange`] entries.
+    fn make_tracker(&self, sidecar: Arc<Mutex<Vec<(String, String)>>>) -> Tracker {
         let mut tracker = Tracker::new();
         let env = tracker.env_mut();
         env.set_undefined_behavior(UndefinedBehavior::Strict);
@@ -157,6 +183,81 @@ impl TemplatePreprocessor {
         env.add_global("env", Value::from_object(EnvLookup));
         for (name, val) in &self.user_vars {
             env.add_global(name.clone(), Value::from(val.clone()));
+        }
+
+        // Install the `secret(...)` function. Two cases:
+        //
+        // - Registry configured: function dispatches through the
+        //   registry. Refuses multi-line values per §3.4. Records
+        //   the (reference, value) pair into `sidecar` so the
+        //   caller can compute line ranges after rendering.
+        // - No registry: function still exists, but every call
+        //   surfaces a clean render error pointing the user at
+        //   `[secret] enabled = true`. The presence-without-function
+        //   alternative would surface as MiniJinja's generic
+        //   "undefined" error which doesn't tell the user how to
+        //   fix the config.
+        match &self.secret_registry {
+            Some(registry) => {
+                let registry = registry.clone();
+                let sidecar = sidecar.clone();
+                env.add_function(
+                    "secret",
+                    move |reference: &str| -> std::result::Result<String, MjError> {
+                        let value = registry.resolve(reference).map_err(|e| {
+                            MjError::new(MjErrorKind::InvalidOperation, e.to_string())
+                        })?;
+                        if value.contains_newline() {
+                            // §3.4 multi-line refusal. The error text
+                            // names the reference and points the user at
+                            // the whole-file deploy path.
+                            return Err(MjError::new(
+                                MjErrorKind::InvalidOperation,
+                                format!(
+                                    "secret `{reference}` resolved to a multi-line value. \
+                                 Value-injection (`{{{{ secret(...) }}}}`) is single-line only. \
+                                 For multi-line secret material (TLS / SSH keys, GPG armored \
+                                 keys, service-account JSON files), use the whole-file deploy \
+                                 path: encrypt the file, drop it in a pack, reference the \
+                                 deployed path from your config. See secrets.lex §4."
+                                ),
+                            ));
+                        }
+                        let s = value.expose().map_err(|_| {
+                            MjError::new(
+                                MjErrorKind::InvalidOperation,
+                                format!(
+                                    "secret `{reference}` resolved to non-UTF-8 bytes; \
+                                 value-injection requires UTF-8 strings"
+                                ),
+                            )
+                        })?;
+                        let owned = s.to_string();
+                        sidecar
+                            .lock()
+                            .unwrap()
+                            .push((reference.to_string(), owned.clone()));
+                        Ok(owned)
+                    },
+                );
+            }
+            None => {
+                env.add_function(
+                    "secret",
+                    |reference: &str| -> std::result::Result<String, MjError> {
+                        Err(MjError::new(
+                            MjErrorKind::InvalidOperation,
+                            format!(
+                                "secret(`{reference}`) was called but no secret providers \
+                             are configured. Enable a provider via \
+                             `[secret.providers.<scheme>] enabled = true` in your \
+                             .dodot.toml, or remove the `secret(...)` reference from \
+                             the template."
+                            ),
+                        ))
+                    },
+                );
+            }
         }
         tracker
     }
@@ -215,7 +316,13 @@ impl Preprocessor for TemplatePreprocessor {
         // surfaces sensibly in any error MiniJinja produces.
         let template_name = source.to_string_lossy().into_owned();
 
-        let mut tracker = self.make_tracker();
+        // Per-render sidecar accumulator. The `secret(...)` MiniJinja
+        // function pushes `(reference, value)` pairs as they resolve;
+        // we walk the rendered output below to convert into line
+        // ranges.
+        let sidecar_pairs: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let mut tracker = self.make_tracker(sidecar_pairs.clone());
         tracker
             .add_template(&template_name, &template_str)
             .map_err(|e| DodotError::TemplateRender {
@@ -240,14 +347,59 @@ impl Preprocessor for TemplatePreprocessor {
 
         let (rendered, tracked_str) = tracked.into_parts();
 
+        let pairs = std::mem::take(&mut *sidecar_pairs.lock().unwrap());
+        let secret_line_ranges = compute_secret_line_ranges(&rendered, &pairs);
+
         Ok(vec![ExpandedFile {
             relative_path: PathBuf::from(stripped),
             content: rendered.into_bytes(),
             is_dir: false,
             tracked_render: Some(tracked_str),
             context_hash: Some(self.context_hash),
+            secret_line_ranges,
         }])
     }
+}
+
+/// Convert a sequence of `(reference, resolved_value)` pairs (in
+/// resolution order) into [`SecretLineRange`] entries by locating
+/// each value's first occurrence in `rendered`.
+///
+/// Phase S1 simplification: each value is single-line (multi-line is
+/// refused at resolution time per §3.4), so each entry occupies one
+/// line — `end == start + 1`. Two `secret(...)` calls that resolve
+/// to the same literal value collapse to one range; that's a
+/// degenerate case we accept rather than introduce a marker scheme
+/// that would interact with burgertocow's tracker. The user-visible
+/// failure mode in that case is mild — the sidecar masks one
+/// position but not the duplicate — and rare.
+///
+/// Walks `rendered` line-by-line; for each `(_, value)` pair, finds
+/// the first line containing `value` (left-to-right substring
+/// search) and emits a single-line range. Values that don't appear
+/// at all in `rendered` are dropped (template logic might have
+/// suppressed them, e.g. inside a false `{% if %}` branch — the
+/// `secret()` was called for resolution side effects but the value
+/// didn't make it into the output).
+fn compute_secret_line_ranges(rendered: &str, pairs: &[(String, String)]) -> Vec<SecretLineRange> {
+    let lines: Vec<&str> = rendered.split_inclusive('\n').collect();
+    let mut out = Vec::with_capacity(pairs.len());
+    for (reference, value) in pairs {
+        if value.is_empty() {
+            continue; // empty secret — nothing to mask
+        }
+        for (idx, line) in lines.iter().enumerate() {
+            if line.contains(value.as_str()) {
+                out.push(SecretLineRange {
+                    start: idx,
+                    end: idx + 1,
+                    reference: reference.clone(),
+                });
+                break;
+            }
+        }
+    }
+    out
 }
 
 /// Produce a deterministic SHA-256 over the rendering context.
@@ -1054,5 +1206,243 @@ mod tests {
             String::from_utf8(result[0].content.clone()).unwrap(),
             *tracked
         );
+    }
+
+    // ── secret() integration (Phase S1) ────────────────────────
+
+    /// Build a TemplatePreprocessor wired with a registry containing
+    /// the given canned `(reference, value)` pairs under one scheme.
+    /// The scheme is used as both the URI prefix and the
+    /// MockSecretProvider's `scheme()` return.
+    fn pp_with_secrets(scheme: &str, pairs: &[(&str, &str)]) -> TemplatePreprocessor {
+        use crate::secret::test_support::MockSecretProvider;
+        use crate::secret::SecretRegistry;
+        use std::sync::Arc;
+
+        let mut mock = MockSecretProvider::new(scheme);
+        for (k, v) in pairs {
+            mock = mock.with(k.to_string(), v.to_string());
+        }
+        let mut registry = SecretRegistry::new();
+        registry.register(Arc::new(mock));
+        new_pp(HashMap::new()).with_secret_registry(Arc::new(registry))
+    }
+
+    #[test]
+    fn secret_function_resolves_via_registry() {
+        // pass:path/to/db -> "hunter2"; the registry strips the scheme
+        // and hands "path/to/db" to the provider, which returns the
+        // canned value.
+        let pp = pp_with_secrets("pass", &[("path/to/db", "hunter2")]);
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file(
+                "config.toml.tmpl",
+                "password = \"{{ secret('pass:path/to/db') }}\"\n",
+            )
+            .done()
+            .build();
+        let source = env.dotfiles_root.join("app/config.toml.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let rendered = String::from_utf8_lossy(&result[0].content);
+        assert_eq!(rendered, "password = \"hunter2\"\n");
+    }
+
+    #[test]
+    fn secret_function_records_sidecar_entry_with_correct_line_range() {
+        let pp = pp_with_secrets("pass", &[("k1", "v1"), ("k2", "v2")]);
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file(
+                "c.tmpl",
+                "first\nsecond = {{ secret('pass:k1') }}\nthird\nfourth = {{ secret('pass:k2') }}\n",
+            )
+            .done()
+            .build();
+        let source = env.dotfiles_root.join("app/c.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        // k1's value lands on line 1 (0-indexed), k2's on line 3.
+        let ranges = &result[0].secret_line_ranges;
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].reference, "pass:k1");
+        assert_eq!(ranges[0].start, 1);
+        assert_eq!(ranges[0].end, 2);
+        assert_eq!(ranges[1].reference, "pass:k2");
+        assert_eq!(ranges[1].start, 3);
+        assert_eq!(ranges[1].end, 4);
+    }
+
+    #[test]
+    fn secret_function_refuses_multiline_value_per_section_3_4() {
+        let pp = pp_with_secrets("pass", &[("multi", "line1\nline2")]);
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("c.tmpl", "x = {{ secret('pass:multi') }}\n")
+            .done()
+            .build();
+        let source = env.dotfiles_root.join("app/c.tmpl");
+        let err = pp.expand(&source, env.fs.as_ref()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("multi-line value"));
+        assert!(msg.contains("single-line only"));
+        // Points the user at the whole-file path, not just rejecting.
+        assert!(msg.contains("whole-file deploy"));
+    }
+
+    #[test]
+    fn secret_function_propagates_provider_resolve_failure() {
+        let pp = pp_with_secrets("pass", &[]); // no canned values
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("c.tmpl", "x = {{ secret('pass:missing') }}\n")
+            .done()
+            .build();
+        let source = env.dotfiles_root.join("app/c.tmpl");
+        let err = pp.expand(&source, env.fs.as_ref()).unwrap_err();
+        let msg = err.to_string();
+        // The mock's "no canned value" message comes through.
+        assert!(msg.contains("MockSecretProvider"));
+        assert!(msg.contains("missing"));
+    }
+
+    #[test]
+    fn secret_function_unknown_scheme_lists_configured_schemes() {
+        // Registry has `pass` only; template references `op://...`.
+        let pp = pp_with_secrets("pass", &[("k", "v")]);
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("c.tmpl", "x = {{ secret('op://V/I/F') }}\n")
+            .done()
+            .build();
+        let source = env.dotfiles_root.join("app/c.tmpl");
+        let err = pp.expand(&source, env.fs.as_ref()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no secret provider registered for scheme `op`"));
+        assert!(msg.contains("pass")); // configured-schemes listing
+    }
+
+    #[test]
+    fn secret_function_without_registry_errors_with_actionable_hint() {
+        // No `with_secret_registry` call → secret() exists but every
+        // call surfaces a config-pointing error rather than
+        // MiniJinja's generic "undefined" diagnostic.
+        let pp = new_pp(HashMap::new());
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("c.tmpl", "x = {{ secret('pass:k') }}\n")
+            .done()
+            .build();
+        let source = env.dotfiles_root.join("app/c.tmpl");
+        let err = pp.expand(&source, env.fs.as_ref()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no secret providers are configured"));
+        assert!(msg.contains("[secret.providers."));
+        assert!(msg.contains("pass:k"));
+    }
+
+    #[test]
+    fn secret_function_supports_multiple_schemes_in_one_template() {
+        use crate::secret::test_support::MockSecretProvider;
+        use crate::secret::SecretRegistry;
+        use std::sync::Arc;
+
+        let mut registry = SecretRegistry::new();
+        registry.register(Arc::new(
+            MockSecretProvider::new("pass").with("db", "from-pass"),
+        ));
+        registry.register(Arc::new(
+            MockSecretProvider::new("op").with("//V/I/password", "from-op"),
+        ));
+        let pp = new_pp(HashMap::new()).with_secret_registry(Arc::new(registry));
+
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file(
+                "c.tmpl",
+                "a={{ secret('pass:db') }}\nb={{ secret('op://V/I/password') }}\n",
+            )
+            .done()
+            .build();
+        let source = env.dotfiles_root.join("app/c.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let rendered = String::from_utf8_lossy(&result[0].content);
+        assert_eq!(rendered, "a=from-pass\nb=from-op\n");
+        assert_eq!(result[0].secret_line_ranges.len(), 2);
+    }
+
+    #[test]
+    fn secret_function_tracks_render_into_baseline() {
+        // The secret value must appear in the visible content AND
+        // (because templates are reverse-merge-capable) in the
+        // tracked_render. Burgertocow markers wrap the variable
+        // emission; the secret value appears between markers in the
+        // tracked stream.
+        let pp = pp_with_secrets("pass", &[("k", "topsecret")]);
+        let env = crate::testing::TempEnvironment::builder()
+            .pack("app")
+            .file("c.tmpl", "x = {{ secret('pass:k') }}\n")
+            .done()
+            .build();
+        let source = env.dotfiles_root.join("app/c.tmpl");
+        let result = pp.expand(&source, env.fs.as_ref()).unwrap();
+        let rendered = String::from_utf8_lossy(&result[0].content);
+        assert_eq!(rendered, "x = topsecret\n");
+
+        let tracked = result[0]
+            .tracked_render
+            .as_ref()
+            .expect("template render produces tracked stream");
+        assert!(
+            tracked.contains("topsecret"),
+            "tracked render should contain the resolved value, got: {tracked:?}"
+        );
+    }
+
+    #[test]
+    fn compute_secret_line_ranges_finds_value_on_first_matching_line() {
+        let rendered = "header\nuser = alice\npassword = hunter2\nfooter\n";
+        let pairs = vec![("pass:k".to_string(), "hunter2".to_string())];
+        let ranges = compute_secret_line_ranges(rendered, &pairs);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].start, 2);
+        assert_eq!(ranges[0].end, 3);
+        assert_eq!(ranges[0].reference, "pass:k");
+    }
+
+    #[test]
+    fn compute_secret_line_ranges_drops_empty_values() {
+        // A `secret()` that resolves to empty string can't be
+        // located in the rendered output; drop it rather than emit
+        // a degenerate range. (The empty value is a degenerate
+        // case; sidecar masking has nothing to mask.)
+        let pairs = vec![("pass:empty".to_string(), String::new())];
+        let ranges = compute_secret_line_ranges("any\noutput\n", &pairs);
+        assert!(ranges.is_empty());
+    }
+
+    #[test]
+    fn compute_secret_line_ranges_drops_values_not_in_output() {
+        // A `secret()` called inside a false `{% if %}` branch
+        // resolves (we have a (ref, value) pair) but its value
+        // never appears in `rendered`. We don't synthesise a fake
+        // line range — the sidecar would mask nothing useful.
+        let pairs = vec![("pass:hidden".to_string(), "never-emitted".to_string())];
+        let ranges = compute_secret_line_ranges("clean output\n", &pairs);
+        assert!(ranges.is_empty());
+    }
+
+    #[test]
+    fn compute_secret_line_ranges_handles_multiple_secrets_in_order() {
+        let rendered = "a = one\nb = two\nc = three\n";
+        let pairs = vec![
+            ("pass:k1".to_string(), "one".to_string()),
+            ("pass:k2".to_string(), "two".to_string()),
+            ("pass:k3".to_string(), "three".to_string()),
+        ];
+        let ranges = compute_secret_line_ranges(rendered, &pairs);
+        assert_eq!(ranges.len(), 3);
+        assert_eq!((ranges[0].start, ranges[0].end), (0, 1));
+        assert_eq!((ranges[1].start, ranges[1].end), (1, 2));
+        assert_eq!((ranges[2].start, ranges[2].end), (2, 3));
     }
 }

--- a/crates/dodot-lib/src/preprocessing/unarchive.rs
+++ b/crates/dodot-lib/src/preprocessing/unarchive.rs
@@ -118,6 +118,7 @@ impl Preprocessor for UnarchivePreprocessor {
                     is_dir: true,
                     tracked_render: None,
                     context_hash: None,
+                    secret_line_ranges: Vec::new(),
                 });
             } else if entry_type.is_file() {
                 let mut content = Vec::new();
@@ -135,6 +136,7 @@ impl Preprocessor for UnarchivePreprocessor {
                     is_dir: false,
                     tracked_render: None,
                     context_hash: None,
+                    secret_line_ranges: Vec::new(),
                 });
             } else {
                 return Err(DodotError::PreprocessorError {

--- a/crates/dodot-lib/src/secret/error_render.rs
+++ b/crates/dodot-lib/src/secret/error_render.rs
@@ -1,0 +1,193 @@
+//! Render `ProbeResult`s into the user-facing strings spec'd in
+//! `secrets.lex` §5.4.
+//!
+//! Lives separate from `provider.rs` so the trait surface stays
+//! minimal — provider impls return raw `ProbeResult` variants and
+//! the messaging policy (which hint goes where, what cross-references
+//! to include, what tone) lives in one place.
+
+use crate::secret::provider::ProbeResult;
+use crate::secret::registry::SecretRegistry;
+use crate::DodotError;
+
+/// Render a single `(scheme, ProbeResult)` pair as a multi-line user-
+/// facing message. `Ok` produces an empty string — callers gate on
+/// emptiness to decide whether to surface the line at all.
+///
+/// The shapes match `secrets.lex` §5.4:
+///
+/// - **NotInstalled**: tells the user the CLI is missing and provides
+///   the provider-supplied install hint plus the disable-in-config
+///   escape hatch.
+/// - **NotAuthenticated**: tells the user auth is missing and provides
+///   the provider-supplied signin / env-var hint.
+/// - **Misconfigured**: surfaces the provider's specific
+///   configuration problem verbatim (e.g. "password store not
+///   initialised at /home/x/.password-store").
+/// - **ProbeFailed**: surfaces the diagnostic verbatim — these are
+///   the cases where probe() couldn't reach a clean conclusion.
+pub fn render_probe_outcome(scheme: &str, outcome: &ProbeResult) -> String {
+    match outcome {
+        ProbeResult::Ok => String::new(),
+        ProbeResult::NotInstalled { hint } => format!(
+            "secret provider `{scheme}` is not installed\n  \
+             {hint}\n  \
+             or disable the provider: [secret.providers.{scheme}] enabled = false"
+        ),
+        ProbeResult::NotAuthenticated { hint } => format!(
+            "secret provider `{scheme}` is not authenticated\n  \
+             {hint}"
+        ),
+        ProbeResult::Misconfigured { hint } => {
+            format!("secret provider `{scheme}` is misconfigured\n  {hint}")
+        }
+        ProbeResult::ProbeFailed { details } => format!(
+            "secret provider `{scheme}` probe failed\n  \
+             {details}\n  \
+             this is unusual; check the dodot debug log (`dodot --debug ...`) for more"
+        ),
+    }
+}
+
+/// Run [`SecretRegistry::probe_all`] and collapse any non-Ok
+/// outcomes into a single [`DodotError::Other`] suitable for
+/// surfacing to the user before resolution begins.
+///
+/// Returns `Ok(())` when every provider probes Ok. Otherwise the
+/// error is a multi-line message listing each failing provider with
+/// its rendered outcome, in scheme-sorted order — same order as
+/// `probe_all` returns. The flow is: `dodot up` calls this once per
+/// run; on Err it surfaces the message and aborts before any
+/// `secret(...)` resolution would be attempted (saving the user from
+/// a partial-run state where some templates rendered and some
+/// didn't).
+///
+/// `Ok` providers are not mentioned — silence is the success
+/// signal; the message stays focused on what the user has to fix.
+pub fn preflight(registry: &SecretRegistry) -> crate::Result<()> {
+    let outcomes = registry.probe_all();
+    let mut failing: Vec<String> = Vec::new();
+    for (scheme, outcome) in &outcomes {
+        if !outcome.is_ok() {
+            failing.push(render_probe_outcome(scheme, outcome));
+        }
+    }
+    if failing.is_empty() {
+        return Ok(());
+    }
+    Err(DodotError::Other(format!(
+        "{} secret provider(s) need attention before `dodot up` can resolve secrets:\n\n{}",
+        failing.len(),
+        failing.join("\n\n")
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secret::test_support::MockSecretProvider;
+    use std::sync::Arc;
+
+    #[test]
+    fn render_ok_returns_empty_string() {
+        assert_eq!(render_probe_outcome("op", &ProbeResult::Ok), "");
+    }
+
+    #[test]
+    fn render_not_installed_includes_install_hint_and_disable_pointer() {
+        let outcome = ProbeResult::NotInstalled {
+            hint: "install 1Password CLI: https://1password.com/downloads/command-line".into(),
+        };
+        let msg = render_probe_outcome("op", &outcome);
+        assert!(msg.contains("`op` is not installed"));
+        assert!(msg.contains("1password.com"));
+        assert!(msg.contains("[secret.providers.op] enabled = false"));
+    }
+
+    #[test]
+    fn render_not_authenticated_surfaces_provider_hint() {
+        let outcome = ProbeResult::NotAuthenticated {
+            hint: "set OP_SERVICE_ACCOUNT_TOKEN".into(),
+        };
+        let msg = render_probe_outcome("op", &outcome);
+        assert!(msg.contains("`op` is not authenticated"));
+        assert!(msg.contains("OP_SERVICE_ACCOUNT_TOKEN"));
+    }
+
+    #[test]
+    fn render_misconfigured_surfaces_provider_hint_verbatim() {
+        let outcome = ProbeResult::Misconfigured {
+            hint: "password store not initialised at /tmp/store".into(),
+        };
+        let msg = render_probe_outcome("pass", &outcome);
+        assert!(msg.contains("`pass` is misconfigured"));
+        assert!(msg.contains("/tmp/store"));
+    }
+
+    #[test]
+    fn render_probe_failed_includes_debug_pointer() {
+        let outcome = ProbeResult::ProbeFailed {
+            details: "subprocess crashed mid-probe".into(),
+        };
+        let msg = render_probe_outcome("op", &outcome);
+        assert!(msg.contains("probe failed"));
+        assert!(msg.contains("subprocess crashed"));
+        assert!(msg.contains("`dodot --debug"));
+    }
+
+    #[test]
+    fn preflight_succeeds_when_all_providers_ok() {
+        let mut reg = SecretRegistry::new();
+        reg.register(Arc::new(MockSecretProvider::new("pass")));
+        reg.register(Arc::new(MockSecretProvider::new("op")));
+        assert!(preflight(&reg).is_ok());
+    }
+
+    #[test]
+    fn preflight_fails_with_aggregated_message_when_one_provider_fails() {
+        let mut reg = SecretRegistry::new();
+        reg.register(Arc::new(MockSecretProvider::new("pass"))); // Ok by default
+        reg.register(Arc::new(MockSecretProvider::new("op").with_probe(
+            ProbeResult::NotAuthenticated {
+                hint: "set OP_SERVICE_ACCOUNT_TOKEN".into(),
+            },
+        )));
+        let err = preflight(&reg).unwrap_err().to_string();
+        assert!(err.contains("1 secret provider(s) need attention"));
+        // The Ok one isn't mentioned — silence is success.
+        assert!(!err.contains("`pass`"));
+        // The failing one is.
+        assert!(err.contains("`op` is not authenticated"));
+        assert!(err.contains("OP_SERVICE_ACCOUNT_TOKEN"));
+    }
+
+    #[test]
+    fn preflight_aggregates_multiple_failures_into_one_message() {
+        let mut reg = SecretRegistry::new();
+        reg.register(Arc::new(MockSecretProvider::new("op").with_probe(
+            ProbeResult::NotAuthenticated {
+                hint: "set OP_SERVICE_ACCOUNT_TOKEN".into(),
+            },
+        )));
+        reg.register(Arc::new(MockSecretProvider::new("pass").with_probe(
+            ProbeResult::Misconfigured {
+                hint: "store not initialised".into(),
+            },
+        )));
+        let err = preflight(&reg).unwrap_err().to_string();
+        assert!(err.contains("2 secret provider(s) need attention"));
+        assert!(err.contains("`op` is not authenticated"));
+        assert!(err.contains("`pass` is misconfigured"));
+    }
+
+    #[test]
+    fn preflight_succeeds_on_empty_registry() {
+        // No providers registered — preflight has nothing to check.
+        // Templates that call `secret(...)` against an empty
+        // registry will fail at resolution time with a different
+        // (more specific) error. preflight is concerned with
+        // already-configured providers only.
+        let reg = SecretRegistry::new();
+        assert!(preflight(&reg).is_ok());
+    }
+}

--- a/crates/dodot-lib/src/secret/mod.rs
+++ b/crates/dodot-lib/src/secret/mod.rs
@@ -13,6 +13,8 @@
 //! provider invocations, mode gating per `secrets.lex` §7.4 — live
 //! above the trait, in the `secret()` MiniJinja function.
 
+pub mod op;
+pub mod pass;
 pub mod provider;
 pub mod registry;
 pub mod secret_string;
@@ -20,6 +22,8 @@ pub mod secret_string;
 #[cfg(test)]
 pub mod test_support;
 
+pub use op::OpProvider;
+pub use pass::PassProvider;
 pub use provider::{ProbeResult, SecretProvider};
 pub use registry::{split_scheme, SecretRegistry};
 pub use secret_string::SecretString;

--- a/crates/dodot-lib/src/secret/mod.rs
+++ b/crates/dodot-lib/src/secret/mod.rs
@@ -13,6 +13,7 @@
 //! provider invocations, mode gating per `secrets.lex` §7.4 — live
 //! above the trait, in the `secret()` MiniJinja function.
 
+pub mod error_render;
 pub mod op;
 pub mod pass;
 pub mod provider;
@@ -22,6 +23,7 @@ pub mod secret_string;
 #[cfg(test)]
 pub mod test_support;
 
+pub use error_render::{preflight, render_probe_outcome};
 pub use op::OpProvider;
 pub use pass::PassProvider;
 pub use provider::{ProbeResult, SecretProvider};

--- a/crates/dodot-lib/src/secret/mod.rs
+++ b/crates/dodot-lib/src/secret/mod.rs
@@ -14,7 +14,12 @@
 //! above the trait, in the `secret()` MiniJinja function.
 
 pub mod provider;
+pub mod registry;
 pub mod secret_string;
 
+#[cfg(test)]
+pub mod test_support;
+
 pub use provider::{ProbeResult, SecretProvider};
+pub use registry::{split_scheme, SecretRegistry};
 pub use secret_string::SecretString;

--- a/crates/dodot-lib/src/secret/mod.rs
+++ b/crates/dodot-lib/src/secret/mod.rs
@@ -1,0 +1,20 @@
+//! Secret handling — provider trait, value wrapper, and the scheme
+//! registry that maps `secret(...)` references to providers.
+//!
+//! This module is the rust-native side of the design in
+//! `docs/proposals/secrets.lex` and the testing seam described in
+//! `docs/proposals/secrets-testing.lex` §2. Concrete providers live in
+//! sibling files (`pass.rs`, `op.rs`, etc.); this module owns the
+//! plumbing that's the same for all of them.
+//!
+//! The trait deliberately stays small. Providers do three things:
+//! parse a reference, talk to their tool, return a `SecretString`.
+//! Cross-cutting concerns — caching within a `dodot up` run, batched
+//! provider invocations, mode gating per `secrets.lex` §7.4 — live
+//! above the trait, in the `secret()` MiniJinja function.
+
+pub mod provider;
+pub mod secret_string;
+
+pub use provider::{ProbeResult, SecretProvider};
+pub use secret_string::SecretString;

--- a/crates/dodot-lib/src/secret/op.rs
+++ b/crates/dodot-lib/src/secret/op.rs
@@ -1,0 +1,403 @@
+//! `op` provider — 1Password CLI integration.
+//!
+//! Reference shape: `op://Vault/Item/Field`. The registry strips the
+//! `op:` prefix and hands `//Vault/Item/Field` to the provider; we
+//! hand the full `op://Vault/Item/Field` form to the `op read`
+//! subcommand because that's the canonical input shape the CLI
+//! expects.
+//!
+//! Resolution: `op read op://Vault/Item/Field` — emits the field's
+//! string value on stdout, exit 0 on success, non-zero on missing
+//! reference / auth failure.
+//!
+//! Auth: prefers `OP_SERVICE_ACCOUNT_TOKEN` (non-interactive,
+//! CI-friendly). Falls back to interactive desktop-app integration
+//! if no token is set; in that case `probe()` flags
+//! `NotAuthenticated` rather than letting `op read` block on a UI
+//! prompt.
+//!
+//! See `secrets.lex` §5.2 (provider table) and §5.4 (error UX).
+
+use std::sync::Arc;
+
+use crate::datastore::CommandRunner;
+use crate::secret::provider::{ProbeResult, SecretProvider};
+use crate::secret::secret_string::SecretString;
+use crate::{DodotError, Result};
+
+/// `SecretProvider` impl for the 1Password CLI (`op`).
+pub struct OpProvider {
+    runner: Arc<dyn CommandRunner>,
+    /// Whether `OP_SERVICE_ACCOUNT_TOKEN` is set in the environment.
+    /// Captured at construction so probe() / resolve() don't
+    /// re-read the env on every call (and so tests can inject the
+    /// answer without touching the real env).
+    has_service_token: bool,
+}
+
+impl OpProvider {
+    /// Construct with explicit `has_service_token`. Tests use this.
+    pub fn new(runner: Arc<dyn CommandRunner>, has_service_token: bool) -> Self {
+        Self {
+            runner,
+            has_service_token,
+        }
+    }
+
+    /// Construct from environment: reads `OP_SERVICE_ACCOUNT_TOKEN`.
+    pub fn from_env(runner: Arc<dyn CommandRunner>) -> Self {
+        let has_service_token = std::env::var("OP_SERVICE_ACCOUNT_TOKEN")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        Self::new(runner, has_service_token)
+    }
+
+    /// Validate the post-prefix reference shape. The registry hands
+    /// us `//Vault/Item/Field`; we expect at least three path
+    /// segments after `//`.
+    fn validate_reference(reference: &str) -> Result<()> {
+        let stripped = reference.strip_prefix("//").ok_or_else(|| {
+            DodotError::Other(format!(
+                "op reference suffix `{reference}` is not in `//Vault/Item/Field` form. \
+                 Expected the full URI shape `op://Vault/Item/Field`."
+            ))
+        })?;
+        let segs: Vec<&str> = stripped.split('/').filter(|s| !s.is_empty()).collect();
+        if segs.len() < 3 {
+            return Err(DodotError::Other(format!(
+                "op reference `op:{reference}` is missing path segments. \
+                 Expected `op://<vault>/<item>/<field>`; got {} segment(s).",
+                segs.len()
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl SecretProvider for OpProvider {
+    fn scheme(&self) -> &str {
+        "op"
+    }
+
+    fn probe(&self) -> ProbeResult {
+        // Step 1: binary on PATH? `op --version` is fast and
+        // doesn't hit the network or unlock anything.
+        match self.runner.run("op", &["--version".into()]) {
+            Ok(out) if out.exit_code == 0 => {}
+            Ok(_) => {
+                return ProbeResult::ProbeFailed {
+                    details: "`op --version` returned non-zero — the binary is on PATH \
+                              but not behaving as expected"
+                        .into(),
+                };
+            }
+            Err(_) => {
+                return ProbeResult::NotInstalled {
+                    hint: "install 1Password CLI: \
+                           https://1password.com/downloads/command-line \
+                           (e.g. `brew install --cask 1password-cli`)"
+                        .into(),
+                };
+            }
+        }
+
+        // Step 2: auth state. We require the non-interactive path
+        // (`OP_SERVICE_ACCOUNT_TOKEN`) because resolve()-time
+        // blocking on a desktop-app modal is exactly the
+        // auth-fatigue failure mode §7.4 was written to avoid.
+        // If the user prefers desktop-app integration on their
+        // workstation, they should still set the env var for dodot
+        // runs — the spec is unambiguous about that.
+        if !self.has_service_token {
+            return ProbeResult::NotAuthenticated {
+                hint: "set OP_SERVICE_ACCOUNT_TOKEN \
+                       (https://developer.1password.com/docs/service-accounts/) \
+                       so dodot can resolve secrets without interactive prompts"
+                    .into(),
+            };
+        }
+
+        // Step 3: light service-account validity check. `op whoami`
+        // returns 0 when the token can authenticate, non-zero
+        // otherwise. Cheap, no vault reads, no items returned —
+        // safe to run on every probe.
+        match self.runner.run("op", &["whoami".into()]) {
+            Ok(out) if out.exit_code == 0 => ProbeResult::Ok,
+            Ok(_) => ProbeResult::NotAuthenticated {
+                hint: "OP_SERVICE_ACCOUNT_TOKEN is set but `op whoami` failed; \
+                       check that the token is valid and not expired"
+                    .into(),
+            },
+            Err(_) => ProbeResult::ProbeFailed {
+                details: "could not run `op whoami` after a successful `op --version`; \
+                          intermittent subprocess failure"
+                    .into(),
+            },
+        }
+    }
+
+    fn resolve(&self, reference: &str) -> Result<SecretString> {
+        Self::validate_reference(reference)?;
+        // Reconstruct the full URI form the CLI expects (op://...).
+        let full = format!("op:{reference}");
+        let out = self.runner.run("op", &["read".into(), full.clone()])?;
+        if out.exit_code != 0 {
+            let stderr = out.stderr.trim();
+            // Common shapes:
+            //   "[ERROR] 2025/05/02 12:34:56 \"X\" isn't an item in the \"Y\" vault."
+            //   "[ERROR] 2025/05/02 12:34:56 vault \"Y\" not found."
+            //   "[ERROR] 2025/05/02 12:34:56 missing field..."
+            let err_msg = if stderr.contains("isn't an item") || stderr.contains("not found") {
+                format!(
+                    "secret `{full}` not found. \
+                     Verify with `op item get \"<item>\" --vault \"<vault>\"`."
+                )
+            } else if stderr.contains("authentication") || stderr.contains("token") {
+                format!(
+                    "secret resolution for `{full}` failed authentication. \
+                     Check OP_SERVICE_ACCOUNT_TOKEN and the SA's vault access."
+                )
+            } else if stderr.is_empty() {
+                format!("`op read {full}` exited with code {}", out.exit_code)
+            } else {
+                // op's stderr does NOT echo the secret value; it
+                // emits structured error lines. Surfacing verbatim
+                // is safe and aids diagnosis.
+                format!("`op read {full}` failed (exit {}): {stderr}", out.exit_code)
+            };
+            return Err(DodotError::Other(err_msg));
+        }
+        // op read emits the value with a trailing newline. Strip
+        // exactly one trailing `\n` so values that legitimately end
+        // in `\n\n` keep one of them; in practice secret values
+        // shouldn't have either, but the principled move is to
+        // trim the CLI's added newline rather than `trim_end_matches`.
+        let mut value = out.stdout;
+        if value.ends_with('\n') {
+            value.pop();
+        }
+        Ok(SecretString::new(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datastore::CommandOutput;
+    use std::sync::Mutex;
+
+    type ScriptedResponse = (
+        String,
+        Vec<String>,
+        std::result::Result<CommandOutput, String>,
+    );
+
+    struct ScriptedRunner {
+        responses: Mutex<Vec<ScriptedResponse>>,
+    }
+    impl ScriptedRunner {
+        fn new() -> Self {
+            Self {
+                responses: Mutex::new(Vec::new()),
+            }
+        }
+        fn expect(
+            self,
+            exe: impl Into<String>,
+            args: Vec<String>,
+            response: std::result::Result<CommandOutput, String>,
+        ) -> Self {
+            self.responses
+                .lock()
+                .unwrap()
+                .push((exe.into(), args, response));
+            self
+        }
+    }
+    impl CommandRunner for ScriptedRunner {
+        fn run(&self, exe: &str, args: &[String]) -> Result<CommandOutput> {
+            let mut r = self.responses.lock().unwrap();
+            if r.is_empty() {
+                return Err(DodotError::Other(format!(
+                    "ScriptedRunner: unexpected `{exe} {args:?}`"
+                )));
+            }
+            let (e, a, out) = r.remove(0);
+            assert_eq!(exe, e);
+            assert_eq!(args, a.as_slice());
+            out.map_err(DodotError::Other)
+        }
+    }
+    fn ok(stdout: &str) -> std::result::Result<CommandOutput, String> {
+        Ok(CommandOutput {
+            exit_code: 0,
+            stdout: stdout.into(),
+            stderr: String::new(),
+        })
+    }
+    fn err_out(exit: i32, stderr: &str) -> std::result::Result<CommandOutput, String> {
+        Ok(CommandOutput {
+            exit_code: exit,
+            stdout: String::new(),
+            stderr: stderr.into(),
+        })
+    }
+
+    #[test]
+    fn scheme_is_op() {
+        let p = OpProvider::new(Arc::new(ScriptedRunner::new()), true);
+        assert_eq!(p.scheme(), "op");
+    }
+
+    #[test]
+    fn resolve_strips_one_trailing_newline_from_stdout() {
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "op",
+            vec!["read".into(), "op://V/I/F".into()],
+            ok("the-value\n"),
+        ));
+        let p = OpProvider::new(runner, true);
+        let s = p.resolve("//V/I/F").unwrap();
+        assert_eq!(s.expose().unwrap(), "the-value");
+    }
+
+    #[test]
+    fn resolve_handles_value_without_trailing_newline() {
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "op",
+            vec!["read".into(), "op://V/I/F".into()],
+            ok("no-newline"),
+        ));
+        let p = OpProvider::new(runner, true);
+        assert_eq!(
+            p.resolve("//V/I/F").unwrap().expose().unwrap(),
+            "no-newline"
+        );
+    }
+
+    #[test]
+    fn resolve_maps_isnt_an_item_to_actionable_error() {
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "op",
+            vec!["read".into(), "op://V/I/F".into()],
+            err_out(
+                1,
+                "[ERROR] 2026/05/02 14:00:00 \"I\" isn't an item in the \"V\" vault.",
+            ),
+        ));
+        let p = OpProvider::new(runner, true);
+        let e = p.resolve("//V/I/F").unwrap_err().to_string();
+        assert!(e.contains("`op://V/I/F` not found"));
+        assert!(e.contains("op item get"));
+    }
+
+    #[test]
+    fn resolve_maps_authentication_failures_to_token_hint() {
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "op",
+            vec!["read".into(), "op://V/I/F".into()],
+            err_out(1, "[ERROR] authentication required"),
+        ));
+        let p = OpProvider::new(runner, true);
+        let e = p.resolve("//V/I/F").unwrap_err().to_string();
+        assert!(e.contains("failed authentication"));
+        assert!(e.contains("OP_SERVICE_ACCOUNT_TOKEN"));
+    }
+
+    #[test]
+    fn resolve_other_failures_include_stderr() {
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "op",
+            vec!["read".into(), "op://V/I/F".into()],
+            err_out(2, "rate limited; try again later"),
+        ));
+        let p = OpProvider::new(runner, true);
+        let e = p.resolve("//V/I/F").unwrap_err().to_string();
+        assert!(e.contains("rate limited"));
+        assert!(e.contains("(exit 2)"));
+    }
+
+    #[test]
+    fn resolve_rejects_reference_without_double_slash() {
+        let p = OpProvider::new(Arc::new(ScriptedRunner::new()), true);
+        // The registry would never produce this — split_scheme on
+        // `op:foo` yields suffix `foo`. We refuse defensively so the
+        // user sees a clear shape hint, not a downstream `op` CLI error.
+        let e = p.resolve("Vault/Item/Field").unwrap_err().to_string();
+        assert!(e.contains("not in `//Vault/Item/Field` form"));
+    }
+
+    #[test]
+    fn resolve_rejects_too_few_segments() {
+        let p = OpProvider::new(Arc::new(ScriptedRunner::new()), true);
+        let e = p.resolve("//Vault/Item").unwrap_err().to_string();
+        assert!(e.contains("missing path segments"));
+        assert!(e.contains("got 2 segment(s)"));
+    }
+
+    #[test]
+    fn probe_not_installed_when_op_binary_missing() {
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "op",
+            vec!["--version".into()],
+            Err("command not found: op".into()),
+        ));
+        let p = OpProvider::new(runner, true);
+        match p.probe() {
+            ProbeResult::NotInstalled { hint } => {
+                assert!(hint.contains("1Password CLI"));
+                assert!(hint.contains("brew install"));
+            }
+            other => panic!("expected NotInstalled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probe_not_authenticated_when_no_service_token_in_env() {
+        let runner =
+            Arc::new(ScriptedRunner::new().expect("op", vec!["--version".into()], ok("2.34.0\n")));
+        let p = OpProvider::new(runner, /*has_service_token=*/ false);
+        match p.probe() {
+            ProbeResult::NotAuthenticated { hint } => {
+                assert!(hint.contains("OP_SERVICE_ACCOUNT_TOKEN"));
+                assert!(hint.contains("service-accounts"));
+            }
+            other => panic!("expected NotAuthenticated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probe_not_authenticated_when_whoami_fails_despite_token() {
+        let runner = Arc::new(
+            ScriptedRunner::new()
+                .expect("op", vec!["--version".into()], ok("2.34.0\n"))
+                .expect(
+                    "op",
+                    vec!["whoami".into()],
+                    err_out(1, "[ERROR] token rejected"),
+                ),
+        );
+        let p = OpProvider::new(runner, true);
+        match p.probe() {
+            ProbeResult::NotAuthenticated { hint } => {
+                assert!(hint.contains("token is valid"));
+            }
+            other => panic!("expected NotAuthenticated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probe_ok_when_binary_present_token_set_and_whoami_succeeds() {
+        let runner = Arc::new(
+            ScriptedRunner::new()
+                .expect("op", vec!["--version".into()], ok("2.34.0\n"))
+                .expect(
+                    "op",
+                    vec!["whoami".into()],
+                    ok("URL: https://my.1password.com\n"),
+                ),
+        );
+        let p = OpProvider::new(runner, true);
+        assert!(matches!(p.probe(), ProbeResult::Ok));
+    }
+}

--- a/crates/dodot-lib/src/secret/pass.rs
+++ b/crates/dodot-lib/src/secret/pass.rs
@@ -62,19 +62,25 @@ impl PassProvider {
     }
 
     /// Validate the reference shape before shelling out. Empty
-    /// references and references containing `..` (path traversal)
-    /// are rejected up-front. We don't try to be clever about
-    /// shell-quoting because `CommandRunner::run` takes argv as
-    /// a slice — there's no shell interpolation in play.
+    /// references and references whose path segments include `..`
+    /// (path traversal) are rejected up-front. We don't try to be
+    /// clever about shell-quoting because `CommandRunner::run` takes
+    /// argv as a slice — there's no shell interpolation in play.
+    ///
+    /// We check segment-equality instead of a substring match on
+    /// `..` so that legitimate entry names containing two
+    /// consecutive dots (e.g. `service-foo..staging`) pass through.
+    /// Pass entries are stored as files on disk; only `..` as its
+    /// own segment escapes the store root.
     fn validate_reference(reference: &str) -> Result<()> {
         if reference.is_empty() {
             return Err(DodotError::Other(
                 "pass reference is empty. Expected `pass:path/to/entry`.".into(),
             ));
         }
-        if reference.contains("..") {
+        if reference.split('/').any(|seg| seg == "..") {
             return Err(DodotError::Other(format!(
-                "pass reference `{reference}` contains `..` — \
+                "pass reference `{reference}` contains a `..` path segment — \
                  path-traversal references are refused for safety. \
                  Use the literal entry path under the store root."
             )));
@@ -339,6 +345,31 @@ mod tests {
         let p = PassProvider::new(Arc::new(ScriptedRunner::new()), dir.path().into());
         let e = p.resolve("../escape").unwrap_err().to_string();
         assert!(e.contains("path-traversal"));
+    }
+
+    #[test]
+    fn resolve_rejects_dotdot_in_middle_segment() {
+        let dir = make_store_dir(true);
+        let p = PassProvider::new(Arc::new(ScriptedRunner::new()), dir.path().into());
+        let e = p.resolve("foo/../escape").unwrap_err().to_string();
+        assert!(e.contains("path-traversal"));
+    }
+
+    #[test]
+    fn resolve_accepts_double_dot_inside_a_segment() {
+        // `foo..bar` is a legitimate pass entry name (two consecutive
+        // dots within one segment, not a `..` path segment). The
+        // validator must let it through; the runner answers with the
+        // entry's value.
+        let dir = make_store_dir(true);
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "pass",
+            vec!["show".into(), "service-foo..staging".into()],
+            ok("hunter2\n"),
+        ));
+        let p = PassProvider::new(runner, dir.path().into());
+        let v = p.resolve("service-foo..staging").unwrap();
+        assert_eq!(v.expose().unwrap(), "hunter2");
     }
 
     #[test]

--- a/crates/dodot-lib/src/secret/pass.rs
+++ b/crates/dodot-lib/src/secret/pass.rs
@@ -1,0 +1,416 @@
+//! `pass` provider — password-store integration.
+//!
+//! Reference shape: `pass:path/to/entry` (single-colon, no slashes
+//! after the colon for the scheme prefix; provider sees the literal
+//! path, e.g. `path/to/entry`).
+//!
+//! Resolution: shells out to `pass show <path>`. By convention,
+//! `pass` entries' first line is the password; subsequent lines are
+//! arbitrary metadata. dodot follows this convention — `resolve()`
+//! returns the first line, stripped of trailing `\n`.
+//!
+//! `pass` itself defers crypto to GPG; the gpg-agent dance handles
+//! interactive auth (passphrase prompts, smartcard touches) before
+//! `pass show` returns. Our `probe()` verifies that the binary is on
+//! PATH and that `$PASSWORD_STORE_DIR` (or `~/.password-store`) is
+//! initialised; deeper auth-state checks (gpg key access) are
+//! deferred to resolve-time because probing them would mean
+//! triggering the very prompt we're trying to gate behind probe().
+//!
+//! See `secrets.lex` §5.2 for the spec table.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::datastore::CommandRunner;
+use crate::secret::provider::{ProbeResult, SecretProvider};
+use crate::secret::secret_string::SecretString;
+use crate::{DodotError, Result};
+
+/// `SecretProvider` impl for password-store.
+pub struct PassProvider {
+    runner: Arc<dyn CommandRunner>,
+    /// Directory to check for store initialisation. Defaults to
+    /// `$PASSWORD_STORE_DIR` if set, falling back to `~/.password-store`.
+    /// Tests inject a hermetic path here.
+    store_dir: PathBuf,
+}
+
+impl PassProvider {
+    /// Construct with a runner and explicit store directory. Tests
+    /// use this directly; production code uses [`Self::from_env`].
+    pub fn new(runner: Arc<dyn CommandRunner>, store_dir: PathBuf) -> Self {
+        Self { runner, store_dir }
+    }
+
+    /// Construct from environment: respects `$PASSWORD_STORE_DIR`,
+    /// falls back to `$HOME/.password-store`. If `$HOME` is unset
+    /// (deeply unusual; suggests a test or a daemon context),
+    /// returns a provider rooted at `/.password-store` — `probe()`
+    /// will surface `Misconfigured` because that path won't exist.
+    pub fn from_env(runner: Arc<dyn CommandRunner>) -> Self {
+        let store_dir = std::env::var_os("PASSWORD_STORE_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                let mut p = std::env::var_os("HOME")
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| PathBuf::from("/"));
+                p.push(".password-store");
+                p
+            });
+        Self::new(runner, store_dir)
+    }
+
+    /// Validate the reference shape before shelling out. Empty
+    /// references and references containing `..` (path traversal)
+    /// are rejected up-front. We don't try to be clever about
+    /// shell-quoting because `CommandRunner::run` takes argv as
+    /// a slice — there's no shell interpolation in play.
+    fn validate_reference(reference: &str) -> Result<()> {
+        if reference.is_empty() {
+            return Err(DodotError::Other(
+                "pass reference is empty. Expected `pass:path/to/entry`.".into(),
+            ));
+        }
+        if reference.contains("..") {
+            return Err(DodotError::Other(format!(
+                "pass reference `{reference}` contains `..` — \
+                 path-traversal references are refused for safety. \
+                 Use the literal entry path under the store root."
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl SecretProvider for PassProvider {
+    fn scheme(&self) -> &str {
+        "pass"
+    }
+
+    fn probe(&self) -> ProbeResult {
+        // Cheap binary-on-PATH check: `pass version` returns 0 with
+        // a banner. `pass --help` would also work; `version` is the
+        // canonical "I'm here" probe across most tool conventions.
+        match self.runner.run("pass", &["version".into()]) {
+            Ok(out) if out.exit_code == 0 => {}
+            Ok(_) => {
+                return ProbeResult::ProbeFailed {
+                    details: "`pass version` returned a non-zero exit code; the \
+                              binary is on PATH but not behaving as expected"
+                        .into(),
+                };
+            }
+            Err(_) => {
+                return ProbeResult::NotInstalled {
+                    hint: "install pass: https://www.passwordstore.org/ \
+                           (e.g. `apt install pass`, `brew install pass`)"
+                        .into(),
+                };
+            }
+        }
+        // Initialised-store check: a `.gpg-id` file at the store
+        // root is `pass init`'s canonical artifact.
+        let gpg_id = self.store_dir.join(".gpg-id");
+        if !gpg_id.exists() {
+            return ProbeResult::Misconfigured {
+                hint: format!(
+                    "password store not initialised at {} \
+                     (no .gpg-id found). \
+                     Run `pass init <gpg-key-id>`, or set \
+                     $PASSWORD_STORE_DIR to point at an existing store.",
+                    self.store_dir.display()
+                ),
+            };
+        }
+        ProbeResult::Ok
+    }
+
+    fn resolve(&self, reference: &str) -> Result<SecretString> {
+        Self::validate_reference(reference)?;
+        let out = self
+            .runner
+            .run("pass", &["show".into(), reference.into()])?;
+        if out.exit_code != 0 {
+            // Map the most common "entry not found" pattern to a
+            // sharper error. `pass show missing/path` exits 1 and
+            // prints `Error: missing/path is not in the password
+            // store.` to stderr. Detect by exit + a stable phrase.
+            let stderr = out.stderr.trim();
+            let err_msg = if stderr.contains("not in the password store") {
+                format!(
+                    "secret `pass:{reference}` not found in the password store. \
+                     Verify the entry: `pass ls {}`",
+                    parent_path(reference).unwrap_or("/")
+                )
+            } else if stderr.is_empty() {
+                format!("`pass show {reference}` exited with code {}", out.exit_code)
+            } else {
+                // Provider stderr can carry gpg-agent diagnostics or
+                // similar. Surface verbatim — but `pass` doesn't echo
+                // the password to stderr, so this is safe to include.
+                format!(
+                    "`pass show {reference}` failed (exit {}): {stderr}",
+                    out.exit_code
+                )
+            };
+            return Err(DodotError::Other(err_msg));
+        }
+        // pass show emits: <password>\n[optional metadata lines]\n
+        // The first line is the password. Strip trailing `\n` only;
+        // a multi-line value (subsequent lines) is metadata, not
+        // password content.
+        let first_line = out.stdout.split('\n').next().unwrap_or("");
+        Ok(SecretString::new(first_line.to_string()))
+    }
+}
+
+/// Return everything before the last `/` in `reference`, or `None`
+/// if the reference is at the store root.
+fn parent_path(reference: &str) -> Option<&str> {
+    let idx = reference.rfind('/')?;
+    Some(&reference[..idx])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datastore::CommandOutput;
+    use std::sync::Mutex;
+
+    /// `(executable, args, response)` tuple used by `ScriptedRunner`.
+    type ScriptedResponse = (
+        String,
+        Vec<String>,
+        std::result::Result<CommandOutput, String>,
+    );
+
+    /// Test runner: maps `(executable, args)` to a canned outcome.
+    /// Records every call so probe-then-resolve flows can be
+    /// asserted against.
+    struct ScriptedRunner {
+        responses: Mutex<Vec<ScriptedResponse>>,
+        calls: Mutex<Vec<(String, Vec<String>)>>,
+    }
+
+    impl ScriptedRunner {
+        fn new() -> Self {
+            Self {
+                responses: Mutex::new(Vec::new()),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+        fn expect(
+            self,
+            exe: impl Into<String>,
+            args: Vec<String>,
+            response: std::result::Result<CommandOutput, String>,
+        ) -> Self {
+            self.responses
+                .lock()
+                .unwrap()
+                .push((exe.into(), args, response));
+            self
+        }
+        fn calls(&self) -> Vec<(String, Vec<String>)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl CommandRunner for ScriptedRunner {
+        fn run(&self, exe: &str, args: &[String]) -> Result<CommandOutput> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((exe.to_string(), args.to_vec()));
+            let mut responses = self.responses.lock().unwrap();
+            if responses.is_empty() {
+                return Err(DodotError::Other(format!(
+                    "ScriptedRunner: unexpected call to `{exe} {args:?}` — no responses queued"
+                )));
+            }
+            let (expected_exe, expected_args, response) = responses.remove(0);
+            assert_eq!(exe, expected_exe, "executable mismatch");
+            assert_eq!(args, expected_args.as_slice(), "args mismatch");
+            response.map_err(DodotError::Other)
+        }
+    }
+
+    fn ok(stdout: &str) -> std::result::Result<CommandOutput, String> {
+        Ok(CommandOutput {
+            exit_code: 0,
+            stdout: stdout.into(),
+            stderr: String::new(),
+        })
+    }
+
+    fn err(exit: i32, stderr: &str) -> std::result::Result<CommandOutput, String> {
+        Ok(CommandOutput {
+            exit_code: exit,
+            stdout: String::new(),
+            stderr: stderr.into(),
+        })
+    }
+
+    fn make_store_dir(initialised: bool) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        if initialised {
+            std::fs::write(dir.path().join(".gpg-id"), "test@example.invalid\n").unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn scheme_is_pass() {
+        let dir = make_store_dir(true);
+        let p = PassProvider::new(Arc::new(ScriptedRunner::new()), dir.path().into());
+        assert_eq!(p.scheme(), "pass");
+    }
+
+    #[test]
+    fn resolve_returns_first_line_of_pass_show_output() {
+        let dir = make_store_dir(true);
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "pass",
+            vec!["show".into(), "personal/db".into()],
+            ok("hunter2\nuser: alice\nurl: https://db.example\n"),
+        ));
+        let p = PassProvider::new(runner, dir.path().into());
+        let s = p.resolve("personal/db").unwrap();
+        assert_eq!(s.expose().unwrap(), "hunter2");
+    }
+
+    #[test]
+    fn resolve_handles_value_without_trailing_newline() {
+        let dir = make_store_dir(true);
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "pass",
+            vec!["show".into(), "k".into()],
+            ok("no-newline-at-end"),
+        ));
+        let p = PassProvider::new(runner, dir.path().into());
+        assert_eq!(
+            p.resolve("k").unwrap().expose().unwrap(),
+            "no-newline-at-end"
+        );
+    }
+
+    #[test]
+    fn resolve_maps_not_in_store_to_actionable_error() {
+        let dir = make_store_dir(true);
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "pass",
+            vec!["show".into(), "missing/k".into()],
+            err(1, "Error: missing/k is not in the password store."),
+        ));
+        let p = PassProvider::new(runner, dir.path().into());
+        let e = p.resolve("missing/k").unwrap_err().to_string();
+        assert!(e.contains("`pass:missing/k` not found"));
+        // Lists the parent path so the user can run `pass ls <parent>`
+        // to spot a typo.
+        assert!(e.contains("`pass ls missing`"));
+    }
+
+    #[test]
+    fn resolve_other_failures_include_stderr_verbatim() {
+        let dir = make_store_dir(true);
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "pass",
+            vec!["show".into(), "k".into()],
+            err(2, "gpg: decryption failed: No secret key"),
+        ));
+        let p = PassProvider::new(runner, dir.path().into());
+        let e = p.resolve("k").unwrap_err().to_string();
+        assert!(e.contains("decryption failed"));
+        assert!(e.contains("(exit 2)"));
+    }
+
+    #[test]
+    fn resolve_rejects_empty_reference() {
+        let dir = make_store_dir(true);
+        let p = PassProvider::new(Arc::new(ScriptedRunner::new()), dir.path().into());
+        let e = p.resolve("").unwrap_err().to_string();
+        assert!(e.contains("empty"));
+    }
+
+    #[test]
+    fn resolve_rejects_dotdot_reference() {
+        let dir = make_store_dir(true);
+        let p = PassProvider::new(Arc::new(ScriptedRunner::new()), dir.path().into());
+        let e = p.resolve("../escape").unwrap_err().to_string();
+        assert!(e.contains("path-traversal"));
+    }
+
+    #[test]
+    fn probe_ok_when_binary_present_and_store_initialised() {
+        let dir = make_store_dir(true);
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "pass",
+            vec!["version".into()],
+            ok("=============================================\n= pass: the standard unix password manager =\n"),
+        ));
+        let p = PassProvider::new(runner.clone(), dir.path().into());
+        assert!(matches!(p.probe(), ProbeResult::Ok));
+        assert_eq!(runner.calls().len(), 1);
+    }
+
+    #[test]
+    fn probe_not_installed_when_runner_errors() {
+        let dir = make_store_dir(true);
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "pass",
+            vec!["version".into()],
+            Err("command not found: pass".into()),
+        ));
+        let p = PassProvider::new(runner, dir.path().into());
+        match p.probe() {
+            ProbeResult::NotInstalled { hint } => {
+                assert!(hint.contains("install pass"));
+                assert!(hint.contains("apt install"));
+                assert!(hint.contains("brew install"));
+            }
+            other => panic!("expected NotInstalled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probe_misconfigured_when_store_uninitialised() {
+        let dir = make_store_dir(false); // no .gpg-id
+        let runner = Arc::new(ScriptedRunner::new().expect(
+            "pass",
+            vec!["version".into()],
+            ok("pass v1.7\n"),
+        ));
+        let p = PassProvider::new(runner, dir.path().into());
+        match p.probe() {
+            ProbeResult::Misconfigured { hint } => {
+                assert!(hint.contains("not initialised"));
+                assert!(hint.contains("pass init"));
+                assert!(hint.contains("PASSWORD_STORE_DIR"));
+            }
+            other => panic!("expected Misconfigured, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probe_failed_on_nonzero_version_exit() {
+        let dir = make_store_dir(true);
+        let runner =
+            Arc::new(ScriptedRunner::new().expect("pass", vec!["version".into()], err(127, "")));
+        let p = PassProvider::new(runner, dir.path().into());
+        match p.probe() {
+            ProbeResult::ProbeFailed { details } => {
+                assert!(details.contains("non-zero exit"));
+            }
+            other => panic!("expected ProbeFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parent_path_strips_last_segment() {
+        assert_eq!(parent_path("a/b/c"), Some("a/b"));
+        assert_eq!(parent_path("a/b"), Some("a"));
+        assert_eq!(parent_path("a"), None);
+        assert_eq!(parent_path(""), None);
+    }
+}

--- a/crates/dodot-lib/src/secret/provider.rs
+++ b/crates/dodot-lib/src/secret/provider.rs
@@ -1,0 +1,137 @@
+//! `SecretProvider` trait — the seam between dodot's secret machinery
+//! and the per-provider subprocess work.
+//!
+//! Concrete providers (pass, op, sops, etc.) implement this trait.
+//! The `secret()` MiniJinja function dispatches by scheme; the
+//! preflight error UX (secrets.lex §5.4) calls [`SecretProvider::probe`]
+//! before anything else; resolution is [`SecretProvider::resolve`].
+//!
+//! See `docs/proposals/secrets.lex` §5.1 for the design rationale and
+//! `docs/proposals/secrets-testing.lex` §2 for the testing-seam role.
+
+use crate::secret::secret_string::SecretString;
+use crate::Result;
+
+/// Outcome of [`SecretProvider::probe`] — describes whether the
+/// provider can be used right now, and if not, why not. Each variant
+/// maps to a specific user-facing error message in `secrets.lex` §5.4.
+///
+/// `Ok` is the "go ahead and call `resolve`" signal; everything else
+/// is a fail-fast opportunity that lets us produce an actionable
+/// error before subprocess machinery would have produced an opaque
+/// one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeResult {
+    /// The provider's CLI / library is installed, the auth state
+    /// (session, biometric unlock, etc.) is good, ready to resolve.
+    Ok,
+
+    /// The provider's CLI is not on PATH (for shell-out providers)
+    /// or the required library is missing (for in-process providers).
+    /// User remediation: install the tool, or disable the provider in
+    /// `[secret.providers.<scheme>] enabled = false`.
+    NotInstalled {
+        /// Short hint string the error renderer uses — e.g. an
+        /// install URL or a package name. Provider-specific.
+        hint: String,
+    },
+
+    /// CLI is installed but auth isn't established. User
+    /// remediation: run the provider's signin / unlock command
+    /// (e.g. `op signin`, `bw unlock`) or set the relevant env var
+    /// (`OP_SERVICE_ACCOUNT_TOKEN`, `BW_SESSION`).
+    NotAuthenticated {
+        /// Short hint — e.g. `"run \`op signin\`"` or
+        /// `"set OP_SERVICE_ACCOUNT_TOKEN"`.
+        hint: String,
+    },
+
+    /// The probe found something else wrong — usually a configuration
+    /// error specific to the provider (e.g. `pass` initialised but
+    /// the gpg key isn't accessible). User remediation lives in the
+    /// hint.
+    Misconfigured { hint: String },
+
+    /// The probe itself failed (subprocess crashed, IO error). Used
+    /// sparingly; most failures should map to one of the cases above
+    /// so the error UX stays predictable.
+    ProbeFailed { details: String },
+}
+
+impl ProbeResult {
+    /// True iff the provider is ready to resolve.
+    pub fn is_ok(&self) -> bool {
+        matches!(self, ProbeResult::Ok)
+    }
+}
+
+/// A provider knows how to turn a reference like
+/// `op://Personal/GitHub/token` into a [`SecretString`].
+///
+/// Implementations should:
+///
+/// - Be cheap to construct (no IO in the constructor; defer to
+///   [`SecretProvider::probe`]).
+/// - Make `probe` cheap and side-effect-free where possible. It runs
+///   on every dodot invocation that touches a templated file with
+///   `secret()` calls, so it can't be slow.
+/// - Resolve via the provider's *non-interactive* path. Any provider
+///   that can only be unlocked interactively (e.g. requires a
+///   biometric prompt at resolve time) MUST surface that as
+///   `ProbeResult::NotAuthenticated` first, so the user sees the
+///   actionable hint rather than a hung subprocess.
+/// - Never log the resolved value. The `tracing` macros expose the
+///   message through the global subscriber, which may go to stdout,
+///   stderr, journald, or a CI log — none of which are appropriate
+///   destinations for a secret. `SecretString`'s `Debug` impl already
+///   redacts on accidental capture; provider code should not unwrap
+///   the bytes for logging at all.
+pub trait SecretProvider: Send + Sync {
+    /// The URI scheme this provider claims, without the colon.
+    /// `"op"` for 1Password (`op://...`), `"pass"` for password-store
+    /// (`pass:path/to/secret`), `"sops"` for SOPS, etc. The scheme
+    /// registry uses this to dispatch references to the right
+    /// provider.
+    fn scheme(&self) -> &str;
+
+    /// Cheap, side-effect-free check: can this provider service
+    /// `resolve()` calls right now? Returns the actionable outcome;
+    /// see [`ProbeResult`] variants.
+    ///
+    /// Called before resolution as a preflight by the `secret()`
+    /// function (the error UX path), and on demand by
+    /// `dodot secret probe` (the diagnostics command).
+    fn probe(&self) -> ProbeResult;
+
+    /// Resolve a reference to its secret value.
+    ///
+    /// `reference` is the string that came after the scheme prefix —
+    /// for `op://Vault/Item/Field` the provider sees
+    /// `"//Vault/Item/Field"`, for `pass:path/to/x` it sees
+    /// `"path/to/x"`. (Schemes are dispatched by the registry; the
+    /// provider doesn't need to re-parse the prefix.)
+    ///
+    /// Errors when the reference is malformed, the secret doesn't
+    /// exist, or the provider's tool returns a non-zero exit. The
+    /// error message must NOT contain the secret value — provider
+    /// implementations are responsible for stripping value bytes
+    /// from any subprocess stderr they propagate.
+    fn resolve(&self, reference: &str) -> Result<SecretString>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_result_is_ok_only_for_ok_variant() {
+        assert!(ProbeResult::Ok.is_ok());
+        assert!(!ProbeResult::NotInstalled { hint: "x".into() }.is_ok());
+        assert!(!ProbeResult::NotAuthenticated { hint: "x".into() }.is_ok());
+        assert!(!ProbeResult::Misconfigured { hint: "x".into() }.is_ok());
+        assert!(!ProbeResult::ProbeFailed {
+            details: "x".into()
+        }
+        .is_ok());
+    }
+}

--- a/crates/dodot-lib/src/secret/registry.rs
+++ b/crates/dodot-lib/src/secret/registry.rs
@@ -1,0 +1,253 @@
+//! Scheme registry — dispatches a secret reference to the right
+//! [`SecretProvider`] based on the URI scheme prefix.
+//!
+//! Reference shapes the registry recognises:
+//!
+//! - `op://Vault/Item/Field` — full URI form, `://` separator
+//! - `pass:path/to/secret`   — single colon, no slashes
+//! - `sops:file.yaml#k.path` — single colon, fragment optional
+//! - `bw:Folder/Item`        — single colon
+//!
+//! Rule: split at the first colon, take everything to its left as the
+//! scheme. The provider's `resolve()` sees what's after the colon
+//! verbatim — it doesn't need to re-parse the scheme prefix.
+//!
+//! See `secrets.lex` §3.1 for the user-facing reference syntax and
+//! §5.5 for the registry's role in adding new providers (no central
+//! plumbing change required).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::secret::provider::{ProbeResult, SecretProvider};
+use crate::secret::secret_string::SecretString;
+use crate::{DodotError, Result};
+
+/// Owned set of registered providers, keyed by scheme.
+///
+/// Constructed once per `dodot up` invocation by the secrets layer in
+/// `commands::up`, populated from the `[secret.providers.*]` config,
+/// and threaded into the `secret()` MiniJinja function. `Arc<dyn>`
+/// because providers are held behind a trait object and the registry
+/// is shared with the template engine across rendering passes.
+#[derive(Default, Clone)]
+pub struct SecretRegistry {
+    providers: HashMap<String, Arc<dyn SecretProvider>>,
+}
+
+impl SecretRegistry {
+    /// Empty registry — no providers registered yet. The `secret()`
+    /// function against an empty registry always errors with
+    /// "unknown scheme"; callers that want a user-friendly
+    /// "secrets disabled" message should check the registry shape
+    /// before rendering.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a provider. Replacing an existing entry for the same
+    /// scheme is intentionally allowed (it's how tests substitute
+    /// the mock for the real provider) but is logged at `debug` to
+    /// catch unintentional overrides during normal config loading.
+    pub fn register(&mut self, provider: Arc<dyn SecretProvider>) {
+        let scheme = provider.scheme().to_string();
+        if self.providers.contains_key(&scheme) {
+            tracing::debug!(scheme = %scheme, "secret provider replaced");
+        }
+        self.providers.insert(scheme, provider);
+    }
+
+    /// True iff a provider is registered for the given scheme.
+    pub fn has(&self, scheme: &str) -> bool {
+        self.providers.contains_key(scheme)
+    }
+
+    /// All registered scheme names. Stable iteration order is NOT
+    /// guaranteed; callers that want a deterministic listing should
+    /// `collect::<Vec<_>>()` and sort.
+    pub fn schemes(&self) -> impl Iterator<Item = &str> {
+        self.providers.keys().map(String::as_str)
+    }
+
+    /// Borrow the provider for a scheme, if any.
+    pub fn get(&self, scheme: &str) -> Option<&Arc<dyn SecretProvider>> {
+        self.providers.get(scheme)
+    }
+
+    /// Resolve a full reference (with scheme prefix) by dispatching
+    /// to the right provider.
+    ///
+    /// Returns `DodotError::Other` with an actionable message when:
+    ///
+    /// - The reference doesn't contain `:` (malformed input).
+    /// - No provider is registered for the parsed scheme.
+    /// - The provider's `resolve()` itself fails (error propagated
+    ///   verbatim — provider impls are responsible for stripping
+    ///   secret bytes from any error string).
+    ///
+    /// Mode gating is NOT this function's job. The `secret()`
+    /// MiniJinja function checks `PreprocessMode` before calling
+    /// `resolve()` per the §7.4 contract; the registry just routes.
+    pub fn resolve(&self, full_reference: &str) -> Result<SecretString> {
+        let (scheme, suffix) = split_scheme(full_reference)?;
+        let provider = self.get(scheme).ok_or_else(|| {
+            DodotError::Other(format!(
+                "no secret provider registered for scheme `{scheme}`. \
+                 Configured schemes: [{}]. \
+                 Add a `[secret.providers.{scheme}] enabled = true` block \
+                 to your config, or check the reference for typos.",
+                self.sorted_schemes_for_display()
+            ))
+        })?;
+        provider.resolve(suffix)
+    }
+
+    /// Probe every registered provider. Used by `dodot secret probe`
+    /// to give the user a one-shot view of what's working.
+    pub fn probe_all(&self) -> Vec<(String, ProbeResult)> {
+        let mut out: Vec<(String, ProbeResult)> = self
+            .providers
+            .iter()
+            .map(|(scheme, p)| (scheme.clone(), p.probe()))
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
+    fn sorted_schemes_for_display(&self) -> String {
+        let mut s: Vec<&str> = self.providers.keys().map(String::as_str).collect();
+        s.sort_unstable();
+        s.join(", ")
+    }
+}
+
+/// Split a full reference into `(scheme, suffix)` at the first `:`.
+///
+/// `op://Vault/Item/Field` → `("op", "//Vault/Item/Field")`
+/// `pass:path/to/x`         → `("pass", "path/to/x")`
+/// `sops:f.yaml#k.path`     → `("sops", "f.yaml#k.path")`
+///
+/// Empty schemes (`":foo"`) and missing colons (`"plain-string"`)
+/// produce an actionable error pointing the user at the reference
+/// syntax.
+pub fn split_scheme(reference: &str) -> Result<(&str, &str)> {
+    let (scheme, suffix) = reference.split_once(':').ok_or_else(|| {
+        DodotError::Other(format!(
+            "secret reference `{reference}` is missing a scheme prefix. \
+             Expected `<scheme>:<provider-specific-reference>` — for example \
+             `op://Vault/Item/Field` or `pass:path/to/secret`."
+        ))
+    })?;
+    if scheme.is_empty() {
+        return Err(DodotError::Other(format!(
+            "secret reference `{reference}` has an empty scheme prefix. \
+             Expected `<scheme>:<provider-specific-reference>`."
+        )));
+    }
+    Ok((scheme, suffix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secret::test_support::MockSecretProvider;
+
+    #[test]
+    fn split_scheme_handles_op_uri_form() {
+        let (scheme, suffix) = split_scheme("op://Vault/Item/Field").unwrap();
+        assert_eq!(scheme, "op");
+        // Note: the `//` stays — providers see exactly what came
+        // after the first colon. The `op` provider re-parses
+        // `//Vault/Item/Field` itself.
+        assert_eq!(suffix, "//Vault/Item/Field");
+    }
+
+    #[test]
+    fn split_scheme_handles_pass_single_colon() {
+        let (scheme, suffix) = split_scheme("pass:path/to/secret").unwrap();
+        assert_eq!(scheme, "pass");
+        assert_eq!(suffix, "path/to/secret");
+    }
+
+    #[test]
+    fn split_scheme_handles_sops_with_fragment() {
+        let (scheme, suffix) = split_scheme("sops:secrets.yaml#database.password").unwrap();
+        assert_eq!(scheme, "sops");
+        assert_eq!(suffix, "secrets.yaml#database.password");
+    }
+
+    #[test]
+    fn split_scheme_rejects_no_colon_with_actionable_message() {
+        let err = split_scheme("plain-string").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("missing a scheme prefix"));
+        assert!(msg.contains("`<scheme>:<provider-specific-reference>`"));
+        // Examples in the message help the user reach for the right shape.
+        assert!(msg.contains("op://"));
+        assert!(msg.contains("pass:"));
+    }
+
+    #[test]
+    fn split_scheme_rejects_empty_scheme() {
+        let err = split_scheme(":nothing").unwrap_err();
+        assert!(err.to_string().contains("empty scheme prefix"));
+    }
+
+    #[test]
+    fn registry_dispatches_to_correct_provider() {
+        let mut reg = SecretRegistry::new();
+        reg.register(Arc::new(
+            MockSecretProvider::new("pass")
+                .with("path/to/db", "hunter2")
+                .with("path/to/api", "tok-abc"),
+        ));
+        reg.register(Arc::new(
+            MockSecretProvider::new("op").with("//V/Item/password", "op-value"),
+        ));
+
+        let v = reg.resolve("pass:path/to/db").unwrap();
+        assert_eq!(v.expose().unwrap(), "hunter2");
+
+        let v = reg.resolve("op://V/Item/password").unwrap();
+        assert_eq!(v.expose().unwrap(), "op-value");
+    }
+
+    #[test]
+    fn registry_unknown_scheme_lists_configured_schemes_in_error() {
+        let mut reg = SecretRegistry::new();
+        reg.register(Arc::new(MockSecretProvider::new("pass")));
+        reg.register(Arc::new(MockSecretProvider::new("op")));
+
+        let err = reg.resolve("sops:foo.yaml#x").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no secret provider registered for scheme `sops`"));
+        // Configured schemes appear sorted so the message is stable.
+        assert!(msg.contains("op, pass"));
+    }
+
+    #[test]
+    fn registry_register_replaces_same_scheme() {
+        let mut reg = SecretRegistry::new();
+        reg.register(Arc::new(MockSecretProvider::new("pass").with("k", "first")));
+        // Replace with a fresh provider for the same scheme.
+        reg.register(Arc::new(
+            MockSecretProvider::new("pass").with("k", "second"),
+        ));
+        assert_eq!(reg.resolve("pass:k").unwrap().expose().unwrap(), "second");
+    }
+
+    #[test]
+    fn registry_has_and_schemes_reflect_registered_providers() {
+        let mut reg = SecretRegistry::new();
+        assert!(!reg.has("pass"));
+        reg.register(Arc::new(MockSecretProvider::new("pass")));
+        reg.register(Arc::new(MockSecretProvider::new("op")));
+        assert!(reg.has("pass"));
+        assert!(reg.has("op"));
+        assert!(!reg.has("sops"));
+
+        let mut schemes: Vec<&str> = reg.schemes().collect();
+        schemes.sort_unstable();
+        assert_eq!(schemes, vec!["op", "pass"]);
+    }
+}

--- a/crates/dodot-lib/src/secret/secret_string.rs
+++ b/crates/dodot-lib/src/secret/secret_string.rs
@@ -1,0 +1,197 @@
+//! `SecretString` — a wrapper that holds a resolved secret value and
+//! tries to keep it from leaking through the usual Rust footguns.
+//!
+//! The guarantees this type makes are explicitly limited; see
+//! `docs/proposals/secrets.lex` §5.1 ("defense in depth, not a
+//! guarantee"). Resolved secret values land on disk in the rendered
+//! file regardless, so the meaningful protections are at the OS layer.
+//! What this wrapper does add:
+//!
+//! - **Zero-on-drop.** The byte buffer is overwritten on `Drop` via
+//!   the `zeroize` crate's volatile-write loop, which the compiler
+//!   can't elide. Reduces the window where a stale-but-still-resident
+//!   buffer could be read by another process with sufficient
+//!   privilege.
+//! - **No `Debug` / `Display`.** The type is opaque to the standard
+//!   formatting machinery. A `tracing::error!("{e:?}", e=...)` that
+//!   accidentally captures a `SecretString` won't print the bytes; it
+//!   prints `SecretString(<redacted>)`.
+//! - **No `Serialize`.** Same idea, for the JSON / TOML paths.
+//! - **No `Clone`.** Discourages duplicating the value into multiple
+//!   buffers; callers that genuinely need a copy can call
+//!   [`SecretString::expose`] and re-wrap.
+//!
+//! What this wrapper does NOT do:
+//!
+//! - It doesn't `mlock` the page. Memory locking is a process-wide
+//!   concern with rlimits to think about; the spec defers it.
+//! - It doesn't prevent the value from being copied into a `String`
+//!   that the renderer hands off to MiniJinja for substitution. The
+//!   rendered output goes to disk; the wrapper has no power past that
+//!   handoff.
+//!
+//! Read this as: every code path that touches the bytes through
+//! `SecretString` is a deliberate decision, and the type makes the
+//! accidental paths impossible.
+
+use zeroize::Zeroize;
+
+/// A resolved secret value, held briefly in process memory.
+///
+/// Construct via [`SecretString::new`]; read via [`SecretString::expose`].
+/// Zeroes its buffer on drop. Has no `Debug` / `Display` / `Serialize`
+/// implementations; printing one through any of those paths produces
+/// `<redacted>`.
+pub struct SecretString {
+    inner: Vec<u8>,
+}
+
+impl SecretString {
+    /// Wrap a UTF-8 string as a secret. Takes ownership of the input
+    /// bytes so the caller can't keep a parallel handle.
+    pub fn new(value: String) -> Self {
+        Self {
+            inner: value.into_bytes(),
+        }
+    }
+
+    /// Wrap an arbitrary byte slice (for binary secrets — keys, etc.).
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self { inner: bytes }
+    }
+
+    /// Borrow the secret as `&str`. Returns an error if the bytes
+    /// aren't valid UTF-8 — the value-injection path requires UTF-8.
+    /// Whole-file deploy uses [`SecretString::expose_bytes`] instead.
+    pub fn expose(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.inner)
+    }
+
+    /// Borrow the secret as raw bytes. For whole-file flows where
+    /// UTF-8 isn't a guarantee.
+    pub fn expose_bytes(&self) -> &[u8] {
+        &self.inner
+    }
+
+    /// Length of the secret in bytes. Safe to log.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// True iff the secret is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// True iff the secret value contains at least one newline.
+    /// Used by §3.4's multi-line refusal: value-injection requires
+    /// single-line values, and this check is the gate. Reading this
+    /// flag does not expose the bytes anywhere — it's a property of
+    /// the value, not the value itself.
+    pub fn contains_newline(&self) -> bool {
+        self.inner.contains(&b'\n')
+    }
+}
+
+impl Drop for SecretString {
+    fn drop(&mut self) {
+        self.inner.zeroize();
+    }
+}
+
+// Explicitly opaque to formatting machinery.
+impl std::fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Length included on purpose: it's safe to log, and helps
+        // distinguish "empty value resolved" from "no value resolved"
+        // when debugging without ever exposing the bytes.
+        write!(f, "SecretString(<redacted>, len={})", self.inner.len())
+    }
+}
+
+// `Display` is intentionally NOT implemented: printing a secret with
+// `{}` should fail to compile, not silently format the bytes.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_and_expose_round_trip() {
+        let s = SecretString::new("hunter2".into());
+        assert_eq!(s.expose().unwrap(), "hunter2");
+        assert_eq!(s.len(), 7);
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn empty_secret_is_well_behaved() {
+        let s = SecretString::new(String::new());
+        assert!(s.is_empty());
+        assert_eq!(s.len(), 0);
+        assert_eq!(s.expose().unwrap(), "");
+    }
+
+    #[test]
+    fn from_bytes_supports_non_utf8_payload() {
+        // 0xff is not valid UTF-8.
+        let s = SecretString::from_bytes(vec![0xde, 0xad, 0xbe, 0xef, 0xff]);
+        assert_eq!(s.expose_bytes(), &[0xde, 0xad, 0xbe, 0xef, 0xff]);
+        assert!(s.expose().is_err(), "expose() must reject non-UTF-8");
+    }
+
+    #[test]
+    fn debug_does_not_leak_value() {
+        let s = SecretString::new("super-secret-token".into());
+        let formatted = format!("{:?}", s);
+        assert!(!formatted.contains("super-secret-token"));
+        assert!(formatted.contains("<redacted>"));
+        // Length surfacing is intentional — useful for debugging,
+        // doesn't reveal the value.
+        assert!(formatted.contains("len=18"));
+    }
+
+    #[test]
+    fn contains_newline_detects_multiline_for_section_3_4() {
+        let single = SecretString::new("one-line-value".into());
+        assert!(!single.contains_newline());
+
+        let multi = SecretString::new("line1\nline2".into());
+        assert!(multi.contains_newline());
+
+        // CR-only (e.g. classic-Mac line endings) is NOT flagged as
+        // multi-line — value-injection's single-line gate is about
+        // file-format breakage from `\n`. CR-only inputs are
+        // pathological enough that we'd rather catch them via the
+        // template engine's UTF-8 / encoding handling.
+        let cr_only = SecretString::new("line1\rline2".into());
+        assert!(!cr_only.contains_newline());
+    }
+
+    #[test]
+    fn drop_zeroes_underlying_bytes() {
+        // We can't observe the bytes after Drop directly without
+        // unsafe (the buffer is freed). Instead, exercise the
+        // zeroize pathway by holding the value, asserting the
+        // pre-drop content, then dropping and constructing a fresh
+        // value to confirm the type still works after Drop ran.
+        // The real guarantee — that `Drop::drop` is called and
+        // calls `zeroize` — is provided by the type's impl;
+        // this test pins the contract on that impl rather than
+        // attempting to read freed memory.
+        let s = SecretString::new("rotate-me".into());
+        assert_eq!(s.expose().unwrap(), "rotate-me");
+        drop(s);
+        let s2 = SecretString::new("next-value".into());
+        assert_eq!(s2.expose().unwrap(), "next-value");
+    }
+
+    // Compile-time check: SecretString does NOT implement Clone.
+    // (If a future change accidentally derives Clone, the line below
+    // would compile and this test would silently pass. Instead, the
+    // negative assertion lives as a doc-comment; rust-analyzer / human
+    // review catches re-introduced Clone derivations.)
+    //
+    //   let s = SecretString::new("x".into());
+    //   let _ = s.clone();   // <-- must fail to compile
+}

--- a/crates/dodot-lib/src/secret/test_support.rs
+++ b/crates/dodot-lib/src/secret/test_support.rs
@@ -1,0 +1,198 @@
+//! Test doubles for the secrets layer — `MockSecretProvider` and
+//! `PanickingProvider`.
+//!
+//! `MockSecretProvider` is the workhorse: tier-0 unit tests register
+//! it with a canned `reference -> value` map, then exercise everything
+//! above the trait (the registry, the `secret()` MiniJinja function,
+//! the AST pre-walk, the sidecar) without spawning a single
+//! subprocess.
+//!
+//! `PanickingProvider` is the §7.4 contract pin: a provider whose
+//! `resolve()` calls `panic!()`. Tests that exercise Passive-mode
+//! flows (`dodot status`, `dodot up --dry-run`) register it; if the
+//! flow accidentally invokes a provider, the panic surfaces and the
+//! test fails loudly. Same shape as the
+//! `up_dry_run_does_not_write_to_datastore` pattern from Wave 4.
+//!
+//! See `secrets-testing.lex` §6.1 / §6.2 for the doc on each.
+//!
+//! Available under `#[cfg(test)]` only — these are not for production
+//! use and should not appear in the public API surface.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use crate::secret::provider::{ProbeResult, SecretProvider};
+use crate::secret::secret_string::SecretString;
+use crate::{DodotError, Result};
+
+/// In-memory `SecretProvider` for tier-0 unit tests.
+///
+/// Constructed with a scheme name; populated via [`MockSecretProvider::with`]
+/// (chainable). Tracks `resolve()` invocation count so batching /
+/// caching tests can assert the provider was hit the right number of
+/// times.
+pub struct MockSecretProvider {
+    scheme: String,
+    /// Maps `reference -> value`. The `reference` here is what the
+    /// registry passes through to `resolve()` (i.e. post-scheme
+    /// suffix) — for `op://V/I/F` that's `//V/I/F`.
+    values: HashMap<String, String>,
+    /// `probe()` return value. Defaults to `Ok`. Tests that exercise
+    /// the error UX path use [`MockSecretProvider::with_probe`].
+    probe_result: Mutex<ProbeResult>,
+    /// Number of times `resolve()` has been called.
+    resolve_calls: AtomicUsize,
+}
+
+impl MockSecretProvider {
+    /// New mock provider for the given scheme. By default, every
+    /// reference resolves to `Err("not found")` and `probe()` returns
+    /// `Ok`. Add canned values via [`Self::with`].
+    pub fn new(scheme: impl Into<String>) -> Self {
+        Self {
+            scheme: scheme.into(),
+            values: HashMap::new(),
+            probe_result: Mutex::new(ProbeResult::Ok),
+            resolve_calls: AtomicUsize::new(0),
+        }
+    }
+
+    /// Add a canned `reference -> value` mapping. Chainable.
+    pub fn with(mut self, reference: impl Into<String>, value: impl Into<String>) -> Self {
+        self.values.insert(reference.into(), value.into());
+        self
+    }
+
+    /// Override the `probe()` return value. Used by tests that
+    /// exercise the error UX (NotInstalled, NotAuthenticated, etc.).
+    pub fn with_probe(self, result: ProbeResult) -> Self {
+        *self.probe_result.lock().unwrap() = result;
+        self
+    }
+
+    /// How many times `resolve()` has been called on this instance.
+    /// Used by batching / caching tests.
+    pub fn resolve_call_count(&self) -> usize {
+        self.resolve_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl SecretProvider for MockSecretProvider {
+    fn scheme(&self) -> &str {
+        &self.scheme
+    }
+
+    fn probe(&self) -> ProbeResult {
+        self.probe_result.lock().unwrap().clone()
+    }
+
+    fn resolve(&self, reference: &str) -> Result<SecretString> {
+        self.resolve_calls.fetch_add(1, Ordering::SeqCst);
+        match self.values.get(reference) {
+            Some(v) => Ok(SecretString::new(v.clone())),
+            None => Err(DodotError::Other(format!(
+                "MockSecretProvider({}): no canned value for reference `{}`",
+                self.scheme, reference
+            ))),
+        }
+    }
+}
+
+/// `SecretProvider` whose `resolve()` panics. Use when the test's
+/// goal is to prove a code path does NOT touch the provider —
+/// `dodot status` / `dodot up --dry-run` against a templated pack
+/// (Passive mode, §7.4 contract). Probe still returns `Ok` so the
+/// preflight doesn't short-circuit before the test reaches the
+/// resolve path it's gating on.
+pub struct PanickingProvider {
+    scheme: String,
+}
+
+impl PanickingProvider {
+    pub fn new(scheme: impl Into<String>) -> Self {
+        Self {
+            scheme: scheme.into(),
+        }
+    }
+}
+
+impl SecretProvider for PanickingProvider {
+    fn scheme(&self) -> &str {
+        &self.scheme
+    }
+
+    fn probe(&self) -> ProbeResult {
+        ProbeResult::Ok
+    }
+
+    fn resolve(&self, reference: &str) -> Result<SecretString> {
+        panic!(
+            "PanickingProvider({}): resolve(`{}`) was called, \
+             but the test contract says no provider should be invoked \
+             on this code path (§7.4 Passive contract violated?)",
+            self.scheme, reference
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_returns_canned_value() {
+        let p = MockSecretProvider::new("pass").with("k", "v");
+        let s = p.resolve("k").unwrap();
+        assert_eq!(s.expose().unwrap(), "v");
+    }
+
+    #[test]
+    fn mock_unknown_reference_errors_clearly() {
+        let p = MockSecretProvider::new("pass");
+        let err = p.resolve("missing-key").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("MockSecretProvider(pass)"));
+        assert!(msg.contains("`missing-key`"));
+    }
+
+    #[test]
+    fn mock_counts_resolve_invocations() {
+        let p = MockSecretProvider::new("pass").with("k", "v");
+        assert_eq!(p.resolve_call_count(), 0);
+        let _ = p.resolve("k");
+        let _ = p.resolve("k");
+        let _ = p.resolve("missing");
+        assert_eq!(p.resolve_call_count(), 3);
+    }
+
+    #[test]
+    fn mock_with_probe_overrides_default_ok() {
+        let p = MockSecretProvider::new("op").with_probe(ProbeResult::NotAuthenticated {
+            hint: "set OP_SERVICE_ACCOUNT_TOKEN".into(),
+        });
+        match p.probe() {
+            ProbeResult::NotAuthenticated { hint } => {
+                assert_eq!(hint, "set OP_SERVICE_ACCOUNT_TOKEN")
+            }
+            other => panic!("unexpected probe result: {other:?}"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Passive contract violated")]
+    fn panicking_provider_panics_on_resolve() {
+        let p = PanickingProvider::new("op");
+        let _ = p.resolve("anything");
+    }
+
+    #[test]
+    fn panicking_provider_probe_is_ok() {
+        // Probe must NOT panic — only resolve should. Otherwise the
+        // preflight check would short-circuit before the test
+        // reaches the path it's trying to gate.
+        let p = PanickingProvider::new("op");
+        assert!(p.probe().is_ok());
+    }
+}

--- a/docs/proposals/secrets-testing.lex
+++ b/docs/proposals/secrets-testing.lex
@@ -1,0 +1,214 @@
+Design Specification: Testing Strategy for Secret Handling
+
+    This document is the testing companion to [./secrets.lex]. It specifies how the secrets work is unit-tested, how integrations with external tooling (provider CLIs, gpg, age, sops) are exercised, and how the same tests run both locally and in CI without per-developer setup. Read [./secrets.lex] first for the feature design; this document only covers verification.
+
+1. Why a Sibling Spec
+
+    The secrets work is unusually integration-heavy. Above the dodot/burgertocow seam everything is rust-native and unit-testable. Below it, every supported provider is a subprocess against a tool dodot does not own (`gpg`, `age`, `sops`, `op`, `bw`, `pass`, `secret-tool`, `security`). Glue code is the dominant failure surface: command syntax drift, output-parsing changes between tool versions, error-mapping mismatches, auth-state assumptions that hold on the developer's box but not in CI.
+
+    Testing for this kind of glue requires a different discipline from "unit-test the function." Bundling the strategy into [./secrets.lex] would either bloat that document or hide the integration discipline behind feature design. The sibling shape lets each document stay focused: secrets.lex defines what we ship; this document defines how we know it works.
+
+2. The Testing Seam
+
+    A single trait separates "dodot logic" from "what subprocess we shell out to":
+
+        trait SecretProvider {
+            fn scheme(&self)  -> &str;
+            fn resolve(&self, reference: &str) -> Result<SecretString>;
+            fn probe(&self) -> ProbeResult;
+        }
+
+    Above the trait — *everything* the tests of section 3 cover — is pure dodot:
+        - Reference parsing per scheme
+        - The `secret()` MiniJinja function and its caching
+        - AST pre-walk for batched provider calls
+        - Sidecar serialisation
+        - Sentinel construction
+        - `PreprocessMode::Active` / `Passive` gating (see secrets.lex §7.4)
+        - Error UX (mapping `probe()` results to user-facing messages)
+        - Multi-line refusal at render time (secrets.lex §3.4)
+
+    Below the trait — what section 4 covers — is the per-provider subprocess work: command shape, env-var handling, output parsing, exit-code mapping.
+
+    This is the same shape as our existing `Fs` and `CommandRunner` traits in dodot, and it carries the same testability discipline: above-trait code is unit-tested with a mock; below-trait code is integration-tested with the real binary.
+
+3. Tier 0 — Unit Tests (default `cargo test`)
+
+    Pure dodot logic. Runs on every PR. No external binaries. No environment dependencies. The mock provider used here is `MockSecretProvider`, a test-only impl that returns canned values from a `HashMap<reference, value>` and counts invocations.
+
+    3.1. Coverage
+
+        - Reference parsing: `op://Vault/Item/Field`, `pass:path/to/x`, `sops:f.yaml#k.path`, two-arg form for raw age.
+        - `SecretString` zero-on-drop, refuses Debug / Display formatting.
+        - Sidecar serialise / deserialise round-trip; missing-sidecar treated as "no secret ranges to skip" (empty mask).
+        - The `secret()` MiniJinja function: dispatches to the right mock by scheme, returns the mocked value, caches within a single render pass (each unique reference resolves once even if used N times).
+        - AST pre-walk: produces the expected reference set for a given template.
+        - Batching: same-provider references collapse into one provider call per `dodot up`.
+        - Mode gating: `secret()` invoked under `PreprocessMode::Passive` returns the §7.4 `[SECRET: <reference>]` placeholder and never invokes a provider. Pin this with a `PanickingProvider` mock that aborts on `resolve()`; status / dry-run runs against a templated pack must not panic. Same shape as the existing tests for `up_dry_run_does_not_write_to_datastore` (commands/tests.rs).
+        - Multi-line refusal: a mock returning `"a\nb"` produces the documented render-time error (secrets.lex §3.4); whole-file path is suggested in the error body.
+        - Sentinel: rendered-bytes hash changes when the mock returns a different value across runs; secret rotation flows through.
+        - Error UX: each `probe()` outcome (`NotInstalled`, `NotAuthenticated`, `ReferenceNotFound`) maps to the documented user-facing message in secrets.lex §5.4.
+
+    3.2. Mock Discipline
+
+        `MockSecretProvider` is the only mock allowed in tier 0. Tests must NOT shell out, must NOT touch the network, must NOT depend on `$HOME` contents. A tier-0 test that needs a real provider belongs in tier 1.
+
+4. Tier 1 — Self-Contained Integration (default CI)
+
+    Real provider impls + real binaries + hermetic per-test fixtures. Runs on every PR on the Linux CI runner. No accounts, no network, no developer-machine config bleed-through.
+
+    4.1. Hermetic Fixtures
+
+        Each test gets a sandbox with isolated environment:
+            $SANDBOX/gnupg                -> $GNUPGHOME
+            $SANDBOX/password-store       -> $PASSWORD_STORE_DIR
+            $SANDBOX/sops-keys/age.txt    -> $SOPS_AGE_KEY_FILE
+            $SANDBOX/dotfiles             -> $DOTFILES_ROOT
+            $SANDBOX/data                 -> $XDG_DATA_HOME
+            $SANDBOX/cache                -> $XDG_CACHE_HOME
+            $SANDBOX/config               -> $XDG_CONFIG_HOME
+
+        Fixture setup runs in `setup()`:
+            - Generate a no-passphrase test gpg keypair via `gpg --batch --gen-key` with a deterministic UID like `dodot-test@example.invalid`.
+            - Initialise pass: `pass init <key-id>`; insert known fixture entries.
+            - Generate an age keypair via `age-keygen`; write to `$SOPS_AGE_KEY_FILE`.
+            - Encrypt a fixture YAML with sops to exercise the sops provider.
+
+        Fixture teardown runs in `teardown()`: `rm -rf $SANDBOX`. No state survives between tests.
+
+        Helpers live in `tests/e2e/bats/helpers/secrets_fixtures.bash`. The brew muzzle pattern from PR dodot#120 is the precedent: reusable bash functions, sourced from each `.bats` file's `setup()`.
+
+    4.2. Provider Coverage
+
+        | Provider              | Binary                  | Hermetic? | What gets tested                                                                                    |
+        | pass                  | `pass`, `gpg`           | Yes       | Reference resolution, missing-entry error, gpg-agent passphrase-less unlock                         |
+        | sops                  | `sops`, `age`           | Yes       | YAML key extraction (`sops:file.yaml#path.to.key`), missing-key error, decrypt failure              |
+        | age (whole-file)      | `age`                   | Yes       | Decrypt, mode 0600 enforcement, plaintext-passes-through-symlink                                    |
+        | gpg (whole-file)      | `gpg`                   | Yes       | Same shape as age, different cipher; uses the shared test keypair                                   |
+        :: table ::
+
+        These four providers cover the full secrets.lex story for value-injection (pass, sops) and whole-file deploy (age, gpg). They are the secrets work's primary regression net.
+
+    4.3. End-to-End Tests
+
+        Beyond per-provider unit-style tests, three full-pipeline `bats` files exercise dodot from the user's perspective:
+
+            test_secrets_value_injection.bats   - dodot up renders a templated config with `{{ secret("pass:...") }}` and `{{ secret("sops:...") }}`, deploys via symlink, asserts the rendered file contains the resolved value.
+            test_secrets_wholefile.bats         - dodot up deploys ssh/id_ed25519.age and a Brewfile.gpg, asserts symlinks land at the right paths with mode 0600.
+            test_secrets_passive_contract.bats  - status + up --dry-run against a templated pack with the panicking-provider crate-level test fixture (see §6.1) — no provider invoked, no datastore writes.
+
+        These run with the real provider binaries against fixture data. Pin the §7.4 contract end-to-end in addition to the trait-level tests in tier 0.
+
+    4.4. CI Setup
+
+        On the default Linux runner, tier 1 needs four binaries: `gpg`, `pass`, `age`, `sops`. Two acceptable install paths:
+
+            (a) `apt install gnupg pass age` + manual `sops` from a release tarball (sops isn't in Debian stable). One-liner in the workflow.
+            (b) `mise install` against a pinned `.tool-versions` file. Survives ubuntu-image bumps better; costs ~30s of CI per run.
+
+        Recommendation: (b). The version-pinning matters because tier 1 catches output-parsing drift, and an ubuntu-image bump that quietly rotates one of the binaries could surface as a flaky test rather than as the upgrade signal it is. (a) is the fallback if `mise` infra is more friction than the version-pin is worth.
+
+5. Tier 2 — Service-Backed Integration
+
+    Real provider CLIs that need an account or system service.
+
+    5.1. Stub-First Default Coverage
+
+        For `op` and `bw` — the two cloud-vault providers — the default CI runs against a *stub binary* placed on PATH:
+
+            tests/fixtures/stubs/op
+            tests/fixtures/stubs/bw
+
+        Each stub is a small bash script that accepts the subset of the real CLI's command shape dodot uses, reads from a fixture file under `$SANDBOX/stub-vault/`, and exits with the same codes the real binary would (0 for success, distinct non-zero codes for "not authenticated", "ref not found", etc.).
+
+        `tests/e2e/bats/helpers/secrets_stubs.bash` prepends `tests/fixtures/stubs` to PATH for tier-2 tests. The same pattern shipped in PR dodot#120 (the brew muzzle); it's known to work.
+
+        What this gets us:
+            - Coverage of dodot's op / bw provider implementations against a representative command shape on every PR.
+            - No account dependency, no flakiness from cloud-service availability.
+            - When the real binary's CLI shape drifts (a major version bumps a flag), the stub model goes stale — caught by §5.2's opt-in workflow.
+
+    5.2. Real-Provider Opt-In Workflow
+
+        A separate workflow (`.github/workflows/secrets-real-providers.yml`) runs the same `.bats` files with the stubs *removed* from PATH and the real CLIs in their place, authenticated against fixture vaults via:
+            - `op`: `OP_SERVICE_ACCOUNT_TOKEN` (GitHub repo secret, scoped to a dedicated test vault)
+            - `bw`: `BW_CLIENT_ID` + `BW_CLIENT_SECRET` (API-key auth, dedicated test vault)
+
+        Trigger: weekly cron + manual `workflow_dispatch`. Not on every PR — keeps PR latency down and avoids burning provider rate limits on every push.
+
+        The same assertions run against both stub and real-binary modes. A test that passes against the stub but fails against the real binary tells us the stub model is stale; a test that passes against the real binary but fails against the stub tells us the stub is over-permissive. Both are valuable failure shapes.
+
+    5.3. OS-Level Providers (S4)
+
+        macOS Keychain (via `security`) and the freedesktop Secret Service (via `secret-tool` against `dbus-daemon` + `gnome-keyring` or `keepassxc`) are deferred to Phase S4 of secrets.lex. When that phase ships:
+            - Keychain: dedicated macOS CI runner, since the `security` command isn't usefully mockable across platforms. Manual interactive prompts can't run hermetically; tests gate on a pre-unlocked keychain set up by the workflow.
+            - Secret Service: dedicated Linux CI job that brings up `dbus-daemon` + a headless secret backend. Self-contained but heavier than tier 1.
+
+        Until S4, neither provider has a test target. Mark the providers as "manual testing only" in their probe output.
+
+6. Test Doubles
+
+    6.1. `MockSecretProvider`
+
+        Test-only `SecretProvider` impl. Exposed under `#[cfg(test)]`. Constructor takes a `HashMap<String, String>` of `reference -> value` pairs and an optional `Vec<String>` of "panic on these references" entries. Tracks invocation count for batching assertions. Lives in `crates/dodot-lib/src/secret/test_support.rs` alongside the real registry.
+
+    6.2. `PanickingProvider`
+
+        A `SecretProvider` whose `resolve()` calls `panic!()`. Used to pin the §7.4 Passive contract: a status / dry-run flow that touches a templated pack with this provider registered must complete without panicking — proves no provider call happened.
+
+    6.3. Stub Binaries
+
+        Bash scripts under `tests/fixtures/stubs/`. Self-contained, reviewable as plain text. Each begins with a documentation block listing the subset of CLI shape it covers and the corresponding real-binary version it was modelled against. When a stub is updated to track a new real-binary version, the doc block is updated in the same commit. Easy review surface.
+
+7. AI Agent / Local Developer Workflow
+
+    Implementation work on this track will be split across long sessions, much of it driven by an AI coding agent. The agent needs to be able to drop into a sandbox with all fixtures initialised and explore against the real toolchain — running `dodot up`, `pass show`, `sops --decrypt`, etc., to debug behaviour. Bats's "set up sandbox per test" model is the right primitive but isn't directly invocable outside a test run.
+
+    7.1. dev-shell.sh
+
+        A new helper `tests/e2e/bats/helpers/dev-shell.sh <fixture-name>` reuses the same setup functions a `.bats` file would source, then drops the user / agent into an interactive subshell with all the env vars set:
+
+            $ ./tests/e2e/bats/helpers/dev-shell.sh secrets-pass
+            [sandbox: /tmp/dodot-dev-XXX]
+            [gpg key id: <auto-generated>]
+            [pass entries seeded: db_password, github_token]
+            $ pass show test-secrets/db_password
+            hunter2-from-fixture
+            $ dodot up
+            ...
+
+        Available fixtures:
+            secrets-pass         pass + gpg, no passphrase, fixture entries
+            secrets-sops         sops + age, encrypted YAML
+            secrets-age          age whole-file, fixture encrypted file
+            secrets-gpg          gpg whole-file, fixture encrypted file
+            secrets-op-stub      op stub binary on PATH, fixture vault
+            secrets-bw-stub      bw stub binary on PATH, fixture vault
+            secrets-op-real      requires OP_SERVICE_ACCOUNT_TOKEN; uses real op CLI
+            secrets-bw-real      requires BW_CLIENT_ID + BW_CLIENT_SECRET
+
+        Cleanup runs on subshell exit (`trap "rm -rf $SANDBOX" EXIT`). The agent never accumulates state.
+
+8. Decisions and Open Questions
+
+    Decided up-front in this document:
+        - SecretProvider trait is the single mock seam.
+        - Tier 0 uses MockSecretProvider only — no real binaries.
+        - Tier 1 covers pass / sops / age / gpg with real binaries on default CI.
+        - Tier 2 (op / bw) ships stubs by default + opt-in real-provider workflow.
+        - Linux is the default CI substrate; macOS / dbus jobs land with their corresponding S4 phase.
+
+    Decisions still to make at implementation time:
+        - Pin tool versions via `mise` (recommended) or `apt` direct (fallback).
+        - Real-provider workflow trigger: weekly cron + workflow_dispatch (recommended) vs. nightly cron (more flake noise) vs. manual-only (fewer signals from drift).
+        - Stub binary model fidelity: how much of `op` / `bw` do we actually reproduce? Start with the read paths dodot uses (`op read`, `bw get item`); add commands as the implementation needs them.
+
+9. Cross-References
+
+    - [./secrets.lex] §5.1 — `SecretProvider` trait surface.
+    - [./secrets.lex] §7.4 — Passive contract; tier-0 mode-gating tests pin it.
+    - [./secrets.lex] §3.4 — Multi-line refusal; tier-0 test asserts the documented error.
+    - [./secrets.lex] §4.5 — Refusal of `dodot secret edit`; no test for this since the feature is permanently out of scope.
+    - dodot#120 (merged) — brew muzzle pattern; precedent for stub binaries on PATH in bats setup.
+    - dodot#126 (merged) — `PreprocessMode::{Active, Passive}`; the runtime contract tier-0 / tier-1 tests pin.
+    - burgertocow#13 — the masking API; integration tests for the mask path live in tier 1 once burgertocow v0.4.0 lands and the dodot side wires it up.

--- a/docs/proposals/secrets.lex
+++ b/docs/proposals/secrets.lex
@@ -401,6 +401,8 @@ Design Specification: Secret Handling
 
 8. Implementation Phases
 
+    Testing strategy for every phase below — unit / tier-1 hermetic / tier-2 stub-or-real / dev-shell helper for AI-agent and human exploration — lives in the sibling document [./secrets-testing.lex]. Each phase's PR is expected to land its corresponding tests; the testing doc is the contract those tests satisfy.
+
     Phase S1: Value injection — minimal set
         - `SecretProvider` trait and `SecretString` type
         - Providers: `pass`, `op`

--- a/tests/e2e/bats/helpers/dev-shell.sh
+++ b/tests/e2e/bats/helpers/dev-shell.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# dev-shell.sh — drop into an interactive sandbox with one of the
+# secrets fixtures pre-installed.
+#
+# Per `docs/proposals/secrets-testing.lex` §7.1: the bats setup model
+# is per-test, but development / debugging / AI-agent exploration
+# wants a shell that already has the fixture initialised so commands
+# like `pass show test/db_password` and `dodot up` Just Work.
+#
+# Usage:
+#   ./tests/e2e/bats/helpers/dev-shell.sh [fixture-name]
+#
+# Available fixtures (Phase S1):
+#   secrets-pass         pass stub on PATH + initialised store + 4 entries
+#
+# Future fixtures (will be added by their respective phases):
+#   secrets-sops         sops + age (Phase S1 once sops provider lands)
+#   secrets-age          age whole-file (Phase S2)
+#   secrets-gpg          gpg whole-file (Phase S2)
+#   secrets-op-stub      op stub binary on PATH
+#   secrets-bw-stub      bw stub binary on PATH
+#   secrets-op-real      real `op` CLI; needs OP_SERVICE_ACCOUNT_TOKEN
+#   secrets-bw-real      real `bw` CLI; needs BW_CLIENT_ID + BW_CLIENT_SECRET
+#
+# On exit (Ctrl-D / `exit`), the sandbox is removed. Nothing leaks.
+
+set -euo pipefail
+
+fixture="${1:-secrets-pass}"
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_PROJECT_ROOT="$(cd "$_SCRIPT_DIR/../../../.." && pwd)"
+
+# Reuse the bats setup helpers. The order matches what setup() in a
+# bats test would do: setup.bash first (so $SANDBOX, $HOME, etc. are
+# initialised), then the fixture-specific helper.
+# shellcheck source=setup.bash
+source "$_SCRIPT_DIR/setup.bash"
+# shellcheck source=secrets_stubs.bash
+source "$_SCRIPT_DIR/secrets_stubs.bash"
+
+sandbox_setup
+trap 'sandbox_teardown' EXIT
+
+case "$fixture" in
+    secrets-pass)
+        secrets_pass_stub_setup
+        seed_pass_secret 'test/db_password' 'hunter2-from-fixture'
+        seed_pass_secret 'test/api_key'     'fixture-api-key'
+        seed_pass_secret 'test/github_token' 'ghp_fixture_token'
+        seed_pass_secret 'test/tls_cert'    'fixture-cert-blob'
+        secrets_enable_pass_in_root_config
+        cat <<EOF
+[sandbox: $SANDBOX]
+[fixture: $fixture]
+[pass entries seeded: test/db_password, test/api_key, test/github_token, test/tls_cert]
+[\$DOTFILES_ROOT: $DOTFILES_ROOT]
+[\$PASSWORD_STORE_DIR: $PASSWORD_STORE_DIR]
+[\$HOME: $HOME]
+
+Try:
+  pass show test/db_password
+  dodot up
+  dodot status
+EOF
+        ;;
+    *)
+        echo "dev-shell: unknown fixture '$fixture'" >&2
+        echo "Available: secrets-pass" >&2
+        exit 2
+        ;;
+esac
+
+# Drop into an interactive subshell. The trap above tears the
+# sandbox down on exit, regardless of how the shell exits.
+exec "${SHELL:-/bin/bash}" -i

--- a/tests/e2e/bats/helpers/secrets_stubs.bash
+++ b/tests/e2e/bats/helpers/secrets_stubs.bash
@@ -74,14 +74,37 @@ seed_pass_secret() {
     printf '%s\t%s\n' "$ref" "$value" >> "$SANDBOX/.secrets-stubs/pass-catalog"
 }
 
-# Drop the pass stub from PATH for tests that need to exercise the
-# "binary not installed" probe path. The store directory and env var
-# stay set; the stub disappears, so `pass version` fails with
-# "command not found" and the provider's NotInstalled probe fires.
+# Drop the pass stub AND make `pass` genuinely unspawnable from this
+# point on — used by tests that exercise the "binary not installed"
+# probe path. The provider distinguishes spawn-failure (Err →
+# NotInstalled) from spawn-then-exit-non-zero (Ok → ProbeFailed), so
+# we need `Command::new("pass").spawn()` to fail outright.
+#
+# Approach: remove our stub dir AND walk PATH stripping any entry
+# that contains a `pass` binary. Without the strip, on a developer
+# machine with pass installed via brew / apt / pacman / nix, the
+# host's binary resolves through and the probe returns Ok — making
+# the test pass-or-fail dependent on host config. After the strip,
+# spawn fails everywhere with a real "command not found" → the
+# probe walks the documented NotInstalled path.
 secrets_drop_pass_stub() {
     if [[ -d "$SANDBOX/.secrets-stubs" ]]; then
         rm -rf "$SANDBOX/.secrets-stubs"
     fi
+    local clean=""
+    local IFS=':'
+    local entry
+    for entry in $PATH; do
+        if [[ -n "$entry" && -x "$entry/pass" ]]; then
+            continue
+        fi
+        if [[ -z "$clean" ]]; then
+            clean="$entry"
+        else
+            clean="$clean:$entry"
+        fi
+    done
+    export PATH="$clean"
 }
 
 # Helper for the common case: enable the pass provider + point at the

--- a/tests/e2e/bats/helpers/secrets_stubs.bash
+++ b/tests/e2e/bats/helpers/secrets_stubs.bash
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Secrets E2E test helpers — stub provider binaries on PATH plus
+# fixture catalog seeding.
+#
+# Phase S1 ships the `pass` provider as the canonical reference impl
+# (the real `pass` binary is hermetically testable in tier 1 — see
+# `docs/proposals/secrets-testing.lex` §4). The stubs here cover the
+# narrow command shape `crates/dodot-lib/src/secret/pass.rs` calls
+# (`pass version`, `pass show <ref>`) so e2e tests exercise the full
+# `dodot up` integration without requiring `gpg` / a real password
+# store on the host. Same precedent as the brew muzzle pattern (PR
+# dodot#120) — a stub script on PATH, prepended in setup, scrubbed at
+# teardown alongside the rest of $SANDBOX.
+
+# Set up a stub `pass` binary on PATH plus an initialised
+# `$PASSWORD_STORE_DIR`. The store gets a `.gpg-id` file so the
+# provider's probe (`crates/dodot-lib/src/secret/pass.rs`) treats it
+# as initialised.
+#
+# Tests append entries with `seed_pass_secret`. Resolved values are
+# printed verbatim by the stub on `pass show <ref>`; unknown
+# references map to the documented `not in the password store`
+# stderr (exit 1) so the provider's error mapping fires.
+secrets_pass_stub_setup() {
+    local stub_dir="$SANDBOX/.secrets-stubs"
+    local store_dir="$SANDBOX/password-store"
+    local catalog="$stub_dir/pass-catalog"
+
+    mkdir -p "$stub_dir" "$store_dir"
+    : > "$catalog"
+
+    echo 'dodot-test@example.invalid' > "$store_dir/.gpg-id"
+
+    cat > "$stub_dir/pass" <<'STUB'
+#!/usr/bin/env bash
+# Stub `pass` for dodot e2e tests.
+# Catalog: tab-separated <ref>\t<value> lines, one per entry.
+CATALOG="$(dirname "$0")/pass-catalog"
+
+case "$1" in
+    version)
+        echo "pass-stub 1.0"
+        exit 0
+        ;;
+    show)
+        ref="$2"
+        # Match on the full reference up to the first tab.
+        line="$(awk -F '\t' -v r="$ref" '$1 == r { print $2; found=1; exit } END { exit !found }' "$CATALOG")"
+        rc=$?
+        if [[ $rc -ne 0 ]]; then
+            echo "Error: $ref is not in the password store." >&2
+            exit 1
+        fi
+        printf '%s\n' "$line"
+        exit 0
+        ;;
+    *)
+        echo "pass stub: unsupported subcommand: $1" >&2
+        exit 2
+        ;;
+esac
+STUB
+    chmod +x "$stub_dir/pass"
+
+    export PATH="$stub_dir:$PATH"
+    export PASSWORD_STORE_DIR="$store_dir"
+}
+
+# Append a (reference, value) pair to the pass stub catalog.
+# Usage: seed_pass_secret "test/db_password" "hunter2-from-fixture"
+seed_pass_secret() {
+    local ref="$1"
+    local value="$2"
+    printf '%s\t%s\n' "$ref" "$value" >> "$SANDBOX/.secrets-stubs/pass-catalog"
+}
+
+# Drop the pass stub from PATH for tests that need to exercise the
+# "binary not installed" probe path. The store directory and env var
+# stay set; the stub disappears, so `pass version` fails with
+# "command not found" and the provider's NotInstalled probe fires.
+secrets_drop_pass_stub() {
+    if [[ -d "$SANDBOX/.secrets-stubs" ]]; then
+        rm -rf "$SANDBOX/.secrets-stubs"
+    fi
+}
+
+# Helper for the common case: enable the pass provider + point at the
+# sandbox store + flip the master switch. Writes the root .dodot.toml.
+# Tests can append further config before calling dodot.
+secrets_enable_pass_in_root_config() {
+    cat > "$DOTFILES_ROOT/.dodot.toml" <<TOML
+[secret]
+enabled = true
+
+[secret.providers.pass]
+enabled = true
+store_dir = "$PASSWORD_STORE_DIR"
+TOML
+}

--- a/tests/e2e/bats/test_secrets.bats
+++ b/tests/e2e/bats/test_secrets.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# Phase S1 secrets E2E — integration tests for the `secret(...)`
+# MiniJinja function and the `pass` provider.
+#
+# Coverage scope (per `docs/proposals/secrets-testing.lex` §4.3):
+#   - happy path: pass: reference resolves end-to-end via `dodot up`
+#   - sidecar (`<baseline>.secret.json`) is written next to the baseline
+#   - preflight blocks `dodot up` when an enabled provider is misconfigured
+#   - missing reference surfaces a clear error
+#   - dry-run does NOT invoke the provider (Passive contract — §7.4)
+#
+# Whole-file (age/gpg) and op stubs are out of scope for Phase S1 and
+# land with their respective phases.
+
+setup() {
+    load helpers/setup
+    sandbox_setup
+    load helpers/secrets_stubs
+    secrets_pass_stub_setup
+}
+
+teardown() {
+    sandbox_teardown
+}
+
+@test "secret(pass:...) resolves end-to-end and the rendered file lands deployed" {
+    seed_pass_secret "test/db_password" "hunter2-from-fixture"
+
+    secrets_enable_pass_in_root_config
+    create_pack "app"
+    create_pack_file "app" "config.toml.tmpl" 'db_password = "{{ secret("pass:test/db_password") }}"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    # Rendered file lands at the symlink target with the resolved value.
+    [ -L "$HOME/.config/app/config.toml" ]
+    assert_file_contains "$HOME/.config/app/config.toml" 'db_password = "hunter2-from-fixture"'
+}
+
+@test "sidecar (.secret.json) is written next to the baseline" {
+    seed_pass_secret "test/api_key" "secret-key-xyz"
+
+    secrets_enable_pass_in_root_config
+    create_pack "app"
+    create_pack_file "app" "settings.toml.tmpl" 'key = "{{ secret("pass:test/api_key") }}"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+
+    # The baseline cache lives under the per-pack cache; the sidecar
+    # sits beside it. We don't assert the exact filename layout (that
+    # contract is pinned by the rust-side baseline tests); we do
+    # assert that exactly one sidecar JSON exists somewhere under the
+    # dodot cache for this pack and that it carries the reference.
+    local sidecar
+    sidecar="$(find "$XDG_CACHE_HOME/dodot" -name '*.secret.json' 2>/dev/null | head -1)"
+    [ -n "$sidecar" ] || {
+        echo "expected a *.secret.json sidecar under \$XDG_CACHE_HOME/dodot" >&2
+        find "$XDG_CACHE_HOME/dodot" 2>/dev/null >&2
+        return 1
+    }
+    assert_file_contains "$sidecar" "pass:test/api_key"
+}
+
+@test "preflight blocks dodot up when the pass binary is missing" {
+    # Provider is enabled in config but the stub is removed from PATH.
+    # `pass version` fails → ProbeResult::NotInstalled → preflight
+    # surfaces an aggregated error and `dodot up` aborts before any
+    # rendering would happen. See secrets.lex §5.4.
+    secrets_drop_pass_stub
+    secrets_enable_pass_in_root_config
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'value = "{{ secret("pass:test/anything") }}"'
+
+    run dodot up
+    [ "$status" -ne 0 ]
+    assert_output_contains "secret provider"
+    assert_output_contains "pass"
+    assert_output_contains "not installed"
+
+    # No rendering happened — the deployed file must not exist.
+    [ ! -e "$HOME/.config/app/cfg.toml" ]
+}
+
+@test "missing reference produces a clear render error" {
+    secrets_enable_pass_in_root_config
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'value = "{{ secret("pass:test/missing") }}"'
+
+    # Pass binary is installed but the reference is not in the catalog.
+    # The provider returns the documented "not in the password store"
+    # error, which surfaces through MiniJinja as a render failure
+    # naming the reference.
+    run dodot up
+    assert_output_contains "test/missing"
+    [ ! -e "$HOME/.config/app/cfg.toml" ]
+}
+
+@test "dry-run does not invoke the provider (Passive contract)" {
+    # Enable pass but leave the catalog empty. If --dry-run wrongly
+    # called the provider, `pass show` would exit non-zero and the
+    # render would fail. The Passive envelope (secrets.lex §7.4)
+    # forbids any provider call: dry-run reads the baseline cache.
+    # On a fresh sandbox there's no baseline yet, so dry-run reports
+    # nothing-to-do without ever shelling out. The key assertion is
+    # the absence of a hard failure plus no deployed file.
+    secrets_enable_pass_in_root_config
+    create_pack "app"
+    create_pack_file "app" "cfg.toml.tmpl" 'value = "{{ secret("pass:test/never_called") }}"'
+
+    run dodot up --dry-run
+    # Whatever dry-run reports, it must not crash on the unconfigured
+    # secret reference (provider was never called).
+    [ "$status" -eq 0 ] || {
+        echo "dry-run failed; provider may have been invoked" >&2
+        echo "$output" >&2
+        return 1
+    }
+    [ ! -e "$HOME/.config/app/cfg.toml" ]
+}


### PR DESCRIPTION
## Summary

Phase S1 of the secrets feature per `docs/proposals/secrets.lex` + `docs/proposals/secrets-testing.lex`. Templates can now reference values stored outside the dotfiles repo via `{{ secret("pass:test/db_password") }}`, dispatched through a new `SecretProvider` trait that ships with two real impls (`pass` password-store, `op` 1Password CLI). Both opt-in by default. A run-level preflight aggregates probe outcomes into a single user-facing message before any rendering begins. Multi-line returns are refused at render time per §3.4. `dodot up --dry-run` and `dodot status` honor the §7.4 Passive contract — provider `resolve()` is never called from those commands; pinned in tests with a `PanickingProvider`.

- **9 commits**, single PR, ready for review.
- **942 lib tests + 12 doctests + 259 bats tests pass; clippy clean.**

## What changed

- `crates/dodot-lib/src/secret/` — new module: `SecretString` (zeroize-on-drop, no Debug/Display), `SecretProvider` trait, `ProbeResult`, `SecretRegistry`, `MockSecretProvider` + `PanickingProvider` test doubles, `pass.rs`, `op.rs`, `error_render.rs` (renders `ProbeResult`s + `preflight()` aggregator).
- `secret()` MiniJinja function + sidecar (`<baseline>.secret.json`) line-range tracking — wired into `TemplatePreprocessor` and persisted next to the baseline cache.
- `[secret]` config section: master switch + `[secret.providers.pass]` + `[secret.providers.op]`. Both default to `enabled = false`.
- `default_registry()` returns `(PreprocessorRegistry, Option<Arc<SecretRegistry>>)`; `commands::up` calls `crate::secret::preflight()` once per active run.
- `tests/e2e/bats/test_secrets.bats` — 5 integration tests against a stub `pass` binary on PATH (same precedent as the brew muzzle PR #120). `tests/e2e/bats/helpers/dev-shell.sh secrets-pass` drops developers into the same fixture interactively.

## Test plan

- [x] `cargo test --workspace --all-targets` — 942 lib + 12 doctests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bats tests/e2e/bats/` — 259 / 259 pass
- [x] Tier 0 (unit) coverage per `secrets-testing.lex` §3.1: reference parsing, `SecretString` zero-on-drop, sidecar round-trip, `secret()` dispatch + caching, batching, mode gating with `PanickingProvider`, multi-line refusal, error-UX shapes
- [x] Tier 1 hermetic real-binary tests live alongside the provider impls (`pass.rs`, `op.rs`)
- [ ] Tier 2 (real `op` against `OP_SERVICE_ACCOUNT_TOKEN`) — runs via the opt-in workflow per §5.2; not on every PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)