### PR TITLE
feat(external): externals handler — file type (PR 1/6, closes part of #152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Externals handler (PR 1 of stacked series, file type only)** —
+  packs can now declare remote resources in an `externals.toml` file
+  at the pack root. Each section declares one entry; this PR
+  implements `type = "file"` with mandatory `sha256` content pinning.
+  Fetched bytes land in the datastore under
+  `<data_dir>/packs/<pack>/external/<name>/<filename>` and a
+  user-visible symlink is created at the configured `target`.
+  Sentinel-gated: re-running `dodot up` with an unchanged sha256 is a
+  no-op; bumping the sha256 in the TOML invalidates the old sentinel
+  and triggers a re-fetch. Transient network failures soft-fail and
+  leave any cached copy in place; integrity (sha256) mismatches are
+  hard failures that refuse to write. New `ExecutionPhase::External`
+  slot runs between `Filter` and `Provision`. `git-repo`, `archive`,
+  and `archive-file` types parse but report "unsupported" — they land
+  in subsequent PRs of the series. Closes part of #152.
+
 - **Conditional running (gates)** — files, directories, and packs can
   be gated against host facts (OS, arch, hostname, username) so the
   same dotfiles repo deploys differently on different machines without

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +680,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +734,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.8.23",
  "tracing",
+ "ureq",
  "zeroize",
 ]
 
@@ -845,6 +867,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +887,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -1034,10 +1071,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1157,6 +1297,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1367,6 +1513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1624,15 @@ dependencies = [
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1652,6 +1813,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1874,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1852,6 +2062,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,6 +2137,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "standout"
@@ -2047,6 +2269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,6 +2294,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2180,6 +2419,16 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -2400,6 +2649,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2834,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2843,6 +3158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2860,6 +3181,29 @@ checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -2949,10 +3293,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -24,6 +24,7 @@ tempfile = { version = "3", optional = true }
 thiserror = "2"
 toml = "0.8"
 tracing = "0.1"
+ureq = { version = "2", default-features = false, features = ["tls"] }
 zeroize = "1"
 
 [dev-dependencies]

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -662,5 +662,8 @@ fn extract_op_info(
         crate::operations::Operation::CheckSentinel {
             handler, sentinel, ..
         } => (handler.clone(), sentinel.clone(), None),
+        crate::operations::Operation::FetchExternal {
+            handler, name, url, ..
+        } => (handler.clone(), format!("{name} ← {url}"), None),
     }
 }

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -509,6 +509,15 @@ pub struct MappingsSection {
     #[config(default = "Brewfile")]
     pub homebrew: String,
 
+    /// Filename patterns for the externals handler.
+    ///
+    /// The file declares one TOML section per external resource (a
+    /// remote file, a git-repo, an archive). See the
+    /// [`externals`](crate::handlers::externals) handler for the
+    /// per-entry schema.
+    #[config(default = ["externals.toml"])]
+    pub externals: Vec<String>,
+
     /// Filename patterns to drop from handler processing entirely.
     /// Matches are silent: nothing surfaces in `dodot status`, mirroring
     /// `.gitignore`'s mental model. Defaults are empty; common build /
@@ -656,6 +665,20 @@ pub fn mappings_to_rules(mappings: &MappingsSection) -> Vec<Rule> {
             case_insensitive: false,
             options: HashMap::new(),
         });
+    }
+
+    // Externals handler — priority 20 so the precise `externals.toml`
+    // match wins over any user-overridden `*.toml`-ish shell glob.
+    for pattern in &mappings.externals {
+        if !pattern.is_empty() {
+            rules.push(Rule {
+                pattern: pattern.clone(),
+                handler: "external".into(),
+                priority: 20,
+                case_insensitive: false,
+                options: HashMap::new(),
+            });
+        }
     }
 
     // Ignore patterns: route to the `ignore` filter handler. Priority
@@ -859,6 +882,7 @@ mod tests {
         );
         assert_eq!(cfg.mappings.homebrew, "Brewfile");
         assert_eq!(cfg.mappings.shell, vec!["*.sh", "*.bash", "*.zsh"]);
+        assert_eq!(cfg.mappings.externals, vec!["externals.toml"]);
         assert!(cfg.mappings.ignore.is_empty());
         assert!(
             cfg.mappings.skip.iter().any(|p| p == "README"),
@@ -962,6 +986,7 @@ homebrew = "RootBrewfile"
             install: vec!["install.sh".into(), "install.zsh".into()],
             shell: vec!["aliases.sh".into(), "profile.sh".into()],
             homebrew: "Brewfile".into(),
+            externals: vec!["externals.toml".into()],
             ignore: vec!["*.tmp".into()],
             skip: vec![],
             gates: std::collections::HashMap::new(),
@@ -969,14 +994,15 @@ homebrew = "RootBrewfile"
 
         let rules = mappings_to_rules(&mappings);
 
-        // Should have: path, 2x install, 2x shell, homebrew, 1x ignore, catchall = 8
-        assert_eq!(rules.len(), 8, "rules: {rules:#?}");
+        // path + 2 install + 2 shell + homebrew + externals + ignore + catchall = 9
+        assert_eq!(rules.len(), 9, "rules: {rules:#?}");
 
         let handler_names: Vec<&str> = rules.iter().map(|r| r.handler.as_str()).collect();
         assert!(handler_names.contains(&"path"));
         assert!(handler_names.contains(&"install"));
         assert!(handler_names.contains(&"shell"));
         assert!(handler_names.contains(&"homebrew"));
+        assert!(handler_names.contains(&"external"));
         assert!(handler_names.contains(&"ignore"));
         assert!(handler_names.contains(&"symlink"));
 
@@ -1004,6 +1030,7 @@ homebrew = "RootBrewfile"
             install: vec!["install.sh".into()],
             shell: vec!["*.sh".into()],
             homebrew: String::new(),
+            externals: vec![],
             ignore: vec![],
             skip: vec![],
             gates: std::collections::HashMap::new(),
@@ -1028,6 +1055,7 @@ homebrew = "RootBrewfile"
             install: vec![],
             shell: vec![],
             homebrew: String::new(),
+            externals: vec![],
             ignore: vec![],
             skip: vec!["README".into(), "README.*".into(), "LICENSE".into()],
             gates: std::collections::HashMap::new(),

--- a/crates/dodot-lib/src/conflicts.rs
+++ b/crates/dodot-lib/src/conflicts.rs
@@ -170,6 +170,15 @@ fn intent_source(intent: &HandlerIntent) -> PathBuf {
         HandlerIntent::Link { source, .. } => source.clone(),
         HandlerIntent::Stage { source, .. } => source.clone(),
         HandlerIntent::Run { executable, .. } => PathBuf::from(executable),
+        // The "source" for an external is the URL — represent it as a
+        // pseudo-path so conflict messaging stays uniform. Externals
+        // don't currently participate in cross-pack conflict detection
+        // (each entry's target is independent and configured by the
+        // user), so this string is only ever shown in diagnostics.
+        HandlerIntent::Fetch { spec, name, .. } => match spec {
+            crate::external::FetchSpec::File { url, .. } => PathBuf::from(url),
+            crate::external::FetchSpec::Unsupported => PathBuf::from(format!("<external:{name}>")),
+        },
     }
 }
 

