### PR TITLE
feat(external): git-repo type with ls-remote freshness (replaces #155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Externals handler `type = "git-repo"` (PR 2 of stacked series)** —
+  `externals.toml` now accepts `type = "git-repo"` entries. The
+  executor shallow-clones (`--depth=1 --filter=blob:none`) into the
+  datastore on first run and uses `git ls-remote HEAD` as the
+  freshness oracle on subsequent runs: only when the upstream SHA
+  differs from the local clone's HEAD does dodot shell out to
+  `git fetch --depth=1` + `git reset --hard FETCH_HEAD`. Offline
+  is tolerated — `ls-remote` failing during a refresh leaves the
+  cached clone in place and surfaces a non-success result. The
+  `git` binary on PATH is required; missing-git is a hard error
+  (not transient). Sparse-tree fetch via `subpath` and
+  `ref` / `commit` pinning arrive in a follow-up PR.
+
 - **Externals handler (PR 1 of stacked series, file type only)** —
   packs can now declare remote resources in an `externals.toml` file
   at the pack root. Each section declares one entry; this PR

--- a/crates/dodot-lib/src/conflicts.rs
+++ b/crates/dodot-lib/src/conflicts.rs
@@ -182,6 +182,7 @@ fn intent_source(intent: &HandlerIntent) -> PathBuf {
         // pseudo-path so conflict messaging stays uniform.
         HandlerIntent::Fetch { spec, name, .. } => match spec {
             crate::external::FetchSpec::File { url, .. } => PathBuf::from(url),
+            crate::external::FetchSpec::GitRepo { url } => PathBuf::from(url),
             crate::external::FetchSpec::Unsupported => PathBuf::from(format!("<external:{name}>")),
         },
     }

--- a/crates/dodot-lib/src/execution/fetch.rs
+++ b/crates/dodot-lib/src/execution/fetch.rs
@@ -2,17 +2,23 @@
 //! create the user-visible symlink that exposes it.
 //!
 //! Sentinel posture mirrors the install handler: the entry's content
-//! signature (for `file`, the configured sha256) is the sentinel
-//! payload. Re-running `up` with the same sha256 is a no-op. Bumping
-//! the sha256 in `externals.toml` invalidates the old sentinel, so the
-//! file is re-fetched and re-verified.
+//! signature is the sentinel payload.
+//!
+//! - For `file`, the signature is the user-declared sha256 in
+//!   `externals.toml`. Re-running `up` with the same sha256 is a
+//!   no-op; bumping it invalidates the old sentinel.
+//! - For `git-repo`, the signature is the upstream HEAD SHA returned
+//!   by a cheap `git ls-remote`. If the remote SHA matches the local
+//!   clone's HEAD, the clone is left alone — even if `up` is run
+//!   many times in a session. If the remote has moved, the executor
+//!   shells out to `git fetch --depth=1 + reset --hard FETCH_HEAD`.
 //!
 //! Failure posture:
 //! - **Integrity failure** (sha256 mismatch) is fatal — we refuse to
 //!   write tampered content into the datastore.
 //! - **Network failure** is soft — if a cached copy is present we leave
 //!   it in place and report the failure as a non-success result; other
-//!   intents still execute.
+//!   intents still execute. This covers both HTTP and git transports.
 
 use std::path::Path;
 
@@ -42,10 +48,13 @@ impl<'a> Executor<'a> {
             FetchSpec::File { url, sha256 } => {
                 self.execute_fetch_file(pack, handler, name, url, sha256, user_path)
             }
+            FetchSpec::GitRepo { url } => {
+                self.execute_fetch_git_repo(pack, handler, name, url, user_path)
+            }
             FetchSpec::Unsupported => Ok(vec![OperationResult::fail(
                 fetch_op(pack, handler, name, "<unsupported>"),
                 format!(
-                    "external '{name}': unsupported type — only `type = \"file\"` is implemented in this release"
+                    "external '{name}': unsupported type — supported in this release: `file`, `git-repo`"
                 ),
             )]),
         }
@@ -77,6 +86,20 @@ impl<'a> Executor<'a> {
                         "[dry-run] would fetch {url} → {} (verify sha256={})",
                         user_path.display(),
                         short(sha256)
+                    )
+                };
+                vec![OperationResult::ok(fetch_op(pack, handler, name, url), msg)]
+            }
+            FetchSpec::GitRepo { url } => {
+                let datastore_path = self.paths.handler_data_dir(pack, handler).join(name);
+                let already = self.fs.exists(&datastore_path);
+                let msg = if already {
+                    format!("[dry-run] {name} would ls-remote {url} and refresh only if upstream differs")
+                } else {
+                    format!(
+                        "[dry-run] would clone {url} → {} → {}",
+                        datastore_path.display(),
+                        user_path.display()
                     )
                 };
                 vec![OperationResult::ok(fetch_op(pack, handler, name, url), msg)]
@@ -207,6 +230,211 @@ impl<'a> Executor<'a> {
             OperationResult::ok(
                 op(),
                 format!("{name}: fetched {} bytes from {url}", bytes.len()),
+            ),
+            OperationResult::ok(create_link, format!("{name} → {}", user_path.display())),
+        ])
+    }
+
+    /// Fetch one `type = "git-repo"` external.
+    ///
+    /// Upstream HEAD is the freshness oracle. Flow:
+    /// 1. Compute the datastore path: `<handler_data_dir>/<name>`.
+    /// 2. If the path doesn't exist → shallow-clone fresh.
+    /// 3. Otherwise → `git ls-remote HEAD` on the upstream URL. If
+    ///    it matches the local clone's HEAD, no-op. If it differs,
+    ///    fetch + reset --hard.
+    /// 4. Make sure the user-visible symlink target → datastore path.
+    ///
+    /// Network failures (ls-remote, fetch, even initial clone) are
+    /// soft: the cached clone (if any) stays put and the result
+    /// surfaces as a non-success — `up` continues with the rest of
+    /// the pack.
+    fn execute_fetch_git_repo(
+        &self,
+        pack: &str,
+        handler: &str,
+        name: &str,
+        url: &str,
+        user_path: &Path,
+    ) -> Result<Vec<OperationResult>> {
+        let op = || fetch_op(pack, handler, name, url);
+
+        let Some(git) = self.git() else {
+            return Ok(vec![OperationResult::fail(
+                op(),
+                format!(
+                    "external '{name}': executor has no git runner configured; call Executor::with_git() in production wiring"
+                ),
+            )]);
+        };
+
+        let datastore_path = self.paths.handler_data_dir(pack, handler).join(name);
+        let already_cloned = self.fs.exists(&datastore_path);
+
+        if !already_cloned {
+            // Fresh clone path. The datastore dir's parent must exist.
+            if let Some(parent) = datastore_path.parent() {
+                self.fs.mkdir_all(parent)?;
+            }
+            info!(pack, name, url, "shallow-cloning external");
+            let sha = match git.shallow_clone(url, &datastore_path) {
+                Ok(s) => s,
+                Err(err) => {
+                    warn!(pack, name, %err, "git clone failed");
+                    return Ok(vec![OperationResult::fail(
+                        op(),
+                        format!("{name}: clone failed: {err}"),
+                    )]);
+                }
+            };
+            return self.finish_git_repo(
+                pack,
+                handler,
+                name,
+                url,
+                &datastore_path,
+                user_path,
+                &sha,
+            );
+        }
+
+        // Existing clone path. Cheap freshness check first.
+        let upstream = match git.ls_remote_head(url) {
+            Ok(s) => Some(s),
+            Err(err) if err.is_transient() => {
+                warn!(pack, name, %err, "ls-remote failed (transient); using cached clone");
+                None
+            }
+            Err(err) => {
+                return Ok(vec![OperationResult::fail(
+                    op(),
+                    format!("{name}: ls-remote failed: {err}"),
+                )]);
+            }
+        };
+
+        let local = match git.local_head(&datastore_path) {
+            Ok(s) => s,
+            Err(err) => {
+                // The clone exists but git can't read it — corrupted
+                // state. Better to surface than to silently re-clone
+                // (which could mask a deeper problem).
+                return Ok(vec![OperationResult::fail(
+                    op(),
+                    format!(
+                        "{name}: existing clone at {} is unreadable: {err}",
+                        datastore_path.display()
+                    ),
+                )]);
+            }
+        };
+
+        // If we couldn't reach upstream, keep the cached copy and
+        // report success-ish (it's still deployed). If upstream is
+        // reachable and matches local, no-op. Otherwise refresh.
+        let (final_sha, was_refreshed) = match upstream {
+            None => (local, false),
+            Some(remote) if remote == self.force_refresh_target(&local) => (remote, false),
+            Some(remote) => {
+                info!(
+                    pack, name,
+                    local = %short(&local),
+                    remote = %short(&remote),
+                    "upstream moved; fetching + reset"
+                );
+                match git.fetch_and_reset(&datastore_path) {
+                    Ok(s) => (s, true),
+                    Err(err) if err.is_transient() => {
+                        warn!(pack, name, %err, "fetch+reset failed (transient); keeping cached");
+                        // Cached SHA stands; we tried to refresh but
+                        // the network blipped.
+                        return Ok(vec![OperationResult::fail(
+                            op(),
+                            format!(
+                                "{name}: fetch failed ({err}); cached clone at {} stays in place",
+                                short(&local)
+                            ),
+                        )]);
+                    }
+                    Err(err) => {
+                        return Ok(vec![OperationResult::fail(
+                            op(),
+                            format!("{name}: fetch failed: {err}"),
+                        )]);
+                    }
+                }
+            }
+        };
+
+        // Refresh sentinel + symlink either way (idempotent).
+        let mut results = self.finish_git_repo(
+            pack,
+            handler,
+            name,
+            url,
+            &datastore_path,
+            user_path,
+            &final_sha,
+        )?;
+        if !was_refreshed && self.fetcher_message_overridable(&results) {
+            // Replace the "fetched" message with a "fresh" one — the
+            // wire was tickled (ls-remote), but no bytes moved.
+            results[0] = OperationResult::ok(
+                op(),
+                format!("{name}: fresh ({} == upstream)", short(&final_sha)),
+            );
+        }
+        Ok(results)
+    }
+
+    /// Forced refresh shim: when `--force` is set we want to refresh
+    /// even if local == remote, so flip the comparison target to
+    /// guarantee a mismatch.
+    fn force_refresh_target(&self, local: &str) -> String {
+        if self.force {
+            format!("force-refresh-{local}")
+        } else {
+            local.to_string()
+        }
+    }
+
+    /// True when the first result is the "fetched bytes" message that
+    /// the caller can safely replace with a "fresh" message.
+    fn fetcher_message_overridable(&self, results: &[OperationResult]) -> bool {
+        results.first().is_some_and(|r| r.success)
+    }
+
+    /// Symlink + sentinel finalize for git-repo. Shared by initial
+    /// clone and refresh paths.
+    #[allow(clippy::too_many_arguments)]
+    fn finish_git_repo(
+        &self,
+        pack: &str,
+        handler: &str,
+        name: &str,
+        url: &str,
+        datastore_path: &Path,
+        user_path: &Path,
+        sha: &str,
+    ) -> Result<Vec<OperationResult>> {
+        self.create_external_user_link(datastore_path, user_path)?;
+        let sentinel = git_repo_sentinel(name, sha);
+        self.write_sentinel(pack, handler, &sentinel)?;
+
+        let create_link = Operation::CreateUserLink {
+            pack: pack.to_string(),
+            handler: handler.to_string(),
+            datastore_path: datastore_path.to_path_buf(),
+            user_path: user_path.to_path_buf(),
+        };
+        Ok(vec![
+            OperationResult::ok(
+                fetch_op(pack, handler, name, url),
+                format!(
+                    "{name}: HEAD={} at {}",
+                    short(sha),
+                    datastore_path.display()
+                ),
             ),
             OperationResult::ok(create_link, format!("{name} → {}", user_path.display())),
         ])
@@ -347,6 +575,14 @@ fn file_sentinel(name: &str, sha256: &str) -> String {
     format!("{name}-{}", short(sha256))
 }
 
+/// Sentinel filename for a `type = "git-repo"` entry. The SHA prefix
+/// is the upstream HEAD commit we deployed; bumping upstream changes
+/// the sentinel, so `dodot status` can tell at a glance which commit
+/// is live.
+fn git_repo_sentinel(name: &str, sha: &str) -> String {
+    format!("{name}-git-{}", short(sha))
+}
+
 /// Derive the on-disk filename inside the datastore subdir from the
 /// target path. Falls back to "content" when the target ends in `/`.
 fn filename_for_target(target: &Path) -> String {
@@ -394,6 +630,7 @@ mod tests {
     use crate::external::{FetchSpec, HttpFetchError, HttpFetcher};
     use crate::fs::Fs;
     use crate::operations::HandlerIntent;
+    use crate::paths::Pather;
     use crate::testing::TempEnvironment;
     use std::sync::Mutex;
 
@@ -815,5 +1052,228 @@ mod tests {
         assert!(fetcher.calls().is_empty());
         assert!(!env.fs.exists(&user_path));
         env.assert_no_handler_state("shared", "external");
+    }
+
+    // ── git-repo ───────────────────────────────────────────────
+
+    use crate::external::MockGitRunner;
+
+    fn git_intent(name: &str, url: &str, user_path: std::path::PathBuf) -> HandlerIntent {
+        HandlerIntent::Fetch {
+            pack: "frameworks".into(),
+            handler: "external".into(),
+            name: name.into(),
+            spec: FetchSpec::GitRepo { url: url.into() },
+            user_path,
+        }
+    }
+
+    #[test]
+    fn git_repo_fresh_clone_runs_once_then_idempotent() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let git = MockGitRunner::new("a".repeat(40).as_str(), b"# omz\n");
+        let user_path = env.home.join(".oh-my-zsh");
+        let intent = git_intent("omz", "https://x/omz.git", user_path.clone());
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_git(&git);
+
+        // First run: clone happens.
+        let first = executor.execute(vec![intent.clone()]).unwrap();
+        assert_eq!(first.len(), 2);
+        assert!(first.iter().all(|r| r.success), "{first:#?}");
+        assert!(
+            git.calls().iter().any(|c| c.starts_with("clone ")),
+            "{:?}",
+            git.calls()
+        );
+        assert!(env.fs.is_symlink(&user_path));
+
+        // Second run: clone exists, ls-remote matches local → no fetch.
+        let calls_before = git.calls().len();
+        let second = executor.execute(vec![intent]).unwrap();
+        assert!(second.iter().all(|r| r.success), "{second:#?}");
+        assert!(
+            second[0].message.contains("fresh"),
+            "msg: {}",
+            second[0].message
+        );
+        let calls_after = git.calls();
+        // The second run should add ls-remote + local_head, but no
+        // fetch / clone.
+        let added = &calls_after[calls_before..];
+        assert!(
+            added.iter().any(|c| c.starts_with("ls-remote ")),
+            "{added:?}"
+        );
+        assert!(added.iter().all(|c| !c.starts_with("clone ")), "{added:?}");
+        assert!(
+            added.iter().all(|c| !c.starts_with("fetch+reset ")),
+            "{added:?}"
+        );
+    }
+
+    #[test]
+    fn git_repo_refreshes_when_upstream_moves() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let git = MockGitRunner::new(&"a".repeat(40), b"v1");
+        let user_path = env.home.join(".oh-my-zsh");
+        let intent = git_intent("omz", "https://x/omz.git", user_path.clone());
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_git(&git);
+
+        // Initial clone.
+        executor.execute(vec![intent.clone()]).unwrap();
+
+        // Upstream moves; next run must fetch+reset.
+        git.set_upstream_sha(&"b".repeat(40));
+        let results = executor.execute(vec![intent]).unwrap();
+        assert!(results.iter().all(|r| r.success), "{results:#?}");
+        assert!(
+            git.calls().iter().any(|c| c.starts_with("fetch+reset ")),
+            "{:?}",
+            git.calls()
+        );
+        // The marker file should reflect the refresh.
+        let datastore_path = env
+            .paths
+            .handler_data_dir("frameworks", "external")
+            .join("omz");
+        let content = std::fs::read_to_string(datastore_path.join("README.md")).unwrap();
+        assert!(content.contains("# refreshed"), "got: {content:?}");
+    }
+
+    #[test]
+    fn git_repo_offline_ls_remote_uses_cached_clone() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let git = MockGitRunner::new(&"a".repeat(40), b"# omz\n");
+        let user_path = env.home.join(".oh-my-zsh");
+        let intent = git_intent("omz", "https://x/omz.git", user_path.clone());
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_git(&git);
+
+        // Initial clone succeeds.
+        executor.execute(vec![intent.clone()]).unwrap();
+
+        // Now the network is down; ls-remote fails, executor must
+        // keep the cached clone in place rather than abort.
+        git.set_ls_remote_offline(true);
+        let results = executor.execute(vec![intent]).unwrap();
+        assert!(results.iter().all(|r| r.success), "{results:#?}");
+        // No fetch was attempted because the freshness check failed.
+        assert!(
+            results[0].message.contains("fresh") || results[0].message.contains("HEAD="),
+            "msg: {}",
+            results[0].message
+        );
+        // Symlink still points at the clone.
+        assert!(env.fs.is_symlink(&user_path));
+    }
+
+    #[test]
+    fn git_repo_offline_initial_clone_soft_fails() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let git = MockGitRunner::new(&"a".repeat(40), b"# omz\n");
+        // Force the initial clone to fail (no real network anyway, but
+        // we trigger the same code path by making local_head fail
+        // after clone — clone returns the sha, so use ls-remote-style
+        // offline before clone happens).
+        // Trick: the executor doesn't call ls-remote for the
+        // first-time path, so we instead trigger a clone failure by
+        // having the mock signal offline through a different lever.
+        // Since MockGitRunner.shallow_clone doesn't honour an offline
+        // flag, we exercise the second-run path's `fetch_offline`
+        // setting after an initial successful clone.
+        let user_path = env.home.join(".oh-my-zsh");
+        let intent = git_intent("omz", "https://x/omz.git", user_path.clone());
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            false,
+            false,
+            false,
+            true,
+        )
+        .with_git(&git);
+
+        // First run clones.
+        executor.execute(vec![intent.clone()]).unwrap();
+
+        // Move upstream; fetch fails transiently.
+        git.set_upstream_sha(&"b".repeat(40));
+        git.set_fetch_offline(true);
+        let results = executor.execute(vec![intent]).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(
+            results[0].message.contains("fetch failed") || results[0].message.contains("cached"),
+            "msg: {}",
+            results[0].message
+        );
+    }
+
+    #[test]
+    fn git_repo_dry_run_does_not_touch_filesystem() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+        let git = MockGitRunner::new(&"a".repeat(40), b"# omz\n");
+        let user_path = env.home.join(".oh-my-zsh");
+        let intent = git_intent("omz", "https://x/omz.git", user_path.clone());
+
+        let executor = Executor::new(
+            &ds,
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            true,
+            false,
+            false,
+            true,
+        )
+        .with_git(&git);
+
+        let results = executor.execute(vec![intent]).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert!(
+            results[0].message.contains("[dry-run]"),
+            "msg: {}",
+            results[0].message
+        );
+        // No clone calls, no symlink, no datastore tree.
+        assert!(git.calls().is_empty());
+        assert!(!env.fs.exists(&user_path));
+        env.assert_no_handler_state("frameworks", "external");
     }
 }

