### PR TITLE
feat(external): archive + archive-file types (PR 4/6, #152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Externals handler: `archive` and `archive-file` types (PR 4 of stacked series)** —
+  Two new spec variants in `externals.toml`:
+  - `type = "archive"` — download an archive, sha256-verify, extract
+    the whole tree into the datastore. The user-visible target
+    symlink points at the extracted directory.
+  - `type = "archive-file"` — same fetch + verify path, but only
+    one named member is extracted. The target symlink points at
+    the single extracted file.
+
+  Supported formats: gzipped tar (`.tar.gz` / `.tgz`) and zip
+  (`.zip`). Format is inferred from the URL filename; pass
+  `format = "tar-gz"` or `format = "zip"` explicitly for URLs
+  without a recognized suffix. Archive entries with unsafe paths
+  (absolute, `..` components) are rejected at extraction time.
+  `zip = "2"` added as a dependency for zip support.
+
 - **Externals handler: `subpath`, `ref`, `commit` (PR 3 of stacked series)** —
   `type = "git-repo"` now accepts three optional fields:
   - `subpath = "themes"` — sparse-checkout pattern. Only that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +617,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "detect-desktop-environment"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +756,7 @@ dependencies = [
  "tracing",
  "ureq",
  "zeroize",
+ "zip",
 ]
 
 [[package]]
@@ -3353,10 +3374,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -26,6 +26,7 @@ toml = "0.8"
 tracing = "0.1"
 ureq = { version = "2", default-features = false, features = ["tls"] }
 zeroize = "1"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dodot-lib/src/conflicts.rs
+++ b/crates/dodot-lib/src/conflicts.rs
@@ -183,6 +183,8 @@ fn intent_source(intent: &HandlerIntent) -> PathBuf {
         HandlerIntent::Fetch { spec, name, .. } => match spec {
             crate::external::FetchSpec::File { url, .. } => PathBuf::from(url),
             crate::external::FetchSpec::GitRepo { url, .. } => PathBuf::from(url),
+            crate::external::FetchSpec::Archive { url, .. } => PathBuf::from(url),
+            crate::external::FetchSpec::ArchiveFile { url, .. } => PathBuf::from(url),
             crate::external::FetchSpec::Unsupported => PathBuf::from(format!("<external:{name}>")),
         },
     }

--- a/crates/dodot-lib/src/execution/fetch.rs
+++ b/crates/dodot-lib/src/execution/fetch.rs
@@ -63,10 +63,32 @@ impl<'a> Executor<'a> {
                 commit.as_deref(),
                 user_path,
             ),
+            FetchSpec::Archive {
+                url,
+                sha256,
+                format,
+            } => self.execute_fetch_archive(
+                pack, handler, name, url, sha256, *format, None, user_path,
+            ),
+            FetchSpec::ArchiveFile {
+                url,
+                sha256,
+                member,
+                format,
+            } => self.execute_fetch_archive(
+                pack,
+                handler,
+                name,
+                url,
+                sha256,
+                *format,
+                Some(member.as_str()),
+                user_path,
+            ),
             FetchSpec::Unsupported => Ok(vec![OperationResult::fail(
                 fetch_op(pack, handler, name, "<unsupported>"),
                 format!(
-                    "external '{name}': unsupported type — supported in this release: `file`, `git-repo`"
+                    "external '{name}': unsupported type — supported in this release: `file`, `git-repo`, `archive`, `archive-file`"
                 ),
             )]),
         }
@@ -133,6 +155,45 @@ impl<'a> Executor<'a> {
                     format!(
                         "[dry-run] would clone {url}{pin_label} → {}{subpath_label} → {}",
                         datastore_path.display(),
+                        user_path.display()
+                    )
+                };
+                vec![OperationResult::ok(fetch_op(pack, handler, name, url), msg)]
+            }
+            FetchSpec::Archive { url, sha256, .. } => {
+                let sentinel = archive_sentinel(name, sha256, None);
+                let already = self
+                    .datastore
+                    .has_sentinel(pack, handler, &sentinel)
+                    .unwrap_or(false);
+                let msg = if already {
+                    format!("[dry-run] {name} fresh (archive sha256 matches)")
+                } else {
+                    format!(
+                        "[dry-run] would download {url}, verify sha256={}, extract → {}",
+                        short(sha256),
+                        user_path.display()
+                    )
+                };
+                vec![OperationResult::ok(fetch_op(pack, handler, name, url), msg)]
+            }
+            FetchSpec::ArchiveFile {
+                url,
+                sha256,
+                member,
+                ..
+            } => {
+                let sentinel = archive_sentinel(name, sha256, Some(member));
+                let already = self
+                    .datastore
+                    .has_sentinel(pack, handler, &sentinel)
+                    .unwrap_or(false);
+                let msg = if already {
+                    format!("[dry-run] {name} fresh (archive sha256 + member matches)")
+                } else {
+                    format!(
+                        "[dry-run] would download {url}, verify sha256={}, extract `{member}` → {}",
+                        short(sha256),
                         user_path.display()
                     )
                 };
@@ -267,6 +328,188 @@ impl<'a> Executor<'a> {
             ),
             OperationResult::ok(create_link, format!("{name} → {}", user_path.display())),
         ])