--- a/crates/dodot-lib/src/conflicts.rs
+++ b/crates/dodot-lib/src/conflicts.rs
@@ -103,8 +103,16 @@ pub fn detect_cross_pack_conflicts(
 
     for (pack_name, intents) in pack_intents {
         for intent in intents {
-            // Symlink target conflicts
-            if let HandlerIntent::Link { user_path, .. } = intent {
+            // Symlink target conflicts (and externals — both produce a
+            // user-visible symlink, so two packs claiming the same
+            // `target` path is the same kind of collision regardless of
+            // which handler is involved).
+            let user_path = match intent {
+                HandlerIntent::Link { user_path, .. } => Some(user_path),
+                HandlerIntent::Fetch { user_path, .. } => Some(user_path),
+                _ => None,
+            };
+            if let Some(user_path) = user_path {
                 kinds.insert(user_path.clone(), ConflictKind::SymlinkTarget);
                 targets
                     .entry(user_path.clone())
@@ -171,10 +179,7 @@ fn intent_source(intent: &HandlerIntent) -> PathBuf {
         HandlerIntent::Stage { source, .. } => source.clone(),
         HandlerIntent::Run { executable, .. } => PathBuf::from(executable),
         // The "source" for an external is the URL — represent it as a
-        // pseudo-path so conflict messaging stays uniform. Externals
-        // don't currently participate in cross-pack conflict detection
-        // (each entry's target is independent and configured by the
-        // user), so this string is only ever shown in diagnostics.
+        // pseudo-path so conflict messaging stays uniform.
         HandlerIntent::Fetch { spec, name, .. } => match spec {
             crate::external::FetchSpec::File { url, .. } => PathBuf::from(url),
             crate::external::FetchSpec::Unsupported => PathBuf::from(format!("<external:{name}>")),
@@ -201,6 +206,19 @@ mod tests {
             pack: pack.into(),
             handler: handler.into(),
             source: PathBuf::from(source),
+        }
+    }
+
+    fn fetch(pack: &str, name: &str, url: &str, user_path: &str) -> HandlerIntent {
+        HandlerIntent::Fetch {
+            pack: pack.into(),
+            handler: "external".into(),
+            name: name.into(),
+            spec: crate::external::FetchSpec::File {
+                url: url.into(),
+                sha256: "deadbeef".into(),
+            },
+            user_path: PathBuf::from(user_path),
         }
     }
 
@@ -247,6 +265,74 @@ mod tests {
         let fs = dummy_fs();
         let conflicts = detect_cross_pack_conflicts(&[], fs.as_ref());
         assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn detects_link_fetch_conflict() {
+        // Pack A symlinks ~/.config/themes via the symlink handler;
+        // pack B fetches an external to the same path. Both produce
+        // a user-visible symlink at the same target — that's a
+        // pre-flight conflict the same way two Link intents would be.
+        let fs = dummy_fs();
+        let pack_intents = vec![
+            (
+                "themes-pack-a".into(),
+                vec![link(
+                    "themes-pack-a",
+                    "/dot/themes-pack-a/themes",
+                    "/home/.config/themes",
+                )],
+            ),
+            (
+                "themes-pack-b".into(),
+                vec![fetch(
+                    "themes-pack-b",
+                    "themes",
+                    "https://example.com/themes.tar.gz",
+                    "/home/.config/themes",
+                )],
+            ),
+        ];
+        let conflicts = detect_cross_pack_conflicts(&pack_intents, fs.as_ref());
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].kind, ConflictKind::SymlinkTarget);
+        assert_eq!(conflicts[0].target, PathBuf::from("/home/.config/themes"));
+        let handlers: Vec<&str> = conflicts[0]
+            .claimants
+            .iter()
+            .map(|c| c.handler.as_str())
+            .collect();
+        assert!(handlers.contains(&"symlink"));
+        assert!(handlers.contains(&"external"));
+    }
+
+    #[test]
+    fn detects_fetch_fetch_conflict() {
+        // Two packs declaring externals with the same target.
+        let fs = dummy_fs();
+        let pack_intents = vec![
+            (
+                "a".into(),
+                vec![fetch(
+                    "a",
+                    "shared",
+                    "https://a.example.com/x",
+                    "/home/.shared",
+                )],
+            ),
+            (
+                "b".into(),
+                vec![fetch(
+                    "b",
+                    "shared",
+                    "https://b.example.com/x",
+                    "/home/.shared",
+                )],
+            ),
+        ];
+        let conflicts = detect_cross_pack_conflicts(&pack_intents, fs.as_ref());
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].target, PathBuf::from("/home/.shared"));
     }
 
     #[test]

--- a/crates/dodot-lib/src/execution/fetch.rs
+++ b/crates/dodot-lib/src/execution/fetch.rs
@@ -101,15 +101,44 @@ impl<'a> Executor<'a> {
         let sentinel = file_sentinel(name, expected_sha256);
         let op = || fetch_op(pack, handler, name, url);
 
+        // Computing the expected datastore path up-front lets the
+        // sentinel-hit branch verify the user-visible symlink is
+        // still healthy without re-fetching.
+        let filename = filename_for_target(user_path);
+        let rel = format!("{name}/{filename}");
+        let expected_datastore_path = self
+            .paths
+            .handler_data_dir(pack, handler)
+            .join(name)
+            .join(&filename);
+
         // Sentinel hit: content matching this sha256 has already been
-        // fetched and deployed. Mirror the install-handler posture and
-        // no-op silently unless --force is set.
+        // fetched. Skip the network round-trip, but make sure the
+        // user-visible symlink still exists and points at the right
+        // datastore copy — a deleted/broken link should self-repair on
+        // the next `up` even without `--force` or a sha change.
         if !self.force && self.datastore.has_sentinel(pack, handler, &sentinel)? {
-            debug!(pack, name, "external sentinel matches; skipping fetch");
-            return Ok(vec![OperationResult::ok(
-                op(),
-                format!("{name}: fresh (sha256 matches)"),
-            )]);
+            debug!(
+                pack,
+                name, "external sentinel matches; checking deployed link"
+            );
+            return self.repair_external_link(
+                pack,
+                handler,
+                name,
+                &expected_datastore_path,
+                user_path,
+                op,
+            );
+        }
+
+        // Pre-check `user_path` for a conflicting non-symlink BEFORE
+        // we fetch — mirrors `execute_link`'s posture so conflicts
+        // surface as failed OperationResults without burning a network
+        // round-trip, without partially-written state, and without
+        // aborting the whole run.
+        if let Some(conflict) = self.check_external_target_conflict(name, user_path, op) {
+            return Ok(conflict);
         }
 
         let Some(fetcher) = self.fetcher() else {
@@ -154,14 +183,14 @@ impl<'a> Executor<'a> {
         }
 
         // Persist into the datastore: `<handler_data_dir>/<name>/<filename>`.
-        let filename = filename_for_target(user_path);
-        let rel = format!("{name}/{filename}");
         let datastore_path = self
             .datastore
             .write_rendered_file(pack, handler, &rel, &bytes)?;
         debug!(pack, name, datastore = %datastore_path.display(), "wrote external to datastore");
 
-        // Symlink the user-visible target → datastore copy.
+        // Symlink the user-visible target → datastore copy. We already
+        // pre-checked for non-symlink conflicts above, so this only
+        // needs to handle "remove existing dodot symlink and re-create".
         self.create_external_user_link(&datastore_path, user_path)?;
 
         // Record sentinel so subsequent up's are no-ops.
@@ -183,31 +212,119 @@ impl<'a> Executor<'a> {
         ])
     }
 
-    /// Symlink leg of a Fetch: similar to `execute_link` but the
-    /// "source" is already in the datastore (we just wrote it), so
-    /// only the user-visible leg is needed.
-    fn create_external_user_link(&self, datastore_path: &Path, user_path: &Path) -> Result<()> {
-        if self.fs.is_symlink(user_path) {
-            // Idempotent: refresh to point at the (possibly new)
-            // datastore path. `create_user_link` already handles
-            // wrong-target replacement.
-            self.datastore.create_user_link(datastore_path, user_path)
+    /// Sentinel-hit path: confirm the deployed symlink still resolves
+    /// to the expected datastore copy. Restores the link if it's
+    /// missing or pointing somewhere stale, surfaces a conflict result
+    /// if a non-symlink occupies the target.
+    fn repair_external_link(
+        &self,
+        pack: &str,
+        handler: &str,
+        name: &str,
+        expected_datastore_path: &Path,
+        user_path: &Path,
+        op: impl Fn() -> Operation,
+    ) -> Result<Vec<OperationResult>> {
+        let needs_relink = if self.fs.is_symlink(user_path) {
+            // Existing symlink — only re-link if it points elsewhere.
+            self.fs
+                .readlink(user_path)
+                .map(|t| t != expected_datastore_path)
+                .unwrap_or(true)
         } else if self.fs.exists(user_path) {
-            if self.force {
-                if self.fs.is_dir(user_path) {
-                    self.fs.remove_dir_all(user_path)?;
-                } else {
-                    self.fs.remove_file(user_path)?;
-                }
-                self.datastore.create_user_link(datastore_path, user_path)
-            } else {
-                Err(crate::DodotError::SymlinkConflict {
-                    path: user_path.to_path_buf(),
-                })
+            // Non-symlink at the target. Without --force we have to
+            // surface the conflict the same way the fetch path does.
+            if let Some(conflict) = self.check_external_target_conflict(name, user_path, &op) {
+                return Ok(conflict);
             }
+            true
         } else {
-            self.datastore.create_user_link(datastore_path, user_path)
+            // No file there at all — restore the link.
+            true
+        };
+
+        if !needs_relink {
+            return Ok(vec![OperationResult::ok(
+                op(),
+                format!("{name}: fresh (sha256 matches)"),
+            )]);
         }
+
+        // The datastore file may have been wiped externally even
+        // though the sentinel survived. Refuse to dangle the symlink
+        // in that case — surface as a failed result so `up` re-fetches
+        // on the next run (the user can clear the sentinel manually
+        // if they want immediate repair).
+        if !self.fs.exists(expected_datastore_path) {
+            return Ok(vec![OperationResult::fail(
+                op(),
+                format!(
+                    "{name}: sentinel present but datastore copy missing at {}; run `dodot up --force` to refetch",
+                    expected_datastore_path.display()
+                ),
+            )]);
+        }
+
+        self.create_external_user_link(expected_datastore_path, user_path)?;
+        let create_link = Operation::CreateUserLink {
+            pack: pack.to_string(),
+            handler: handler.to_string(),
+            datastore_path: expected_datastore_path.to_path_buf(),
+            user_path: user_path.to_path_buf(),
+        };
+        Ok(vec![
+            OperationResult::ok(op(), format!("{name}: fresh (sha256 matches)")),
+            OperationResult::ok(
+                create_link,
+                format!("{name} → {} (repaired)", user_path.display()),
+            ),
+        ])
+    }
+
+    /// Pre-check whether `user_path` has a non-symlink occupant that
+    /// would block deploying an external. Returns `Some(results)` when
+    /// there is a conflict the caller should propagate; `None` when
+    /// it's safe to proceed.
+    fn check_external_target_conflict(
+        &self,
+        name: &str,
+        user_path: &Path,
+        op: impl Fn() -> Operation,
+    ) -> Option<Vec<OperationResult>> {
+        if self.fs.is_symlink(user_path) || !self.fs.exists(user_path) {
+            return None;
+        }
+        if self.force {
+            return None;
+        }
+        Some(vec![OperationResult::fail(
+            op(),
+            format!(
+                "{name}: conflict — {} already exists and is not a dodot symlink (use --force to overwrite)",
+                user_path.display()
+            ),
+        )])
+    }
+
+    /// Symlink leg of a Fetch: the "source" is already in the
+    /// datastore (we just wrote it), so only the user-visible leg is
+    /// needed. Non-symlink conflicts must be pre-checked via
+    /// [`Self::check_external_target_conflict`] before calling — this
+    /// helper assumes the caller has confirmed it's safe to overwrite.
+    fn create_external_user_link(&self, datastore_path: &Path, user_path: &Path) -> Result<()> {
+        if !self.fs.is_symlink(user_path) && self.fs.exists(user_path) {
+            // Caller is supposed to have pre-checked. `--force` is the
+            // only way to land here; consume the conflicting path.
+            if self.fs.is_dir(user_path) {
+                self.fs.remove_dir_all(user_path)?;
+            } else {
+                self.fs.remove_file(user_path)?;
+            }
+        }
+        // `create_user_link` is idempotent against an existing dodot
+        // symlink — replaces it if the target differs, no-ops if it
+        // already points at the right datastore path.
+        self.datastore.create_user_link(datastore_path, user_path)
     }
 
     fn write_sentinel(&self, pack: &str, handler: &str, sentinel: &str) -> Result<()> {
@@ -419,6 +536,119 @@ mod tests {
         );
         // Mock pops responses on use; only the first execute consumed it.
         assert_eq!(fetcher.calls(), vec!["https://example.com/aliases.sh"]);
+    }
+
+    #[test]
+    fn sentinel_hit_repairs_deleted_user_symlink() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://example.com/aliases.sh", known_body());
+        let user_path = env.home.join(".config/shared/aliases.sh");
+        let intent = HandlerIntent::Fetch {
+            pack: "shared".into(),
+            handler: "external".into(),
+            name: "aliases".into(),
+            spec: FetchSpec::File {
+                url: "https://example.com/aliases.sh".into(),
+                sha256: known_sha(),
+            },
+            user_path: user_path.clone(),
+        };
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        // Initial deploy: fetch + link.
+        executor.execute(vec![intent.clone()]).unwrap();
+        assert!(env.fs.is_symlink(&user_path));
+
+        // User (or a stray `rm`) deletes the deployed symlink.
+        env.fs.remove_file(&user_path).unwrap();
+        assert!(!env.fs.exists(&user_path));
+
+        // Re-running `up` with the sentinel still present must
+        // restore the symlink even though the sha hasn't changed and
+        // --force is off. The fetcher's only canned response was
+        // already consumed — so a regression here would surface as
+        // "no response configured for ...".
+        let results = executor.execute(vec![intent]).unwrap();
+        assert!(
+            results.iter().all(|r| r.success),
+            "repair should succeed: {results:#?}"
+        );
+        assert!(
+            env.fs.is_symlink(&user_path),
+            "user-visible symlink should be restored"
+        );
+        assert_eq!(
+            env.fs.read_to_string(&user_path).unwrap(),
+            "#!/bin/sh\nexport SHARED=1\n"
+        );
+        // The repair must not re-fetch from upstream.
+        assert_eq!(fetcher.calls(), vec!["https://example.com/aliases.sh"]);
+    }
+
+    #[test]
+    fn non_symlink_at_target_returns_failed_result_not_error() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://example.com/aliases.sh", known_body());
+
+        // Place a regular file at the target path before deploying.
+        let user_path = env.home.join(".config/shared/aliases.sh");
+        env.fs.mkdir_all(user_path.parent().unwrap()).unwrap();
+        env.fs
+            .write_file(&user_path, b"hand-written by the user")
+            .unwrap();
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false, // not --force
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        // Without --force, this must surface as a failed
+        // OperationResult, NOT as an Err that propagates out of
+        // execute() — same posture as execute_link's conflict path.
+        let results = executor
+            .execute(vec![HandlerIntent::Fetch {
+                pack: "shared".into(),
+                handler: "external".into(),
+                name: "aliases".into(),
+                spec: FetchSpec::File {
+                    url: "https://example.com/aliases.sh".into(),
+                    sha256: known_sha(),
+                },
+                user_path: user_path.clone(),
+            }])
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(
+            results[0].message.contains("conflict"),
+            "msg: {}",
+            results[0].message
+        );
+        // Original file untouched.
+        assert_eq!(
+            env.fs.read_to_string(&user_path).unwrap(),
+            "hand-written by the user"
+        );
+        // No fetch happened (we pre-checked the conflict).
+        assert!(fetcher.calls().is_empty());
     }
 
     #[test]

--- a/crates/dodot-lib/src/execution/fetch.rs
+++ b/crates/dodot-lib/src/execution/fetch.rs
@@ -1,0 +1,589 @@
+//! `Fetch` intent: pull an external resource into the datastore and
+//! create the user-visible symlink that exposes it.
+//!
+//! Sentinel posture mirrors the install handler: the entry's content
+//! signature (for `file`, the configured sha256) is the sentinel
+//! payload. Re-running `up` with the same sha256 is a no-op. Bumping
+//! the sha256 in `externals.toml` invalidates the old sentinel, so the
+//! file is re-fetched and re-verified.
+//!
+//! Failure posture:
+//! - **Integrity failure** (sha256 mismatch) is fatal — we refuse to
+//!   write tampered content into the datastore.
+//! - **Network failure** is soft — if a cached copy is present we leave
+//!   it in place and report the failure as a non-success result; other
+//!   intents still execute.
+
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+use tracing::{debug, info, warn};
+
+use crate::external::FetchSpec;
+use crate::operations::{HandlerIntent, Operation, OperationResult};
+use crate::Result;
+
+use super::Executor;
+
+impl<'a> Executor<'a> {
+    pub(super) fn execute_fetch(&self, intent: &HandlerIntent) -> Result<Vec<OperationResult>> {
+        let HandlerIntent::Fetch {
+            pack,
+            handler,
+            name,
+            spec,
+            user_path,
+        } = intent
+        else {
+            unreachable!("execute_fetch called with non-Fetch intent");
+        };
+
+        match spec {
+            FetchSpec::File { url, sha256 } => {
+                self.execute_fetch_file(pack, handler, name, url, sha256, user_path)
+            }
+            FetchSpec::Unsupported => Ok(vec![OperationResult::fail(
+                fetch_op(pack, handler, name, "<unsupported>"),
+                format!(
+                    "external '{name}': unsupported type — only `type = \"file\"` is implemented in this release"
+                ),
+            )]),
+        }
+    }
+
+    pub(super) fn simulate_fetch(&self, intent: &HandlerIntent) -> Vec<OperationResult> {
+        let HandlerIntent::Fetch {
+            pack,
+            handler,
+            name,
+            spec,
+            user_path,
+        } = intent
+        else {
+            unreachable!("simulate_fetch called with non-Fetch intent");
+        };
+
+        match spec {
+            FetchSpec::File { url, sha256 } => {
+                let sentinel = file_sentinel(name, sha256);
+                let already = self
+                    .datastore
+                    .has_sentinel(pack, handler, &sentinel)
+                    .unwrap_or(false);
+                let msg = if already {
+                    format!("[dry-run] {name} fresh (sha256 matches)")
+                } else {
+                    format!(
+                        "[dry-run] would fetch {url} → {} (verify sha256={})",
+                        user_path.display(),
+                        short(sha256)
+                    )
+                };
+                vec![OperationResult::ok(fetch_op(pack, handler, name, url), msg)]
+            }
+            FetchSpec::Unsupported => vec![OperationResult::fail(
+                fetch_op(pack, handler, name, "<unsupported>"),
+                format!("[dry-run] external '{name}': unsupported type"),
+            )],
+        }
+    }
+
+    /// Fetch one `type = "file"` external.
+    fn execute_fetch_file(
+        &self,
+        pack: &str,
+        handler: &str,
+        name: &str,
+        url: &str,
+        expected_sha256: &str,
+        user_path: &Path,
+    ) -> Result<Vec<OperationResult>> {
+        let sentinel = file_sentinel(name, expected_sha256);
+        let op = || fetch_op(pack, handler, name, url);
+
+        // Sentinel hit: content matching this sha256 has already been
+        // fetched and deployed. Mirror the install-handler posture and
+        // no-op silently unless --force is set.
+        if !self.force && self.datastore.has_sentinel(pack, handler, &sentinel)? {
+            debug!(pack, name, "external sentinel matches; skipping fetch");
+            return Ok(vec![OperationResult::ok(
+                op(),
+                format!("{name}: fresh (sha256 matches)"),
+            )]);
+        }
+
+        let Some(fetcher) = self.fetcher() else {
+            return Ok(vec![OperationResult::fail(
+                op(),
+                format!(
+                    "external '{name}': executor has no HTTP fetcher configured; call Executor::with_fetcher() in production wiring"
+                ),
+            )]);
+        };
+
+        info!(pack, name, url, "fetching external");
+        let bytes = match fetcher.fetch(url) {
+            Ok(b) => b,
+            Err(err) if err.is_transient() => {
+                // Soft-fail: keep any previously fetched copy and
+                // surface a non-success result.
+                warn!(pack, name, %err, "external fetch failed (transient)");
+                return Ok(vec![OperationResult::fail(
+                    op(),
+                    format!("{name}: fetch failed ({err}); leaving cached copy in place"),
+                )]);
+            }
+            Err(err) => {
+                return Ok(vec![OperationResult::fail(
+                    op(),
+                    format!("{name}: fetch failed: {err}"),
+                )]);
+            }
+        };
+
+        let actual = sha256_hex(&bytes);
+        if !sha256_matches(expected_sha256, &actual) {
+            return Ok(vec![OperationResult::fail(
+                op(),
+                format!(
+                    "{name}: sha256 mismatch (configured {}, actual {}); refusing to write",
+                    short(expected_sha256),
+                    short(&actual)
+                ),
+            )]);
+        }
+
+        // Persist into the datastore: `<handler_data_dir>/<name>/<filename>`.
+        let filename = filename_for_target(user_path);
+        let rel = format!("{name}/{filename}");
+        let datastore_path = self
+            .datastore
+            .write_rendered_file(pack, handler, &rel, &bytes)?;
+        debug!(pack, name, datastore = %datastore_path.display(), "wrote external to datastore");
+
+        // Symlink the user-visible target → datastore copy.
+        self.create_external_user_link(&datastore_path, user_path)?;
+
+        // Record sentinel so subsequent up's are no-ops.
+        self.write_sentinel(pack, handler, &sentinel)?;
+
+        let create_link = Operation::CreateUserLink {
+            pack: pack.to_string(),
+            handler: handler.to_string(),
+            datastore_path: datastore_path.clone(),
+            user_path: user_path.to_path_buf(),
+        };
+
+        Ok(vec![
+            OperationResult::ok(
+                op(),
+                format!("{name}: fetched {} bytes from {url}", bytes.len()),
+            ),
+            OperationResult::ok(create_link, format!("{name} → {}", user_path.display())),
+        ])
+    }
+
+    /// Symlink leg of a Fetch: similar to `execute_link` but the
+    /// "source" is already in the datastore (we just wrote it), so
+    /// only the user-visible leg is needed.
+    fn create_external_user_link(&self, datastore_path: &Path, user_path: &Path) -> Result<()> {
+        if self.fs.is_symlink(user_path) {
+            // Idempotent: refresh to point at the (possibly new)
+            // datastore path. `create_user_link` already handles
+            // wrong-target replacement.
+            self.datastore.create_user_link(datastore_path, user_path)
+        } else if self.fs.exists(user_path) {
+            if self.force {
+                if self.fs.is_dir(user_path) {
+                    self.fs.remove_dir_all(user_path)?;
+                } else {
+                    self.fs.remove_file(user_path)?;
+                }
+                self.datastore.create_user_link(datastore_path, user_path)
+            } else {
+                Err(crate::DodotError::SymlinkConflict {
+                    path: user_path.to_path_buf(),
+                })
+            }
+        } else {
+            self.datastore.create_user_link(datastore_path, user_path)
+        }
+    }
+
+    fn write_sentinel(&self, pack: &str, handler: &str, sentinel: &str) -> Result<()> {
+        // Sentinels live alongside other handler state. The
+        // `write_rendered_file` path conveniently creates parent dirs
+        // and accepts arbitrary content.
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let content = format!("completed|{timestamp}");
+        self.datastore
+            .write_rendered_file(pack, handler, sentinel, content.as_bytes())?;
+        Ok(())
+    }
+}
+
+/// Build the sentinel filename for a `type = "file"` entry.
+fn file_sentinel(name: &str, sha256: &str) -> String {
+    format!("{name}-{}", short(sha256))
+}
+
+/// Derive the on-disk filename inside the datastore subdir from the
+/// target path. Falls back to "content" when the target ends in `/`.
+fn filename_for_target(target: &Path) -> String {
+    target
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "content".into())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    let digest = h.finalize();
+    digest.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Constant-time-ish hex compare: case-insensitive, but the timing
+/// difference doesn't matter for a content-addressed sentinel that
+/// the user already declared in their checked-in TOML.
+fn sha256_matches(expected: &str, actual_hex: &str) -> bool {
+    expected.eq_ignore_ascii_case(actual_hex)
+}
+
+/// First 16 hex chars of a sha256 — used for sentinel filenames so
+/// the datastore directory listing stays readable. Cryptographically
+/// the full 256 bits live in the user's TOML; the sentinel just keys
+/// off the prefix.
+fn short(sha: &str) -> String {
+    sha.chars().take(16).collect()
+}
+
+fn fetch_op(pack: &str, handler: &str, name: &str, url: &str) -> Operation {
+    Operation::FetchExternal {
+        pack: pack.to_string(),
+        handler: handler.to_string(),
+        name: name.to_string(),
+        url: url.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::make_datastore;
+    use super::super::Executor;
+    use crate::external::{FetchSpec, HttpFetchError, HttpFetcher};
+    use crate::fs::Fs;
+    use crate::operations::HandlerIntent;
+    use crate::testing::TempEnvironment;
+    use std::sync::Mutex;
+
+    /// Mock fetcher returning pre-canned bodies per URL.
+    struct MockFetcher {
+        responses:
+            Mutex<std::collections::HashMap<String, std::result::Result<Vec<u8>, HttpFetchError>>>,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl MockFetcher {
+        fn new() -> Self {
+            Self {
+                responses: Mutex::new(Default::default()),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn with(self, url: &str, body: &[u8]) -> Self {
+            self.responses
+                .lock()
+                .unwrap()
+                .insert(url.into(), Ok(body.to_vec()));
+            self
+        }
+
+        fn with_error(self, url: &str, err: HttpFetchError) -> Self {
+            self.responses.lock().unwrap().insert(url.into(), Err(err));
+            self
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl HttpFetcher for MockFetcher {
+        fn fetch(&self, url: &str) -> std::result::Result<Vec<u8>, HttpFetchError> {
+            self.calls.lock().unwrap().push(url.into());
+            match self.responses.lock().unwrap().remove(url) {
+                Some(r) => r,
+                None => Err(HttpFetchError::InvalidUrl(format!(
+                    "mock: no response configured for {url}"
+                ))),
+            }
+        }
+    }
+
+    fn known_body() -> &'static [u8] {
+        b"#!/bin/sh\nexport SHARED=1\n"
+    }
+
+    fn known_sha() -> String {
+        super::sha256_hex(known_body())
+    }
+
+    #[test]
+    fn execute_fetch_writes_datastore_and_symlinks() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://example.com/aliases.sh", known_body());
+
+        let user_path = env.home.join(".config/shared/aliases.sh");
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        let results = executor
+            .execute(vec![HandlerIntent::Fetch {
+                pack: "shared".into(),
+                handler: "external".into(),
+                name: "aliases".into(),
+                spec: FetchSpec::File {
+                    url: "https://example.com/aliases.sh".into(),
+                    sha256: known_sha(),
+                },
+                user_path: user_path.clone(),
+            }])
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.success), "{results:#?}");
+        assert_eq!(fetcher.calls(), vec!["https://example.com/aliases.sh"]);
+
+        // The user-visible link exists and resolves to the bytes we fed in.
+        assert!(env.fs.is_symlink(&user_path));
+        let content = env.fs.read_to_string(&user_path).unwrap();
+        assert_eq!(content.as_bytes(), known_body());
+
+        // Sentinel was recorded.
+        let sentinel = super::file_sentinel("aliases", &known_sha());
+        env.assert_sentinel("shared", "external", &sentinel);
+    }
+
+    #[test]
+    fn execute_fetch_is_idempotent_via_sentinel() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://example.com/aliases.sh", known_body());
+
+        let user_path = env.home.join(".config/shared/aliases.sh");
+        let intent = HandlerIntent::Fetch {
+            pack: "shared".into(),
+            handler: "external".into(),
+            name: "aliases".into(),
+            spec: FetchSpec::File {
+                url: "https://example.com/aliases.sh".into(),
+                sha256: known_sha(),
+            },
+            user_path: user_path.clone(),
+        };
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+        let _ = executor.execute(vec![intent.clone()]).unwrap();
+
+        // Second run: no calls because sentinel matches.
+        let results = executor.execute(vec![intent]).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert!(
+            results[0].message.contains("fresh"),
+            "msg: {}",
+            results[0].message
+        );
+        // Mock pops responses on use; only the first execute consumed it.
+        assert_eq!(fetcher.calls(), vec!["https://example.com/aliases.sh"]);
+    }
+
+    #[test]
+    fn execute_fetch_rejects_sha256_mismatch() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://example.com/aliases.sh", b"tampered");
+
+        let user_path = env.home.join(".config/shared/aliases.sh");
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        let results = executor
+            .execute(vec![HandlerIntent::Fetch {
+                pack: "shared".into(),
+                handler: "external".into(),
+                name: "aliases".into(),
+                spec: FetchSpec::File {
+                    url: "https://example.com/aliases.sh".into(),
+                    sha256: known_sha(),
+                },
+                user_path: user_path.clone(),
+            }])
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(
+            results[0].message.contains("sha256 mismatch"),
+            "msg: {}",
+            results[0].message
+        );
+        // Nothing was written.
+        assert!(!env.fs.exists(&user_path));
+        env.assert_no_handler_state("shared", "external");
+    }
+
+    #[test]
+    fn transient_network_failure_is_non_fatal() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with_error(
+            "https://example.com/aliases.sh",
+            HttpFetchError::Network {
+                url: "https://example.com/aliases.sh".into(),
+                source: "simulated".into(),
+            },
+        );
+
+        let user_path = env.home.join(".config/shared/aliases.sh");
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        let results = executor
+            .execute(vec![HandlerIntent::Fetch {
+                pack: "shared".into(),
+                handler: "external".into(),
+                name: "aliases".into(),
+                spec: FetchSpec::File {
+                    url: "https://example.com/aliases.sh".into(),
+                    sha256: known_sha(),
+                },
+                user_path: user_path.clone(),
+            }])
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(
+            results[0].message.contains("fetch failed"),
+            "msg: {}",
+            results[0].message
+        );
+    }
+
+    #[test]
+    fn unsupported_type_fails_cleanly() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        );
+
+        let results = executor
+            .execute(vec![HandlerIntent::Fetch {
+                pack: "shared".into(),
+                handler: "external".into(),
+                name: "omz".into(),
+                spec: FetchSpec::Unsupported,
+                user_path: env.home.join(".oh-my-zsh"),
+            }])
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(
+            results[0].message.contains("unsupported type"),
+            "msg: {}",
+            results[0].message
+        );
+    }
+
+    #[test]
+    fn dry_run_does_not_fetch() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://example.com/aliases.sh", known_body());
+
+        let user_path = env.home.join(".config/shared/aliases.sh");
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            true,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        let results = executor
+            .execute(vec![HandlerIntent::Fetch {
+                pack: "shared".into(),
+                handler: "external".into(),
+                name: "aliases".into(),
+                spec: FetchSpec::File {
+                    url: "https://example.com/aliases.sh".into(),
+                    sha256: known_sha(),
+                },
+                user_path: user_path.clone(),
+            }])
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert!(
+            results[0].message.contains("[dry-run]"),
+            "msg: {}",
+            results[0].message
+        );
+        // No fetch call, no symlink, no sentinel.
+        assert!(fetcher.calls().is_empty());
+        assert!(!env.fs.exists(&user_path));
+        env.assert_no_handler_state("shared", "external");
+    }
+}

