### PR TITLE
feat(handlers): retrofit install + homebrew onto RunOnceHandler<C> (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Internal: `RunOnceCommand` trait + generic `RunOnceHandler<C>` in `crates/dodot-lib/src/handlers/run_once.rs`, the shared shape for the `install` / `homebrew` / forthcoming `nix` handlers (#169, PR A). Pure addition — not yet wired into the registry; existing handlers are unchanged. Subsequent PRs retrofit the existing handlers (PR B) and flip the run-once policy from auto-rerun-on-change to notify-don't-rerun (PR C).
+- Internal: `RunOnceCommand` trait + generic `RunOnceHandler<C>` in `crates/dodot-lib/src/handlers/run_once.rs`, the shared shape behind the `install` / `homebrew` / forthcoming `nix` handlers (#169, PR A). The shared body owns checksum, sentinel, intent emission, and status lookup; per-handler specialization (program name, argument shape, optional pre-flight validation, status copy) is a small trait surface. A subsequent PR (PR C) will flip the run-once policy from auto-rerun-on-change to notify-don't-rerun, touching the shared body once instead of each handler separately.
 
 ### Changed
 
-- Internal: `install` and `homebrew` handlers are now built on top of `RunOnceHandler<C>` via `InstallCommand` / `BrewfileCommand` specializations (#169, PR B). Duplicated checksum helpers consolidated in the shared module. **No user-visible behavior change** — sentinel format, auto-run-on-change semantics, and all observable behavior are preserved exactly; this PR is the foundation that lets PR C flip the run-once policy with one set of changes instead of three.
+- Internal: `install` and `homebrew` handlers are now built on top of `RunOnceHandler<C>` via `InstallCommand` / `BrewfileCommand` specializations (#169, PR B). Duplicated checksum helpers consolidated in the shared module. **No user-visible behavior change** — sentinel format, auto-run-on-change semantics, and all observable behavior are preserved exactly.
 
 ## [4.1.1] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Internal: `RunOnceCommand` trait + generic `RunOnceHandler<C>` in `crates/dodot-lib/src/handlers/run_once.rs`, the shared shape for the `install` / `homebrew` / forthcoming `nix` handlers (#169, PR A). Pure addition — not yet wired into the registry; existing handlers are unchanged. Subsequent PRs retrofit the existing handlers (PR B) and flip the run-once policy from auto-rerun-on-change to notify-don't-rerun (PR C).
 
+### Changed
+
+- Internal: `install` and `homebrew` handlers are now built on top of `RunOnceHandler<C>` via `InstallCommand` / `BrewfileCommand` specializations (#169, PR B). Duplicated checksum helpers consolidated in the shared module. **No user-visible behavior change** — sentinel format, auto-run-on-change semantics, and all observable behavior are preserved exactly; this PR is the foundation that lets PR C flip the run-once policy with one set of changes instead of three.
+
 ## [4.1.1] - 2026-05-12
 
 

--- a/crates/dodot-lib/src/handlers/homebrew.rs
+++ b/crates/dodot-lib/src/handlers/homebrew.rs
@@ -1,30 +1,25 @@
-//! Homebrew handler — runs `brew bundle` with sentinel tracking.
+//! Homebrew handler — runs `brew bundle` with checksum-based sentinel
+//! tracking, via the shared [`crate::handlers::run_once`] machinery.
+//!
+//! The bulk of the behavior lives in
+//! [`crate::handlers::run_once::RunOnceHandler`]. This module supplies
+//! the [`BrewfileCommand`] specialization: program name (`brew`) and
+//! argument shape (`bundle --file <path>`).
 
-use std::io::Read;
 use std::path::Path;
 
-use sha2::{Digest, Sha256};
+use crate::handlers::run_once::RunOnceCommand;
+use crate::handlers::{ExecutionPhase, HANDLER_HOMEBREW};
 
-use crate::datastore::DataStore;
-use crate::fs::Fs;
-use crate::handlers::{ExecutionPhase, Handler, HandlerConfig, HandlerStatus, HANDLER_HOMEBREW};
-use crate::operations::HandlerIntent;
-use crate::paths::Pather;
-use crate::rules::RuleMatch;
-use crate::Result;
+/// [`RunOnceCommand`] for the `homebrew` handler.
+///
+/// Invokes `brew bundle --file <abs path>`. No pre-flight validation —
+/// `brew` itself surfaces parse errors clearly when the Brewfile is
+/// malformed.
+pub struct BrewfileCommand;
 
-pub struct HomebrewHandler<'a> {
-    fs: &'a dyn Fs,
-}
-
-impl<'a> HomebrewHandler<'a> {
-    pub fn new(fs: &'a dyn Fs) -> Self {
-        Self { fs }
-    }
-}
-
-impl Handler for HomebrewHandler<'_> {
-    fn name(&self) -> &str {
+impl RunOnceCommand for BrewfileCommand {
+    fn handler_name(&self) -> &str {
         HANDLER_HOMEBREW
     }
 
@@ -32,110 +27,102 @@ impl Handler for HomebrewHandler<'_> {
         ExecutionPhase::Provision
     }
 
-    fn to_intents(
-        &self,
-        matches: &[RuleMatch],
-        _config: &HandlerConfig,
-        _paths: &dyn Pather,
-        _fs: &dyn Fs,
-    ) -> Result<Vec<HandlerIntent>> {
-        let mut intents = Vec::new();
+    fn command_for(&self, path: &Path) -> (String, Vec<String>) {
+        (
+            "brew".to_string(),
+            vec![
+                "bundle".into(),
+                "--file".into(),
+                path.to_string_lossy().into_owned(),
+            ],
+        )
+    }
 
-        for m in matches {
-            if m.is_dir {
-                continue;
-            }
+    fn status_deployed(&self) -> &str {
+        "brew packages installed"
+    }
 
-            // Same in-memory-first sentinel pattern as the install
-            // handler, including the first-time-pack passive
-            // placeholder case (no bytes, no on-disk file → skip
-            // intent generation). See install.rs and issue #121.
-            let checksum = match m.rendered_bytes.as_deref() {
-                Some(bytes) => brewfile_checksum_bytes(bytes),
-                None => match self.fs.exists(&m.absolute_path) {
-                    true => brewfile_checksum(self.fs, &m.absolute_path)?,
-                    false => {
-                        tracing::debug!(
-                            pack = %m.pack,
-                            file = %m.absolute_path.display(),
-                            "skipping homebrew intent — no rendered bytes and no on-disk file \
-                             (first-time-pack passive placeholder)"
-                        );
-                        continue;
-                    }
-                },
-            };
-            let filename = m
-                .relative_path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy();
-            let sentinel = format!("{filename}-{checksum}");
+    fn status_pending(&self) -> &str {
+        "brew packages not installed"
+    }
+}
 
-            intents.push(HandlerIntent::Run {
-                pack: m.pack.clone(),
-                handler: HANDLER_HOMEBREW.into(),
-                executable: "brew".into(),
-                arguments: vec![
-                    "bundle".into(),
-                    "--file".into(),
-                    m.absolute_path.to_string_lossy().into_owned(),
-                ],
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::Fs;
+    use crate::handlers::run_once::RunOnceHandler;
+    use crate::handlers::{Handler, HandlerConfig};
+    use crate::operations::HandlerIntent;
+    use crate::rules::RuleMatch;
+    use crate::testing::TempEnvironment;
+    use std::collections::HashMap;
+
+    #[test]
+    fn brewfile_command_identity() {
+        assert_eq!(BrewfileCommand.handler_name(), HANDLER_HOMEBREW);
+        assert_eq!(BrewfileCommand.phase(), ExecutionPhase::Provision);
+        assert_eq!(BrewfileCommand.status_deployed(), "brew packages installed");
+        assert_eq!(
+            BrewfileCommand.status_pending(),
+            "brew packages not installed"
+        );
+    }
+
+    #[test]
+    fn brewfile_command_emits_run_intent_with_expected_shape() {
+        let env = TempEnvironment::builder()
+            .pack("dev")
+            .file("Brewfile", "brew \"ripgrep\"")
+            .done()
+            .build();
+
+        let handler = RunOnceHandler::new(env.fs.as_ref(), BrewfileCommand);
+        let matches = vec![RuleMatch {
+            relative_path: "Brewfile".into(),
+            absolute_path: env.dotfiles_root.join("dev/Brewfile"),
+            pack: "dev".into(),
+            handler: "homebrew".into(),
+            is_dir: false,
+            options: HashMap::new(),
+            preprocessor_source: None,
+            rendered_bytes: None,
+        }];
+
+        let pather = crate::paths::XdgPather::builder()
+            .home(&env.home)
+            .dotfiles_root(&env.dotfiles_root)
+            .build()
+            .unwrap();
+
+        let intents = handler
+            .to_intents(
+                &matches,
+                &HandlerConfig::default(),
+                &pather,
+                env.fs.as_ref() as &dyn Fs,
+            )
+            .unwrap();
+
+        assert_eq!(intents.len(), 1);
+        match &intents[0] {
+            HandlerIntent::Run {
+                pack,
+                handler: h,
+                executable,
+                arguments,
                 sentinel,
-            });
+            } => {
+                assert_eq!(pack, "dev");
+                assert_eq!(h, HANDLER_HOMEBREW);
+                assert_eq!(executable, "brew");
+                assert_eq!(arguments[0], "bundle");
+                assert_eq!(arguments[1], "--file");
+                assert!(arguments[2].ends_with("Brewfile"));
+                assert!(sentinel.starts_with("Brewfile-"));
+                assert_eq!(sentinel.len(), "Brewfile-".len() + 16);
+            }
+            other => panic!("expected Run, got {other:?}"),
         }
-
-        Ok(intents)
     }
-
-    fn check_status(
-        &self,
-        file: &Path,
-        pack: &str,
-        datastore: &dyn DataStore,
-    ) -> Result<HandlerStatus> {
-        let checksum = brewfile_checksum(self.fs, file)?;
-        let filename = file.file_name().unwrap_or_default().to_string_lossy();
-        let sentinel = format!("{filename}-{checksum}");
-        let has_sentinel = datastore.has_sentinel(pack, HANDLER_HOMEBREW, &sentinel)?;
-
-        Ok(HandlerStatus {
-            file: file.to_string_lossy().into_owned(),
-            handler: HANDLER_HOMEBREW.into(),
-            deployed: has_sentinel,
-            message: if has_sentinel {
-                "brew packages installed".into()
-            } else {
-                "brew packages not installed".into()
-            },
-        })
-    }
-}
-
-fn brewfile_checksum(fs: &dyn Fs, path: &Path) -> Result<String> {
-    let mut reader = fs.open_read(path)?;
-    let mut hasher = Sha256::new();
-    let mut buf = [0u8; 8192];
-    loop {
-        let n = reader.read(&mut buf).map_err(|e| crate::DodotError::Fs {
-            path: path.to_path_buf(),
-            source: e,
-        })?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-    let hash = hasher.finalize();
-    Ok(hash[..8].iter().map(|b| format!("{b:02x}")).collect())
-}
-
-/// Same digest format as [`brewfile_checksum`], but over an in-memory
-/// byte slice — used when the rendered Brewfile is available without
-/// a disk read (Passive mode).
-fn brewfile_checksum_bytes(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    let hash = hasher.finalize();
-    hash[..8].iter().map(|b| format!("{b:02x}")).collect()
 }

--- a/crates/dodot-lib/src/handlers/install.rs
+++ b/crates/dodot-lib/src/handlers/install.rs
@@ -1,46 +1,44 @@
-//! Install handler — runs setup scripts with checksum-based sentinel tracking.
+//! Install handler — runs setup scripts with checksum-based sentinel
+//! tracking, via the shared [`crate::handlers::run_once`] machinery.
+//!
+//! The bulk of the behavior (checksum, sentinel, intent emission,
+//! status lookup) lives in [`crate::handlers::run_once::RunOnceHandler`].
+//! This module supplies the [`InstallCommand`] specialization, which
+//! tells the shared handler how to invoke an `install.sh` (or `.bash`
+//! / `.zsh`) script.
 //!
 //! # Interpreter selection
 //!
-//! The interpreter is chosen from the script's file extension rather than
-//! from the user's login shell. This keeps script execution predictable:
-//! a script runs in its own subprocess with a fresh environment, so the
-//! user's interactive shell (aliases, functions, options) is irrelevant
-//! to how the script behaves — only the interpreter is.
+//! The interpreter is chosen from the script's file extension rather
+//! than from the user's login shell. This keeps script execution
+//! predictable: a script runs in its own subprocess with a fresh
+//! environment, so the user's interactive shell (aliases, functions,
+//! options) is irrelevant to how the script behaves — only the
+//! interpreter is.
 //!
 //! - `.sh`, `.bash`, or unknown extension → `bash`
 //! - `.zsh` → `zsh`
 //!
-//! The extension is the contract the pack author declares. A script named
-//! `install.zsh` announces that it uses zsh-specific syntax; invoking it
-//! with bash would be incorrect. A script named `install.sh` announces
-//! portability and should work anywhere `bash` is available.
+//! The extension is the contract the pack author declares. A script
+//! named `install.zsh` announces that it uses zsh-specific syntax;
+//! invoking it with bash would be incorrect. A script named
+//! `install.sh` announces portability and should work anywhere `bash`
+//! is available.
 
-use std::io::Read;
 use std::path::Path;
 
-use sha2::{Digest, Sha256};
+use crate::handlers::run_once::RunOnceCommand;
+use crate::handlers::{ExecutionPhase, HANDLER_INSTALL};
 
-use crate::datastore::DataStore;
-use crate::fs::Fs;
-use crate::handlers::{ExecutionPhase, Handler, HandlerConfig, HandlerStatus, HANDLER_INSTALL};
-use crate::operations::HandlerIntent;
-use crate::paths::Pather;
-use crate::rules::RuleMatch;
-use crate::Result;
+/// [`RunOnceCommand`] for the `install` handler.
+///
+/// Picks the interpreter from the script's extension and invokes it
+/// as `<interpreter> -- <abs path>` (the `--` end-of-flags separator
+/// guards against scripts whose names start with a dash).
+pub struct InstallCommand;
 
-pub struct InstallHandler<'a> {
-    fs: &'a dyn Fs,
-}
-
-impl<'a> InstallHandler<'a> {
-    pub fn new(fs: &'a dyn Fs) -> Self {
-        Self { fs }
-    }
-}
-
-impl Handler for InstallHandler<'_> {
-    fn name(&self) -> &str {
+impl RunOnceCommand for InstallCommand {
+    fn handler_name(&self) -> &str {
         HANDLER_INSTALL
     }
 
@@ -48,98 +46,26 @@ impl Handler for InstallHandler<'_> {
         ExecutionPhase::Setup
     }
 
-    fn to_intents(
-        &self,
-        matches: &[RuleMatch],
-        _config: &HandlerConfig,
-        _paths: &dyn Pather,
-        _fs: &dyn Fs,
-    ) -> Result<Vec<HandlerIntent>> {
-        let mut intents = Vec::new();
-
-        for m in matches {
-            if m.is_dir {
-                continue;
-            }
-
-            // Sentinel hashing prefers in-memory rendered bytes when
-            // they're available (preprocessor-produced files); falls
-            // back to a disk read for plain on-disk files. The
-            // in-memory path is the §7.4 enabler — `dodot status`
-            // and `up --dry-run` need a correct sentinel for
-            // templated install scripts without writing the
-            // rendered file to disk. See issue #121.
-            //
-            // First-time-pack passive case: a templated `install.sh`
-            // with no baseline yet lands here as a placeholder match
-            // (no bytes, no file on disk). We can't compute a
-            // sentinel without rendering, and rendering is the §7.4
-            // violation we're refusing to do. Skip intent generation
-            // for this match — status / dry-run will report the file
-            // as pending via the symlink chain instead, and the next
-            // real `dodot up` plans the Run intent normally.
-            let checksum = match m.rendered_bytes.as_deref() {
-                Some(bytes) => file_checksum_bytes(bytes),
-                None => match self.fs.exists(&m.absolute_path) {
-                    true => file_checksum(self.fs, &m.absolute_path)?,
-                    false => {
-                        tracing::debug!(
-                            pack = %m.pack,
-                            file = %m.absolute_path.display(),
-                            "skipping install intent — no rendered bytes and no on-disk file \
-                             (first-time-pack passive placeholder)"
-                        );
-                        continue;
-                    }
-                },
-            };
-            let filename = m
-                .relative_path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy();
-            let sentinel = format!("{filename}-{checksum}");
-
-            intents.push(HandlerIntent::Run {
-                pack: m.pack.clone(),
-                handler: HANDLER_INSTALL.into(),
-                executable: interpreter_for(&m.absolute_path).into(),
-                arguments: vec!["--".into(), m.absolute_path.to_string_lossy().into_owned()],
-                sentinel,
-            });
-        }
-
-        Ok(intents)
+    fn command_for(&self, path: &Path) -> (String, Vec<String>) {
+        (
+            interpreter_for(path).to_string(),
+            vec!["--".into(), path.to_string_lossy().into_owned()],
+        )
     }
 
-    fn check_status(
-        &self,
-        file: &Path,
-        pack: &str,
-        datastore: &dyn DataStore,
-    ) -> Result<HandlerStatus> {
-        let checksum = file_checksum(self.fs, file)?;
-        let filename = file.file_name().unwrap_or_default().to_string_lossy();
-        let sentinel = format!("{filename}-{checksum}");
-        let has_sentinel = datastore.has_sentinel(pack, HANDLER_INSTALL, &sentinel)?;
+    fn status_deployed(&self) -> &str {
+        "installed"
+    }
 
-        Ok(HandlerStatus {
-            file: file.to_string_lossy().into_owned(),
-            handler: HANDLER_INSTALL.into(),
-            deployed: has_sentinel,
-            message: if has_sentinel {
-                "installed".into()
-            } else {
-                "never run".into()
-            },
-        })
+    fn status_pending(&self) -> &str {
+        "never run"
     }
 }
 
 /// Pick the interpreter for an install script based on its extension.
 ///
-/// Module-level docs explain why extension — not the user's login shell —
-/// is the right signal.
+/// Module-level docs explain why extension — not the user's login
+/// shell — is the right signal.
 fn interpreter_for(path: &Path) -> &'static str {
     match path.extension().and_then(|e| e.to_str()) {
         Some("zsh") => "zsh",
@@ -147,129 +73,16 @@ fn interpreter_for(path: &Path) -> &'static str {
     }
 }
 
-/// Compute a short SHA-256 hex digest of a file's contents.
-fn file_checksum(fs: &dyn Fs, path: &Path) -> Result<String> {
-    let mut reader = fs.open_read(path)?;
-    let mut hasher = Sha256::new();
-    let mut buf = [0u8; 8192];
-    loop {
-        let n = reader.read(&mut buf).map_err(|e| crate::DodotError::Fs {
-            path: path.to_path_buf(),
-            source: e,
-        })?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-    let hash = hasher.finalize();
-    // Use first 8 bytes (16 hex chars) for a short but unique sentinel
-    Ok(hex::encode(&hash[..8]))
-}
-
-/// Same digest format as [`file_checksum`], but over an in-memory
-/// byte slice — used when the rendered content is available without
-/// a disk read.
-fn file_checksum_bytes(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    let hash = hasher.finalize();
-    hex::encode(&hash[..8])
-}
-
-/// Minimal hex encoding (avoids pulling in the `hex` crate).
-mod hex {
-    pub fn encode(bytes: &[u8]) -> String {
-        bytes.iter().map(|b| format!("{b:02x}")).collect()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fs::Fs;
+    use crate::handlers::run_once::RunOnceHandler;
+    use crate::handlers::{Handler, HandlerConfig};
+    use crate::operations::HandlerIntent;
+    use crate::rules::RuleMatch;
     use crate::testing::TempEnvironment;
-
-    #[test]
-    fn checksum_is_deterministic() {
-        let env = TempEnvironment::builder()
-            .pack("test")
-            .file("install.sh", "#!/bin/sh\necho hello")
-            .done()
-            .build();
-
-        let path = env.dotfiles_root.join("test/install.sh");
-        let c1 = file_checksum(env.fs.as_ref(), &path).unwrap();
-        let c2 = file_checksum(env.fs.as_ref(), &path).unwrap();
-        assert_eq!(c1, c2);
-        assert_eq!(c1.len(), 16); // 8 bytes = 16 hex chars
-    }
-
-    #[test]
-    fn checksum_changes_with_content() {
-        let env = TempEnvironment::builder()
-            .pack("test")
-            .file("a.sh", "version 1")
-            .file("b.sh", "version 2")
-            .done()
-            .build();
-
-        let ca = file_checksum(env.fs.as_ref(), &env.dotfiles_root.join("test/a.sh")).unwrap();
-        let cb = file_checksum(env.fs.as_ref(), &env.dotfiles_root.join("test/b.sh")).unwrap();
-        assert_ne!(ca, cb);
-    }
-
-    #[test]
-    fn to_intents_produces_run_with_sentinel() {
-        let env = TempEnvironment::builder()
-            .pack("vim")
-            .file("install.sh", "#!/bin/sh\nsetup")
-            .done()
-            .build();
-
-        let handler = InstallHandler::new(env.fs.as_ref());
-        let matches = vec![crate::rules::RuleMatch {
-            relative_path: "install.sh".into(),
-            absolute_path: env.dotfiles_root.join("vim/install.sh"),
-            pack: "vim".into(),
-            handler: "install".into(),
-            is_dir: false,
-            options: std::collections::HashMap::new(),
-            preprocessor_source: None,
-            rendered_bytes: None,
-        }];
-
-        let pather = crate::paths::XdgPather::builder()
-            .home(&env.home)
-            .dotfiles_root(&env.dotfiles_root)
-            .build()
-            .unwrap();
-
-        let intents = handler
-            .to_intents(
-                &matches,
-                &HandlerConfig::default(),
-                &pather,
-                env.fs.as_ref(),
-            )
-            .unwrap();
-
-        assert_eq!(intents.len(), 1);
-        match &intents[0] {
-            HandlerIntent::Run {
-                executable,
-                arguments,
-                sentinel,
-                ..
-            } => {
-                assert_eq!(executable, "bash");
-                assert_eq!(arguments[0], "--");
-                assert!(arguments[1].contains("install.sh"));
-                assert!(sentinel.starts_with("install.sh-"));
-                assert_eq!(sentinel.len(), "install.sh-".len() + 16);
-            }
-            other => panic!("expected Run, got {other:?}"),
-        }
-    }
+    use std::collections::HashMap;
 
     #[test]
     fn interpreter_for_selects_by_extension() {
@@ -284,7 +97,15 @@ mod tests {
     }
 
     #[test]
-    fn to_intents_picks_interpreter_per_script() {
+    fn install_command_identity() {
+        assert_eq!(InstallCommand.handler_name(), HANDLER_INSTALL);
+        assert_eq!(InstallCommand.phase(), ExecutionPhase::Setup);
+        assert_eq!(InstallCommand.status_deployed(), "installed");
+        assert_eq!(InstallCommand.status_pending(), "never run");
+    }
+
+    #[test]
+    fn install_command_picks_interpreter_per_script_via_handler() {
         let env = TempEnvironment::builder()
             .pack("vim")
             .file("install.sh", "echo sh")
@@ -293,14 +114,14 @@ mod tests {
             .done()
             .build();
 
-        let handler = InstallHandler::new(env.fs.as_ref());
-        let make_match = |name: &str| crate::rules::RuleMatch {
+        let handler = RunOnceHandler::new(env.fs.as_ref(), InstallCommand);
+        let make_match = |name: &str| RuleMatch {
             relative_path: name.into(),
             absolute_path: env.dotfiles_root.join(format!("vim/{name}")),
             pack: "vim".into(),
             handler: "install".into(),
             is_dir: false,
-            options: std::collections::HashMap::new(),
+            options: HashMap::new(),
             preprocessor_source: None,
             rendered_bytes: None,
         };
@@ -321,7 +142,7 @@ mod tests {
                 &matches,
                 &HandlerConfig::default(),
                 &pather,
-                env.fs.as_ref(),
+                env.fs.as_ref() as &dyn Fs,
             )
             .unwrap();
 
@@ -338,7 +159,7 @@ mod tests {
                         .last()
                         .cloned()
                         .and_then(|p| {
-                            std::path::Path::new(&p)
+                            Path::new(&p)
                                 .file_name()
                                 .map(|n| n.to_string_lossy().into_owned())
                         })
@@ -351,5 +172,61 @@ mod tests {
         assert!(chosen.contains(&("bash".into(), "install.sh".into())));
         assert!(chosen.contains(&("bash".into(), "install.bash".into())));
         assert!(chosen.contains(&("zsh".into(), "install.zsh".into())));
+    }
+
+    #[test]
+    fn install_command_emits_run_intent_with_expected_shape() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("install.sh", "#!/bin/sh\nsetup")
+            .done()
+            .build();
+
+        let handler = RunOnceHandler::new(env.fs.as_ref(), InstallCommand);
+        let matches = vec![RuleMatch {
+            relative_path: "install.sh".into(),
+            absolute_path: env.dotfiles_root.join("vim/install.sh"),
+            pack: "vim".into(),
+            handler: "install".into(),
+            is_dir: false,
+            options: HashMap::new(),
+            preprocessor_source: None,
+            rendered_bytes: None,
+        }];
+
+        let pather = crate::paths::XdgPather::builder()
+            .home(&env.home)
+            .dotfiles_root(&env.dotfiles_root)
+            .build()
+            .unwrap();
+
+        let intents = handler
+            .to_intents(
+                &matches,
+                &HandlerConfig::default(),
+                &pather,
+                env.fs.as_ref() as &dyn Fs,
+            )
+            .unwrap();
+
+        assert_eq!(intents.len(), 1);
+        match &intents[0] {
+            HandlerIntent::Run {
+                pack,
+                handler: h,
+                executable,
+                arguments,
+                sentinel,
+            } => {
+                assert_eq!(pack, "vim");
+                assert_eq!(h, HANDLER_INSTALL);
+                assert_eq!(executable, "bash");
+                assert_eq!(arguments[0], "--");
+                assert!(arguments[1].ends_with("install.sh"));
+                assert!(sentinel.starts_with("install.sh-"));
+                assert_eq!(sentinel.len(), "install.sh-".len() + 16);
+            }
+            other => panic!("expected Run, got {other:?}"),
+        }
     }
 }

--- a/crates/dodot-lib/src/handlers/mod.rs
+++ b/crates/dodot-lib/src/handlers/mod.rs
@@ -321,8 +321,8 @@ pub fn configuration_handler_names(fs: &dyn Fs) -> Vec<String> {
 /// Create the default handler registry.
 ///
 /// Returns a map from handler name to handler instance. The `fs`
-/// reference is needed by install and homebrew handlers for checksum
-/// computation.
+/// reference is needed by the run-once handlers (install, homebrew)
+/// for checksum computation.
 pub fn create_registry(fs: &dyn Fs) -> HashMap<String, Box<dyn Handler + '_>> {
     let mut registry: HashMap<String, Box<dyn Handler>> = HashMap::new();
     registry.insert(HANDLER_IGNORE.into(), Box::new(filter::IgnoreHandler));
@@ -337,11 +337,11 @@ pub fn create_registry(fs: &dyn Fs) -> HashMap<String, Box<dyn Handler + '_>> {
     registry.insert(HANDLER_PATH.into(), Box::new(path::PathHandler));
     registry.insert(
         HANDLER_INSTALL.into(),
-        Box::new(install::InstallHandler::new(fs)),
+        Box::new(run_once::RunOnceHandler::new(fs, install::InstallCommand)),
     );
     registry.insert(
         HANDLER_HOMEBREW.into(),
-        Box::new(homebrew::HomebrewHandler::new(fs)),
+        Box::new(run_once::RunOnceHandler::new(fs, homebrew::BrewfileCommand)),
     );
     validate_registry(&registry);
     registry


### PR DESCRIPTION
Closes #171. PR B of #169 (Standardize Run Once Handlers).

## Summary

Retrofits `install.rs` and `homebrew.rs` onto the `RunOnceHandler<C>` abstraction introduced by PR A (#170). Both files shrink to a small `RunOnceCommand` specialization (`InstallCommand`, `BrewfileCommand`) plus per-command tests; the shared body — checksum, sentinel, intent emission, status lookup — now lives in one place.

**No user-visible behavior change.** Sentinel format (`<filename>-<hash>`), auto-run-on-change semantics, `HandlerIntent::Run` shape, and `check_status` deployed/not-deployed all match the prior implementations exactly. This is the pure refactor PR that validates the abstraction; the policy flip lives in PR C.

Net diff: -132 lines.

## Checklist

- [x] Changelog `Unreleased` section updated
- [x] Project umbrella check passes locally — `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
- [x] Tests added or updated for behavior changes — see notes below.

## Notes for reviewers

**Test migration.** The original `install.rs` had 5 tests; some tested the shared checksum helpers (now covered in `run_once.rs` tests from PR A), some tested per-command specialization (interpreter selection from file extension, which stays here). I kept three tests in `install.rs`:

- `interpreter_for_selects_by_extension` — pure unit on `interpreter_for`; per-command, stays.
- `install_command_picks_interpreter_per_script_via_handler` — end-to-end through `RunOnceHandler<InstallCommand>` confirming different extensions pick different interpreters. Renamed from the old `to_intents_picks_interpreter_per_script`.
- `install_command_emits_run_intent_with_expected_shape` — end-to-end confirming the install handler's specific Run intent shape (executable=bash, args=["--", path]). Replaces the old `to_intents_produces_run_with_sentinel`.
- `install_command_identity` — small smoke test for the trait impl's identity methods.

The old `checksum_is_deterministic` / `checksum_changes_with_content` tests are dropped — equivalent coverage already exists in `run_once.rs` (`file_checksum_and_bytes_agree`, `file_checksum_changes_with_content`).

`homebrew.rs` had no tests; I added two thin ones (`brewfile_command_identity`, `brewfile_command_emits_run_intent_with_expected_shape`) to match the install coverage shape.

**Registry construction.** `create_registry` now builds the install and homebrew slots as `Box::new(RunOnceHandler::new(fs, InstallCommand))` and `Box::new(RunOnceHandler::new(fs, BrewfileCommand))`. The map type and the `Box<dyn Handler + '_>` value type are unchanged.

**What's deferred to PR C.** The notify-don't-rerun policy flip, `did_run` datastore API, and snapshot writes all live in PR C. PR B is strictly preserve-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)