+    }
+
+    /// Fetch + extract a `type = "archive"` (whole tree) or
+    /// `type = "archive-file"` (single entry) external.
+    ///
+    /// When `member` is `None`, the whole archive is materialised
+    /// under `<handler_data_dir>/<name>/` and the user-visible
+    /// symlink points at that directory. When `member = Some(p)`,
+    /// only that entry is written, at `<handler_data_dir>/<name>/<basename>`,
+    /// and the symlink points at the single file.
+    ///
+    /// Sentinel: `<name>-archive-<sha-prefix>[-<member-hash>]`. The
+    /// sha256 is the archive's hash (already declared by the user);
+    /// for archive-file we mix in a short hash of the member path so
+    /// changing `member = ...` in the TOML re-extracts.
+    #[allow(clippy::too_many_arguments)]
+    fn execute_fetch_archive(
+        &self,
+        pack: &str,
+        handler: &str,
+        name: &str,
+        url: &str,
+        expected_sha256: &str,
+        format: Option<crate::external::ArchiveFormat>,
+        member: Option<&str>,
+        user_path: &Path,
+    ) -> Result<Vec<OperationResult>> {
+        let op = || fetch_op(pack, handler, name, url);
+        let sentinel = archive_sentinel(name, expected_sha256, member);
+
+        if !self.force && self.datastore.has_sentinel(pack, handler, &sentinel)? {
+            debug!(pack, name, "archive sentinel matches; skipping fetch");
+            return Ok(vec![OperationResult::ok(
+                op(),
+                format!("{name}: fresh (archive sha256 matches)"),
+            )]);
+        }
+
+        // Resolve format: explicit field wins; otherwise infer from
+        // the URL filename.
+        let format = match format.or_else(|| crate::external::ArchiveFormat::infer_from_url(url)) {
+            Some(f) => f,
+            None => {
+                return Ok(vec![OperationResult::fail(
+                    op(),
+                    format!(
+                        "{name}: archive format could not be inferred from URL {url}; set `format` explicitly"
+                    ),
+                )]);
+            }
+        };
+
+        let Some(fetcher) = self.fetcher() else {
+            return Ok(vec![OperationResult::fail(
+                op(),
+                format!(
+                    "external '{name}': executor has no HTTP fetcher configured; call Executor::with_fetcher() in production wiring"
+                ),
+            )]);
+        };
+
+        info!(pack, name, url, ?format, ?member, "downloading archive");
+        let bytes = match fetcher.fetch(url) {
+            Ok(b) => b,
+            Err(err) if err.is_transient() => {
+                warn!(pack, name, %err, "archive fetch failed (transient)");
+                return Ok(vec![OperationResult::fail(
+                    op(),
+                    format!("{name}: fetch failed ({err}); leaving cached copy in place"),
+                )]);
+            }
+            Err(err) => {
+                return Ok(vec![OperationResult::fail(
+                    op(),
+                    format!("{name}: fetch failed: {err}"),
+                )]);
+            }
+        };
+
+        let actual = sha256_hex(&bytes);
+        if !sha256_matches(expected_sha256, &actual) {
+            return Ok(vec![OperationResult::fail(
+                op(),
+                format!(
+                    "{name}: sha256 mismatch (configured {}, actual {}); refusing to extract",
+                    short(expected_sha256),
+                    short(&actual)
+                ),
+            )]);
+        }
+
+        // Wipe any previous extraction for this entry so a refresh
+        // doesn't leave stale files behind. `remove_state` removes
+        // the whole handler dir which is too aggressive — we want
+        // just `<name>/`. The datastore doesn't expose a per-subdir
+        // remove, so do it via Fs against the resolved path.
+        let entry_root = self.paths.handler_data_dir(pack, handler).join(name);
+        if self.fs.exists(&entry_root) {
+            // For archive-file we wrote a single file; for archive we
+            // wrote a directory tree. Handle both.
+            if self.fs.is_dir(&entry_root) {
+                self.fs.remove_dir_all(&entry_root)?;
+            } else {
+                self.fs.remove_file(&entry_root)?;
+            }
+        }
+
+        // Extract.
+        let (symlink_target, ops) = if let Some(m) = member {
+            let entry = match crate::external::read_member(&bytes, format, m) {
+                Ok(e) => e,
+                Err(err) => {
+                    return Ok(vec![OperationResult::fail(op(), format!("{name}: {err}"))]);
+                }
+            };
+            // Land the single file at `<name>/<basename-of-member>`.
+            // basename so users get a stable path inside the
+            // datastore even when the archive uses a deep member.
+            let basename = std::path::Path::new(m)
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "content".into());
+            let rel = format!("{name}/{basename}");
+            let dst = self
+                .datastore
+                .write_rendered_file(pack, handler, &rel, &entry.bytes)?;
+            (
+                dst.clone(),
+                vec![format!(
+                    "{name}: extracted `{m}` ({} bytes)",
+                    entry.bytes.len()
+                )],
+            )
+        } else {
+            let entries = match crate::external::read_all(&bytes, format) {
+                Ok(e) => e,
+                Err(err) => {
+                    return Ok(vec![OperationResult::fail(op(), format!("{name}: {err}"))]);
+                }
+            };
+            let mut written = 0usize;
+            for (rel_path, entry) in &entries {
+                let rel_str = rel_path.to_string_lossy();
+                let rel_full = format!("{name}/{rel_str}");
+                if entry.is_dir {
+                    self.datastore
+                        .write_rendered_dir(pack, handler, &rel_full)?;
+                } else {
+                    self.datastore
+                        .write_rendered_file(pack, handler, &rel_full, &entry.bytes)?;
+                    written += 1;
+                }
+            }
+            (
+                entry_root.clone(),
+                vec![format!(
+                    "{name}: extracted {} files into {}",
+                    written,
+                    entry_root.display()
+                )],
+            )
+        };
+
+        // User-visible symlink.
+        self.create_external_user_link(&symlink_target, user_path)?;
+        self.write_sentinel(pack, handler, &sentinel)?;
+
+        let create_link = Operation::CreateUserLink {
+            pack: pack.to_string(),
+            handler: handler.to_string(),
+            datastore_path: symlink_target.clone(),
+            user_path: user_path.to_path_buf(),
+        };
+        let mut results = Vec::new();
+        for msg in ops {
+            results.push(OperationResult::ok(op(), msg));
+        }
+        results.push(OperationResult::ok(
+            create_link,
+            format!("{name} → {}", user_path.display()),
+        ));
+        Ok(results)
     }
 
     /// Fetch one `type = "git-repo"` external.