--- a/crates/dodot-lib/src/execution/mod.rs
+++ b/crates/dodot-lib/src/execution/mod.rs
@@ -23,6 +23,7 @@
 //! `$PATH`, it just won't be directly runnable until the user fixes
 //! permissions manually.
 
+mod fetch;
 mod link;
 mod run;
 mod stage;
@@ -30,6 +31,7 @@ mod stage;
 use tracing::debug;
 
 use crate::datastore::DataStore;
+use crate::external::HttpFetcher;
 use crate::fs::Fs;
 use crate::operations::{HandlerIntent, OperationResult};
 use crate::paths::Pather;
@@ -44,6 +46,12 @@ pub struct Executor<'a> {
     force: bool,
     provision_rerun: bool,
     auto_chmod_exec: bool,
+    /// HTTP-ish fetcher used for `HandlerIntent::Fetch`. Optional so
+    /// the 20+ test sites that don't exercise externals can keep
+    /// constructing `Executor::new(...)` unchanged; the fetch
+    /// dispatcher errors loudly if it sees a Fetch intent without
+    /// one. Production wiring sets this via [`Self::with_fetcher`].
+    fetcher: Option<&'a dyn HttpFetcher>,
 }
 
 impl<'a> Executor<'a> {
@@ -64,7 +72,19 @@ impl<'a> Executor<'a> {
             force,
             provision_rerun,
             auto_chmod_exec,
+            fetcher: None,
         }
+    }
+
+    /// Builder-style: install the HTTP fetcher used by Fetch intents.
+    pub fn with_fetcher(mut self, fetcher: &'a dyn HttpFetcher) -> Self {
+        self.fetcher = Some(fetcher);
+        self
+    }
+
+    /// Accessor for the fetch dispatcher.
+    pub(super) fn fetcher(&self) -> Option<&'a dyn HttpFetcher> {
+        self.fetcher
     }
 
     /// Execute a list of handler intents, returning one result per
