### PR TITLE
feat: cloud SessionStart hook + new copilot-review policy

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/setup-dev-env.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,12 +1,23 @@
 name: Copilot Review
 
+# Trigger policy:
+#   - Fires once at PR creation (`opened`), regardless of draft state.
+#     Drafts get Copilot too — the Auto-fix loop can address comments
+#     while the PR is still draft.
+#   - `ready_for_review` is intentionally NOT in the types list — going
+#     draft → ready does not re-trigger Copilot, since it already
+#     reviewed at open. Avoids the "two Copilot reviews per PR" pattern
+#     that the prior policy produced.
+#   - Fork PRs still skipped (security: don't pass RELEASE_TOKEN to
+#     untrusted source).
+
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened]
 
 jobs:
   request:
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
       pull-requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ docs/research
 __pycache__/
 *.pyc
 *.pyo
+
+# But do track the SessionStart hook config
+!.claude/settings.json

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# scripts/setup-dev-env.sh — per-session dev-environment setup, invoked by
+# the SessionStart hook in .claude/settings.json.
+#
+# Cloud-only: local sessions exit early (devs already have their env set up).
+# Detects stack by filesystem signals — works for rust, node-flavored
+# (npm/yarn/pnpm), ruby (bundle), and nvim/zed/static-site (no project
+# deps, just lefthook wiring). Stack-specific extras (e.g. resource
+# download scripts, submodule init) can be added below the universal
+# section as needed for the particular repo.
+#
+# Idempotent — safe to re-run. Errors are best-effort: a failure in one
+# step doesn't abort the rest (e.g. transient registry hiccup on cargo
+# fetch shouldn't block the lefthook install).
+
+set -euo pipefail
+
+# Cloud-only gate. Local sessions already have their env set up.
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+# 1. Project dep cache — pick the right tool based on lockfile / manifest.
+
+# Rust: cargo fetch with --locked so we don't silently mutate Cargo.lock
+# in the per-session clone. Stale lockfile produces a non-fatal exit;
+# the agent's later cargo build/test surfaces the real issue.
+if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
+  cargo fetch --locked --quiet || true
+fi
+
+# Node-based (npm / yarn / pnpm). Skip if node_modules already exists
+# (warm from a previous session within the same env-snapshot).
+if [ -f package.json ] && [ ! -d node_modules ]; then
+  if [ -f package-lock.json ] && command -v npm >/dev/null 2>&1; then
+    npm ci 2>/dev/null || npm install
+  elif [ -f yarn.lock ] && command -v yarn >/dev/null 2>&1; then
+    yarn install --frozen-lockfile 2>/dev/null || yarn install
+  elif [ -f pnpm-lock.yaml ] && command -v pnpm >/dev/null 2>&1; then
+    pnpm install --frozen-lockfile 2>/dev/null || pnpm install
+  fi
+fi
+
+# Ruby / Bundler.
+if [ -f Gemfile ] && command -v bundle >/dev/null 2>&1; then
+  bundle install --quiet || true
+fi
+
+# 2. Pre-commit hook wiring (lefthook).
+# Binary is installed at env-setup time (arthur-debert/release env/setup.sh);
+# this just wires .git/hooks/pre-commit to call it. Errors are surfaced
+# loudly — the whole point of the script is the hook install.
+if [ -f lefthook.yml ] && command -v lefthook >/dev/null 2>&1; then
+  if ! lefthook install; then
+    echo "warning: lefthook install failed — pre-commit hook NOT wired" >&2
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with a SessionStart hook calling `scripts/setup-dev-env.sh`, so a fresh cloud session warms project deps + wires lefthook automatically.
- Adds `scripts/setup-dev-env.sh` — universal stack-detecting script (rust / node / ruby / lefthook). Cloud-only via `CLAUDE_CODE_REMOTE` gate, so it no-ops on local sessions.
- Updates `.github/workflows/copilot-review.yml` to the new `[opened]`-only policy: drafts get Copilot at PR open, and flipping draft→ready does **not** re-trigger Copilot. This avoids the prior "two reviews per PR" pattern.

## Why

This is the per-consumer fanout for [arthur-debert/release#26](https://github.com/arthur-debert/release/issues/26) (Phase 2 / Group B). Tracking issue: [arthur-debert/release#28](https://github.com/arthur-debert/release/issues/28).

The mechanism was proven on arthur-debert/release and arami-core. This PR brings dodot onto the same canonical loop.

## Test plan

- [ ] CI green on this PR
- [ ] Copilot review fires at PR open (validates new `[opened]` policy)
- [ ] On merge, a fresh cloud session in this repo triggers the SessionStart hook without errors