@@ -746,6 +989,22 @@ fn file_sentinel(name: &str, sha256: &str) -> String {
 /// is live.
 fn git_repo_sentinel(name: &str, sha: &str) -> String {
     format!("{name}-git-{}", short(sha))
+}
+
+/// Sentinel filename for `archive` / `archive-file` entries.
+///
+/// The archive sha256 prefix is the primary key. For archive-file we
+/// also mix in a short hash of the member path so changing the
+/// `member` field in the TOML (without changing the archive itself)
+/// still invalidates the sentinel.
+fn archive_sentinel(name: &str, sha256: &str, member: Option<&str>) -> String {
+    match member {
+        Some(m) => {
+            let member_hash = sha256_hex(m.as_bytes());
+            format!("{name}-archive-{}-{}", short(sha256), short(&member_hash))
+        }
+        None => format!("{name}-archive-{}", short(sha256)),
+    }
 }
 
 /// Derive the on-disk filename inside the datastore subdir from the
@@ -1617,5 +1876,293 @@ mod tests {
         assert!(git.calls().is_empty());
         assert!(!env.fs.exists(&user_path));
         env.assert_no_handler_state("frameworks", "external");
+    }
+
+    // ── archive / archive-file ─────────────────────────────────
+
+    fn make_tar_gz_two_files() -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let mut tar_buf: Vec<u8> = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+
+            let mut header = tar::Header::new_gnu();
+            let body = b"# alpha theme\n";
+            header.set_path("themes/alpha.zsh").unwrap();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, &body[..]).unwrap();
+
+            let mut header = tar::Header::new_gnu();
+            let body = b"#!/bin/sh\necho setup\n";
+            header.set_path("scripts/setup.sh").unwrap();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append(&header, &body[..]).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        gz.write_all(&tar_buf).unwrap();
+        gz.finish().unwrap()
+    }
+
+    fn archive_intent(
+        name: &str,
+        url: &str,
+        sha256: String,
+        user_path: std::path::PathBuf,
+    ) -> HandlerIntent {
+        HandlerIntent::Fetch {
+            pack: "themes".into(),
+            handler: "external".into(),
+            name: name.into(),
+            spec: FetchSpec::Archive {
+                url: url.into(),
+                sha256,
+                format: None,
+            },
+            user_path,
+        }
+    }
+
+    fn archive_file_intent(
+        name: &str,
+        url: &str,
+        sha256: String,
+        member: &str,
+        user_path: std::path::PathBuf,
+    ) -> HandlerIntent {
+        HandlerIntent::Fetch {
+            pack: "themes".into(),
+            handler: "external".into(),
+            name: name.into(),
+            spec: FetchSpec::ArchiveFile {
+                url: url.into(),
+                sha256,
+                member: member.into(),
+                format: None,
+            },
+            user_path,
+        }
+    }
+
+    #[test]
+    fn archive_full_extracts_tree_and_symlinks() {
+        let bytes = make_tar_gz_two_files();
+        let sha = super::sha256_hex(&bytes);
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://x/p10k.tar.gz", &bytes);
+        let user_path = env.home.join(".config/themes/p10k");
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        let results = executor
+            .execute(vec![archive_intent(
+                "p10k",
+                "https://x/p10k.tar.gz",
+                sha,
+                user_path.clone(),
+            )])
+            .unwrap();
+        assert!(results.iter().all(|r| r.success), "{results:#?}");
+        assert!(env.fs.is_symlink(&user_path));
+        // Two files materialised under the entry dir.
+        let theme = user_path.join("themes/alpha.zsh");
+        let script = user_path.join("scripts/setup.sh");
+        assert!(env.fs.exists(&theme));
+        assert!(env.fs.exists(&script));
+        assert_eq!(env.fs.read_to_string(&theme).unwrap(), "# alpha theme\n");
+    }
+
+    #[test]
+    fn archive_idempotent_via_sentinel() {
+        let bytes = make_tar_gz_two_files();
+        let sha = super::sha256_hex(&bytes);
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://x/p10k.tar.gz", &bytes);
+        let user_path = env.home.join(".config/themes/p10k");
+        let intent = archive_intent("p10k", "https://x/p10k.tar.gz", sha.clone(), user_path);
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        executor.execute(vec![intent.clone()]).unwrap();
+        // Second run: mock only had one canned response, so a second
+        // fetch attempt would fail. Sentinel must prevent the fetch.
+        let second = executor.execute(vec![intent]).unwrap();
+        assert!(second.iter().all(|r| r.success), "{second:#?}");
+        assert!(
+            second[0].message.contains("fresh"),
+            "msg: {}",
+            second[0].message
+        );
+    }
+
+    #[test]
+    fn archive_sha256_mismatch_refuses_to_extract() {
+        let bytes = make_tar_gz_two_files();
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://x/p10k.tar.gz", &bytes);
+        let user_path = env.home.join(".config/themes/p10k");
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        let results = executor
+            .execute(vec![archive_intent(
+                "p10k",
+                "https://x/p10k.tar.gz",
+                "wrong".repeat(13), // 65 chars
+                user_path.clone(),
+            )])
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(
+            results[0].message.contains("sha256 mismatch"),
+            "msg: {}",
+            results[0].message
+        );
+        assert!(!env.fs.exists(&user_path));
+    }
+
+    #[test]
+    fn archive_file_extracts_single_member() {
+        let bytes = make_tar_gz_two_files();
+        let sha = super::sha256_hex(&bytes);
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://x/p10k.tar.gz", &bytes);
+        let user_path = env.home.join("setup.sh");
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        let results = executor
+            .execute(vec![archive_file_intent(
+                "setup",
+                "https://x/p10k.tar.gz",
+                sha,
+                "scripts/setup.sh",
+                user_path.clone(),
+            )])
+            .unwrap();
+        assert!(results.iter().all(|r| r.success), "{results:#?}");
+        assert!(env.fs.is_symlink(&user_path));
+        // The deployed file's content matches the archive member.
+        assert_eq!(
+            env.fs.read_to_string(&user_path).unwrap(),
+            "#!/bin/sh\necho setup\n"
+        );
+    }
+
+    #[test]
+    fn archive_file_missing_member_fails_clearly() {
+        let bytes = make_tar_gz_two_files();
+        let sha = super::sha256_hex(&bytes);
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://x/p10k.tar.gz", &bytes);
+        let user_path = env.home.join("doesnt-matter");
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        let results = executor
+            .execute(vec![archive_file_intent(
+                "missing",
+                "https://x/p10k.tar.gz",
+                sha,
+                "no/such/path.sh",
+                user_path,
+            )])
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(
+            results[0].message.contains("does not contain member"),
+            "msg: {}",
+            results[0].message
+        );
+    }
+
+    #[test]
+    fn archive_unknown_format_url_fails_helpfully() {
+        let bytes = b"some-bytes".to_vec();
+        let sha = super::sha256_hex(&bytes);
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let fetcher = MockFetcher::new().with("https://x/no-extension", &bytes);
+        let user_path = env.home.join("x");
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_fetcher(&fetcher);
+
+        let results = executor
+            .execute(vec![archive_intent(
+                "weird",
+                "https://x/no-extension",
+                sha,
+                user_path,
+            )])
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(
+            results[0].message.contains("format could not be inferred"),
+            "msg: {}",
+            results[0].message
+        );
     }
 }

--- a/crates/dodot-lib/src/execution/fetch.rs
+++ b/crates/dodot-lib/src/execution/fetch.rs
@@ -20,14 +20,24 @@
 //!   it in place and report the failure as a non-success result; other
 //!   intents still execute. This covers both HTTP and git transports.
 
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
-use crate::external::FetchSpec;
+use crate::external::{ArchiveEntry, FetchSpec};
 use crate::operations::{HandlerIntent, Operation, OperationResult};
 use crate::Result;
+
+/// Parsed archive contents, held in memory between successful parse
+/// and (potentially destructive) cleanup of the prior extraction.
+enum ArchiveExtracted {
+    /// `type = "archive-file"`: a single member extracted by name.
+    Single(ArchiveEntry),
+    /// `type = "archive"`: the whole archive's entry tree.
+    Tree(HashMap<PathBuf, ArchiveEntry>),
+}
 
 use super::Executor;
 
@@ -419,12 +429,28 @@ impl<'a> Executor<'a> {
             )]);
         }
 
-        // Wipe any previous extraction for this entry so a refresh
-        // doesn't leave stale files behind. `remove_state` removes
-        // the whole handler dir which is too aggressive — we want
-        // just `<name>/`. The datastore doesn't expose a per-subdir
-        // remove, so do it via Fs against the resolved path.
+        // Parse + validate the archive BEFORE touching the previous
+        // extraction on disk — a corrupt download or an unsafe path
+        // must not destroy the cached copy that's already deployed.
         let entry_root = self.paths.handler_data_dir(pack, handler).join(name);