--- a/crates/dodot-lib/src/execution/fetch.rs
+++ b/crates/dodot-lib/src/execution/fetch.rs
@@ -298,21 +298,10 @@ impl<'a> Executor<'a> {
             );
         }
 
-        // Existing clone path. Cheap freshness check first.
-        let upstream = match git.ls_remote_head(url) {
-            Ok(s) => Some(s),
-            Err(err) if err.is_transient() => {
-                warn!(pack, name, %err, "ls-remote failed (transient); using cached clone");
-                None
-            }
-            Err(err) => {
-                return Ok(vec![OperationResult::fail(
-                    op(),
-                    format!("{name}: ls-remote failed: {err}"),
-                )]);
-            }
-        };
-
+        // Existing clone path. We need the local HEAD regardless of
+        // whether ls-remote succeeds, so read it first — a corrupted
+        // local clone is a hard error that should surface even if
+        // upstream happens to be reachable.
         let local = match git.local_head(&datastore_path) {
             Ok(s) => s,
             Err(err) => {
@@ -329,39 +318,60 @@ impl<'a> Executor<'a> {
             }
         };
 
-        // If we couldn't reach upstream, keep the cached copy and
-        // report success-ish (it's still deployed). If upstream is
-        // reachable and matches local, no-op. Otherwise refresh.
-        let (final_sha, was_refreshed) = match upstream {
-            None => (local, false),
-            Some(remote) if remote == self.force_refresh_target(&local) => (remote, false),
-            Some(remote) => {
-                info!(
-                    pack, name,
-                    local = %short(&local),
-                    remote = %short(&remote),
-                    "upstream moved; fetching + reset"
-                );
-                match git.fetch_and_reset(&datastore_path) {
-                    Ok(s) => (s, true),
-                    Err(err) if err.is_transient() => {
-                        warn!(pack, name, %err, "fetch+reset failed (transient); keeping cached");
-                        // Cached SHA stands; we tried to refresh but
-                        // the network blipped.
-                        return Ok(vec![OperationResult::fail(
-                            op(),
-                            format!(
-                                "{name}: fetch failed ({err}); cached clone at {} stays in place",
-                                short(&local)
-                            ),
-                        )]);
-                    }
-                    Err(err) => {
-                        return Ok(vec![OperationResult::fail(
-                            op(),
-                            format!("{name}: fetch failed: {err}"),
-                        )]);
-                    }
+        // Cheap freshness check. Transient ls-remote failures don't
+        // abort the run, but they DO surface as non-success results —
+        // claiming "fresh" when we couldn't actually verify upstream
+        // would be misleading. The cached clone is already symlinked
+        // from a prior successful run; nothing more needed on disk.
+        let upstream = match git.ls_remote_head(url) {
+            Ok(s) => s,
+            Err(err) if err.is_transient() => {
+                warn!(pack, name, %err, "ls-remote failed (transient); using cached clone");
+                return Ok(vec![OperationResult::fail(
+                    op(),
+                    format!(
+                        "{name}: ls-remote failed ({err}); using cached clone at {}",
+                        short(&local)
+                    ),
+                )]);
+            }
+            Err(err) => {
+                return Ok(vec![OperationResult::fail(
+                    op(),
+                    format!("{name}: ls-remote failed: {err}"),
+                )]);
+            }
+        };
+
+        // From here on, upstream and local are both known SHAs.
+        let (final_sha, was_refreshed) = if upstream == self.force_refresh_target(&local) {
+            (local, false)
+        } else {
+            info!(
+                pack, name,
+                local = %short(&local),
+                remote = %short(&upstream),
+                "upstream moved; fetching + reset"
+            );
+            match git.fetch_and_reset(&datastore_path) {
+                Ok(s) => (s, true),
+                Err(err) if err.is_transient() => {
+                    warn!(pack, name, %err, "fetch+reset failed (transient); keeping cached");
+                    // Cached SHA stands; we tried to refresh but the
+                    // network blipped after ls-remote succeeded.
+                    return Ok(vec![OperationResult::fail(
+                        op(),
+                        format!(
+                            "{name}: fetch failed ({err}); cached clone at {} stays in place",
+                            short(&local)
+                        ),
+                    )]);
+                }
+                Err(err) => {
+                    return Ok(vec![OperationResult::fail(
+                        op(),
+                        format!("{name}: fetch failed: {err}"),
+                    )]);
                 }
             }
         };
@@ -377,8 +387,10 @@ impl<'a> Executor<'a> {
             &final_sha,
         )?;
         if !was_refreshed && self.fetcher_message_overridable(&results) {
-            // Replace the "fetched" message with a "fresh" one — the
-            // wire was tickled (ls-remote), but no bytes moved.
+            // Only rewrite the "fetched" message when we actually
+            // know upstream matches local — i.e. ls-remote succeeded
+            // and the SHAs lined up. The transient-failure path
+            // already returned above.
             results[0] = OperationResult::ok(
                 op(),
                 format!("{name}: fresh ({} == upstream)", short(&final_sha)),
@@ -1163,7 +1175,7 @@ mod tests {
     }
 
     #[test]
-    fn git_repo_offline_ls_remote_uses_cached_clone() {
+    fn git_repo_offline_ls_remote_surfaces_failure_keeps_clone() {
         let env = TempEnvironment::builder().build();
         let (ds, _) = make_datastore(&env);
         let git = MockGitRunner::new(&"a".repeat(40), b"# omz\n");
@@ -1184,36 +1196,38 @@ mod tests {
         // Initial clone succeeds.
         executor.execute(vec![intent.clone()]).unwrap();
 
-        // Now the network is down; ls-remote fails, executor must
-        // keep the cached clone in place rather than abort.
+        // Network goes down. ls-remote fails transiently; we must
+        // SURFACE that as a failed OperationResult (claiming "fresh"
+        // would lie about an upstream check we couldn't perform), but
+        // the cached clone and its symlink stay healthy.
         git.set_ls_remote_offline(true);
         let results = executor.execute(vec![intent]).unwrap();
-        assert!(results.iter().all(|r| r.success), "{results:#?}");
-        // No fetch was attempted because the freshness check failed.
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success, "{results:#?}");
         assert!(
-            results[0].message.contains("fresh") || results[0].message.contains("HEAD="),
+            results[0].message.contains("ls-remote failed"),
             "msg: {}",
             results[0].message
         );
-        // Symlink still points at the clone.
+        assert!(
+            results[0].message.contains("cached clone"),
+            "msg: {}",
+            results[0].message
+        );
+        // Symlink still points at the clone — the previous successful
+        // run left it in place and we didn't disturb it.
         assert!(env.fs.is_symlink(&user_path));
     }
 
     #[test]
-    fn git_repo_offline_initial_clone_soft_fails() {
+    fn git_repo_offline_fetch_after_upstream_move_soft_fails() {
+        // Exercise the post-ls-remote, mid-refresh failure path:
+        // upstream moved, ls-remote returned a new SHA, but fetch+reset
+        // hits a transient error. The cached clone (at the old SHA)
+        // stays in place and the result surfaces as non-success.
         let env = TempEnvironment::builder().build();
         let (ds, _) = make_datastore(&env);
         let git = MockGitRunner::new(&"a".repeat(40), b"# omz\n");
-        // Force the initial clone to fail (no real network anyway, but
-        // we trigger the same code path by making local_head fail
-        // after clone — clone returns the sha, so use ls-remote-style
-        // offline before clone happens).
-        // Trick: the executor doesn't call ls-remote for the
-        // first-time path, so we instead trigger a clone failure by
-        // having the mock signal offline through a different lever.
-        // Since MockGitRunner.shallow_clone doesn't honour an offline
-        // flag, we exercise the second-run path's `fetch_offline`
-        // setting after an initial successful clone.
         let user_path = env.home.join(".oh-my-zsh");
         let intent = git_intent("omz", "https://x/omz.git", user_path.clone());
 

--- a/crates/dodot-lib/src/execution/mod.rs
+++ b/crates/dodot-lib/src/execution/mod.rs
@@ -31,7 +31,7 @@ mod stage;
 use tracing::debug;
 
 use crate::datastore::DataStore;
-use crate::external::HttpFetcher;
+use crate::external::{GitRunner, HttpFetcher};
 use crate::fs::Fs;
 use crate::operations::{HandlerIntent, OperationResult};
 use crate::paths::Pather;
@@ -52,6 +52,9 @@ pub struct Executor<'a> {
     /// dispatcher errors loudly if it sees a Fetch intent without
     /// one. Production wiring sets this via [`Self::with_fetcher`].
     fetcher: Option<&'a dyn HttpFetcher>,
+    /// Git runner for `git-repo` externals. Same opt-in posture as
+    /// [`Self::fetcher`].
+    git: Option<&'a dyn GitRunner>,
 }
 
 impl<'a> Executor<'a> {
@@ -73,6 +76,7 @@ impl<'a> Executor<'a> {
             provision_rerun,
             auto_chmod_exec,
             fetcher: None,
+            git: None,
         }
     }
 
@@ -82,9 +86,21 @@ impl<'a> Executor<'a> {
         self
     }
 
+    /// Builder-style: install the git runner used by `git-repo`
+    /// externals.
+    pub fn with_git(mut self, git: &'a dyn GitRunner) -> Self {
+        self.git = Some(git);
+        self
+    }
+
     /// Accessor for the fetch dispatcher.
     pub(super) fn fetcher(&self) -> Option<&'a dyn HttpFetcher> {
         self.fetcher
+    }
+
+    /// Accessor for the fetch dispatcher (git side).
+    pub(super) fn git(&self) -> Option<&'a dyn GitRunner> {
+        self.git
     }
 
     /// Execute a list of handler intents, returning one result per

--- a/crates/dodot-lib/src/external/git.rs
+++ b/crates/dodot-lib/src/external/git.rs
@@ -1,0 +1,374 @@
+//! Git operations for `type = "git-repo"` externals.
+//!
+//! Shell-out to the user's `git` binary is the simplest design that
+//! supports shallow clones (`--depth=1 --filter=blob:none`) and
+//! sparse-tree fetch — both features the issue explicitly requires
+//! and that the pure-Rust gitoxide crates don't yet expose at a
+//! porcelain level. The dependency on a system `git` is a reasonable
+//! prerequisite for dodot users (they're managing dotfiles, after all).
+//!
+//! The trait abstraction exists so tests don't have to network out to
+//! real repos. Tests use [`MockGitRunner`] which records calls and
+//! returns canned SHAs.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Error category returned by a git runner.
+///
+/// The executor distinguishes transient (network / `ls-remote` /
+/// fetch) failures from misconfiguration so a temporary network blip
+/// doesn't kill the whole `up` invocation.
+#[derive(Debug, thiserror::Error)]
+pub enum GitError {
+    /// Could not invoke `git` at all — probably missing from PATH.
+    #[error("`git` not found on PATH: {0}")]
+    NotFound(String),
+    /// `git` ran but failed. `stderr` carries the actual message.
+    #[error("git {operation} failed (exit {exit_code}): {stderr}")]
+    CommandFailed {
+        operation: String,
+        exit_code: i32,
+        stderr: String,
+    },
+    /// Output was structurally not what we expected (e.g. ls-remote
+    /// returned 0 rows for HEAD).
+    #[error("git {operation} produced unexpected output: {detail}")]
+    BadOutput { operation: String, detail: String },
+}
+
+impl GitError {
+    /// Is this a network-style failure that should soft-fail with a
+    /// cached copy rather than abort `up`?
+    pub fn is_transient(&self) -> bool {
+        match self {
+            // `git` itself is missing → user has to fix it; never soft-fail.
+            Self::NotFound(_) => false,
+            // Command failures during network ops are almost always
+            // transient (DNS, auth blip, server flake). Misuse of git
+            // is the runner's bug, not the user's, so we still surface
+            // it but treat it as transient — the cached clone stays.
+            Self::CommandFailed { .. } => true,
+            // ls-remote returning nothing usually means upstream is
+            // unreachable or moved; treat as transient.
+            Self::BadOutput { .. } => true,
+        }
+    }
+}
+
+/// Abstraction over the small handful of git operations dodot needs.
+///
+/// Each method is a porcelain-level verb: implementations shell out
+/// to `git` with the right flags. Tests mock this trait.
+pub trait GitRunner: Send + Sync {
+    /// `git ls-remote <url> HEAD` — return the upstream HEAD SHA
+    /// without fetching any objects. The cheap freshness oracle.
+    fn ls_remote_head(&self, url: &str) -> std::result::Result<String, GitError>;
+
+    /// `git clone --depth=1 --filter=blob:none <url> <dest>`.
+    /// Returns the cloned HEAD SHA.
+    fn shallow_clone(&self, url: &str, dest: &Path) -> std::result::Result<String, GitError>;
+
+    /// `git -C <repo> fetch --depth=1 origin HEAD` followed by
+    /// `git -C <repo> reset --hard FETCH_HEAD`. Returns the new
+    /// HEAD SHA.
+    fn fetch_and_reset(&self, repo: &Path) -> std::result::Result<String, GitError>;
+
+    /// `git -C <repo> rev-parse HEAD` — local HEAD SHA.
+    fn local_head(&self, repo: &Path) -> std::result::Result<String, GitError>;
+}
+
+/// Production `git` runner: actually shells out.
+pub struct ShellGitRunner;
+
+impl ShellGitRunner {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn run(operation: &str, cmd: &mut Command) -> std::result::Result<String, GitError> {
+        let output = cmd
+            .output()
+            .map_err(|e| GitError::NotFound(e.to_string()))?;
+        if !output.status.success() {
+            return Err(GitError::CommandFailed {
+                operation: operation.to_string(),
+                exit_code: output.status.code().unwrap_or(-1),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+}
+
+impl Default for ShellGitRunner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GitRunner for ShellGitRunner {
+    fn ls_remote_head(&self, url: &str) -> std::result::Result<String, GitError> {
+        let stdout = Self::run(
+            "ls-remote",
+            Command::new("git").args(["ls-remote", "--exit-code", url, "HEAD"]),
+        )?;
+        // Output shape: `<sha>\tHEAD`. We want the first whitespace-
+        // delimited field on the first line.
+        let sha = stdout
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().next())
+            .map(str::to_string)
+            .ok_or_else(|| GitError::BadOutput {
+                operation: "ls-remote".into(),
+                detail: format!("no rows for HEAD on {url}"),
+            })?;
+        if sha.len() < 7 {
+            return Err(GitError::BadOutput {
+                operation: "ls-remote".into(),
+                detail: format!("sha too short: {sha:?}"),
+            });
+        }
+        Ok(sha)
+    }
+
+    fn shallow_clone(&self, url: &str, dest: &Path) -> std::result::Result<String, GitError> {
+        Self::run(
+            "clone",
+            Command::new("git").args([
+                "clone",
+                "--depth=1",
+                "--filter=blob:none",
+                url,
+                &dest.to_string_lossy(),
+            ]),
+        )?;
+        self.local_head(dest)
+    }
+
+    fn fetch_and_reset(&self, repo: &Path) -> std::result::Result<String, GitError> {
+        Self::run(
+            "fetch",
+            Command::new("git")
+                .arg("-C")
+                .arg(repo)
+                .args(["fetch", "--depth=1", "origin", "HEAD"]),
+        )?;
+        Self::run(
+            "reset",
+            Command::new("git")
+                .arg("-C")
+                .arg(repo)
+                .args(["reset", "--hard", "FETCH_HEAD"]),
+        )?;
+        self.local_head(repo)
+    }
+
+    fn local_head(&self, repo: &Path) -> std::result::Result<String, GitError> {
+        Self::run(
+            "rev-parse",
+            Command::new("git")
+                .arg("-C")
+                .arg(repo)
+                .args(["rev-parse", "HEAD"]),
+        )
+    }
+}
+
+/// Mock GitRunner for tests. Records call sites and returns canned
+/// SHAs. Exposed so tests in sibling modules (`execution::fetch`) can
+/// reuse it without duplication.
+#[cfg(any(test, feature = "test-utils"))]
+pub struct MockGitRunner {
+    inner: std::sync::Mutex<MockGitInner>,
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+struct MockGitInner {
+    /// Upstream SHA returned by `ls_remote_head`. None = error.
+    pub ls_remote_sha: Option<String>,
+    /// SHA recorded by the last clone / fetch+reset / used by
+    /// `local_head` to answer subsequent queries.
+    pub local_sha: Option<String>,
+    /// Whether ls_remote_head should fail with a transient error
+    /// to exercise the offline-tolerant path.
+    pub ls_remote_offline: bool,
+    /// Whether fetch_and_reset should fail.
+    pub fetch_offline: bool,
+    pub calls: Vec<String>,
+    /// Per-clone marker file written into the destination so tests
+    /// can confirm the executor actually "produced" a clone tree.
+    pub clone_marker_content: Vec<u8>,
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl MockGitRunner {
+    pub fn new(upstream_sha: &str, clone_marker: &[u8]) -> Self {
+        Self {
+            inner: std::sync::Mutex::new(MockGitInner {
+                ls_remote_sha: Some(upstream_sha.into()),
+                local_sha: None,
+                ls_remote_offline: false,
+                fetch_offline: false,
+                calls: Vec::new(),
+                clone_marker_content: clone_marker.to_vec(),
+            }),
+        }
+    }
+
+    /// Replace the upstream SHA — used to simulate a remote update
+    /// between two `up` runs.
+    pub fn set_upstream_sha(&self, sha: &str) {
+        let mut g = self.inner.lock().unwrap();
+        g.ls_remote_sha = Some(sha.into());
+    }
+
+    /// Force `ls_remote_head` to fail transiently (network down).
+    pub fn set_ls_remote_offline(&self, offline: bool) {
+        let mut g = self.inner.lock().unwrap();
+        g.ls_remote_offline = offline;
+    }
+
+    /// Force `fetch_and_reset` to fail transiently.
+    pub fn set_fetch_offline(&self, offline: bool) {
+        let mut g = self.inner.lock().unwrap();
+        g.fetch_offline = offline;
+    }
+
+    pub fn calls(&self) -> Vec<String> {
+        self.inner.lock().unwrap().calls.clone()
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl GitRunner for MockGitRunner {
+    fn ls_remote_head(&self, url: &str) -> std::result::Result<String, GitError> {
+        let mut g = self.inner.lock().unwrap();
+        g.calls.push(format!("ls-remote {url}"));
+        if g.ls_remote_offline {
+            return Err(GitError::CommandFailed {
+                operation: "ls-remote".into(),
+                exit_code: 1,
+                stderr: "simulated offline".into(),
+            });
+        }
+        g.ls_remote_sha.clone().ok_or_else(|| GitError::BadOutput {
+            operation: "ls-remote".into(),
+            detail: "mock returned no SHA".into(),
+        })
+    }
+
+    fn shallow_clone(&self, url: &str, dest: &Path) -> std::result::Result<String, GitError> {
+        let mut g = self.inner.lock().unwrap();
+        g.calls.push(format!("clone {url} -> {}", dest.display()));
+        // Write a small marker file so the executor's symlink leg has
+        // something to point at — mirrors what a real clone would
+        // produce on disk.
+        std::fs::create_dir_all(dest).map_err(|e| GitError::CommandFailed {
+            operation: "clone".into(),
+            exit_code: -1,
+            stderr: e.to_string(),
+        })?;
+        let marker = dest.join("README.md");
+        std::fs::write(&marker, &g.clone_marker_content).map_err(|e| GitError::CommandFailed {
+            operation: "clone".into(),
+            exit_code: -1,
+            stderr: e.to_string(),
+        })?;
+        let sha = g
+            .ls_remote_sha
+            .clone()
+            .unwrap_or_else(|| "0000000000000000000000000000000000000000".into());
+        g.local_sha = Some(sha.clone());
+        Ok(sha)
+    }
+
+    fn fetch_and_reset(&self, repo: &Path) -> std::result::Result<String, GitError> {
+        let mut g = self.inner.lock().unwrap();
+        g.calls.push(format!("fetch+reset {}", repo.display()));
+        if g.fetch_offline {
+            return Err(GitError::CommandFailed {
+                operation: "fetch".into(),
+                exit_code: 1,
+                stderr: "simulated offline".into(),
+            });
+        }
+        // Bump the marker file so callers can verify the tree
+        // actually changed after a refresh.
+        let marker = repo.join("README.md");
+        let mut buf = g.clone_marker_content.clone();
+        buf.extend_from_slice(b"\n# refreshed");
+        let _ = std::fs::write(&marker, &buf);
+        let sha = g
+            .ls_remote_sha
+            .clone()
+            .unwrap_or_else(|| "1111111111111111111111111111111111111111".into());
+        g.local_sha = Some(sha.clone());
+        Ok(sha)
+    }
+
+    fn local_head(&self, _repo: &Path) -> std::result::Result<String, GitError> {
+        let mut g = self.inner.lock().unwrap();
+        g.calls.push("rev-parse".into());
+        g.local_sha.clone().ok_or_else(|| GitError::BadOutput {
+            operation: "rev-parse".into(),
+            detail: "mock has no local sha (clone wasn't called)".into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_classification() {
+        assert!(GitError::CommandFailed {
+            operation: "fetch".into(),
+            exit_code: 128,
+            stderr: "dns failure".into(),
+        }
+        .is_transient());
+        assert!(GitError::BadOutput {
+            operation: "ls-remote".into(),
+            detail: "x".into(),
+        }
+        .is_transient());
+        assert!(!GitError::NotFound("missing".into()).is_transient());
+    }
+
+    #[test]
+    fn mock_clone_writes_marker_and_records_sha() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("clone");
+        let mock = MockGitRunner::new("abc123def456", b"# hello\n");
+        let sha = mock
+            .shallow_clone("https://example.com/repo.git", &dest)
+            .unwrap();
+        assert_eq!(sha, "abc123def456");
+        assert!(dest.join("README.md").exists());
+        assert_eq!(mock.local_head(&dest).unwrap(), "abc123def456");
+    }
+
+    #[test]
+    fn mock_fetch_updates_marker_and_sha() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("clone");
+        let mock = MockGitRunner::new("aaa", b"# v1\n");
+        mock.shallow_clone("https://x/r.git", &dest).unwrap();
+        mock.set_upstream_sha("bbb");
+        let new_sha = mock.fetch_and_reset(&dest).unwrap();
+        assert_eq!(new_sha, "bbb");
+        let body = std::fs::read_to_string(dest.join("README.md")).unwrap();
+        assert!(body.contains("# refreshed"));
+    }
+
+    #[test]
+    fn mock_offline_ls_remote() {
+        let mock = MockGitRunner::new("aaa", b"");
+        mock.set_ls_remote_offline(true);
+        let err = mock.ls_remote_head("https://x/r.git").unwrap_err();
+        assert!(err.is_transient());
+    }
+}

--- a/crates/dodot-lib/src/external/git.rs
+++ b/crates/dodot-lib/src/external/git.rs
@@ -87,9 +87,19 @@ impl ShellGitRunner {
     }
 
     fn run(operation: &str, cmd: &mut Command) -> std::result::Result<String, GitError> {
-        let output = cmd
-            .output()
-            .map_err(|e| GitError::NotFound(e.to_string()))?;
+        let output = cmd.output().map_err(|e| match e.kind() {
+            // Only "no such binary" gets the NotFound diagnostic —
+            // permission-denied, ENOMEM, etc. shouldn't masquerade as
+            // "user has to install git". Map those to CommandFailed
+            // with the kernel's reason so `is_transient()` can still
+            // route them through the soft-fail path.
+            std::io::ErrorKind::NotFound => GitError::NotFound(e.to_string()),
+            _ => GitError::CommandFailed {
+                operation: operation.to_string(),
+                exit_code: -1,
+                stderr: format!("spawn failed: {e}"),
+            },
+        })?;
         if !output.status.success() {
             return Err(GitError::CommandFailed {
                 operation: operation.to_string(),
@@ -134,15 +144,14 @@ impl GitRunner for ShellGitRunner {
     }
 
     fn shallow_clone(&self, url: &str, dest: &Path) -> std::result::Result<String, GitError> {
+        // Pass `dest` as an OsStr so non-UTF-8 paths survive verbatim
+        // — `to_string_lossy` would corrupt them, and Command accepts
+        // `&OsStr` natively anyway.
         Self::run(
             "clone",
-            Command::new("git").args([
-                "clone",
-                "--depth=1",
-                "--filter=blob:none",
-                url,
-                &dest.to_string_lossy(),
-            ]),
+            Command::new("git")
+                .args(["clone", "--depth=1", "--filter=blob:none", url])
+                .arg(dest),
         )?;
         self.local_head(dest)
     }

--- a/crates/dodot-lib/src/external/mod.rs
+++ b/crates/dodot-lib/src/external/mod.rs
@@ -20,7 +20,12 @@
 //! actual network work.
 
 mod fetch;
+mod git;
 mod spec;
 
 pub use fetch::{HttpFetchError, HttpFetcher, UreqFetcher};
+pub use git::{GitError, GitRunner, ShellGitRunner};
 pub use spec::{parse_externals_toml, ExternalEntry, ExternalsToml, FetchSpec};
+
+#[cfg(any(test, feature = "test-utils"))]
+pub use git::MockGitRunner;

--- a/crates/dodot-lib/src/external/spec.rs
+++ b/crates/dodot-lib/src/external/spec.rs
@@ -15,13 +15,12 @@
 //! sha256 = "..."
 //! ```
 //!
-//! For PR 1 only `type = "file"` is implemented; any other `type`
-//! value parses to [`FetchSpec::Unsupported`]. The original type
-//! string is not retained — `#[serde(other)]` does not carry it over
-//! — so the handler's diagnostic surfaces the entry name and a
-//! generic "unsupported type" message rather than echoing back
-//! what the user wrote. Subsequent PRs add the real variants
-//! (`git-repo`, `archive`, `archive-file`).
+//! `file` and `git-repo` are implemented; any other `type` value
+//! parses to [`FetchSpec::Unsupported`]. The original type string is
+//! not retained — `#[serde(other)]` does not carry it over — so the
+//! handler's diagnostic surfaces the entry name and a generic
+//! "unsupported type" message rather than echoing back what the user
+//! wrote. Subsequent PRs add `archive` / `archive-file`.
 
 use std::collections::BTreeMap;
 
@@ -54,10 +53,10 @@ pub struct ExternalEntry {
 
 /// The fetch recipe for one external entry.
 ///
-/// Tagged externally by the `type` field per TOML convention. Future
-/// PRs add `git-repo`, `archive`, `archive-file` variants — until they
-/// land, those parse into [`FetchSpec::Unsupported`] so the handler
-/// can surface "not yet implemented" without choking the whole pack.
+/// Tagged externally by the `type` field per TOML convention.
+/// `archive` and `archive-file` arrive in a later PR — until then,
+/// those parse into [`FetchSpec::Unsupported`] so the handler can
+/// surface "not yet implemented" without choking the whole pack.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum FetchSpec {
@@ -69,6 +68,15 @@ pub enum FetchSpec {
         /// without one is the same posture Home Manager takes.
         sha256: String,
     },
+
+    /// A shallow git clone, tracking `HEAD` of the default branch.
+    ///
+    /// Freshness is upstream-driven: each `dodot up` runs a cheap
+    /// `git ls-remote HEAD`; the actual clone is only re-fetched
+    /// when the remote SHA differs from the local one. Sparse-tree
+    /// checkout (`subpath`) and pinned `ref` / `commit` arrive in
+    /// a follow-up PR; for now the whole repo's HEAD is cloned.
+    GitRepo { url: String },
 
     /// Catchall for type values dodot doesn't implement yet.
     #[serde(other)]
@@ -229,15 +237,34 @@ mod tests {
     }
 
     #[test]
-    fn unknown_type_becomes_unsupported() {
+    fn parses_git_repo_entry() {
         let toml = r#"
             [omz]
-            type = "git-repo"
-            url = "https://github.com/ohmyzsh/ohmyzsh.git"
+            type   = "git-repo"
+            url    = "https://github.com/ohmyzsh/ohmyzsh.git"
             target = "~/.oh-my-zsh"
         "#;
         let parsed = parse_externals_toml(toml.as_bytes()).unwrap();
         let entry = parsed.entries.get("omz").unwrap();
+        assert_eq!(entry.target, "~/.oh-my-zsh");
+        match &entry.spec {
+            FetchSpec::GitRepo { url } => {
+                assert_eq!(url, "https://github.com/ohmyzsh/ohmyzsh.git");
+            }
+            other => panic!("expected GitRepo spec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_type_becomes_unsupported() {
+        let toml = r#"
+            [bogus]
+            type = "this-will-never-exist"
+            url = "https://example.com"
+            target = "~/x"
+        "#;
+        let parsed = parse_externals_toml(toml.as_bytes()).unwrap();
+        let entry = parsed.entries.get("bogus").unwrap();
         assert!(matches!(entry.spec, FetchSpec::Unsupported));
     }
 

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -221,6 +221,7 @@ pub fn execute_intents(
     );
     let auto_chmod = ctx.config_manager.root_config()?.path.auto_chmod_exec;
     let fetcher = crate::external::UreqFetcher::new();
+    let git = crate::external::ShellGitRunner::new();
     let executor = Executor::new(
         ctx.datastore.as_ref(),
         ctx.fs.as_ref(),
@@ -230,7 +231,8 @@ pub fn execute_intents(
         ctx.provision_rerun,
         auto_chmod,
     )
-    .with_fetcher(&fetcher);
+    .with_fetcher(&fetcher)
+    .with_git(&git);
     executor.execute(intents)
 }
 


### PR DESCRIPTION
Replacement for #155, which auto-closed when its base branch got deleted during the squash-merge of #154.

Rebased onto current main; no functional changes since the last review pass on #155.

## What's in

- New \`GitRunner\` trait + \`ShellGitRunner\` impl in \`crate::external\`
- Executor's \`with_git()\` builder hook
- \`FetchSpec::GitRepo { url }\` variant
- Shallow-clone (\`git clone --depth=1 --filter=blob:none\`) + ls-remote-based freshness
- All review fixes from #155 carried over (ErrorKind discrimination, &Path arg, transient ls-remote → failed result, etc.)

## Test plan

- [x] 1183 tests pass
- [x] CI green on the rebased branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)