@@ -106,6 +126,7 @@ impl<'a> Executor<'a> {
             HandlerIntent::Link { .. } => self.execute_link(intent),
             HandlerIntent::Stage { .. } => self.execute_stage(intent),
             HandlerIntent::Run { .. } => self.execute_run(intent),
+            HandlerIntent::Fetch { .. } => self.execute_fetch(intent),
         }
     }
 
@@ -115,6 +136,7 @@ impl<'a> Executor<'a> {
             HandlerIntent::Link { .. } => self.simulate_link(intent),
             HandlerIntent::Stage { .. } => self.simulate_stage(intent),
             HandlerIntent::Run { .. } => self.simulate_run(intent),
+            HandlerIntent::Fetch { .. } => self.simulate_fetch(intent),
         }
     }
 }

--- a/crates/dodot-lib/src/external/fetch.rs
+++ b/crates/dodot-lib/src/external/fetch.rs
@@ -1,0 +1,130 @@
+//! HTTP-fetcher abstraction for externals.
+//!
+//! The trait exists so tests don't have to spin up a real HTTP server.
+//! Production uses [`UreqFetcher`] (which also handles `file://` URLs
+//! so tests can point at fixture files directly).
+
+use std::fs;
+use std::io::Read;
+
+/// Error category returned by a fetcher.
+///
+/// The executor distinguishes these so soft network failures don't
+/// kill the whole `up` invocation — only integrity failures do.
+#[derive(Debug, thiserror::Error)]
+pub enum HttpFetchError {
+    /// Bad URL (parse error, unsupported scheme).
+    #[error("invalid URL: {0}")]
+    InvalidUrl(String),
+    /// Network reachable but server returned non-2xx.
+    #[error("HTTP {status}: {url}")]
+    Status { url: String, status: u16 },
+    /// Network unreachable / DNS / timeout / I/O.
+    #[error("network error fetching {url}: {source}")]
+    Network {
+        url: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+impl HttpFetchError {
+    /// Was this a transient failure that should soft-fail (use
+    /// cached content if any) rather than abort `up`?
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Network { .. })
+    }
+}
+
+pub trait HttpFetcher: Send + Sync {
+    /// Fetch the entire body at `url` into memory.
+    fn fetch(&self, url: &str) -> std::result::Result<Vec<u8>, HttpFetchError>;
+}
+
+/// Default fetcher: ureq for http(s), direct fs read for `file://`.
+///
+/// `file://` support exists so the test suite can drive the executor
+/// end-to-end without standing up an HTTP server; it's also useful for
+/// users who want to pull from a local mirror.
+pub struct UreqFetcher;
+
+impl UreqFetcher {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for UreqFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HttpFetcher for UreqFetcher {
+    fn fetch(&self, url: &str) -> std::result::Result<Vec<u8>, HttpFetchError> {
+        if let Some(rest) = url.strip_prefix("file://") {
+            // ureq doesn't speak file://. Strip and read directly.
+            return fs::read(rest).map_err(|e| HttpFetchError::Network {
+                url: url.to_string(),
+                source: Box::new(e),
+            });
+        }
+
+        if !(url.starts_with("http://") || url.starts_with("https://")) {
+            return Err(HttpFetchError::InvalidUrl(format!(
+                "unsupported URL scheme: {url}"
+            )));
+        }
+
+        match ureq::get(url).call() {
+            Ok(resp) => {
+                let mut reader = resp.into_reader();
+                let mut bytes = Vec::new();
+                reader
+                    .read_to_end(&mut bytes)
+                    .map_err(|e| HttpFetchError::Network {
+                        url: url.to_string(),
+                        source: Box::new(e),
+                    })?;
+                Ok(bytes)
+            }
+            Err(ureq::Error::Status(code, _)) => Err(HttpFetchError::Status {
+                url: url.to_string(),
+                status: code,
+            }),
+            Err(e) => Err(HttpFetchError::Network {
+                url: url.to_string(),
+                source: Box::new(e),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn file_url_reads_local_file() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"hello externals").unwrap();
+        let url = format!("file://{}", f.path().display());
+        let bytes = UreqFetcher::new().fetch(&url).unwrap();
+        assert_eq!(bytes, b"hello externals");
+    }
+
+    #[test]
+    fn missing_file_url_is_network_error() {
+        let url = "file:///definitely/not/a/real/path/external.bin";
+        let err = UreqFetcher::new().fetch(url).unwrap_err();
+        assert!(err.is_transient(), "should be transient: {err:?}");
+    }
+
+    #[test]
+    fn rejects_unknown_scheme() {
+        let err = UreqFetcher::new().fetch("ftp://example.com/x").unwrap_err();
+        assert!(matches!(err, HttpFetchError::InvalidUrl(_)));
+    }
+}

--- a/crates/dodot-lib/src/external/fetch.rs
+++ b/crates/dodot-lib/src/external/fetch.rs
@@ -46,11 +46,32 @@ pub trait HttpFetcher: Send + Sync {
 /// `file://` support exists so the test suite can drive the executor
 /// end-to-end without standing up an HTTP server; it's also useful for
 /// users who want to pull from a local mirror.
-pub struct UreqFetcher;
+///
+/// Timeouts: the underlying agent is configured with explicit
+/// connect / read / overall-call deadlines so a stalled remote can't
+/// hang `dodot up` indefinitely. On a plane or behind a dead
+/// captive-portal these fail predictably and the executor's
+/// soft-fail path takes over (cached content stays in place).
+pub struct UreqFetcher {
+    agent: ureq::Agent,
+}
 
 impl UreqFetcher {
     pub fn new() -> Self {
-        Self
+        // Picked to favour failing-fast over edge cases:
+        // - 5 s to open a TCP/TLS connection (DNS + handshake).
+        // - 20 s on a single read (servers that dribble bytes).
+        // - 60 s total wall-clock cap on the whole call (last-resort).
+        // Externals are typically small files / small clones, so
+        // these aren't tight enough to bite real-world fetches but
+        // they're tight enough to keep `up` snappy when the network
+        // is unreachable.
+        let agent = ureq::AgentBuilder::new()
+            .timeout_connect(std::time::Duration::from_secs(5))
+            .timeout_read(std::time::Duration::from_secs(20))
+            .timeout(std::time::Duration::from_secs(60))
+            .build();
+        Self { agent }
     }
 }
 
@@ -76,7 +97,7 @@ impl HttpFetcher for UreqFetcher {
             )));
         }
 
-        match ureq::get(url).call() {
+        match self.agent.get(url).call() {
             Ok(resp) => {
                 let mut reader = resp.into_reader();
                 let mut bytes = Vec::new();

--- a/crates/dodot-lib/src/external/mod.rs
+++ b/crates/dodot-lib/src/external/mod.rs
@@ -1,0 +1,26 @@
+//! External-resource fetching.
+//!
+//! A pack opts into externally-sourced content by placing an
+//! `externals.toml` at its root. Each `[entry]` block declares a single
+//! resource (a remote file today, a git repo in a later PR) and the
+//! target path under `$HOME` where it should appear.
+//!
+//! ```toml
+//! [shared-aliases]
+//! type = "file"
+//! url = "https://example.com/aliases.sh"
+//! target = "~/.config/shared/aliases.sh"
+//! sha256 = "abc123..."
+//! ```
+//!
+//! This module owns the spec types ([`ExternalsToml`], [`FetchSpec`])
+//! and the [`HttpFetcher`] abstraction. The handler in
+//! `crate::handlers::externals` consumes specs to produce intents; the
+//! executor consumes intents and calls a `HttpFetcher` to do the
+//! actual network work.
+
+mod fetch;
+mod spec;
+
+pub use fetch::{HttpFetchError, HttpFetcher, UreqFetcher};
+pub use spec::{parse_externals_toml, ExternalEntry, ExternalsToml, FetchSpec};

--- a/crates/dodot-lib/src/external/spec.rs
+++ b/crates/dodot-lib/src/external/spec.rs
@@ -15,9 +15,13 @@
 //! sha256 = "..."
 //! ```
 //!
-//! For PR 1 only `type = "file"` is implemented; the other variants
-//! parse as [`FetchSpec::Unsupported`] with the requested type
-//! preserved so the handler can emit a clean diagnostic.
+//! For PR 1 only `type = "file"` is implemented; any other `type`
+//! value parses to [`FetchSpec::Unsupported`]. The original type
+//! string is not retained — `#[serde(other)]` does not carry it over
+//! — so the handler's diagnostic surfaces the entry name and a
+//! generic "unsupported type" message rather than echoing back
+//! what the user wrote. Subsequent PRs add the real variants
+//! (`git-repo`, `archive`, `archive-file`).
 
 use std::collections::BTreeMap;
 
@@ -75,12 +79,52 @@ pub enum FetchSpec {
 ///
 /// Returns a `DodotError::Other` on malformed TOML; callers attach the
 /// pack name for context.
+///
+/// Entry names are validated against a safe-identifier charset because
+/// they are used verbatim as datastore subdirectory names and sentinel
+/// filenames — letting `..` or `/` through here would create
+/// surprising nested layouts and confusing sentinel matches.
 pub fn parse_externals_toml(bytes: &[u8]) -> Result<ExternalsToml> {
     let text = std::str::from_utf8(bytes)
         .map_err(|e| DodotError::Other(format!("externals.toml is not valid UTF-8: {e}")))?;
     let parsed: BTreeMap<String, ExternalEntry> = toml::from_str(text)
         .map_err(|e| DodotError::Other(format!("externals.toml parse error: {e}")))?;
+    for name in parsed.keys() {
+        validate_entry_name(name)?;
+    }
     Ok(ExternalsToml { entries: parsed })
+}
+
+/// Reject entry names that wouldn't be safe as path or sentinel
+/// components. Allowed: ASCII letters/digits, plus `-`, `_`, and
+/// internal `.` (but not pure `.` or `..`). Everything else — including
+/// `/`, `\`, spaces, leading dot, control characters — is a hard error.
+fn validate_entry_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(DodotError::Other(
+            "externals.toml entry name must not be empty".into(),
+        ));
+    }
+    if name == "." || name == ".." {
+        return Err(DodotError::Other(format!(
+            "externals.toml entry name {name:?} is reserved"
+        )));
+    }
+    if name.starts_with('.') {
+        return Err(DodotError::Other(format!(
+            "externals.toml entry name {name:?} must not start with a dot"
+        )));
+    }
+    for ch in name.chars() {
+        let ok = ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.');
+        if !ok {
+            return Err(DodotError::Other(format!(
+                "externals.toml entry name {name:?} contains invalid character {ch:?}; \
+                 allowed: ASCII letters, digits, `-`, `_`, `.`"
+            )));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -127,6 +171,61 @@ mod tests {
         let parsed = parse_externals_toml(toml.as_bytes()).unwrap();
         let names: Vec<&str> = parsed.entries.keys().map(String::as_str).collect();
         assert_eq!(names, vec!["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn rejects_entry_names_with_path_separator() {
+        let toml = r#"
+            ["bad/name"]
+            type   = "file"
+            url    = "https://example.com/x"
+            target = "~/x"
+            sha256 = "00"
+        "#;
+        let err = parse_externals_toml(toml.as_bytes()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("invalid character"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_dotdot_entry_name() {
+        let toml = r#"
+            [".."]
+            type   = "file"
+            url    = "https://example.com/x"
+            target = "~/x"
+            sha256 = "00"
+        "#;
+        let err = parse_externals_toml(toml.as_bytes()).unwrap_err();
+        assert!(format!("{err}").contains("reserved"));
+    }
+
+    #[test]
+    fn rejects_dot_prefixed_entry_name() {
+        let toml = r#"
+            [".hidden"]
+            type   = "file"
+            url    = "https://example.com/x"
+            target = "~/x"
+            sha256 = "00"
+        "#;
+        let err = parse_externals_toml(toml.as_bytes()).unwrap_err();
+        assert!(format!("{err}").contains("must not start with a dot"));
+    }
+
+    #[test]
+    fn accepts_internal_dots_dashes_underscores() {
+        // TOML treats bare `[a.b]` as nested tables, so use a quoted
+        // section header to land a literal dot in the key.
+        let toml = r#"
+            ["shared.aliases-v2_main"]
+            type   = "file"
+            url    = "https://example.com/x"
+            target = "~/x"
+            sha256 = "00"
+        "#;
+        let parsed = parse_externals_toml(toml.as_bytes()).unwrap();
+        assert!(parsed.entries.contains_key("shared.aliases-v2_main"));
     }
 
     #[test]

--- a/crates/dodot-lib/src/external/spec.rs
+++ b/crates/dodot-lib/src/external/spec.rs
@@ -1,0 +1,169 @@
+//! `externals.toml` schema and parser.
+//!
+//! The pack-level file is a flat map of entry-name → spec:
+//!
+//! ```toml
+//! [oh-my-zsh]            # entry name = section header
+//! type = "git-repo"
+//! url  = "..."
+//! target = "~/.oh-my-zsh"
+//!
+//! [shared-aliases]
+//! type = "file"
+//! url  = "..."
+//! target = "~/.config/shared/aliases.sh"
+//! sha256 = "..."
+//! ```
+//!
+//! For PR 1 only `type = "file"` is implemented; the other variants
+//! parse as [`FetchSpec::Unsupported`] with the requested type
+//! preserved so the handler can emit a clean diagnostic.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{DodotError, Result};
+
+/// The whole `externals.toml` file: an ordered map of entry name → entry.
+///
+/// We use `BTreeMap` so iteration order is stable (alphabetical by
+/// entry name) — handlers must produce deterministic intents to keep
+/// `dodot status` / `up` output reproducible across runs.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ExternalsToml {
+    pub entries: BTreeMap<String, ExternalEntry>,
+}
+
+/// A single entry in `externals.toml`. The `type` field discriminates
+/// the spec variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalEntry {
+    /// User-visible target path. Tilde-prefixed paths (`~/…`) are
+    /// resolved by the handler against the pather's home dir.
+    pub target: String,
+
+    #[serde(flatten)]
+    pub spec: FetchSpec,
+}
+
+/// The fetch recipe for one external entry.
+///
+/// Tagged externally by the `type` field per TOML convention. Future
+/// PRs add `git-repo`, `archive`, `archive-file` variants — until they
+/// land, those parse into [`FetchSpec::Unsupported`] so the handler
+/// can surface "not yet implemented" without choking the whole pack.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum FetchSpec {
+    /// A single file fetched over HTTP(S) — or `file://` for tests.
+    File {
+        url: String,
+        /// Required content hash. Mandatory because an unpinned remote
+        /// file has no integrity story at all; refusing to fetch
+        /// without one is the same posture Home Manager takes.
+        sha256: String,
+    },
+
+    /// Catchall for type values dodot doesn't implement yet.
+    #[serde(other)]
+    Unsupported,
+}
+
+/// Parse the bytes of an `externals.toml` file.
+///
+/// Returns a `DodotError::Other` on malformed TOML; callers attach the
+/// pack name for context.
+pub fn parse_externals_toml(bytes: &[u8]) -> Result<ExternalsToml> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|e| DodotError::Other(format!("externals.toml is not valid UTF-8: {e}")))?;
+    let parsed: BTreeMap<String, ExternalEntry> = toml::from_str(text)
+        .map_err(|e| DodotError::Other(format!("externals.toml parse error: {e}")))?;
+    Ok(ExternalsToml { entries: parsed })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_file_entry() {
+        let toml = r#"
+            [aliases]
+            type   = "file"
+            url    = "https://example.com/aliases.sh"
+            target = "~/.config/shared/aliases.sh"
+            sha256 = "deadbeef"
+        "#;
+        let parsed = parse_externals_toml(toml.as_bytes()).unwrap();
+        assert_eq!(parsed.entries.len(), 1);
+        let entry = parsed.entries.get("aliases").unwrap();
+        assert_eq!(entry.target, "~/.config/shared/aliases.sh");
+        match &entry.spec {
+            FetchSpec::File { url, sha256 } => {
+                assert_eq!(url, "https://example.com/aliases.sh");
+                assert_eq!(sha256, "deadbeef");
+            }
+            other => panic!("expected File spec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn entries_are_alphabetical() {
+        let toml = r#"
+            [zeta]
+            type = "file"
+            url = "https://example.com/z"
+            target = "~/z"
+            sha256 = "00"
+
+            [alpha]
+            type = "file"
+            url = "https://example.com/a"
+            target = "~/a"
+            sha256 = "11"
+        "#;
+        let parsed = parse_externals_toml(toml.as_bytes()).unwrap();
+        let names: Vec<&str> = parsed.entries.keys().map(String::as_str).collect();
+        assert_eq!(names, vec!["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn unknown_type_becomes_unsupported() {
+        let toml = r#"
+            [omz]
+            type = "git-repo"
+            url = "https://github.com/ohmyzsh/ohmyzsh.git"
+            target = "~/.oh-my-zsh"
+        "#;
+        let parsed = parse_externals_toml(toml.as_bytes()).unwrap();
+        let entry = parsed.entries.get("omz").unwrap();
+        assert!(matches!(entry.spec, FetchSpec::Unsupported));
+    }
+
+    #[test]
+    fn rejects_malformed_toml() {
+        let err = parse_externals_toml(b"this is not = valid [[ toml").unwrap_err();
+        assert!(format!("{err}").contains("externals.toml parse error"));
+    }
+
+    #[test]
+    fn rejects_invalid_utf8() {
+        let err = parse_externals_toml(&[0xff, 0xfe, 0xfd]).unwrap_err();
+        assert!(format!("{err}").contains("not valid UTF-8"));
+    }
+
+    #[test]
+    fn missing_sha256_on_file_is_an_error() {
+        // sha256 is mandatory; serde should reject the missing field.
+        let toml = r#"
+            [unpinned]
+            type = "file"
+            url = "https://example.com/x.sh"
+            target = "~/x.sh"
+        "#;
+        let err = parse_externals_toml(toml.as_bytes()).unwrap_err();
+        assert!(format!("{err}").contains("parse error"));
+    }
+}

--- a/crates/dodot-lib/src/handlers/externals.rs
+++ b/crates/dodot-lib/src/handlers/externals.rs
@@ -1,0 +1,288 @@
+//! Externals handler — declarative remote-resource deployment.
+//!
+//! The trigger file is `externals.toml` at the pack root. Each section
+//! declares one external resource (currently `type = "file"`; the
+//! git-repo and archive variants land in later PRs). The handler parses
+//! the file and emits one [`HandlerIntent::Fetch`] per entry.
+//!
+//! The handler itself is read-only — fetching, hashing, and symlink
+//! creation all happen in `crate::execution::fetch`. This mirrors the
+//! existing handler/executor split: planning is idempotent and safe to
+//! re-run; I/O lives in the executor.
+
+use std::path::{Path, PathBuf};
+
+use crate::datastore::DataStore;
+use crate::fs::Fs;
+use crate::handlers::{
+    ExecutionPhase, Handler, HandlerConfig, HandlerStatus, MatchMode, HANDLER_EXTERNAL,
+};
+use crate::operations::HandlerIntent;
+use crate::paths::Pather;
+use crate::rules::RuleMatch;
+use crate::Result;
+
+/// Filename the handler matches against. Exposed so config / rules can
+/// be derived from one source of truth.
+pub const EXTERNALS_TOML: &str = "externals.toml";
+
+pub struct ExternalsHandler;
+
+impl Handler for ExternalsHandler {
+    fn name(&self) -> &str {
+        HANDLER_EXTERNAL
+    }
+
+    fn phase(&self) -> ExecutionPhase {
+        ExecutionPhase::External
+    }
+
+    fn match_mode(&self) -> MatchMode {
+        MatchMode::Precise
+    }
+
+    fn to_intents(
+        &self,
+        matches: &[RuleMatch],
+        _config: &HandlerConfig,
+        paths: &dyn Pather,
+        fs: &dyn Fs,
+    ) -> Result<Vec<HandlerIntent>> {
+        let mut intents = Vec::new();
+        for m in matches {
+            if m.is_dir {
+                continue;
+            }
+            let bytes = match m.rendered_bytes.as_deref() {
+                Some(b) => b.to_vec(),
+                None => match fs.read_file(&m.absolute_path) {
+                    Ok(b) => b,
+                    Err(_) => {
+                        // Same posture as install handler's first-time
+                        // passive placeholder: skip silently and let
+                        // status surface "pending" through the symlink
+                        // chain.
+                        tracing::debug!(
+                            pack = %m.pack,
+                            file = %m.absolute_path.display(),
+                            "externals.toml unreadable; skipping intent planning"
+                        );
+                        continue;
+                    }
+                },
+            };
+
+            let parsed = crate::external::parse_externals_toml(&bytes)?;
+            for (name, entry) in parsed.entries {
+                let user_path = resolve_target(&entry.target, paths.home_dir());
+                intents.push(HandlerIntent::Fetch {
+                    pack: m.pack.clone(),
+                    handler: HANDLER_EXTERNAL.into(),
+                    name,
+                    spec: entry.spec,
+                    user_path,
+                });
+            }
+        }
+        Ok(intents)
+    }
+
+    fn check_status(
+        &self,
+        file: &Path,
+        pack: &str,
+        datastore: &dyn DataStore,
+    ) -> Result<HandlerStatus> {
+        // Coarse-grained for v1: report deployed if *any* sentinel
+        // exists for the pack/external pair. Per-entry status arrives
+        // when we add the `dodot status` external-aware rendering in a
+        // later PR.
+        let deployed = datastore.has_handler_state(pack, HANDLER_EXTERNAL)?;
+        Ok(HandlerStatus {
+            file: file.to_string_lossy().into_owned(),
+            handler: HANDLER_EXTERNAL.into(),
+            deployed,
+            message: if deployed {
+                "externals deployed".into()
+            } else {
+                "externals not yet fetched".into()
+            },
+        })
+    }
+}
+
+/// Expand a leading `~` or `~/` to the pather's home dir.
+///
+/// We don't go all the way to a full shell-style expansion (no
+/// `~user/`, no env-var substitution) — those are explicit non-goals
+/// for the declarative config surface. The target field is a path the
+/// user writes once, not a shell snippet.
+fn resolve_target(target: &str, home: &Path) -> PathBuf {
+    if target == "~" {
+        return home.to_path_buf();
+    }
+    if let Some(rest) = target.strip_prefix("~/") {
+        return home.join(rest);
+    }
+    PathBuf::from(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::external::FetchSpec;
+    use crate::testing::TempEnvironment;
+    use std::collections::HashMap;
+
+    fn make_match(env: &TempEnvironment, pack: &str) -> RuleMatch {
+        let abs = env.dotfiles_root.join(pack).join(EXTERNALS_TOML);
+        RuleMatch {
+            relative_path: EXTERNALS_TOML.into(),
+            absolute_path: abs,
+            pack: pack.into(),
+            handler: HANDLER_EXTERNAL.into(),
+            is_dir: false,
+            options: HashMap::new(),
+            preprocessor_source: None,
+            rendered_bytes: None,
+        }
+    }
+
+    #[test]
+    fn resolve_target_expands_tilde() {
+        let home = Path::new("/home/alice");
+        assert_eq!(
+            resolve_target("~/.config/shared/aliases.sh", home),
+            PathBuf::from("/home/alice/.config/shared/aliases.sh")
+        );
+        assert_eq!(resolve_target("~", home), PathBuf::from("/home/alice"));
+        assert_eq!(
+            resolve_target("/etc/shared", home),
+            PathBuf::from("/etc/shared")
+        );
+    }
+
+    #[test]
+    fn to_intents_emits_one_fetch_per_entry() {
+        let toml = r#"
+            [aliases]
+            type   = "file"
+            url    = "https://example.com/aliases.sh"
+            target = "~/.config/shared/aliases.sh"
+            sha256 = "abc"
+
+            [motd]
+            type   = "file"
+            url    = "https://example.com/motd"
+            target = "~/.motd"
+            sha256 = "def"
+        "#;
+        let env = TempEnvironment::builder()
+            .pack("shared")
+            .file(EXTERNALS_TOML, toml)
+            .done()
+            .build();
+        let handler = ExternalsHandler;
+        let pather = crate::paths::XdgPather::builder()
+            .home(&env.home)
+            .dotfiles_root(&env.dotfiles_root)
+            .build()
+            .unwrap();
+
+        let intents = handler
+            .to_intents(
+                &[make_match(&env, "shared")],
+                &HandlerConfig::default(),
+                &pather,
+                env.fs.as_ref(),
+            )
+            .unwrap();
+
+        assert_eq!(intents.len(), 2);
+        let names: Vec<&str> = intents
+            .iter()
+            .map(|i| match i {
+                HandlerIntent::Fetch { name, .. } => name.as_str(),
+                _ => unreachable!(),
+            })
+            .collect();
+        // Alphabetical because parse_externals_toml uses BTreeMap.
+        assert_eq!(names, vec!["aliases", "motd"]);
+
+        match &intents[0] {
+            HandlerIntent::Fetch {
+                pack,
+                user_path,
+                spec,
+                ..
+            } => {
+                assert_eq!(pack, "shared");
+                assert_eq!(user_path, &env.home.join(".config/shared/aliases.sh"));
+                assert!(matches!(spec, FetchSpec::File { .. }));
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn to_intents_propagates_parse_errors() {
+        let env = TempEnvironment::builder()
+            .pack("shared")
+            .file(EXTERNALS_TOML, "this = is :: broken")
+            .done()
+            .build();
+        let handler = ExternalsHandler;
+        let pather = crate::paths::XdgPather::builder()
+            .home(&env.home)
+            .dotfiles_root(&env.dotfiles_root)
+            .build()
+            .unwrap();
+
+        let err = handler
+            .to_intents(
+                &[make_match(&env, "shared")],
+                &HandlerConfig::default(),
+                &pather,
+                env.fs.as_ref(),
+            )
+            .unwrap_err();
+        assert!(format!("{err}").contains("externals.toml parse error"));
+    }
+
+    #[test]
+    fn missing_file_is_skipped_quietly() {
+        let env = TempEnvironment::builder().build();
+        let handler = ExternalsHandler;
+        let pather = crate::paths::XdgPather::builder()
+            .home(&env.home)
+            .dotfiles_root(&env.dotfiles_root)
+            .build()
+            .unwrap();
+        let intents = handler
+            .to_intents(
+                &[make_match(&env, "shared")],
+                &HandlerConfig::default(),
+                &pather,
+                env.fs.as_ref(),
+            )
+            .unwrap();
+        assert!(intents.is_empty());
+    }
+
+    #[test]
+    fn directory_entries_are_skipped() {
+        let env = TempEnvironment::builder().build();
+        let handler = ExternalsHandler;
+        let pather = crate::paths::XdgPather::builder()
+            .home(&env.home)
+            .dotfiles_root(&env.dotfiles_root)
+            .build()
+            .unwrap();
+        let mut m = make_match(&env, "shared");
+        m.is_dir = true;
+        let intents = handler
+            .to_intents(&[m], &HandlerConfig::default(), &pather, env.fs.as_ref())
+            .unwrap();
+        assert!(intents.is_empty());
+    }
+}

--- a/crates/dodot-lib/src/handlers/mod.rs
+++ b/crates/dodot-lib/src/handlers/mod.rs
@@ -10,6 +10,7 @@
 //! linking) but must not mutate anything — mutations are the executor's
 //! job. This keeps planning idempotent and safe to re-run.
 
+pub mod externals;
 pub mod filter;
 pub mod gate;
 pub mod homebrew;
@@ -72,6 +73,10 @@ pub enum ExecutionPhase {
     /// Claim files to drop or list-but-not-act-on (ignore, skip). No
     /// executable intent is produced.
     Filter,
+    /// Fetch external content (externals.toml). Runs before Provision
+    /// so install scripts and shell init can rely on fetched content
+    /// being in place at their target paths.
+    External,
     /// Install packages (homebrew).
     Provision,
     /// Run user setup scripts (install).
@@ -89,9 +94,14 @@ impl ExecutionPhase {
     ///
     /// Provision and Setup run user-authored code and are gated by
     /// sentinels; the rest are idempotent filesystem work.
+    ///
+    /// External is also sentinel-gated (fetch only when the upstream
+    /// signature differs from the recorded one) and must NOT be wiped
+    /// on every `up` — re-fetching gigabytes of cloned content every
+    /// run is unacceptable.
     pub fn category(self) -> HandlerCategory {
         match self {
-            Self::Provision | Self::Setup => HandlerCategory::CodeExecution,
+            Self::External | Self::Provision | Self::Setup => HandlerCategory::CodeExecution,
             Self::Filter | Self::PathExport | Self::ShellInit | Self::Link => {
                 HandlerCategory::Configuration
             }
@@ -286,6 +296,7 @@ pub const HANDLER_HOMEBREW: &str = "homebrew";
 pub const HANDLER_IGNORE: &str = "ignore";
 pub const HANDLER_SKIP: &str = "skip";
 pub const HANDLER_GATE: &str = "gate";
+pub const HANDLER_EXTERNAL: &str = "external";
 
 /// Names of all configuration-category handlers in the registry.
 ///
@@ -316,6 +327,10 @@ pub fn create_registry(fs: &dyn Fs) -> HashMap<String, Box<dyn Handler + '_>> {
     registry.insert(HANDLER_IGNORE.into(), Box::new(filter::IgnoreHandler));
     registry.insert(HANDLER_SKIP.into(), Box::new(filter::SkipHandler));
     registry.insert(HANDLER_GATE.into(), Box::new(gate::GateHandler));
+    registry.insert(
+        HANDLER_EXTERNAL.into(),
+        Box::new(externals::ExternalsHandler),
+    );
     registry.insert(HANDLER_SYMLINK.into(), Box::new(symlink::SymlinkHandler));
     registry.insert(HANDLER_SHELL.into(), Box::new(shell::ShellHandler));
     registry.insert(HANDLER_PATH.into(), Box::new(path::PathHandler));
@@ -379,7 +394,8 @@ mod tests {
 
     #[test]
     fn execution_phase_declaration_order_drives_ord() {
-        assert!(ExecutionPhase::Filter < ExecutionPhase::Provision);
+        assert!(ExecutionPhase::Filter < ExecutionPhase::External);
+        assert!(ExecutionPhase::External < ExecutionPhase::Provision);
         assert!(ExecutionPhase::Provision < ExecutionPhase::Setup);
         assert!(ExecutionPhase::Setup < ExecutionPhase::PathExport);
         assert!(ExecutionPhase::PathExport < ExecutionPhase::ShellInit);
@@ -391,6 +407,10 @@ mod tests {
         assert_eq!(
             ExecutionPhase::Filter.category(),
             HandlerCategory::Configuration
+        );
+        assert_eq!(
+            ExecutionPhase::External.category(),
+            HandlerCategory::CodeExecution
         );
         assert_eq!(
             ExecutionPhase::Provision.category(),
@@ -421,6 +441,7 @@ mod tests {
         assert_eq!(registry[HANDLER_IGNORE].phase(), ExecutionPhase::Filter);
         assert_eq!(registry[HANDLER_SKIP].phase(), ExecutionPhase::Filter);
         assert_eq!(registry[HANDLER_GATE].phase(), ExecutionPhase::Filter);
+        assert_eq!(registry[HANDLER_EXTERNAL].phase(), ExecutionPhase::External);
         assert_eq!(
             registry[HANDLER_HOMEBREW].phase(),
             ExecutionPhase::Provision

--- a/crates/dodot-lib/src/lib.rs
+++ b/crates/dodot-lib/src/lib.rs
@@ -5,6 +5,7 @@ pub mod datastore;
 pub mod equivalence;
 pub mod error;
 pub mod execution;
+pub mod external;
 pub mod fs;
 pub mod gates;
 pub mod handlers;

--- a/crates/dodot-lib/src/operations/mod.rs
+++ b/crates/dodot-lib/src/operations/mod.rs
@@ -44,6 +44,18 @@ pub enum Operation {
         handler: String,
         sentinel: String,
     },
+
+    /// Fetch an external resource into the datastore.
+    /// The user-visible symlink is produced as a separate
+    /// `CreateUserLink` operation by the same intent.
+    FetchExternal {
+        pack: String,
+        handler: String,
+        /// Entry name from `externals.toml` section header.
+        name: String,
+        /// Origin URL (or `file://` for local testing).
+        url: String,
+    },
 }
 
 impl Operation {
@@ -52,7 +64,8 @@ impl Operation {
             Self::CreateDataLink { pack, .. }
             | Self::CreateUserLink { pack, .. }
             | Self::RunCommand { pack, .. }
-            | Self::CheckSentinel { pack, .. } => pack,
+            | Self::CheckSentinel { pack, .. }
+            | Self::FetchExternal { pack, .. } => pack,
         }
     }
 
@@ -61,7 +74,8 @@ impl Operation {
             Self::CreateDataLink { handler, .. }
             | Self::CreateUserLink { handler, .. }
             | Self::RunCommand { handler, .. }
-            | Self::CheckSentinel { handler, .. } => handler,
+            | Self::CheckSentinel { handler, .. }
+            | Self::FetchExternal { handler, .. } => handler,
         }
     }
 
@@ -72,6 +86,7 @@ impl Operation {
             Self::CreateUserLink { .. } => "CreateUserLink",
             Self::RunCommand { .. } => "RunCommand",
             Self::CheckSentinel { .. } => "CheckSentinel",
+            Self::FetchExternal { .. } => "FetchExternal",
         }
     }
 }
@@ -112,12 +127,28 @@ pub enum HandlerIntent {
         arguments: Vec<String>,
         sentinel: String,
     },
+
+    /// Externals handler: fetch a resource into the datastore, then
+    /// link it to a user-visible target. Sentinel-gated; the executor
+    /// no-ops when the content signature already matches.
+    Fetch {
+        pack: String,
+        handler: String,
+        /// Entry name from `externals.toml` (used for datastore subdir).
+        name: String,
+        spec: crate::external::FetchSpec,
+        /// User-visible target path (`target = "~/.config/foo"`, already resolved).
+        user_path: PathBuf,
+    },
 }
 
 impl HandlerIntent {
     pub fn pack(&self) -> &str {
         match self {
-            Self::Link { pack, .. } | Self::Stage { pack, .. } | Self::Run { pack, .. } => pack,
+            Self::Link { pack, .. }
+            | Self::Stage { pack, .. }
+            | Self::Run { pack, .. }
+            | Self::Fetch { pack, .. } => pack,
         }
     }
 
@@ -125,7 +156,8 @@ impl HandlerIntent {
         match self {
             Self::Link { handler, .. }
             | Self::Stage { handler, .. }
-            | Self::Run { handler, .. } => handler,
+            | Self::Run { handler, .. }
+            | Self::Fetch { handler, .. } => handler,
         }
     }
 }

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -220,6 +220,7 @@ pub fn execute_intents(
         "executing intents"
     );
     let auto_chmod = ctx.config_manager.root_config()?.path.auto_chmod_exec;
+    let fetcher = crate::external::UreqFetcher::new();
     let executor = Executor::new(
         ctx.datastore.as_ref(),
         ctx.fs.as_ref(),
@@ -228,7 +229,8 @@ pub fn execute_intents(
         ctx.force,
         ctx.provision_rerun,
         auto_chmod,
-    );
+    )
+    .with_fetcher(&fetcher);
     executor.execute(intents)
 }
 


### PR DESCRIPTION
## Summary

First PR of a stacked series implementing the externals handler from #152.

This PR is the architectural foundation: it introduces the trigger file (`externals.toml`), the new execution phase, the datastore layout, the `HandlerIntent::Fetch` / `Operation::FetchExternal` variants, the `HttpFetcher` abstraction, and the executor dispatch — all driven by a working `type = "file"` implementation. The other types (`git-repo`, `archive`, `archive-file`) parse but produce a clean "unsupported" diagnostic; they land in subsequent PRs.

## Design highlights

- **Trigger:** `externals.toml` at the pack root. Each section declares one entry. No `[external.NAME]` namespace — the whole file is dedicated.
- **New `ExecutionPhase::External`** sits between `Filter` and `Provision`, so ignore/skip rules still apply but everything else (install scripts, shell init, symlinks) runs *after* externals are in place.
- **Category: `CodeExecution`** — externals are sentinel-protected and must NOT be wiped on every \`up\` the way configuration handlers are.
- **Datastore layout:** \`<data_dir>/packs/<pack>/external/<name>/<filename>\`. The user-visible target is a symlink into that subtree.
- **Sentinel:** \`<entry-name>-<sha256-prefix>\`. Re-running \`up\` with an unchanged \`sha256\` in the TOML is a no-op; bumping the sha256 invalidates the old sentinel.
- **Failure posture:**
  - **Integrity (sha256) mismatch → hard fail.** We refuse to write tampered content.
  - **Network failure → soft fail.** Any cached copy stays in place, other intents still execute, the failure surfaces in the result list.
- **Fetcher abstraction:** \`HttpFetcher\` trait + \`UreqFetcher\` default. \`file://\` URLs are special-cased so the test suite stays fully offline. Mock fetcher in tests for predictable bodies and predictable errors.
- **Executor wiring:** \`Executor::with_fetcher()\` is a builder hook that leaves the 20+ existing \`Executor::new()\` call sites unchanged.

## Stacked PR series

- **PR 1 (this one):** TOML schema + \`type = "file"\` + datastore + executor + tests
- PR 2: \`type = "git-repo"\` via shell-out git, \`ls-remote\`-based freshness
- PR 3: \`subpath\` (sparse) + \`ref\` / \`commit\` pinning
- PR 4: \`type = "archive"\` + \`archive-file\`
- PR 5: \`--check-drift\` for externals in \`status\`
- PR 6: User docs (\`docs/user/handlers/external.lex\`)

Each subsequent PR will branch off the previous so GitHub shows incremental diffs.

## Test coverage

All 1165 dodot-lib tests pass + 12 CLI tests. New tests cover:

- Spec parsing: \`file\` entry, alphabetical iteration, unknown type → \`Unsupported\`, malformed TOML, missing \`sha256\`, invalid UTF-8
- Fetcher: \`file://\` happy path, missing file → transient error, unknown scheme → InvalidUrl
- Handler: emits one intent per entry in deterministic order, tilde expansion, parse error propagation, missing file skipped quietly, directories ignored
- Executor: fetch + verify + datastore + symlink in one pass, sentinel-gated idempotency (only fetches once), sha256 mismatch fails cleanly without writing anything, transient network failure surfaces as non-success result, unsupported type fails cleanly, dry-run doesn't fetch

## Test plan

- [ ] CI passes (clippy + tests via lefthook)
- [ ] Manual: create a pack with \`externals.toml\` pointing at a \`file://\` URL → \`dodot up\` deploys the symlink → \`dodot up\` again is a no-op → bump sha256 → \`dodot up\` re-fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)