### PR TITLE
feat(external): subpath, ref, and commit pinning for git-repo (PR 3/6, #152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Externals handler: `subpath`, `ref`, `commit` (PR 3 of stacked series)** —
+  `type = "git-repo"` now accepts three optional fields:
+  - `subpath = "themes"` — sparse-checkout pattern. Only that
+    subtree is materialized on disk, and the user-visible target
+    symlink points at it (not the whole clone).
+  - `ref = "v1.2.3"` — tracking reference (tag, branch, etc.).
+    Each `up` runs `git ls-remote <ref>` instead of `HEAD`;
+    refresh fires when that reference's SHA changes.
+  - `commit = "<full-sha>"` — frozen commit. Skips `ls-remote`
+    entirely; the local clone is compared against the configured
+    commit and only refreshes when the user edits the TOML.
+
+  `ref` and `commit` are mutually exclusive — parsing rejects an
+  entry that sets both. Git transport gains sparse-checkout cone
+  mode and `--branch <ref> --single-branch` when configured.
+
 - **Externals handler `type = "git-repo"` (PR 2 of stacked series)** —
   `externals.toml` now accepts `type = "git-repo"` entries. The
   executor shallow-clones (`--depth=1 --filter=blob:none`) into the

--- a/crates/dodot-lib/src/conflicts.rs
+++ b/crates/dodot-lib/src/conflicts.rs
@@ -182,7 +182,7 @@ fn intent_source(intent: &HandlerIntent) -> PathBuf {
         // pseudo-path so conflict messaging stays uniform.
         HandlerIntent::Fetch { spec, name, .. } => match spec {
             crate::external::FetchSpec::File { url, .. } => PathBuf::from(url),
-            crate::external::FetchSpec::GitRepo { url } => PathBuf::from(url),
+            crate::external::FetchSpec::GitRepo { url, .. } => PathBuf::from(url),
             crate::external::FetchSpec::Unsupported => PathBuf::from(format!("<external:{name}>")),
         },
     }

--- a/crates/dodot-lib/src/execution/fetch.rs
+++ b/crates/dodot-lib/src/execution/fetch.rs
@@ -48,9 +48,21 @@ impl<'a> Executor<'a> {
             FetchSpec::File { url, sha256 } => {
                 self.execute_fetch_file(pack, handler, name, url, sha256, user_path)
             }
-            FetchSpec::GitRepo { url } => {
-                self.execute_fetch_git_repo(pack, handler, name, url, user_path)
-            }
+            FetchSpec::GitRepo {
+                url,
+                subpath,
+                git_ref,
+                commit,
+            } => self.execute_fetch_git_repo(
+                pack,
+                handler,
+                name,
+                url,
+                subpath.as_deref(),
+                git_ref.as_deref(),
+                commit.as_deref(),
+                user_path,
+            ),
             FetchSpec::Unsupported => Ok(vec![OperationResult::fail(
                 fetch_op(pack, handler, name, "<unsupported>"),
                 format!(
@@ -90,14 +102,36 @@ impl<'a> Executor<'a> {
                 };
                 vec![OperationResult::ok(fetch_op(pack, handler, name, url), msg)]
             }
-            FetchSpec::GitRepo { url } => {
+            FetchSpec::GitRepo {
+                url,
+                subpath,
+                git_ref,
+                commit,
+            } => {
                 let datastore_path = self.paths.handler_data_dir(pack, handler).join(name);
                 let already = self.fs.exists(&datastore_path);
+                let pin_label = match (git_ref.as_deref(), commit.as_deref()) {
+                    (Some(r), _) => format!(" @ ref={r}"),
+                    (_, Some(c)) => format!(" @ commit={}", short(c)),
+                    _ => String::new(),
+                };
+                let subpath_label = subpath
+                    .as_deref()
+                    .map(|p| format!(" subpath={p}"))
+                    .unwrap_or_default();
                 let msg = if already {
-                    format!("[dry-run] {name} would ls-remote {url} and refresh only if upstream differs")
+                    if commit.is_some() {
+                        format!(
+                            "[dry-run] {name} pinned to commit; refresh only when TOML changes{subpath_label}"
+                        )
+                    } else {
+                        format!(
+                            "[dry-run] {name} would ls-remote {url}{pin_label} and refresh only if upstream differs{subpath_label}"
+                        )
+                    }
                 } else {
                     format!(
-                        "[dry-run] would clone {url} → {} → {}",
+                        "[dry-run] would clone {url}{pin_label} → {}{subpath_label} → {}",
                         datastore_path.display(),
                         user_path.display()
                     )
@@ -237,24 +271,33 @@ impl<'a> Executor<'a> {
 
     /// Fetch one `type = "git-repo"` external.
     ///
-    /// Upstream HEAD is the freshness oracle. Flow:
-    /// 1. Compute the datastore path: `<handler_data_dir>/<name>`.
-    /// 2. If the path doesn't exist → shallow-clone fresh.
-    /// 3. Otherwise → `git ls-remote HEAD` on the upstream URL. If
-    ///    it matches the local clone's HEAD, no-op. If it differs,
-    ///    fetch + reset --hard.
-    /// 4. Make sure the user-visible symlink target → datastore path.
+    /// Freshness model:
+    /// - **Unpinned** (`git_ref = None`, `commit = None`):
+    ///   `git ls-remote HEAD`; refresh when upstream moves.
+    /// - **`ref = "v1"`**: `git ls-remote v1`; refresh when that
+    ///   reference's SHA changes (rare for tags, possible for
+    ///   branch refs).
+    /// - **`commit = "<sha>"`**: no ls-remote at all; check the
+    ///   local clone against the pinned SHA and refresh only if
+    ///   they differ (which happens when the user edits the TOML).
+    ///
+    /// `subpath` triggers sparse-checkout on the initial clone; the
+    /// user-visible symlink then targets that subpath inside the
+    /// clone.
     ///
     /// Network failures (ls-remote, fetch, even initial clone) are
     /// soft: the cached clone (if any) stays put and the result
-    /// surfaces as a non-success — `up` continues with the rest of
-    /// the pack.
+    /// surfaces as a non-success.
+    #[allow(clippy::too_many_arguments)]
     fn execute_fetch_git_repo(
         &self,
         pack: &str,
         handler: &str,
         name: &str,
         url: &str,
+        subpath: Option<&str>,
+        git_ref: Option<&str>,
+        commit: Option<&str>,
         user_path: &Path,
     ) -> Result<Vec<OperationResult>> {
         let op = || fetch_op(pack, handler, name, url);
@@ -268,16 +311,34 @@ impl<'a> Executor<'a> {
             )]);
         };
 
-        let datastore_path = self.paths.handler_data_dir(pack, handler).join(name);
-        let already_cloned = self.fs.exists(&datastore_path);
+        // The clone always lands at <handler_data_dir>/<name>/. When
+        // subpath is set, the user-visible symlink points one level
+        // deeper.
+        let clone_path = self.paths.handler_data_dir(pack, handler).join(name);
+        let already_cloned = self.fs.exists(&clone_path);
+        let symlink_target = match subpath {
+            Some(p) => clone_path.join(p),
+            None => clone_path.clone(),
+        };
+
+        // Reference we ask git about. `commit` pins skip ls-remote
+        // entirely; otherwise we use the configured ref or HEAD.
+        let tracking_ref = git_ref.unwrap_or("HEAD");
 
         if !already_cloned {
-            // Fresh clone path. The datastore dir's parent must exist.
-            if let Some(parent) = datastore_path.parent() {
+            // Fresh clone path.
+            if let Some(parent) = clone_path.parent() {
                 self.fs.mkdir_all(parent)?;
             }
-            info!(pack, name, url, "shallow-cloning external");
-            let sha = match git.shallow_clone(url, &datastore_path) {
+            info!(
+                pack,
+                name,
+                url,
+                ?git_ref,
+                ?subpath,
+                "shallow-cloning external"
+            );
+            let cloned_sha = match git.shallow_clone(url, &clone_path, git_ref, subpath) {
                 Ok(s) => s,
                 Err(err) => {
                     warn!(pack, name, %err, "git clone failed");
@@ -287,50 +348,142 @@ impl<'a> Executor<'a> {
                     )]);
                 }
             };
+            // Pinned to a specific commit: snap HEAD to that commit
+            // after the clone so the local SHA matches the pin.
+            //
+            // A shallow clone (--depth=1) only ships the tip object,
+            // so a non-tip commit won't be reachable yet — fetch it
+            // explicitly first, then check out.
+            let final_sha = if let Some(c) = commit {
+                if !cloned_sha.eq_ignore_ascii_case(c) {
+                    if let Err(err) = git.fetch_and_reset(&clone_path, c) {
+                        return Ok(vec![OperationResult::fail(
+                            op(),
+                            format!("{name}: fetch {} after clone failed: {err}", short(c)),
+                        )]);
+                    }
+                    if let Err(err) = git.checkout(&clone_path, c) {
+                        return Ok(vec![OperationResult::fail(
+                            op(),
+                            format!("{name}: checkout {} after clone failed: {err}", short(c)),
+                        )]);
+                    }
+                }
+                c.to_string()
+            } else {
+                cloned_sha
+            };
             return self.finish_git_repo(
                 pack,
                 handler,
                 name,
                 url,
-                &datastore_path,
+                &clone_path,
+                &symlink_target,
                 user_path,
-                &sha,
+                &final_sha,
             );
         }
 
-        // Existing clone path. We need the local HEAD regardless of
-        // whether ls-remote succeeds, so read it first — a corrupted
-        // local clone is a hard error that should surface even if
-        // upstream happens to be reachable.
-        let local = match git.local_head(&datastore_path) {
+        // Existing clone — read local first so a corrupted clone is
+        // surfaced as a hard failure regardless of whether upstream is
+        // reachable.
+        let local = match git.local_head(&clone_path) {
             Ok(s) => s,
             Err(err) => {
-                // The clone exists but git can't read it — corrupted
-                // state. Better to surface than to silently re-clone
-                // (which could mask a deeper problem).
                 return Ok(vec![OperationResult::fail(
                     op(),
                     format!(
                         "{name}: existing clone at {} is unreadable: {err}",
-                        datastore_path.display()
+                        clone_path.display()
                     ),
                 )]);
             }
         };
 
-        // Cheap freshness check. Transient ls-remote failures don't
-        // abort the run, but they DO surface as non-success results —
-        // claiming "fresh" when we couldn't actually verify upstream
-        // would be misleading. The cached clone is already symlinked
-        // from a prior successful run; nothing more needed on disk.
-        let upstream = match git.ls_remote_head(url) {
+        // Commit pin: compare local against the pin directly; no
+        // ls-remote needed since the spec pins a fixed SHA.
+        if let Some(c) = commit {
+            if local.eq_ignore_ascii_case(c) && !self.force {
+                return self
+                    .finish_git_repo(
+                        pack,
+                        handler,
+                        name,
+                        url,
+                        &clone_path,
+                        &symlink_target,
+                        user_path,
+                        &local,
+                    )
+                    .map(|mut results| {
+                        if let Some(r) = results.first_mut() {
+                            *r = OperationResult::ok(
+                                op(),
+                                format!("{name}: pinned to commit {}", short(c)),
+                            );
+                        }
+                        results
+                    });
+            }
+            // Pin moved or --force: fetch the pin, then checkout.
+            match git.fetch_and_reset(&clone_path, c) {
+                Ok(_) => {}
+                Err(err) if err.is_transient() => {
+                    return Ok(vec![OperationResult::fail(
+                        op(),
+                        format!(
+                            "{name}: fetch {} failed ({err}); cached clone at {} stays in place",
+                            short(c),
+                            short(&local)
+                        ),
+                    )]);
+                }
+                Err(err) => {
+                    return Ok(vec![OperationResult::fail(
+                        op(),
+                        format!("{name}: fetch {} failed: {err}", short(c)),
+                    )]);
+                }
+            }
+            // After fetch+reset, local HEAD should be at `c`. The
+            // explicit checkout is belt-and-braces in case the user
+            // pinned a non-tip commit and FETCH_HEAD landed on a
+            // different ref. Checkout failure is a hard fail rather
+            // than a warning — leaving the tree in a mismatched state
+            // would silently mislead `dodot status`.
+            if let Err(err) = git.checkout(&clone_path, c) {
+                return Ok(vec![OperationResult::fail(
+                    op(),
+                    format!("{name}: checkout {} after fetch failed: {err}", short(c)),
+                )]);
+            }
+            return self.finish_git_repo(
+                pack,
+                handler,
+                name,
+                url,
+                &clone_path,
+                &symlink_target,
+                user_path,
+                c,
+            );
+        }
+
+        // Unpinned or ref-pinned: ls-remote the tracking reference.
+        // Transient ls-remote failures don't abort the run, but they
+        // DO surface as non-success — claiming "fresh" when we
+        // couldn't actually verify upstream would mislead. The cached
+        // clone (already symlinked from the prior successful run)
+        // stays put.
+        let upstream = match git.ls_remote(url, tracking_ref) {
             Ok(s) => s,
             Err(err) if err.is_transient() => {
                 warn!(pack, name, %err, "ls-remote failed (transient); using cached clone");
                 return Ok(vec![OperationResult::fail(
                     op(),
                     format!(
-                        "{name}: ls-remote failed ({err}); using cached clone at {}",
+                        "{name}: ls-remote {tracking_ref} failed ({err}); using cached clone at {}",
                         short(&local)
                     ),
                 )]);
@@ -338,12 +491,12 @@ impl<'a> Executor<'a> {
             Err(err) => {
                 return Ok(vec![OperationResult::fail(
                     op(),
-                    format!("{name}: ls-remote failed: {err}"),
+                    format!("{name}: ls-remote {tracking_ref} failed: {err}"),
                 )]);
             }
         };
 
-        // From here on, upstream and local are both known SHAs.
+        // Both upstream and local are known SHAs from here on.
         let (final_sha, was_refreshed) = if upstream == self.force_refresh_target(&local) {
             (local, false)
         } else {
@@ -353,12 +506,10 @@ impl<'a> Executor<'a> {
                 remote = %short(&upstream),
                 "upstream moved; fetching + reset"
             );
-            match git.fetch_and_reset(&datastore_path) {
+            match git.fetch_and_reset(&clone_path, tracking_ref) {
                 Ok(s) => (s, true),
                 Err(err) if err.is_transient() => {
                     warn!(pack, name, %err, "fetch+reset failed (transient); keeping cached");
-                    // Cached SHA stands; we tried to refresh but the
-                    // network blipped after ls-remote succeeded.
                     return Ok(vec![OperationResult::fail(
                         op(),
                         format!(
@@ -376,20 +527,20 @@ impl<'a> Executor<'a> {
             }
         };
 
-        // Refresh sentinel + symlink either way (idempotent).
         let mut results = self.finish_git_repo(
             pack,
             handler,
             name,
             url,
-            &datastore_path,
+            &clone_path,
+            &symlink_target,
             user_path,
             &final_sha,
         )?;
         if !was_refreshed && self.fetcher_message_overridable(&results) {
-            // Only rewrite the "fetched" message when we actually
+            // Only rewrite to "fresh (== upstream)" when we actually
             // know upstream matches local — i.e. ls-remote succeeded
-            // and the SHAs lined up. The transient-failure path
+            // and the SHAs lined up. The transient-failure paths
             // already returned above.
             results[0] = OperationResult::ok(
                 op(),
@@ -418,6 +569,11 @@ impl<'a> Executor<'a> {
 
     /// Symlink + sentinel finalize for git-repo. Shared by initial
     /// clone and refresh paths.
+    ///
+    /// `clone_path` is the on-disk clone root (always
+    /// `<handler_data_dir>/<name>`); `symlink_target` is where the
+    /// user-visible symlink should point — equal to `clone_path` when
+    /// no subpath is configured, deeper otherwise.
     #[allow(clippy::too_many_arguments)]
     fn finish_git_repo(
         &self,
@@ -425,28 +581,25 @@ impl<'a> Executor<'a> {
         handler: &str,
         name: &str,
         url: &str,
-        datastore_path: &Path,
+        clone_path: &Path,
+        symlink_target: &Path,
         user_path: &Path,
         sha: &str,
     ) -> Result<Vec<OperationResult>> {
-        self.create_external_user_link(datastore_path, user_path)?;
+        self.create_external_user_link(symlink_target, user_path)?;
         let sentinel = git_repo_sentinel(name, sha);
         self.write_sentinel(pack, handler, &sentinel)?;
 
         let create_link = Operation::CreateUserLink {
             pack: pack.to_string(),
             handler: handler.to_string(),
-            datastore_path: datastore_path.to_path_buf(),
+            datastore_path: symlink_target.to_path_buf(),
             user_path: user_path.to_path_buf(),
         };
         Ok(vec![
             OperationResult::ok(
                 fetch_op(pack, handler, name, url),
-                format!(
-                    "{name}: HEAD={} at {}",
-                    short(sha),
-                    datastore_path.display()
-                ),
+                format!("{name}: HEAD={} at {}", short(sha), clone_path.display()),
             ),
             OperationResult::ok(create_link, format!("{name} → {}", user_path.display())),
         ])
@@ -1075,7 +1228,12 @@ mod tests {
             pack: "frameworks".into(),
             handler: "external".into(),
             name: name.into(),
-            spec: FetchSpec::GitRepo { url: url.into() },
+            spec: FetchSpec::GitRepo {
+                url: url.into(),
+                subpath: None,
+                git_ref: None,
+                commit: None,
+            },
             user_path,
         }
     }
@@ -1253,6 +1411,176 @@ mod tests {
         assert!(!results[0].success);
         assert!(
             results[0].message.contains("fetch failed") || results[0].message.contains("cached"),
+            "msg: {}",
+            results[0].message
+        );
+    }
+
+    fn git_intent_with(
+        name: &str,
+        url: &str,
+        subpath: Option<&str>,
+        git_ref: Option<&str>,
+        commit: Option<&str>,
+        user_path: std::path::PathBuf,
+    ) -> HandlerIntent {
+        HandlerIntent::Fetch {
+            pack: "frameworks".into(),
+            handler: "external".into(),
+            name: name.into(),
+            spec: FetchSpec::GitRepo {
+                url: url.into(),
+                subpath: subpath.map(String::from),
+                git_ref: git_ref.map(String::from),
+                commit: commit.map(String::from),
+            },
+            user_path,
+        }
+    }
+
+    #[test]
+    fn git_repo_subpath_targets_subdirectory() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let git = MockGitRunner::new(&"a".repeat(40), b"# themes\n");
+        let user_path = env.home.join(".config/zsh/themes/p10k");
+        let intent = git_intent_with(
+            "p10k",
+            "https://x/p10k.git",
+            Some("themes"),
+            None,
+            None,
+            user_path.clone(),
+        );
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_git(&git);
+
+        let results = executor.execute(vec![intent]).unwrap();
+        assert!(results.iter().all(|r| r.success), "{results:#?}");
+
+        // The symlink resolves through `themes/` inside the clone.
+        assert!(env.fs.is_symlink(&user_path));
+        let clone_root = env
+            .paths
+            .handler_data_dir("frameworks", "external")
+            .join("p10k");
+        let resolved = env.fs.readlink(&user_path).unwrap();
+        assert_eq!(resolved, clone_root.join("themes"));
+        // And the marker file (which the mock writes under subpath)
+        // is reachable through the symlink.
+        let content = env.fs.read_to_string(&user_path.join("README.md")).unwrap();
+        assert!(content.contains("# themes"));
+    }
+
+    #[test]
+    fn git_repo_ref_pin_uses_named_reference() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let git = MockGitRunner::new(&"a".repeat(40), b"# tagged\n");
+        let user_path = env.home.join(".oh-my-zsh");
+        let intent = git_intent_with(
+            "omz",
+            "https://x/omz.git",
+            None,
+            Some("v1.20.0"),
+            None,
+            user_path.clone(),
+        );
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_git(&git);
+
+        // First run clones --branch v1.20.0.
+        executor.execute(vec![intent.clone()]).unwrap();
+        assert!(
+            git.calls()
+                .iter()
+                .any(|c| c.contains("clone") && c.contains("ref=v1.20.0")),
+            "{:?}",
+            git.calls()
+        );
+
+        // Second run: ls-remote uses the configured ref, not HEAD.
+        let calls_before = git.calls().len();
+        executor.execute(vec![intent]).unwrap();
+        let new_calls = &git.calls()[calls_before..];
+        assert!(
+            new_calls
+                .iter()
+                .any(|c| c.contains("ls-remote") && c.ends_with(" v1.20.0")),
+            "{new_calls:?}"
+        );
+    }
+
+    #[test]
+    fn git_repo_commit_pin_skips_ls_remote_when_local_matches() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let commit = "deadbeef1234567890abcdef1234567890abcdef".to_string();
+        let git = MockGitRunner::new(&commit, b"# frozen\n");
+        let user_path = env.home.join(".oh-my-zsh");
+        let intent = git_intent_with(
+            "omz",
+            "https://x/omz.git",
+            None,
+            None,
+            Some(&commit),
+            user_path.clone(),
+        );
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_git(&git);
+
+        // First run clones. When the cloned tip already matches the
+        // pin (as the mock arranges via `MockGitRunner::new(&commit)`),
+        // the executor's commit-pin shortcut avoids an unnecessary
+        // checkout — confirm the clone happened.
+        executor.execute(vec![intent.clone()]).unwrap();
+        assert!(
+            git.calls().iter().any(|c| c.starts_with("clone ")),
+            "{:?}",
+            git.calls()
+        );
+
+        // Second run: local SHA matches pin → no ls-remote, no fetch.
+        let calls_before = git.calls().len();
+        let results = executor.execute(vec![intent]).unwrap();
+        let new_calls = &git.calls()[calls_before..];
+        assert!(
+            new_calls.iter().all(|c| !c.contains("ls-remote")),
+            "commit pin must not poll upstream: {new_calls:?}"
+        );
+        assert!(
+            new_calls.iter().all(|c| !c.contains("fetch+reset")),
+            "{new_calls:?}"
+        );
+        assert!(
+            results[0].message.contains("pinned to commit"),
             "msg: {}",
             results[0].message
         );

--- a/crates/dodot-lib/src/external/git.rs
+++ b/crates/dodot-lib/src/external/git.rs
@@ -61,18 +61,39 @@ impl GitError {
 /// Each method is a porcelain-level verb: implementations shell out
 /// to `git` with the right flags. Tests mock this trait.
 pub trait GitRunner: Send + Sync {
-    /// `git ls-remote <url> HEAD` — return the upstream HEAD SHA
-    /// without fetching any objects. The cheap freshness oracle.
-    fn ls_remote_head(&self, url: &str) -> std::result::Result<String, GitError>;
+    /// `git ls-remote <url> <reference>` — return the upstream SHA
+    /// for a reference without fetching any objects. Use `"HEAD"`
+    /// for the default branch.
+    fn ls_remote(&self, url: &str, reference: &str) -> std::result::Result<String, GitError>;
 
-    /// `git clone --depth=1 --filter=blob:none <url> <dest>`.
+    /// `git clone --depth=1 --filter=blob:none [--branch <ref>] <url> <dest>`,
+    /// optionally followed by a sparse-checkout setup if `subpath` is
+    /// `Some(p)`:
+    /// ```text
+    /// git -C <dest> sparse-checkout init --cone
+    /// git -C <dest> sparse-checkout set <p>
+    /// ```
     /// Returns the cloned HEAD SHA.
-    fn shallow_clone(&self, url: &str, dest: &Path) -> std::result::Result<String, GitError>;
+    fn shallow_clone(
+        &self,
+        url: &str,
+        dest: &Path,
+        reference: Option<&str>,
+        subpath: Option<&str>,
+    ) -> std::result::Result<String, GitError>;
 
-    /// `git -C <repo> fetch --depth=1 origin HEAD` followed by
-    /// `git -C <repo> reset --hard FETCH_HEAD`. Returns the new
+    /// `git -C <repo> fetch --depth=1 origin <reference>` followed
+    /// by `git -C <repo> reset --hard FETCH_HEAD`. Returns the new
     /// HEAD SHA.
-    fn fetch_and_reset(&self, repo: &Path) -> std::result::Result<String, GitError>;
+    fn fetch_and_reset(
+        &self,
+        repo: &Path,
+        reference: &str,
+    ) -> std::result::Result<String, GitError>;
+
+    /// `git -C <repo> checkout <target>`. Used for commit pinning
+    /// when the local clone already has the object.
+    fn checkout(&self, repo: &Path, target: &str) -> std::result::Result<(), GitError>;
 
     /// `git -C <repo> rev-parse HEAD` — local HEAD SHA.
     fn local_head(&self, repo: &Path) -> std::result::Result<String, GitError>;
@@ -118,22 +139,41 @@ impl Default for ShellGitRunner {
 }
 
 impl GitRunner for ShellGitRunner {
-    fn ls_remote_head(&self, url: &str) -> std::result::Result<String, GitError> {
+    fn ls_remote(&self, url: &str, reference: &str) -> std::result::Result<String, GitError> {
         let stdout = Self::run(
             "ls-remote",
-            Command::new("git").args(["ls-remote", "--exit-code", url, "HEAD"]),
+            Command::new("git").args(["ls-remote", "--exit-code", url, reference]),
         )?;
-        // Output shape: `<sha>\tHEAD`. We want the first whitespace-
-        // delimited field on the first line.
-        let sha = stdout
+        // Output is one `<sha>\t<ref>` row per matching ref. For an
+        // annotated tag, `git ls-remote <tag>` returns two rows:
+        //   <tag-object-sha>     refs/tags/<tag>
+        //   <commit-sha>         refs/tags/<tag>^{}
+        // The dereferenced (`^{}`) row is the commit we actually want
+        // to track; the tag-object SHA changes whenever the tag's
+        // message/signer changes, which would cause spurious refresh
+        // loops. Prefer `^{}` when present, fall back to the first
+        // row otherwise.
+        let rows: Vec<(&str, &str)> = stdout
             .lines()
-            .next()
-            .and_then(|line| line.split_whitespace().next())
-            .map(str::to_string)
-            .ok_or_else(|| GitError::BadOutput {
+            .filter_map(|line| {
+                let mut parts = line.split_whitespace();
+                let sha = parts.next()?;
+                let refname = parts.next().unwrap_or("");
+                Some((sha, refname))
+            })
+            .collect();
+        if rows.is_empty() {
+            return Err(GitError::BadOutput {
                 operation: "ls-remote".into(),
-                detail: format!("no rows for HEAD on {url}"),
-            })?;
+                detail: format!("no rows for {reference} on {url}"),
+            });
+        }
+        let chosen = rows
+            .iter()
+            .find(|(_, refname)| refname.ends_with("^{}"))
+            .or_else(|| rows.first())
+            .expect("rows is non-empty");
+        let sha = chosen.0.to_string();
         if sha.len() < 7 {
             return Err(GitError::BadOutput {
                 operation: "ls-remote".into(),
@@ -143,26 +183,70 @@ impl GitRunner for ShellGitRunner {
         Ok(sha)
     }
 
-    fn shallow_clone(&self, url: &str, dest: &Path) -> std::result::Result<String, GitError> {
-        // Pass `dest` as an OsStr so non-UTF-8 paths survive verbatim
-        // — `to_string_lossy` would corrupt them, and Command accepts
-        // `&OsStr` natively anyway.
-        Self::run(
-            "clone",
-            Command::new("git")
-                .args(["clone", "--depth=1", "--filter=blob:none", url])
-                .arg(dest),
-        )?;
+    fn shallow_clone(
+        &self,
+        url: &str,
+        dest: &Path,
+        reference: Option<&str>,
+        subpath: Option<&str>,
+    ) -> std::result::Result<String, GitError> {
+        // Build the clone invocation. Non-path args go through `.args`
+        // as `&str`; `dest` is appended via `.arg(&Path)` so non-UTF-8
+        // paths survive verbatim (`to_string_lossy` would corrupt them).
+        let mut cmd = Command::new("git");
+        cmd.args(["clone", "--depth=1", "--filter=blob:none"]);
+        if let Some(r) = reference {
+            // --single-branch is implied by --depth=1, but be explicit.
+            cmd.args(["--branch", r, "--single-branch"]);
+        }
+        // `--no-checkout` only when a sparse pattern follows so we
+        // don't materialise the whole tree before narrowing it.
+        if subpath.is_some() {
+            cmd.arg("--no-checkout");
+        }
+        cmd.arg("--").arg(url).arg(dest);
+        Self::run("clone", &mut cmd)?;
+
+        if let Some(pattern) = subpath {
+            Self::run(
+                "sparse-checkout init",
+                Command::new("git")
+                    .arg("-C")
+                    .arg(dest)
+                    .args(["sparse-checkout", "init", "--cone"]),
+            )?;
+            // `--` keeps a pattern that starts with `-` (e.g.
+            // `-experimental`) from being interpreted as an option.
+            Self::run(
+                "sparse-checkout set",
+                Command::new("git").arg("-C").arg(dest).args([
+                    "sparse-checkout",
+                    "set",
+                    "--",
+                    pattern,
+                ]),
+            )?;
+            Self::run(
+                "checkout",
+                Command::new("git").arg("-C").arg(dest).args(["checkout"]),
+            )?;
+        }
         self.local_head(dest)
     }
 
-    fn fetch_and_reset(&self, repo: &Path) -> std::result::Result<String, GitError> {
+    fn fetch_and_reset(
+        &self,
+        repo: &Path,
+        reference: &str,
+    ) -> std::result::Result<String, GitError> {
         Self::run(
             "fetch",
-            Command::new("git")
-                .arg("-C")
-                .arg(repo)
-                .args(["fetch", "--depth=1", "origin", "HEAD"]),
+            Command::new("git").arg("-C").arg(repo).args([
+                "fetch",
+                "--depth=1",
+                "origin",
+                reference,
+            ]),
         )?;
         Self::run(
             "reset",
@@ -172,6 +256,17 @@ impl GitRunner for ShellGitRunner {
                 .args(["reset", "--hard", "FETCH_HEAD"]),
         )?;
         self.local_head(repo)
+    }
+
+    fn checkout(&self, repo: &Path, target: &str) -> std::result::Result<(), GitError> {
+        Self::run(
+            "checkout",
+            Command::new("git")
+                .arg("-C")
+                .arg(repo)
+                .args(["checkout", target]),
+        )?;
+        Ok(())
     }
 
     fn local_head(&self, repo: &Path) -> std::result::Result<String, GitError> {
@@ -252,9 +347,9 @@ impl MockGitRunner {
 
 #[cfg(any(test, feature = "test-utils"))]
 impl GitRunner for MockGitRunner {
-    fn ls_remote_head(&self, url: &str) -> std::result::Result<String, GitError> {
+    fn ls_remote(&self, url: &str, reference: &str) -> std::result::Result<String, GitError> {
         let mut g = self.inner.lock().unwrap();
-        g.calls.push(format!("ls-remote {url}"));
+        g.calls.push(format!("ls-remote {url} {reference}"));
         if g.ls_remote_offline {
             return Err(GitError::CommandFailed {
                 operation: "ls-remote".into(),
@@ -268,18 +363,40 @@ impl GitRunner for MockGitRunner {
         })
     }
 
-    fn shallow_clone(&self, url: &str, dest: &Path) -> std::result::Result<String, GitError> {
+    fn shallow_clone(
+        &self,
+        url: &str,
+        dest: &Path,
+        reference: Option<&str>,
+        subpath: Option<&str>,
+    ) -> std::result::Result<String, GitError> {
         let mut g = self.inner.lock().unwrap();
-        g.calls.push(format!("clone {url} -> {}", dest.display()));
-        // Write a small marker file so the executor's symlink leg has
-        // something to point at — mirrors what a real clone would
-        // produce on disk.
+        g.calls.push(format!(
+            "clone {url} ref={} subpath={} -> {}",
+            reference.unwrap_or("HEAD"),
+            subpath.unwrap_or("-"),
+            dest.display()
+        ));
         std::fs::create_dir_all(dest).map_err(|e| GitError::CommandFailed {
             operation: "clone".into(),
             exit_code: -1,
             stderr: e.to_string(),
         })?;
-        let marker = dest.join("README.md");
+        // When subpath is set, materialise the marker inside that
+        // subdir so symlink-into-subpath cases are exercised end-to-end.
+        let marker_dir = match subpath {
+            Some(p) => {
+                let d = dest.join(p);
+                std::fs::create_dir_all(&d).map_err(|e| GitError::CommandFailed {
+                    operation: "sparse-checkout".into(),
+                    exit_code: -1,
+                    stderr: e.to_string(),
+                })?;
+                d
+            }
+            None => dest.to_path_buf(),
+        };
+        let marker = marker_dir.join("README.md");
         std::fs::write(&marker, &g.clone_marker_content).map_err(|e| GitError::CommandFailed {
             operation: "clone".into(),
             exit_code: -1,
@@ -293,9 +410,14 @@ impl GitRunner for MockGitRunner {
         Ok(sha)
     }
 
-    fn fetch_and_reset(&self, repo: &Path) -> std::result::Result<String, GitError> {
+    fn fetch_and_reset(
+        &self,
+        repo: &Path,
+        reference: &str,
+    ) -> std::result::Result<String, GitError> {
         let mut g = self.inner.lock().unwrap();
-        g.calls.push(format!("fetch+reset {}", repo.display()));
+        g.calls
+            .push(format!("fetch+reset {} ref={reference}", repo.display()));
         if g.fetch_offline {
             return Err(GitError::CommandFailed {
                 operation: "fetch".into(),
@@ -315,6 +437,14 @@ impl GitRunner for MockGitRunner {
             .unwrap_or_else(|| "1111111111111111111111111111111111111111".into());
         g.local_sha = Some(sha.clone());
         Ok(sha)
+    }
+
+    fn checkout(&self, repo: &Path, target: &str) -> std::result::Result<(), GitError> {
+        let mut g = self.inner.lock().unwrap();
+        g.calls
+            .push(format!("checkout {} {target}", repo.display()));
+        g.local_sha = Some(target.into());
+        Ok(())
     }
 
     fn local_head(&self, _repo: &Path) -> std::result::Result<String, GitError> {
@@ -353,7 +483,7 @@ mod tests {
         let dest = tmp.path().join("clone");
         let mock = MockGitRunner::new("abc123def456", b"# hello\n");
         let sha = mock
-            .shallow_clone("https://example.com/repo.git", &dest)
+            .shallow_clone("https://example.com/repo.git", &dest, None, None)
             .unwrap();
         assert_eq!(sha, "abc123def456");
         assert!(dest.join("README.md").exists());
@@ -361,23 +491,48 @@ mod tests {
     }
 
     #[test]
+    fn mock_clone_subpath_places_marker_inside_subpath() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("clone");
+        let mock = MockGitRunner::new("abc", b"# theme\n");
+        mock.shallow_clone("https://x/r.git", &dest, None, Some("themes"))
+            .unwrap();
+        // Marker is inside the subpath, not at the repo root —
+        // confirms sparse-checkout was honoured by the mock.
+        assert!(dest.join("themes/README.md").exists());
+        assert!(!dest.join("README.md").exists());
+    }
+
+    #[test]
     fn mock_fetch_updates_marker_and_sha() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("clone");
         let mock = MockGitRunner::new("aaa", b"# v1\n");
-        mock.shallow_clone("https://x/r.git", &dest).unwrap();
+        mock.shallow_clone("https://x/r.git", &dest, None, None)
+            .unwrap();
         mock.set_upstream_sha("bbb");
-        let new_sha = mock.fetch_and_reset(&dest).unwrap();
+        let new_sha = mock.fetch_and_reset(&dest, "HEAD").unwrap();
         assert_eq!(new_sha, "bbb");
         let body = std::fs::read_to_string(dest.join("README.md")).unwrap();
         assert!(body.contains("# refreshed"));
     }
 
     #[test]
+    fn mock_checkout_updates_local_sha() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("clone");
+        let mock = MockGitRunner::new("abc", b"");
+        mock.shallow_clone("https://x/r.git", &dest, None, None)
+            .unwrap();
+        mock.checkout(&dest, "frozen-commit-sha").unwrap();
+        assert_eq!(mock.local_head(&dest).unwrap(), "frozen-commit-sha");
+    }
+
+    #[test]
     fn mock_offline_ls_remote() {
         let mock = MockGitRunner::new("aaa", b"");
         mock.set_ls_remote_offline(true);
-        let err = mock.ls_remote_head("https://x/r.git").unwrap_err();
+        let err = mock.ls_remote("https://x/r.git", "HEAD").unwrap_err();
         assert!(err.is_transient());
     }
 }

--- a/crates/dodot-lib/src/external/spec.rs
+++ b/crates/dodot-lib/src/external/spec.rs
@@ -69,14 +69,39 @@ pub enum FetchSpec {
         sha256: String,
     },
 
-    /// A shallow git clone, tracking `HEAD` of the default branch.
+    /// A shallow git clone.
     ///
-    /// Freshness is upstream-driven: each `dodot up` runs a cheap
-    /// `git ls-remote HEAD`; the actual clone is only re-fetched
-    /// when the remote SHA differs from the local one. Sparse-tree
-    /// checkout (`subpath`) and pinned `ref` / `commit` arrive in
-    /// a follow-up PR; for now the whole repo's HEAD is cloned.
-    GitRepo { url: String },
+    /// Freshness rules depend on the pin configuration:
+    /// - **Unpinned** (no `ref`, no `commit`): `git ls-remote HEAD`
+    ///   on each `up`; refresh only when upstream HEAD moves.
+    /// - **`ref = "v1.2.3"`** (tag, branch, or any other reference):
+    ///   `git ls-remote <ref>` on each `up`; refresh when that
+    ///   reference's SHA changes. Tags don't normally move but the
+    ///   mechanism is uniform.
+    /// - **`commit = "abc1234..."`** (full SHA): no `ls-remote` at
+    ///   all; the local clone is compared against the configured
+    ///   commit and refreshed only when the user edits the TOML.
+    ///
+    /// `subpath = "themes"` triggers a sparse-tree fetch (only that
+    /// subdirectory is materialized). The user-visible target
+    /// symlink then points at the subpath inside the clone, not
+    /// the whole tree.
+    GitRepo {
+        url: String,
+        /// Sparse-checkout pattern (relative to the repo root). When
+        /// set, only that subtree is materialized on disk, and the
+        /// user-visible target symlink points at it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        subpath: Option<String>,
+        /// Reference to track (tag, branch, etc.). `None` means HEAD.
+        /// Mutually exclusive with [`Self::GitRepo::commit`].
+        #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
+        git_ref: Option<String>,
+        /// Frozen commit SHA. Mutually exclusive with
+        /// [`Self::GitRepo::git_ref`]; skips upstream polling.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        commit: Option<String>,
+    },
 
     /// Catchall for type values dodot doesn't implement yet.
     #[serde(other)]
@@ -92,15 +117,92 @@ pub enum FetchSpec {
 /// they are used verbatim as datastore subdirectory names and sentinel
 /// filenames — letting `..` or `/` through here would create
 /// surprising nested layouts and confusing sentinel matches.
+///
+/// Cross-field invariants on `git-repo` entries are enforced here too,
+/// so the executor never has to second-guess a spec it received from
+/// the handler.
 pub fn parse_externals_toml(bytes: &[u8]) -> Result<ExternalsToml> {
     let text = std::str::from_utf8(bytes)
         .map_err(|e| DodotError::Other(format!("externals.toml is not valid UTF-8: {e}")))?;
     let parsed: BTreeMap<String, ExternalEntry> = toml::from_str(text)
         .map_err(|e| DodotError::Other(format!("externals.toml parse error: {e}")))?;
-    for name in parsed.keys() {
+    for (name, entry) in &parsed {
         validate_entry_name(name)?;
+        if let FetchSpec::GitRepo {
+            subpath,
+            git_ref,
+            commit,
+            ..
+        } = &entry.spec
+        {
+            if git_ref.is_some() && commit.is_some() {
+                return Err(DodotError::Other(format!(
+                    "externals.toml entry '{name}': `ref` and `commit` are mutually exclusive — pick one"
+                )));
+            }
+            if let Some(p) = subpath {
+                validate_subpath(name, p)?;
+            }
+            if let Some(c) = commit {
+                validate_commit_sha(name, c)?;
+            }
+        }
     }
     Ok(ExternalsToml { entries: parsed })
+}
+
+/// Reject `subpath` values that wouldn't be safe to join onto the
+/// clone root. We're more permissive than [`validate_entry_name`] —
+/// `subpath` is a real on-disk path inside the git tree, so internal
+/// slashes and most punctuation are fine. But absolute paths, `..`
+/// segments, and leading `-` (which git would treat as an option flag)
+/// are hard errors.
+fn validate_subpath(entry: &str, subpath: &str) -> Result<()> {
+    if subpath.is_empty() {
+        return Err(DodotError::Other(format!(
+            "externals.toml entry '{entry}': `subpath` must not be empty"
+        )));
+    }
+    if subpath.starts_with('/') || subpath.starts_with('\\') {
+        return Err(DodotError::Other(format!(
+            "externals.toml entry '{entry}': `subpath` must be relative, not {subpath:?}"
+        )));
+    }
+    if subpath.starts_with('-') {
+        return Err(DodotError::Other(format!(
+            "externals.toml entry '{entry}': `subpath` must not start with `-` (git would treat it as an option): {subpath:?}"
+        )));
+    }
+    // Reject `..` segments anywhere. Splitting on both `/` and `\`
+    // covers POSIX and Windows-style separators.
+    for segment in subpath.split(['/', '\\']) {
+        if segment == ".." {
+            return Err(DodotError::Other(format!(
+                "externals.toml entry '{entry}': `subpath` may not contain `..` segments: {subpath:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Reject obviously-malformed commit pins early so the executor's
+/// diagnostic budget stays focused on real failures. Accepts 40-char
+/// lowercase-or-mixed-case hex (the full sha1 form); short hashes are
+/// rejected because shallow git can't reliably resolve them, and
+/// they'd also make sentinel filenames ambiguous.
+fn validate_commit_sha(entry: &str, commit: &str) -> Result<()> {
+    if commit.len() != 40 {
+        return Err(DodotError::Other(format!(
+            "externals.toml entry '{entry}': `commit` must be a full 40-char SHA, got {} chars",
+            commit.len()
+        )));
+    }
+    if !commit.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(DodotError::Other(format!(
+            "externals.toml entry '{entry}': `commit` must be hex (a-f, 0-9), got {commit:?}"
+        )));
+    }
+    Ok(())
 }
 
 /// Reject entry names that wouldn't be safe as path or sentinel
@@ -237,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_git_repo_entry() {
+    fn parses_git_repo_entry_minimal() {
         let toml = r#"
             [omz]
             type   = "git-repo"
@@ -248,11 +350,149 @@ mod tests {
         let entry = parsed.entries.get("omz").unwrap();
         assert_eq!(entry.target, "~/.oh-my-zsh");
         match &entry.spec {
-            FetchSpec::GitRepo { url } => {
+            FetchSpec::GitRepo {
+                url,
+                subpath,
+                git_ref,
+                commit,
+            } => {
                 assert_eq!(url, "https://github.com/ohmyzsh/ohmyzsh.git");
+                assert!(subpath.is_none());
+                assert!(git_ref.is_none());
+                assert!(commit.is_none());
             }
             other => panic!("expected GitRepo spec, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_git_repo_entry_with_subpath_and_ref() {
+        let toml = r#"
+            [p10k]
+            type    = "git-repo"
+            url     = "https://github.com/romkatv/powerlevel10k.git"
+            target  = "~/.config/zsh/themes/p10k"
+            subpath = "themes"
+            ref     = "v1.20.0"
+        "#;
+        let parsed = parse_externals_toml(toml.as_bytes()).unwrap();
+        let entry = parsed.entries.get("p10k").unwrap();
+        match &entry.spec {
+            FetchSpec::GitRepo {
+                subpath,
+                git_ref,
+                commit,
+                ..
+            } => {
+                assert_eq!(subpath.as_deref(), Some("themes"));
+                assert_eq!(git_ref.as_deref(), Some("v1.20.0"));
+                assert!(commit.is_none());
+            }
+            other => panic!("expected GitRepo, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_git_repo_entry_with_commit_pin() {
+        let toml = r#"
+            [tpm]
+            type   = "git-repo"
+            url    = "https://github.com/tmux-plugins/tpm.git"
+            target = "~/.tmux/plugins/tpm"
+            commit = "3a8b3f4a5b8d1c2e3f4a5b6c7d8e9f0a1b2c3d4e"
+        "#;
+        let parsed = parse_externals_toml(toml.as_bytes()).unwrap();
+        let entry = parsed.entries.get("tpm").unwrap();
+        match &entry.spec {
+            FetchSpec::GitRepo { commit, .. } => {
+                assert_eq!(
+                    commit.as_deref(),
+                    Some("3a8b3f4a5b8d1c2e3f4a5b6c7d8e9f0a1b2c3d4e")
+                );
+            }
+            other => panic!("expected GitRepo, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_absolute_subpath() {
+        let toml = r#"
+            [bad]
+            type    = "git-repo"
+            url     = "https://example.com/x.git"
+            target  = "~/x"
+            subpath = "/etc"
+        "#;
+        let err = parse_externals_toml(toml.as_bytes()).unwrap_err();
+        assert!(format!("{err}").contains("must be relative"));
+    }
+
+    #[test]
+    fn rejects_dotdot_in_subpath() {
+        let toml = r#"
+            [bad]
+            type    = "git-repo"
+            url     = "https://example.com/x.git"
+            target  = "~/x"
+            subpath = "themes/../../etc"
+        "#;
+        let err = parse_externals_toml(toml.as_bytes()).unwrap_err();
+        assert!(format!("{err}").contains(".."));
+    }
+
+    #[test]
+    fn rejects_dash_prefixed_subpath() {
+        let toml = r#"
+            [bad]
+            type    = "git-repo"
+            url     = "https://example.com/x.git"
+            target  = "~/x"
+            subpath = "-experimental"
+        "#;
+        let err = parse_externals_toml(toml.as_bytes()).unwrap_err();
+        assert!(format!("{err}").contains("must not start with `-`"));
+    }
+
+    #[test]
+    fn rejects_short_commit_sha() {
+        let toml = r#"
+            [bad]
+            type   = "git-repo"
+            url    = "https://example.com/x.git"
+            target = "~/x"
+            commit = "abc1234"
+        "#;
+        let err = parse_externals_toml(toml.as_bytes()).unwrap_err();
+        assert!(format!("{err}").contains("full 40-char SHA"));
+    }
+
+    #[test]
+    fn rejects_non_hex_commit_sha() {
+        let toml = r#"
+            [bad]
+            type   = "git-repo"
+            url    = "https://example.com/x.git"
+            target = "~/x"
+            commit = "zzzzbeef1234567890abcdef1234567890abcdef"
+        "#;
+        let err = parse_externals_toml(toml.as_bytes()).unwrap_err();
+        assert!(format!("{err}").contains("must be hex"));
+    }
+
+    #[test]
+    fn rejects_ref_and_commit_simultaneously() {
+        let toml = r#"
+            [conflicted]
+            type   = "git-repo"
+            url    = "https://example.com/x.git"
+            target = "~/x"
+            ref    = "v1"
+            commit = "abc1234"
+        "#;
+        let err = parse_externals_toml(toml.as_bytes()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("mutually exclusive"), "got: {msg}");
+        assert!(msg.contains("conflicted"), "got: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Third PR of the externals series. Adds the three optional fields the issue calls for on \`type = \"git-repo\"\`: \`subpath\` (sparse checkout), \`ref\` (tag/branch tracking), and \`commit\` (frozen pin).

> [!NOTE]
> **Base is \`feat/external-files-git-repo\` (PR #155), not main.**

## Freshness model per pin shape

| Configuration | What \`up\` does on each run |
|---|---|
| Unpinned | \`git ls-remote HEAD\`; refresh when upstream HEAD moves |
| \`ref = \"v1.2.3\"\` | \`git ls-remote v1.2.3\`; refresh when that reference's SHA changes (rare for tags, possible for branch refs) |
| \`commit = \"<sha>\"\` | No \`ls-remote\` at all — compare local against the pin; refresh only when the user edits the TOML |

\`ref\` and \`commit\` are mutually exclusive; parsing rejects an entry that sets both.

## Subpath semantics

\`subpath = \"themes\"\` triggers sparse-checkout cone mode on the initial clone (\`--no-checkout\` → \`sparse-checkout init --cone\` → \`sparse-checkout set <p>\` → \`checkout\`). The user-visible target symlink then points at \`<clone>/<subpath>\`, not the whole clone — so \`~/.config/zsh/themes/p10k\` resolves through only the bytes the user asked for.

## GitRunner trait refactor

\`ls_remote_head\` → \`ls_remote(url, reference)\`. \`shallow_clone\` gains \`Option<reference>\` + \`Option<subpath>\`. New \`checkout(repo, target)\` for commit pinning. \`MockGitRunner\` writes its marker file under the configured subpath so symlink-into-subpath assertions work end-to-end without networking.

## Test coverage

1183 tests pass (+3 new git-repo + 4 new spec). Highlights:

- \`subpath\` makes the user-visible symlink resolve to the subpath inside the clone
- \`ref = v1.20.0\` causes \`clone --branch\` and subsequent ls-remote against that ref
- \`commit = <sha>\` skips ls-remote when local matches; surfaces \"pinned to commit\"
- Parsing rejects entries that set both \`ref\` and \`commit\`

## Test plan

- [ ] CI passes
- [ ] Manual: pack with \`subpath = \"themes\"\` deploys only that subtree to the target

🤖 Generated with [Claude Code](https://claude.com/claude-code)