### PR TITLE
audit-smoke-test (auto-generated, will be closed)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -86,3 +86,5 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
   `dev/handlers`, `reference/handlers`, `dev/cli-output`, and
   `proposals/shipped/conditional-running` updated to point at the new
   per-topic homes.
+
+<!-- audit-smoke-test 2026-05-08T21:00:16Z -->


### PR DESCRIPTION
Automated smoke test from `bin/audit-smoke-test`. This PR will be closed automatically.

Verifies the canonical PR loop starts: Copilot Review workflow fires + required checks trigger.