+        let archive_parse = if let Some(m) = member {
+            match crate::external::read_member(&bytes, format, m) {
+                Ok(e) => ArchiveExtracted::Single(e),
+                Err(err) => {
+                    return Ok(vec![OperationResult::fail(op(), format!("{name}: {err}"))]);
+                }
+            }
+        } else {
+            match crate::external::read_all(&bytes, format) {
+                Ok(es) => ArchiveExtracted::Tree(es),
+                Err(err) => {
+                    return Ok(vec![OperationResult::fail(op(), format!("{name}: {err}"))]);
+                }
+            }
+        };
+
+        // Now safe to wipe the previous extraction. We only get here
+        // once we've already parsed the new archive successfully.
         if self.fs.exists(&entry_root) {
             // For archive-file we wrote a single file; for archive we
             // wrote a directory tree. Handle both.
@@ -435,60 +461,48 @@ impl<'a> Executor<'a> {
             }
         }
 
-        // Extract.
-        let (symlink_target, ops) = if let Some(m) = member {
-            let entry = match crate::external::read_member(&bytes, format, m) {
-                Ok(e) => e,
-                Err(err) => {
-                    return Ok(vec![OperationResult::fail(op(), format!("{name}: {err}"))]);
-                }
-            };
-            // Land the single file at `<name>/<basename-of-member>`.
-            // basename so users get a stable path inside the
-            // datastore even when the archive uses a deep member.
-            let basename = std::path::Path::new(m)
-                .file_name()
-                .map(|s| s.to_string_lossy().into_owned())
-                .unwrap_or_else(|| "content".into());
-            let rel = format!("{name}/{basename}");
-            let dst = self
-                .datastore
-                .write_rendered_file(pack, handler, &rel, &entry.bytes)?;
-            (
-                dst.clone(),
-                vec![format!(
-                    "{name}: extracted `{m}` ({} bytes)",
-                    entry.bytes.len()
-                )],
-            )
-        } else {
-            let entries = match crate::external::read_all(&bytes, format) {
-                Ok(e) => e,
-                Err(err) => {
-                    return Ok(vec![OperationResult::fail(op(), format!("{name}: {err}"))]);
-                }
-            };
-            let mut written = 0usize;
-            for (rel_path, entry) in &entries {
-                let rel_str = rel_path.to_string_lossy();
-                let rel_full = format!("{name}/{rel_str}");
-                if entry.is_dir {
-                    self.datastore
-                        .write_rendered_dir(pack, handler, &rel_full)?;
-                } else {
-                    self.datastore
-                        .write_rendered_file(pack, handler, &rel_full, &entry.bytes)?;
-                    written += 1;
-                }
+        let (symlink_target, ops) = match archive_parse {
+            ArchiveExtracted::Single(entry) => {
+                let m = member.expect("Single variant only produced for member fetches");
+                // Land the single file at `<name>/<basename-of-member>`.
+                // basename so users get a stable path inside the
+                // datastore even when the archive uses a deep member.
+                let basename = std::path::Path::new(m)
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "content".into());
+                let rel = format!("{name}/{basename}");
+                let dst = self.write_archive_entry(pack, handler, &rel, &entry)?;
+                (
+                    dst,
+                    vec![format!(
+                        "{name}: extracted `{m}` ({} bytes)",
+                        entry.bytes.len()
+                    )],
+                )
             }
-            (
-                entry_root.clone(),
-                vec![format!(
-                    "{name}: extracted {} files into {}",
-                    written,
-                    entry_root.display()
-                )],
-            )
+            ArchiveExtracted::Tree(entries) => {
+                let mut written = 0usize;
+                for (rel_path, entry) in &entries {
+                    let rel_str = rel_path.to_string_lossy();
+                    let rel_full = format!("{name}/{rel_str}");
+                    if entry.is_dir {
+                        self.datastore
+                            .write_rendered_dir(pack, handler, &rel_full)?;
+                    } else {
+                        self.write_archive_entry(pack, handler, &rel_full, entry)?;
+                        written += 1;
+                    }
+                }
+                (
+                    entry_root.clone(),
+                    vec![format!(
+                        "{name}: extracted {} files into {}",
+                        written,
+                        entry_root.display()
+                    )],
+                )
+            }
         };
 
         // User-visible symlink.
@@ -510,6 +524,28 @@ impl<'a> Executor<'a> {
             format!("{name} → {}", user_path.display()),
         ));
         Ok(results)
+    }
+
+    /// Write one archive entry to the datastore, preserving the
+    /// archive's mode bits when present so executable files stay
+    /// executable after `up`. Falls back to `write_rendered_file`
+    /// (umask-default mode) when the entry didn't carry a mode.
+    fn write_archive_entry(
+        &self,
+        pack: &str,
+        handler: &str,
+        rel: &str,
+        entry: &crate::external::ArchiveEntry,
+    ) -> Result<std::path::PathBuf> {
+        match entry.mode {
+            Some(mode) if mode != 0 => {
+                self.datastore
+                    .write_rendered_file_with_mode(pack, handler, rel, &entry.bytes, mode)
+            }
+            _ => self
+                .datastore
+                .write_rendered_file(pack, handler, rel, &entry.bytes),
+        }
     }
 
     /// Fetch one `type = "git-repo"` external.

--- a/crates/dodot-lib/src/external/archive.rs
+++ b/crates/dodot-lib/src/external/archive.rs
@@ -40,12 +40,18 @@ pub struct ArchiveEntry {
     pub mode: Option<u32>,
 }
 
-/// Extract all entries from an archive into memory, keyed by their
-/// relative path. Skips directory entries (they're recreated on write).
+/// Extract every entry from an archive into memory, keyed by relative
+/// path. Both regular files and directory markers are returned (callers
+/// distinguish via [`ArchiveEntry::is_dir`]) so explicit empty
+/// directories survive the round-trip.
 ///
 /// Paths are validated: absolute paths and `..` components are
 /// rejected with [`ArchiveError::UnsafePath`] so a malicious archive
