### PR TITLE
fix(config): rename gen/schema --output to --out; sync configuration.lex

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -86,3 +86,25 @@ Use **level-3** section headings (`### Added`, `### Changed`, `### Deprecated`,
   `dev/handlers`, `reference/handlers`, `dev/cli-output`, and
   `proposals/shipped/conditional-running` updated to point at the new
   per-topic homes.
+- **`docs/user/configuration.lex` brought into sync with the schema.**
+  The doc now covers every key in `DodotConfig`: added `[symlink]
+  force_app` / `app_aliases` / `app_uses_library` / `plist_extensions`,
+  the `[path]` section (`auto_chmod_exec`), `[preprocessor.template]
+  no_reverse`, `[preprocessor.age]`, `[preprocessor.gpg]`,
+  `[profiling]` (root-only), and `[secret]` (root-only) with all six
+  providers. The intro is reframed around the convention vs.
+  customization choice and the per-file (`_home/`, `home.X`, `_app/`,
+  …) vs. per-pack/repo (`.dodot.toml`) scope axes, and surfaces the
+  CLI helpers (`config list` / `get` / `set` / `unset` / `gen`).
+  Stock values cross-checked against `dodot config list` output.
+
+### Fixed
+
+- `dodot config gen` and `dodot config schema` panicked at startup
+  with `Long option names must be unique for each argument, but
+  '--output' is in use by both 'output' and '_output_mode'`. The
+  collision was between standout's global `--output` (output-mode
+  selector) and clapfig's gen/schema output-file flag. Renamed the
+  latter to `--out`; short `-o` is preserved, so `dodot config gen
+  -o .dodot.toml` keeps working and `--out` replaces `--output` as
+  the long form.

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -500,13 +500,21 @@ pub fn probe_shell_init_handler(
 
 // ── Passthrough handlers (bypass standout rendering) ────────────
 
+/// Configured `ConfigCommand` shared by registration and parsing.
+///
+/// `--out` (renamed from clapfig's default `--output`) avoids a clap
+/// collision with standout's global `--output` (output-mode selector).
+/// Both `main::build_clap_command` and `config_passthrough` go through
+/// this helper so the registered surface and the parser stay in lockstep.
+pub(crate) fn config_command() -> clapfig::ConfigCommand {
+    clapfig::ConfigCommand::new().output_long("out")
+}
+
 /// `dodot config` — delegates to clapfig's config subcommands.
 /// Uses `handle_to_string` (clapfig 0.16) for programmatic output.
 pub fn config_passthrough(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> {
     let dotfiles_root = discover_dotfiles_root()?;
-    // Must match the `ConfigCommand` configured in main::build_clap_command.
-    let config_cmd = clapfig::ConfigCommand::new().output_long("out");
-    let action = config_cmd.parse(matches)?;
+    let action = config_command().parse(matches)?;
 
     let output = clapfig::Clapfig::builder::<dodot_lib::config::DodotConfig>()
         .app_name("dodot")

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -504,7 +504,8 @@ pub fn probe_shell_init_handler(
 /// Uses `handle_to_string` (clapfig 0.16) for programmatic output.
 pub fn config_passthrough(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> {
     let dotfiles_root = discover_dotfiles_root()?;
-    let config_cmd = clapfig::ConfigCommand::new();
+    // Must match the `ConfigCommand` configured in main::build_clap_command.
+    let config_cmd = clapfig::ConfigCommand::new().output_long("out");
     let action = config_cmd.parse(matches)?;
 
     let output = clapfig::Clapfig::builder::<dodot_lib::config::DodotConfig>()

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -404,7 +404,12 @@ fn build_app() -> App {
 }
 
 fn build_clap_command() -> ClapCommand {
-    let config_cmd = clapfig::ConfigCommand::new();
+    // Rename clapfig's `gen` / `schema` `--output` flag to `--out`. standout
+    // already registers a global `--output` (output mode: auto/json/yaml/…),
+    // and clap rejects a child arg with the same long as a parent global.
+    // The short `-o` is preserved. `handlers::config_passthrough` builds an
+    // identically-configured `ConfigCommand` to parse — keep these two in sync.
+    let config_cmd = clapfig::ConfigCommand::new().output_long("out");
 
     ClapCommand::new("dodot")
         .about("A dotfiles manager that uses symlinks for live editing")

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -404,12 +404,11 @@ fn build_app() -> App {
 }
 
 fn build_clap_command() -> ClapCommand {
-    // Rename clapfig's `gen` / `schema` `--output` flag to `--out`. standout
-    // already registers a global `--output` (output mode: auto/json/yaml/…),
-    // and clap rejects a child arg with the same long as a parent global.
-    // The short `-o` is preserved. `handlers::config_passthrough` builds an
-    // identically-configured `ConfigCommand` to parse — keep these two in sync.
-    let config_cmd = clapfig::ConfigCommand::new().output_long("out");
+    // `handlers::config_command` is the single source of truth for the
+    // configured `ConfigCommand` — both this registration site and the
+    // `config_passthrough` parser route through it. See its docstring
+    // for why `--output` is renamed to `--out`.
+    let config_cmd = handlers::config_command();
 
     ClapCommand::new("dodot")
         .about("A dotfiles manager that uses symlinks for live editing")

--- a/docs/user/configuration.lex
+++ b/docs/user/configuration.lex
@@ -1,8 +1,39 @@
 Configuration
 
-    dodot works out of the box with no configuration at all. The `.dodot.toml` file is there for when the defaults don't fit: when you want to rename a handler's default file, symlink to an unusual location, or disable a preprocessor for a single pack. This document is the reference for every configuration key.
+    One of dodot's principles is to minimize both adoption and migration
+    cost (off dodot into the next dotfiles tool). One way it does that is
+    by using the dotfiles themselves as the description of what to do:
+    files grouped into packs, and filenames the scanner can infer behavior
+    from. dodot is convention-based — given a name, it knows what to do
+    with the file. Adding `bin/` directories to `$PATH`, running `brew`
+    against `Brewfile`, sourcing `aliases.sh` at shell startup — all of
+    it falls out of names you would pick anyway.
 
-    :: note :: See [./../reference/terms-and-concepts.lex] for terminology used throughout.
+    The convention is rooted in common usage patterns, so for most people
+    the default layout is the most natural approach, and is useful in its
+    own right beyond dodot.
+
+    When the convention doesn't fit, you can customize. For path-related
+    behavior, most knobs are reachable two ways: a `.dodot.toml` entry,
+    or a filename / directory naming convention like `_home/` or `home.X`.
+    The two surfaces serve two preferences — a cleaner file tree with the
+    choices captured in `.dodot.toml`, or an explicit setup where the
+    names themselves carry the intent and no extra config file is needed.
+
+    Scope is the other axis. Filesystem naming acts per file.
+    `.dodot.toml` acts per pack, or repo-wide from the root config — so
+    when many files need the same adjustment a config entry is usually
+    the cleanest path.
+
+    dodot ships a small set of CLI helpers for working with config:
+
+        $ dodot config list                  # show resolved values
+        $ dodot config get <key>             # show one key with its inline doc
+        $ dodot config set <key> <value>
+        $ dodot config unset <key>
+        $ dodot config gen > .dodot.toml     # write a commented starter file
+
+    :: shell ::
 
 1. Where Configuration Lives
 
@@ -18,7 +49,10 @@ Configuration
     - Scalars and arrays: override (the later-layer value replaces the earlier one, no accumulation).
     - Maps: deep-merge (nested keys combine across layers, but any scalar or array within still overrides).
 
-    Generate a fully commented starter with `dodot config gen -o .dodot.toml`.
+    Some sections are _root-only_ — they're read from the root
+    `.dodot.toml` and per-pack overrides are ignored. `[secret]` and
+    `[profiling]` fall in this bucket; `[pack] os` is the mirror image
+    (pack-only — root-level entries are rejected).
 
 2. The `[pack]` Section
 
@@ -76,7 +110,12 @@ Configuration
 
     Controls how the symlink handler resolves targets. Full path-resolution rules live in [./../reference/symlink-paths.lex]; this section is the config knobs.
 
-    By default, every pack-root entry deploys to `$XDG_CONFIG_HOME/<pack>/<name>` (so `nvim/init.lua` → `~/.config/nvim/init.lua`). Use `force_home`, the per-file `home.X` prefix, or the `_home/` directory prefix to opt files out of XDG when needed.
+    By default, every pack-root entry deploys to `$XDG_CONFIG_HOME/<pack>/<name>` (so `nvim/init.lua` → `~/.config/nvim/init.lua`). The escape hatches come in pairs — a config list and a per-file naming convention:
+
+    - `force_home` / `home.X` filename / `_home/` directory → `$HOME/.<name>`
+    - `force_app` / `app.X` filename / `_app/` directory → `~/Library/Application Support/<name>` (macOS; falls back to XDG on Linux or when `app_uses_library = false`)
+    - `xdg.X` filename / `_xdg/` directory → escape from a routing override back to plain XDG
+    - `lib.X` filename / `_lib/` directory → `~/Library/<name>` (macOS only)
 
     3.1. `force_home`
 
@@ -100,9 +139,67 @@ Configuration
 
         :: toml ::
 
-        Override to add your own entries or remove ones you don't need.
+        Override to add your own entries or remove ones you don't need. Equivalent per-file: prefix the filename with `home.` or place it under `_home/`.
 
-    3.2. `protected_paths`
+    3.2. `force_app`
+
+        macOS: GUI-app folder names that route a pack-root entry to
+        `~/Library/Application Support/<name>/<rest>` automatically,
+        without needing the `_app/` directory prefix. Matching is
+        case-sensitive (Library folder names are case-sensitive on
+        macOS) and only against the first path segment.
+
+        Force app:
+
+            [symlink]
+            force_app = ["Code", "Cursor", "Zed", "Emacs"]
+
+        :: toml ::
+
+        Capped at 100 entries. On Linux (or on macOS with
+        `app_uses_library = false`) `force_app` collapses to plain
+        XDG routing — the list is mechanically inert there. Equivalent
+        per-file: prefix with `app.` or place under `_app/`.
+
+    3.3. `app_aliases`
+
+        macOS: pack-name → app-folder rewrites. When a pack's name
+        matches a key, every entry in that pack reroutes from the
+        default `<xdg_config_home>/<pack>/<rest>` to
+        `<app_support_dir>/<value>/<rest>`. Useful when your pack
+        directory and the app's Library folder have different names.
+
+        App aliases:
+
+            [symlink.app_aliases]
+            "vscode"        = "Code"
+            "cursor-editor" = "Cursor"
+
+        :: toml ::
+
+        Defaults empty. Same Linux fallback as `force_app`.
+
+    3.4. `app_uses_library`
+
+        macOS toggle. When `true` (the default), `_app/` directories,
+        `app.X` filenames, `force_app`, and `app_aliases` route
+        through `~/Library/Application Support`. When `false`, they
+        all collapse to plain `~/.config` (Linux-style placement).
+        `_lib/` and `lib.X` are unaffected — those explicitly target
+        `~/Library/`.
+
+        App-uses-library toggle:
+
+            [symlink]
+            app_uses_library = false   # opt out of Application Support routing on this Mac
+
+        :: toml ::
+
+        Ignored on non-macOS hosts (the resolver collapses
+        `app_support_dir` to `xdg_config_home` everywhere except
+        macOS).
+
+    3.5. `protected_paths`
 
         Files dodot refuses to symlink by default, because doing so is almost always a mistake. Private SSH keys, GPG state, cloud credentials.
 
@@ -127,7 +224,7 @@ Configuration
 
         Remove an entry to allow dodot to symlink it anyway.
 
-    3.3. `targets`
+    3.6. `targets`
 
         Per-file symlink target overrides. Maps a pack-relative filename to an absolute or relative target path. Absolute paths are used as-is; relative paths resolve against `$XDG_CONFIG_HOME`.
 
@@ -139,7 +236,54 @@ Configuration
 
         :: toml ::
 
-4. The `[mappings]` Section
+    3.7. `plist_extensions`
+
+        Filename suffixes (without leading dot) that `dodot
+        git-install-filters` and the `.gitattributes` writer treat
+        as plists. Some apps store plists with non-standard suffixes
+        (`.binplist`, `.savedState`); register the extra extensions
+        here to flow them through the same clean/smudge pipeline.
+
+        Plist extensions:
+
+            [symlink]
+            plist_extensions = ["plist", "binplist"]
+
+        :: toml ::
+
+        Default `["plist"]`. Comparison is case-insensitive, and the list honors the standard root → pack inheritance.
+
+4. The `[path]` Section
+
+    Settings for the PATH handler (the one that adds `bin/` directories to `$PATH`).
+
+    4.1. `auto_chmod_exec`
+
+        Whether `dodot up` automatically adds the execute bit (`+x`)
+        to files inside `bin/` directories. Default `true`.
+
+        Auto-chmod:
+
+            [path]
+            auto_chmod_exec = true
+
+        :: toml ::
+
+        Files in a `bin/` directory are there because they're meant
+        to be commands on `$PATH`, but the execute bit gets lost
+        easily — git on macOS defaults to `core.fileMode = false`,
+        and manual file creation often forgets `chmod +x`. Without
+        `+x` the shell finds the file via PATH lookup but fails
+        with "permission denied", a confusing error when the file
+        is clearly in the right place.
+
+        Files that are already executable are left untouched;
+        failures are reported as warnings rather than hard errors.
+        Set to `false` if you have `bin/` files that intentionally
+        should not be executable (data files, sourced library
+        scripts).
+
+5. The `[mappings]` Section
 
     Overrides the default filename-to-handler map. Each key is a handler name; each value is either a single pattern or a list of patterns.
 
@@ -166,14 +310,14 @@ Configuration
 
     Two of the keys map to _filter handlers_ — real handlers that claim a match but produce no executable intent. Their job is to keep matching files away from the deploying handlers (precise mappings, catchall symlink):
 
-    - `ignore` — the `ignore` filter handler claims matches and drops them silently, mirroring `.gitignore`. Nothing surfaces in `dodot status`.
-    - `skip` — the `skip` filter handler claims matches and surfaces them in `dodot status` as `skipped`, but does not deploy them. Defaults cover the documentation/legal files (`README`, `LICENSE`, `CHANGELOG`, `CONTRIBUTING`, `AUTHORS`, `NOTICE`, `COPYING` and their `.*` variants), matched case-insensitively. Override per-pack with `skip = []` to deploy a README intentionally.
+    - `ignore` — claims matches and drops them silently, mirroring `.gitignore`. Nothing surfaces in `dodot status`. Priority 100.
+    - `skip` — claims matches and surfaces them in `dodot status` as `skipped`, but does not deploy them. Defaults cover the documentation/legal files (`README`, `LICENSE`, `CHANGELOG`, `CONTRIBUTING`, `AUTHORS`, `NOTICE`, `COPYING` and their `.*` variants), matched case-insensitively. Override per-pack with `skip = []` to deploy a README intentionally. Priority 50.
 
-    When both could match, `ignore` wins over `skip`; both win over precise mappings (`shell`, `install`, …) and the catchall symlink — so a file the user said to drop is dropped, full stop.
+    Precise mappings (`shell`, `install`, `path`, `homebrew`) sit at priority 10; the catchall symlink at priority 0. So a file the user said to drop is dropped, full stop — `ignore` over `skip` over precise mappings over catchall.
 
     Distinct from `[pack] ignore`: `[mappings] ignore`/`skip` apply only to handler dispatch within a known pack, while `[pack] ignore` affects pack discovery and scanning. To skip an entire pack, drop a `.dodotignore` marker file (the "pack-ignore" mechanism).
 
-    4.1. `[mappings.gates]`
+    5.1. `[mappings.gates]`
 
         Glob → gate-label map for repos that can't rename files. Each
         entry says "this glob inherits this gate"; on a non-matching
@@ -193,7 +337,7 @@ Configuration
         one source of truth. Invalid glob patterns are also a hard
         error at scan time. See [./conditional-running.lex] §7.
 
-5. The `[gates]` Section
+6. The `[gates]` Section
 
     User-defined gate labels. Each entry maps a label name to a table
     of `(dimension, value)` equality checks AND-ed together. Gates can
@@ -223,11 +367,11 @@ Configuration
     labels use names the seed doesn't claim. For the full surface and
     composition rules, see [./conditional-running.lex].
 
-6. The `[preprocessor]` Section
+7. The `[preprocessor]` Section
 
     Controls the preprocessing pipeline. For the concept, see [./../reference/pre-processors.lex].
 
-    6.1. Global kill switch
+    7.1. Global kill switch
 
         Global preprocessor toggle:
 
@@ -238,7 +382,7 @@ Configuration
 
         Set to `false` to disable _all_ preprocessors. `.tmpl` files (and other preprocessor-matched files) will deploy verbatim.
 
-    6.2. `[preprocessor.template]`
+    7.2. `[preprocessor.template]`
 
         Template engine configuration.
 
@@ -246,21 +390,119 @@ Configuration
 
             [preprocessor.template]
             extensions = ["tmpl", "template"]
+            no_reverse = ["complex-config.toml.tmpl", "*.gen.tmpl"]
 
             [preprocessor.template.vars]
-            editor = "nvim"
+            editor    = "nvim"
             host_tier = "workstation"
 
         :: toml ::
 
         `extensions` is the list of trigger extensions. Both `".j2"` and `"j2"` are tolerated (leading dot optional).
 
-        `[preprocessor.template.vars]` defines variables available in templates under their bare names. See [./templates.lex] for usage.
+        `[preprocessor.template.vars]` defines variables available in templates under their bare names. See [./templates.lex] for usage. Reserved: `dodot` and `env` are built-in namespaces, so using them as var names is a hard error at load time.
 
-7. Inheritance Model
+        `no_reverse` is glob patterns (matched against the source file's basename) whose reverse-merge in `dodot transform check` is bypassed. Templates listed here still render normally on `dodot up` and stay in the divergence cache; they just skip the heuristic that tries to backport changes from the deployed copy into the source. Useful for templates that are mostly dynamic — the heuristic degrades there and produces more conflict markers than usable diffs.
 
-    All sections follow the same three-layer model: compiled defaults, then root `.dodot.toml`, then pack `.dodot.toml`. The outermost layer that sets a key wins for scalars and arrays; for maps, the layers deep-merge.
+    7.3. `[preprocessor.age]`
+
+        Opt-in `*.age` whole-file decryption. Off by default so a fresh dodot install never shells out to `age` against random files.
+
+        Age decryption:
+
+            [preprocessor.age]
+            enabled    = true
+            extensions = ["age"]
+            identity   = ""    # empty: defer to $AGE_IDENTITY, then ~/.config/age/identity.txt
+
+        :: toml ::
+
+        `extensions` matches the same shape as `template.extensions`; add entries when your repo uses non-standard suffixes (e.g. `["age", "age.txt"]`). `identity` is the path to the age identity file used for decryption; leaving it empty defers to the runtime, which checks `$AGE_IDENTITY` first, then falls back to `~/.config/age/identity.txt` (the conventional `age-keygen` destination).
+
+    7.4. `[preprocessor.gpg]`
+
+        Opt-in `*.gpg` whole-file decryption. Same posture as `age`. gpg-agent supplies the identity, so there's no `identity` field — auth is your existing gpg setup, not dodot's job to configure.
+
+        Gpg decryption:
+
+            [preprocessor.gpg]
+            enabled    = true
+            extensions = ["gpg"]
+
+        :: toml ::
+
+        :: warning :: Do not add `asc` to `extensions` unless your repo only stores ASCII-armored _encrypted_ payloads under that suffix. `.asc` is conventionally used for armored public keys and detached signatures (release signatures, package-manager keys), neither of which gpg will decrypt; routing them through `gpg --decrypt` produces confusing failures.
+
+8. The `[profiling]` Section
+
+    _Root-only_. Controls shell-init timing instrumentation. Per-pack overrides are ignored — the init script is one thing, you can't half-profile it.
+
+    Profiling configuration:
+
+        [profiling]
+        enabled        = true
+        keep_last_runs = 100
+
+    :: toml ::
+
+    When `enabled = true` (the default), the generated `dodot-init.sh` carries a timing wrapper around each `source` and PATH line. bash 5+ / zsh sessions emit one TSV per shell startup under `<data_dir>/probes/shell-init/`; older shells fall through to the no-op path even with the wrapper present. Set `enabled = false` to make the init script byte-identical to the pre-Phase-2 form.
+
+    `keep_last_runs` caps retained TSV files; older ones get pruned at the end of every `dodot up`. At ~4 KB per run, the default budget is roughly 400 KB on disk.
+
+9. The `[secret]` Section
+
+    _Root-only_. Configuration for secret resolution in templates (the `secret(...)` template function). Per-pack overrides are ignored — secret tooling (binaries, env vars like `$PASSWORD_STORE_DIR`, `OP_SERVICE_ACCOUNT_TOKEN`) is a property of the host, not of any individual pack.
+
+    All providers default to `enabled = false`. Templates that call `secret(...)` against an unregistered scheme surface a "no provider for scheme" render error at `dodot up` time.
+
+    9.1. Global kill switch
+
+        Master switch:
+
+            [secret]
+            enabled = true
+
+        :: toml ::
+
+        Default `true`. Setting `enabled = false` disables the entire secret subsystem without removing per-provider blocks.
+
+    9.2. `[secret.providers]`
+
+        One block per supported provider. Each is opt-in; flip `enabled = true` to register the scheme.
+
+        Providers:
+
+            [secret.providers.pass]
+            enabled   = true
+            store_dir = ""    # optional: overrides $PASSWORD_STORE_DIR
+
+            [secret.providers.op]
+            enabled = true    # 1Password CLI, scheme `op://`
+
+            [secret.providers.bw]
+            enabled = false   # Bitwarden CLI, scheme `bw:`
+
+            [secret.providers.sops]
+            enabled = false   # Mozilla SOPS, scheme `sops:`
+
+            [secret.providers.keychain]
+            enabled = false   # macOS Keychain, scheme `keychain:` (macOS only)
+
+            [secret.providers.secret_tool]
+            enabled = false   # freedesktop Secret Service, scheme `secret-tool:` (Linux-first)
+
+        :: toml ::
+
+        :: note :: The TOML key is `secret_tool` (underscore), but the scheme prefix in `secret(...)` calls is `secret-tool:` (hyphen, matching the binary name). Error messages translate between the two so a "no provider for scheme `secret-tool`" hint points at the right `[secret.providers.secret_tool]` block.
+
+        `pass.store_dir` overrides `$PASSWORD_STORE_DIR` for the `pass` provider. Empty (the default) leaves dodot reading the env var, which itself falls back to `$HOME/.password-store`.
+
+        For details on schemes, providers, and the `secret(...)` template function, see [./secrets.lex].
+
+10. Inheritance Model
+
+    Most sections follow the same three-layer model: compiled defaults, then root `.dodot.toml`, then pack `.dodot.toml`. The outermost layer that sets a key wins for scalars and arrays; for maps, the layers deep-merge. The exceptions: `[secret]` and `[profiling]` are root-only (per-pack entries are ignored), and `[pack] os` is pack-only (root-level entries are rejected).
 
     Example: you set `[preprocessor.template.vars] editor = "nvim"` at the root. In a pack for work configs, you set `[preprocessor.template.vars] editor = "vscode"`. That pack renders templates with `editor = "vscode"`; all others render with `editor = "nvim"`. All other keys under `[preprocessor.template]` (enabled, extensions) remain as defined at the root.
 
-    To see the fully resolved configuration for a context, run `dodot config`. This shows exactly what dodot is using.
+    To see the fully resolved configuration for a context, run `dodot config list`. To inspect a single key with its inline doc, run `dodot config get <key>`.

--- a/docs/user/configuration.lex
+++ b/docs/user/configuration.lex
@@ -156,10 +156,22 @@ Configuration
 
         :: toml ::
 
-        Capped at 100 entries. On Linux (or on macOS with
-        `app_uses_library = false`) `force_app` collapses to plain
-        XDG routing — the list is mechanically inert there. Equivalent
-        per-file: prefix with `app.` or place under `_app/`.
+        On Linux (or on macOS with `app_uses_library = false`),
+        `app_support_dir` collapses to `$XDG_CONFIG_HOME` — but
+        `force_app` is still applied. So `force_app = ["Code"]` on
+        Linux routes `Code/init.json` to
+        `$XDG_CONFIG_HOME/Code/init.json` (skipping the per-pack
+        namespace), not to the macOS Application Support root. If
+        you don't want that behavior on Linux, drop the entry from
+        the list there (or override per-pack).
+
+        The shipped defaults stay under a 100-entry budget — that's
+        a build-time invariant on `force_app`'s seed, not a user
+        validation. You can set a longer list yourself; it just
+        won't be a sane thing to do.
+
+        Equivalent per-file: prefix with `app.` or place under
+        `_app/`.
 
     3.3. `app_aliases`
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `dodot config gen` and `dodot config schema` panicked at startup with a clap `--output` flag collision. Standout registers a global `--output` (output-mode selector); clapfig's `gen`/`schema` subcommands also took `--output` (output file). Renamed clapfig's flag to `--out` at both call sites — the registration in `main.rs::build_clap_command` and the parsing in `handlers::config_passthrough`. Short `-o` is preserved, so `dodot config gen -o .dodot.toml` keeps working.
- **Doc sync**: brought `docs/user/configuration.lex` into full sync with `DodotConfig`. Added every previously-undocumented section: `[symlink] force_app`, `app_aliases`, `app_uses_library`, `plist_extensions`; new `[path]` section (`auto_chmod_exec`); `[preprocessor.template] no_reverse`; `[preprocessor.age]`; `[preprocessor.gpg]`; `[profiling]` (root-only); `[secret]` (root-only) with all six providers. Intro reframed around the *convention vs. customization* and *per-file vs. per-pack/repo* scope axes; added a CLI helper block. Stock values cross-checked against `dodot config list`.

## Test plan

- [x] `cargo test --tests` — 1134 pass (the 2 doctest failures are pre-existing on main, unrelated)
- [x] `dodot config gen` no longer panics; produces 395-line commented file on stdout
- [x] `dodot config gen -o /tmp/x.toml` writes the file (short form preserved)
- [x] `dodot config gen --out /tmp/x.toml` writes the file (renamed long form)
- [x] `dodot config schema` works
- [x] `dodot config list`, `get <key>`, `set`, `unset` unaffected
- [x] Lefthook pre-commit hook passes (rustfmt, clippy, 1146 tests)
- [x] Doc lex syntax checked against the lex-primer rules; no markdown leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)