### PR TITLE
test(adopt): skip chmod-000 test when running with DAC bypass (root)

### DIFF
--- a/crates/dodot-lib/src/commands/tests/adopt.rs
+++ b/crates/dodot-lib/src/commands/tests/adopt.rs
@@ -1491,6 +1491,22 @@ fn adopt_force_preserves_old_content_when_copy_fails() {
     // copying, so a copy failure silently lost the old content.
     use std::os::unix::fs::PermissionsExt;
 
+    // Skip when DAC permissions don't block this process (e.g. running as
+    // root in a container/sandbox — CAP_DAC_READ_SEARCH bypasses chmod 000).
+    // The test fundamentally requires read() to fail on the source file.
+    let probe = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(probe.path(), b"x").unwrap();
+    std::fs::set_permissions(probe.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
+    let can_be_blocked_by_chmod = std::fs::read(probe.path()).is_err();
+    let _ = std::fs::set_permissions(probe.path(), std::fs::Permissions::from_mode(0o644));
+    if !can_be_blocked_by_chmod {
+        eprintln!(
+            "skipping adopt_force_preserves_old_content_when_copy_fails: \
+             process bypasses DAC permissions (running as root?)"
+        );
+        return;
+    }
+
     let env = TempEnvironment::builder()
         .pack("vim")
         .file("home.vimrc", "OLD")


### PR DESCRIPTION
## Cloud-env debugging report

Ran the standard tooling audit in a fresh Claude Code Cloud sandbox to verify the env-setup story still works end-to-end. Result: everything in `scripts/setup-dev-env.sh` is doing its job — `cargo`, `lefthook`, `bats`, `docker`, the rust toolchain pinned in `rust-toolchain.toml`, and the pre-commit wiring all come up clean on session start. One genuine test failure surfaced, which this PR fixes.

## Audit results

| Check | Status |
| --- | --- |
| `cargo --version` (1.94.1 per `rust-toolchain.toml`) | ✅ |
| `lefthook --version` (2.1.6) | ✅ |
| `bats --version` (1.10.0) | ✅ |
| `docker --version` (29.3.1) | ✅ |
| `.git/hooks/pre-commit` wired by `lefthook install` | ✅ |
| `scripts/check-fmt` | ✅ |
| `scripts/check-lint` | ✅ |
| `scripts/check-tests` | ❌ 1 failure (see below) — ✅ after fix |
| `scripts/e2e --local` (311 bats tests) | ✅ |
| `lefthook run pre-commit` | ✅ |

No changes needed to `scripts/setup-dev-env.sh` itself — provisioning is correct.

## The one failure

```
test commands::tests::adopt::adopt_force_preserves_old_content_when_copy_fails ... FAILED
thread '…' panicked at crates/dodot-lib/src/commands/tests/adopt.rs:1520:5:
adopt should fail when the source is unreadable
test result: FAILED. 1236 passed; 1 failed; 15 ignored
```

### Root cause

The test sets a source file to mode `0o000` and asserts that `adopt --force` fails because the copy phase can't `read()` it. That premise holds for a normal Unix user, but **the Claude Code Cloud sandbox runs the session as root** (`uid=0`). Root has `CAP_DAC_READ_SEARCH` + `CAP_DAC_OVERRIDE`, so `chmod 000` does not block reads — the adopt operation succeeds, the assertion fails.

Confirmed with a minimal repro:

```
# echo DATA > /tmp/f && chmod 000 /tmp/f && cat /tmp/f
DATA                                  # root — DAC bypassed
# chown nobody /tmp/f && sudo -u nobody cat /tmp/f
cat: /tmp/f: Permission denied        # non-root — DAC enforced
```

CI (`ubuntu-latest`) runs as a non-root user and is unaffected — this is purely a cloud-sandbox / container-as-root issue.

## The fix

Probe at test start whether `chmod 000` actually blocks reads in the current process. If it doesn't (root / privileged container), log a skip message and return early. The check is self-contained — no new deps, no Cargo.toml change, no behavior change for non-root runs.

```rust
let probe = tempfile::NamedTempFile::new().unwrap();
std::fs::write(probe.path(), b"x").unwrap();
std::fs::set_permissions(probe.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
let can_be_blocked_by_chmod = std::fs::read(probe.path()).is_err();
let _ = std::fs::set_permissions(probe.path(), std::fs::Permissions::from_mode(0o644));
if !can_be_blocked_by_chmod {
    eprintln!("skipping … : process bypasses DAC permissions (running as root?)");
    return;
}
```

This is the standard pattern for tests that depend on DAC enforcement — it lets them run wherever they're meaningful and silently skip where they aren't, rather than reporting a false failure or being permanently `#[ignore]`d.

## Why not change `setup-dev-env.sh`?

Considered creating a non-root user and wrapping `cargo test` to run under it, but it's a lot of moving parts (target/ ownership, cargo home, `$HOME`, the test's own `TempEnvironment` builder) to work around one inherently-DAC-dependent assertion. The test-side probe is smaller, more honest, and doesn't pessimize the common (non-root) case. `setup-dev-env.sh` provisions the env correctly as-is.

## Verification

- `scripts/check` → all 1237 tests pass (1 skips with diagnostic message on root)
- `scripts/e2e --local` → 311/311 pass
- `lefthook run pre-commit` → wired and runs

## Test plan

- [x] `scripts/check` green in cloud sandbox (root)
- [x] `scripts/e2e --local` green in cloud sandbox
- [ ] CI green (non-root path still hits the assertion, as intended)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fe2EqgDEtTqU2wEvTxwQ71)_