-/// can never escape the datastore subdir.
+/// can never escape the datastore subdir. Tar entries that are
+/// neither regular files nor directories (symlinks, hardlinks,
+/// devices, FIFOs, …) are rejected explicitly — dodot does not yet
+/// have a defensible posture for materialising them, so silently
+/// turning them into empty files would be a footgun.
 pub fn read_all(
     bytes: &[u8],
     format: ArchiveFormat,
@@ -57,16 +63,20 @@ pub fn read_all(
 }
 
 /// Extract a single named entry from an archive into memory.
+///
+/// Streams through the archive and returns the first matching entry
+/// without buffering the rest — handy for `type = "archive-file"`
+/// against multi-GB release tarballs.
 pub fn read_member(
     bytes: &[u8],
     format: ArchiveFormat,
     member: &str,
 ) -> Result<ArchiveEntry, ArchiveError> {
     let target = std::path::Path::new(member);
-    let all = read_all(bytes, format)?;
-    all.into_iter()
-        .find_map(|(p, e)| (p == target).then_some(e))
-        .ok_or_else(|| ArchiveError::MissingMember(member.to_string()))
+    match format {
+        ArchiveFormat::TarGz => read_tar_gz_one(bytes, target),
+        ArchiveFormat::Zip => read_zip_one(bytes, target),
+    }
 }
 
 fn read_tar_gz(bytes: &[u8]) -> Result<HashMap<PathBuf, ArchiveEntry>, ArchiveError> {
@@ -77,32 +87,75 @@ fn read_tar_gz(bytes: &[u8]) -> Result<HashMap<PathBuf, ArchiveEntry>, ArchiveEr
         .entries()
         .map_err(|e| ArchiveError::Read(e.to_string()))?
     {
-        let mut entry = entry.map_err(|e| ArchiveError::Read(e.to_string()))?;
-        let raw_path = entry
-            .path()
-            .map_err(|e| ArchiveError::Read(e.to_string()))?
-            .into_owned();
-        let safe = validate_safe_archive_path(&raw_path)?;
-        let header = entry.header();
-        let mode = header.mode().ok();
-        let is_dir = header.entry_type().is_dir();
-        let mut buf = Vec::new();
-        if !is_dir {
-            entry
-                .read_to_end(&mut buf)
-                .map_err(|e| ArchiveError::Read(e.to_string()))?;
+        let entry = entry.map_err(|e| ArchiveError::Read(e.to_string()))?;
+        if let Some(parsed) = read_tar_entry(entry)? {
+            out.insert(parsed.path.clone(), parsed);
         }
-        out.insert(
-            safe.clone(),
-            ArchiveEntry {
-                path: safe,
-                is_dir,
-                bytes: buf,
-                mode,
-            },
-        );
     }
     Ok(out)
+}
+
+fn read_tar_gz_one(bytes: &[u8], member: &std::path::Path) -> Result<ArchiveEntry, ArchiveError> {
+    let gz = flate2::read::GzDecoder::new(Cursor::new(bytes));
+    let mut archive = tar::Archive::new(gz);
+    for entry in archive
+        .entries()
+        .map_err(|e| ArchiveError::Read(e.to_string()))?
+    {
+        let entry = entry.map_err(|e| ArchiveError::Read(e.to_string()))?;
+        if let Some(parsed) = read_tar_entry(entry)? {
+            if parsed.path == member {
+                return Ok(parsed);
+            }
+        }
+    }
+    Err(ArchiveError::MissingMember(member.display().to_string()))
+}
+
+/// Parse one tar entry into an [`ArchiveEntry`].
+///
+/// Returns `Ok(None)` when the entry should be silently skipped (root
+/// `./` placeholder). Returns `Err(UnsafePath)` for entries whose
+/// type is not supported (symlinks, hardlinks, device nodes, etc.) —
+/// we don't have a defensible materialisation story for those and
+/// silently dropping the body would mislead callers.
+fn read_tar_entry<R: std::io::Read>(
+    mut entry: tar::Entry<'_, R>,
+) -> Result<Option<ArchiveEntry>, ArchiveError> {
+    let raw_path = entry
+        .path()
+        .map_err(|e| ArchiveError::Read(e.to_string()))?
+        .into_owned();
+    let safe = match validate_safe_archive_path(&raw_path)? {
+        Some(p) => p,
+        None => return Ok(None), // pure `./` root placeholder
+    };
+    let header_entry_type = entry.header().entry_type();
+    let mode = entry.header().mode().ok();
+    let is_dir = header_entry_type.is_dir();
+    let is_regular = header_entry_type.is_file();
+    if !is_dir && !is_regular {
+        // Symlinks, hardlinks, fifos, char/block devices, sparse, etc.
+        // Reject explicitly so the caller can surface a clear error
+        // rather than silently materialising an empty file.
+        return Err(ArchiveError::UnsafePath(format!(
+            "unsupported tar entry type {:?} at {}",
+            header_entry_type,
+            raw_path.display()
+        )));
+    }
+    let mut buf = Vec::new();
+    if !is_dir {
+        entry
+            .read_to_end(&mut buf)
+            .map_err(|e| ArchiveError::Read(e.to_string()))?;
+    }
+    Ok(Some(ArchiveEntry {
+        path: safe,
+        is_dir,
+        bytes: buf,
+        mode,
+    }))
 }
 
 fn read_zip(bytes: &[u8]) -> Result<HashMap<PathBuf, ArchiveEntry>, ArchiveError> {
@@ -110,46 +163,72 @@ fn read_zip(bytes: &[u8]) -> Result<HashMap<PathBuf, ArchiveEntry>, ArchiveError
         zip::ZipArchive::new(Cursor::new(bytes)).map_err(|e| ArchiveError::Read(e.to_string()))?;
     let mut out: HashMap<PathBuf, ArchiveEntry> = HashMap::new();
     for i in 0..archive.len() {
-        let mut file = archive
-            .by_index(i)
-            .map_err(|e| ArchiveError::Read(e.to_string()))?;
-        // ZipArchive's `enclosed_name()` rejects paths that would
-        // escape the extraction root (absolute, `..` segments). It
-        // returns `None` in those cases — we treat that as an unsafe
-        // entry rather than silently dropping.
-        let raw_path = file
-            .enclosed_name()
-            .ok_or_else(|| ArchiveError::UnsafePath(file.name().to_string()))?;
-        let safe = validate_safe_archive_path(&raw_path)?;
-        let is_dir = file.is_dir();
-        // `unix_mode()` returns the full st_mode with file-type bits;
-        // mask to the permission portion so callers see a familiar
-        // 0o755 / 0o644 rather than 0o100644.
-        let mode = file.unix_mode().map(|m| m & 0o7777);
-        let mut buf = Vec::new();
-        if !is_dir {
-            file.read_to_end(&mut buf)
-                .map_err(|e| ArchiveError::Read(e.to_string()))?;
+        if let Some(parsed) = read_zip_index(&mut archive, i)? {
+            out.insert(parsed.path.clone(), parsed);
         }
-        out.insert(
-            safe.clone(),
-            ArchiveEntry {
-                path: safe,
-                is_dir,
-                bytes: buf,
-                mode,
-            },
-        );
     }
     Ok(out)
 }
 
-/// Reject archive paths that would escape the extraction root.
+fn read_zip_one(bytes: &[u8], member: &std::path::Path) -> Result<ArchiveEntry, ArchiveError> {
+    let mut archive =
+        zip::ZipArchive::new(Cursor::new(bytes)).map_err(|e| ArchiveError::Read(e.to_string()))?;
+    for i in 0..archive.len() {
+        if let Some(parsed) = read_zip_index(&mut archive, i)? {
+            if parsed.path == member {
+                return Ok(parsed);
+            }
+        }
+    }
+    Err(ArchiveError::MissingMember(member.display().to_string()))
+}
+
+fn read_zip_index(
+    archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+    index: usize,
+) -> Result<Option<ArchiveEntry>, ArchiveError> {
+    let mut file = archive
+        .by_index(index)
+        .map_err(|e| ArchiveError::Read(e.to_string()))?;
+    // ZipArchive's `enclosed_name()` rejects paths that would escape
+    // the extraction root (absolute, `..` segments). It returns
+    // `None` in those cases — we treat that as an unsafe entry
+    // rather than silently dropping.
+    let raw_path = file
+        .enclosed_name()
+        .ok_or_else(|| ArchiveError::UnsafePath(file.name().to_string()))?;
+    let safe = match validate_safe_archive_path(&raw_path)? {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+    let is_dir = file.is_dir();
+    // `unix_mode()` returns the full st_mode with file-type bits;
+    // mask to the permission portion so callers see a familiar
+    // 0o755 / 0o644 rather than 0o100644.
+    let mode = file.unix_mode().map(|m| m & 0o7777);
+    let mut buf = Vec::new();
+    if !is_dir {
+        file.read_to_end(&mut buf)
+            .map_err(|e| ArchiveError::Read(e.to_string()))?;
+    }
+    Ok(Some(ArchiveEntry {
+        path: safe,
+        is_dir,
+        bytes: buf,
+        mode,
+    }))
+}
+
+/// Validate an archive-entry path against the rules that keep
+/// extraction inside the datastore subdir.
 ///
-/// Returns the normalized relative path on success. Mirrors the
-/// `validate_safe_relative` helper in `datastore::filesystem` but
-/// scoped to archive contents (which can carry weirder shapes).
-fn validate_safe_archive_path(raw: &std::path::Path) -> Result<PathBuf, ArchiveError> {
+/// - `Ok(Some(path))` — safe relative path, materialise this entry.
+/// - `Ok(None)` — entry resolves to the archive root (e.g. a bare
+///   `./` placeholder). Skip it silently; tarballs produced by GNU
+///   `tar` often start with such a row.
+/// - `Err(UnsafePath)` — the entry has an absolute path, a `..`
+///   segment, or a Windows-style prefix. Refuse the whole archive.
+fn validate_safe_archive_path(raw: &std::path::Path) -> Result<Option<PathBuf>, ArchiveError> {
     use std::path::Component;
     let mut cleaned = PathBuf::new();
     for component in raw.components() {
@@ -164,11 +243,10 @@ fn validate_safe_archive_path(raw: &std::path::Path) -> Result<PathBuf, ArchiveE
         }
     }
     if cleaned.as_os_str().is_empty() {
-        // An archive entry that resolves to an empty path (e.g. just
-        // `./`) is the archive root; skip it cleanly.
-        return Err(ArchiveError::UnsafePath(raw.display().to_string()));
+        Ok(None)
+    } else {
+        Ok(Some(cleaned))
     }
-    Ok(cleaned)
 }
 
 #[cfg(test)]
@@ -273,6 +351,44 @@ mod tests {
                 "expected UnsafePath for {p:?}, got {err:?}"
             );
         }
+    }
+
+    #[test]
+    fn root_placeholder_returns_none_not_err() {
+        // A bare `./` entry (common in tarballs produced by GNU tar)
+        // resolves to an empty cleaned path. The validator returns
+        // `Ok(None)` so the reader can skip it silently — earlier
+        // behaviour was `Err(UnsafePath)`, which would have failed
+        // every otherwise-valid tarball with a root placeholder.
+        let result = validate_safe_archive_path(std::path::Path::new("./")).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn tar_symlink_entries_are_rejected() {
+        // Build a tar that contains a symlink entry — should be
+        // refused so we don't silently extract an empty file.
+        let mut tar_buf: Vec<u8> = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            let mut header = tar::Header::new_gnu();
+            header.set_path("link").unwrap();
+            header.set_size(0);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_link_name("target").unwrap();
+            header.set_cksum();
+            builder.append(&header, std::io::empty()).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        gz.write_all(&tar_buf).unwrap();
+        let bytes = gz.finish().unwrap();
+        let err = read_all(&bytes, ArchiveFormat::TarGz).unwrap_err();
+        assert!(
+            matches!(err, ArchiveError::UnsafePath(ref m) if m.contains("Symlink")),
+            "expected UnsafePath about Symlink, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/dodot-lib/src/external/archive.rs
+++ b/crates/dodot-lib/src/external/archive.rs
@@ -1,0 +1,294 @@
+//! Archive extraction helpers for `type = "archive"` and
+//! `type = "archive-file"` externals.
+//!
+//! Two formats are supported: gzipped tar (the GitHub-release default)
+//! and zip. The format is either inferred from the URL filename or
+//! declared explicitly in the TOML.
+
+use std::collections::HashMap;
+use std::io::{Cursor, Read};
+use std::path::PathBuf;
+
+use crate::external::ArchiveFormat;
+
+/// Error category returned by extraction.
+#[derive(Debug, thiserror::Error)]
+pub enum ArchiveError {
+    #[error("archive format could not be inferred from URL {0}; set `format` explicitly")]
+    FormatUnknown(String),
+    #[error("archive read failed: {0}")]
+    Read(String),
+    #[error("archive contains unsafe path: {0}")]
+    UnsafePath(String),
+    #[error("archive does not contain member: {0}")]
+    MissingMember(String),
+}
+
+/// In-memory representation of a single entry pulled from an archive.
+///
+/// `path` is the entry path relative to the archive root, validated
+/// safe (no absolute paths, no `..` components). `is_dir` is true for
+/// directory entries (no body).
+#[derive(Debug, Clone)]
+pub struct ArchiveEntry {
+    pub path: PathBuf,
+    pub is_dir: bool,
+    pub bytes: Vec<u8>,
+    /// Unix permission mode. None for entries that don't carry one
+    /// (zip entries without external attrs). Callers default to 0o644
+    /// for files and 0o755 for directories.
+    pub mode: Option<u32>,
+}
+
+/// Extract all entries from an archive into memory, keyed by their
+/// relative path. Skips directory entries (they're recreated on write).
+///
+/// Paths are validated: absolute paths and `..` components are
+/// rejected with [`ArchiveError::UnsafePath`] so a malicious archive
+/// can never escape the datastore subdir.
+pub fn read_all(
+    bytes: &[u8],
+    format: ArchiveFormat,
+) -> Result<HashMap<PathBuf, ArchiveEntry>, ArchiveError> {
+    match format {
+        ArchiveFormat::TarGz => read_tar_gz(bytes),
+        ArchiveFormat::Zip => read_zip(bytes),
+    }
+}
+
+/// Extract a single named entry from an archive into memory.
+pub fn read_member(
+    bytes: &[u8],
+    format: ArchiveFormat,
+    member: &str,
+) -> Result<ArchiveEntry, ArchiveError> {
+    let target = std::path::Path::new(member);
+    let all = read_all(bytes, format)?;
+    all.into_iter()
+        .find_map(|(p, e)| (p == target).then_some(e))
+        .ok_or_else(|| ArchiveError::MissingMember(member.to_string()))
+}
+
+fn read_tar_gz(bytes: &[u8]) -> Result<HashMap<PathBuf, ArchiveEntry>, ArchiveError> {
+    let gz = flate2::read::GzDecoder::new(Cursor::new(bytes));
+    let mut archive = tar::Archive::new(gz);
+    let mut out: HashMap<PathBuf, ArchiveEntry> = HashMap::new();
+    for entry in archive
+        .entries()
+        .map_err(|e| ArchiveError::Read(e.to_string()))?
+    {
+        let mut entry = entry.map_err(|e| ArchiveError::Read(e.to_string()))?;
+        let raw_path = entry
+            .path()
+            .map_err(|e| ArchiveError::Read(e.to_string()))?
+            .into_owned();
+        let safe = validate_safe_archive_path(&raw_path)?;
+        let header = entry.header();
+        let mode = header.mode().ok();
+        let is_dir = header.entry_type().is_dir();
+        let mut buf = Vec::new();
+        if !is_dir {
+            entry
+                .read_to_end(&mut buf)
+                .map_err(|e| ArchiveError::Read(e.to_string()))?;
+        }
+        out.insert(
+            safe.clone(),
+            ArchiveEntry {
+                path: safe,
+                is_dir,
+                bytes: buf,
+                mode,
+            },
+        );
+    }
+    Ok(out)
+}
+
+fn read_zip(bytes: &[u8]) -> Result<HashMap<PathBuf, ArchiveEntry>, ArchiveError> {
+    let mut archive =
+        zip::ZipArchive::new(Cursor::new(bytes)).map_err(|e| ArchiveError::Read(e.to_string()))?;
+    let mut out: HashMap<PathBuf, ArchiveEntry> = HashMap::new();
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|e| ArchiveError::Read(e.to_string()))?;
+        // ZipArchive's `enclosed_name()` rejects paths that would
+        // escape the extraction root (absolute, `..` segments). It
+        // returns `None` in those cases — we treat that as an unsafe
+        // entry rather than silently dropping.
+        let raw_path = file
+            .enclosed_name()
+            .ok_or_else(|| ArchiveError::UnsafePath(file.name().to_string()))?;
+        let safe = validate_safe_archive_path(&raw_path)?;
+        let is_dir = file.is_dir();
+        // `unix_mode()` returns the full st_mode with file-type bits;
+        // mask to the permission portion so callers see a familiar
+        // 0o755 / 0o644 rather than 0o100644.
+        let mode = file.unix_mode().map(|m| m & 0o7777);
+        let mut buf = Vec::new();
+        if !is_dir {
+            file.read_to_end(&mut buf)
+                .map_err(|e| ArchiveError::Read(e.to_string()))?;
+        }
+        out.insert(
+            safe.clone(),
+            ArchiveEntry {
+                path: safe,
+                is_dir,
+                bytes: buf,
+                mode,
+            },
+        );
+    }
+    Ok(out)
+}
+
+/// Reject archive paths that would escape the extraction root.
+///
+/// Returns the normalized relative path on success. Mirrors the
+/// `validate_safe_relative` helper in `datastore::filesystem` but
+/// scoped to archive contents (which can carry weirder shapes).
+fn validate_safe_archive_path(raw: &std::path::Path) -> Result<PathBuf, ArchiveError> {
+    use std::path::Component;
+    let mut cleaned = PathBuf::new();
+    for component in raw.components() {
+        match component {
+            Component::Normal(n) => cleaned.push(n),
+            // Skip pure `./` segments rather than fail (tar archives
+            // produced by `tar` itself frequently start with `./`).
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(ArchiveError::UnsafePath(raw.display().to_string()));
+            }
+        }
+    }
+    if cleaned.as_os_str().is_empty() {
+        // An archive entry that resolves to an empty path (e.g. just
+        // `./`) is the archive root; skip it cleanly.
+        return Err(ArchiveError::UnsafePath(raw.display().to_string()));
+    }
+    Ok(cleaned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+
+    /// Build a tiny tar.gz with two entries for tests.
+    fn fake_tar_gz() -> Vec<u8> {
+        let mut tar_buf: Vec<u8> = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            // Plain file.
+            let mut header = tar::Header::new_gnu();
+            let body = b"hello tar\n";
+            header.set_path("themes/alpha.zsh-theme").unwrap();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, &body[..]).unwrap();
+
+            // Nested file.
+            let mut header = tar::Header::new_gnu();
+            let body = b"#!/bin/sh\necho hi\n";
+            header.set_path("themes/scripts/setup.sh").unwrap();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append(&header, &body[..]).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        gz.write_all(&tar_buf).unwrap();
+        gz.finish().unwrap()
+    }
+
+    /// Build a tiny zip with one file for tests.
+    fn fake_zip() -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut writer = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated)
+                .unix_permissions(0o644);
+            writer.start_file("hello.txt", opts).unwrap();
+            writer.write_all(b"zipped hello").unwrap();
+            writer.finish().unwrap();
+        }
+        buf
+    }
+
+    #[test]
+    fn read_all_tar_gz_returns_entries() {
+        let entries = read_all(&fake_tar_gz(), ArchiveFormat::TarGz).unwrap();
+        assert!(entries.contains_key(&PathBuf::from("themes/alpha.zsh-theme")));
+        assert!(entries.contains_key(&PathBuf::from("themes/scripts/setup.sh")));
+        let e = entries
+            .get(&PathBuf::from("themes/scripts/setup.sh"))
+            .unwrap();
+        assert_eq!(e.bytes, b"#!/bin/sh\necho hi\n");
+        assert_eq!(e.mode, Some(0o755));
+    }
+
+    #[test]
+    fn read_member_tar_gz_finds_named_entry() {
+        let e = read_member(
+            &fake_tar_gz(),
+            ArchiveFormat::TarGz,
+            "themes/alpha.zsh-theme",
+        )
+        .unwrap();
+        assert_eq!(e.bytes, b"hello tar\n");
+    }
+
+    #[test]
+    fn read_member_tar_gz_missing_errors_clearly() {
+        let err = read_member(&fake_tar_gz(), ArchiveFormat::TarGz, "no/such.txt").unwrap_err();
+        assert!(matches!(err, ArchiveError::MissingMember(_)), "{err:?}");
+    }
+
+    #[test]
+    fn read_all_zip_returns_entries() {
+        let entries = read_all(&fake_zip(), ArchiveFormat::Zip).unwrap();
+        let e = entries.get(&PathBuf::from("hello.txt")).unwrap();
+        assert_eq!(e.bytes, b"zipped hello");
+        assert_eq!(e.mode, Some(0o644));
+    }
+
+    #[test]
+    fn unsafe_paths_rejected() {
+        // The high-level `tar::Builder` refuses to write `..` paths,
+        // and `zip::ZipArchive::enclosed_name` filters them out on
+        // read — so directly exercise our validator on a synthetic
+        // path that would otherwise reach an extraction site.
+        let cases = ["../escape", "subdir/../../escape", "/absolute/escape"];
+        for p in cases {
+            let err = validate_safe_archive_path(std::path::Path::new(p)).unwrap_err();
+            assert!(
+                matches!(err, ArchiveError::UnsafePath(_)),
+                "expected UnsafePath for {p:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn infer_format_from_url() {
+        assert_eq!(
+            ArchiveFormat::infer_from_url("https://x/foo.tar.gz"),
+            Some(ArchiveFormat::TarGz)
+        );
+        assert_eq!(
+            ArchiveFormat::infer_from_url("https://x/foo.tgz?v=1"),
+            Some(ArchiveFormat::TarGz)
+        );
+        assert_eq!(
+            ArchiveFormat::infer_from_url("https://x/Foo.ZIP"),
+            Some(ArchiveFormat::Zip)
+        );
+        assert_eq!(ArchiveFormat::infer_from_url("https://x/foo.unknown"), None);
+    }
+}

--- a/crates/dodot-lib/src/external/mod.rs
+++ b/crates/dodot-lib/src/external/mod.rs
@@ -19,13 +19,15 @@
 //! executor consumes intents and calls a `HttpFetcher` to do the
 //! actual network work.
 
+mod archive;
 mod fetch;
 mod git;
 mod spec;
 
+pub use archive::{read_all, read_member, ArchiveEntry, ArchiveError};
 pub use fetch::{HttpFetchError, HttpFetcher, UreqFetcher};
 pub use git::{GitError, GitRunner, ShellGitRunner};
-pub use spec::{parse_externals_toml, ExternalEntry, ExternalsToml, FetchSpec};
+pub use spec::{parse_externals_toml, ArchiveFormat, ExternalEntry, ExternalsToml, FetchSpec};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use git::MockGitRunner;

--- a/crates/dodot-lib/src/external/spec.rs
+++ b/crates/dodot-lib/src/external/spec.rs
@@ -103,9 +103,67 @@ pub enum FetchSpec {
         commit: Option<String>,
     },
 
+    /// A downloaded archive, extracted whole into the datastore. The
+    /// user-visible symlink target points at the extracted tree.
+    Archive {
+        url: String,
+        /// Required content hash of the archive bytes (mandatory for
+        /// the same reason as [`Self::File::sha256`] — an unpinned
+        /// archive has no integrity story).
+        sha256: String,
+        /// Optional explicit format. When omitted, the format is
+        /// inferred from the URL's filename: `.tar.gz` / `.tgz` →
+        /// tar+gzip; `.zip` → zip. Anything else requires this
+        /// field.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        format: Option<ArchiveFormat>,
+    },
+
+    /// A single entry extracted from a downloaded archive.
+    ///
+    /// Use this when the archive contains many files but the user
+    /// wants only one deployed to the target.
+    ArchiveFile {
+        url: String,
+        sha256: String,
+        /// Path of the archive member to extract, relative to the
+        /// archive root (e.g. `"powerlevel10k-master/powerlevel10k.zsh-theme"`).
+        member: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        format: Option<ArchiveFormat>,
+    },
+
     /// Catchall for type values dodot doesn't implement yet.
     #[serde(other)]
     Unsupported,
+}
+
+/// Supported archive formats. Both can be deflate-compressed (gzip
+/// for tar, deflate for zip).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ArchiveFormat {
+    TarGz,
+    Zip,
+}
+
+impl ArchiveFormat {
+    /// Infer the archive format from a URL's filename. Returns
+    /// `None` when no suffix matches a supported format — caller
+    /// should ask for an explicit `format` field in that case.
+    pub fn infer_from_url(url: &str) -> Option<Self> {
+        // Drop query / fragment so URLs like `…/foo.zip?token=…`
+        // still match.
+        let stem = url.split(['?', '#']).next().unwrap_or(url);
+        let stem_lower = stem.to_ascii_lowercase();
+        if stem_lower.ends_with(".tar.gz") || stem_lower.ends_with(".tgz") {
+            Some(Self::TarGz)
+        } else if stem_lower.ends_with(".zip") {
+            Some(Self::Zip)
+        } else {
+            None
+        }
+    }
 }
 
 /// Parse the bytes of an `externals.toml` file.


### PR DESCRIPTION
## Summary

Fourth PR of the externals series. Adds the two archive variants from the issue: \`type = \"archive\"\` (extract whole tree) and \`type = \"archive-file\"\` (extract one entry).

> [!NOTE]
> **Base is \`feat/external-files-pinning\` (PR #156).**

## Variants

- \`archive\` — download, sha256-verify, extract whole tree into the datastore. User-visible symlink points at the extracted directory.
- \`archive-file\` — same fetch+verify; only the named member is extracted. Symlink points at the single file.

## Format inference

Format comes from the URL filename:

- \`.tar.gz\` / \`.tgz\` → tar+gzip
- \`.zip\` → zip
- Anything else: \`format = \"tar-gz\"\` / \`format = \"zip\"\` in the TOML

Query strings and fragments are stripped before inference, so \`https://x/foo.zip?token=…\` works.

## Security posture

- sha256 over the archive bytes is mandatory and is the sentinel; bumping it forces re-extraction.
- Archive entries with unsafe paths (absolute, \`..\` components) are rejected at extraction time. ZipArchive's \`enclosed_name\` filters the obvious cases on read; a shared validator double-checks.

## Sentinel naming

- archive: \`<name>-archive-<sha-prefix>\`
- archive-file: \`<name>-archive-<sha-prefix>-<member-hash>\` — so changing the \`member\` field invalidates the sentinel without changing the archive itself.

## Test coverage

1195 tests pass (+6 archive). Highlights:

- whole-tree extract materialises every entry under the entry dir; symlink resolves through it
- single-member extract deploys just that file
- sha256 mismatch refuses to extract (no files written)
- missing member surfaces a clear diagnostic
- unknown format URL fails helpfully
- sentinel-driven idempotency (second \`up\` is a no-op)

## Test plan

- [ ] CI passes
- [ ] Manual: pack with \`type = \"archive\"\` pointing at a GitHub release tarball deploys the whole tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)