### PR TITLE
docs: add mkdocs site infrastructure for dodot.sh

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,15 +7,18 @@ on:
       - docs/**
       - mkdocs.yml
       - .github/workflows/docs.yml
+  pull_request:
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/docs.yml
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -41,13 +44,18 @@ jobs:
         run: mkdocs build
 
       - name: Upload artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,52 +14,45 @@ on:
       - .github/workflows/docs.yml
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
-  group: pages-${{ github.ref }}
+  group: docs-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v6
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: docs/requirements.txt
 
-      - name: Install dependencies
-        run: pip install -r docs/requirements.txt
+      - run: pip install -r docs/requirements.txt
 
-      - name: Build site
-        run: mkdocs build
-
-      - name: Upload artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
+      - run: mkdocs build
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      contents: write
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - run: pip install -r docs/requirements.txt
+
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build site
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ __pycache__/
 
 # But do track the SessionStart hook config
 !.claude/settings.json
+
+# mkdocs build output + plugin cache + local venv
+site/
+.mkdocs_lex_cache/
+.venv-docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Docs site infrastructure.** `mkdocs.yml` (Material theme + `mkdocs-lex-plugin`) renders the `.lex` files under `docs/` as a static site. `.github/workflows/docs.yml` builds on every push to `main` that touches `docs/**` or `mkdocs.yml` and deploys to GitHub Pages via `actions/deploy-pages@v4`. Custom domain `dodot.sh` wired in via `docs/CNAME` (Google Cloud DNS zone, A records pointing at GitHub Pages + apex AAAA + `www` CNAME). `docs/requirements.txt` pins the build deps. Content wiring is incremental — sample nav covers home + four user-guide pages + three reference pages; the rest of the existing `.lex` files build but aren't yet in the nav.
+
 ## [5.0.0] - 2026-05-15
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Docs site infrastructure.** `mkdocs.yml` (Material theme + `mkdocs-lex-plugin`) renders the `.lex` files under `docs/` as a static site. `.github/workflows/docs.yml` builds on every push to `main` that touches `docs/**` or `mkdocs.yml` and deploys to GitHub Pages via `actions/deploy-pages@v4`. Custom domain `dodot.sh` wired in via `docs/CNAME` (Google Cloud DNS zone, A records pointing at GitHub Pages + apex AAAA + `www` CNAME). `docs/requirements.txt` pins the build deps. Content wiring is incremental — sample nav covers home + four user-guide pages + three reference pages; the rest of the existing `.lex` files build but aren't yet in the nav.
+- **Docs site infrastructure.** `mkdocs.yml` (Material theme + `mkdocs-lex-plugin`) renders the `.lex` files under `docs/` as a static site. `.github/workflows/docs.yml` builds on every push to `main` that touches `docs/**` or `mkdocs.yml` and deploys to GitHub Pages via `actions/deploy-pages@v4`. Custom domain `dodot.sh` wired in via `docs/CNAME` (Google Cloud DNS zone, A records pointing at GitHub Pages + apex AAAA + `www` CNAME). `docs/requirements.txt` pins the build deps to exact versions for reproducibility. Content wiring is incremental — sample nav covers home + four user-guide pages + three reference pages; the rest of the existing `.lex` files build but aren't yet in the nav.
 
 ## [5.0.0] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Docs site infrastructure.** `mkdocs.yml` (Material theme + `mkdocs-lex-plugin`) renders the `.lex` files under `docs/` as a static site. `.github/workflows/docs.yml` builds on every push to `main` that touches `docs/**` or `mkdocs.yml` and deploys to GitHub Pages via `actions/deploy-pages@v4`. Custom domain `dodot.sh` wired in via `docs/CNAME` (Google Cloud DNS zone, A records pointing at GitHub Pages + apex AAAA + `www` CNAME). `docs/requirements.txt` pins the build deps to exact versions for reproducibility. Content wiring is incremental — sample nav covers home + four user-guide pages + three reference pages; the rest of the existing `.lex` files build but aren't yet in the nav.
+- **Docs site infrastructure.** `mkdocs.yml` (Material theme + `mkdocs-lex-plugin`) renders the `.lex` files under `docs/` as a static site. `.github/workflows/docs.yml` builds on every push to `main` (and validates on PRs) when `docs/**` or `mkdocs.yml` change, then deploys via `mkdocs gh-deploy --force` to the `gh-pages` branch. Custom domain `dodot.sh` wired in via `docs/CNAME` (Google Cloud DNS zone, A records pointing at GitHub Pages + apex AAAA + `www` CNAME). `docs/requirements.txt` pins the build deps to exact versions for reproducibility. Content wiring is incremental — sample nav covers home + four user-guide pages + three reference pages; the rest of the existing `.lex` files build but aren't yet in the nav.
 
 ## [5.0.0] - 2026-05-15
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+dodot.sh

--- a/docs/index.lex
+++ b/docs/index.lex
@@ -1,0 +1,19 @@
+dodot
+
+    A dotfiles manager that adapts to you, rather than the other way around.
+
+    Group config files into directories ("packs"). dodot reads filenames as conventions and decides what to do with each file — symlink it, source it from your shell, run it once, install brew formulae. No apply step, no datastore drift, no separate state from git.
+
+1. Start here
+
+    - [user/getting-started.lex] — from "I have a dotfiles repo" to your first `dodot up`.
+    - [user/adopting.lex] — migrating an existing $HOME / ~/.config layout into packs.
+    - [user/handlers.lex] — the catalog of filename conventions dodot recognizes.
+
+2. Go deeper
+
+    - [reference/philosophy.lex] — the design choices behind dodot.
+    - [reference/architecture.lex] — how the pieces fit together.
+    - [reference/terms-and-concepts.lex] — the full vocabulary.
+
+    :: note :: This site is a work in progress. Content is being rolled in piece by piece.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.6
+mkdocs-material>=9.5
+mkdocs-lex-plugin>=0.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs>=1.6
-mkdocs-material>=9.5
-mkdocs-lex-plugin>=0.2.0
+mkdocs==1.6.1
+mkdocs-material==9.7.6
+mkdocs-lex-plugin==0.2.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,8 +36,8 @@ theme:
         name: Switch to light mode
 
 plugins:
-  - search
   - lex
+  - search
 
 markdown_extensions:
   - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,72 @@
+site_name: dodot
+site_description: A dotfiles manager that adapts to you, rather than the other way around.
+site_url: https://dodot.sh/
+repo_url: https://github.com/arthur-debert/dodot
+repo_name: arthur-debert/dodot
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+    - search.highlight
+    - search.suggest
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+  - search
+  - lex
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+# Note: paths use .md even though source files are .lex —
+# the mkdocs-lex plugin rewrites .lex to .md internally.
+nav:
+  - Home: index.md
+  - User Guide:
+      - Getting started: user/getting-started.md
+      - Adopting: user/adopting.md
+      - Handlers: user/handlers.md
+      - Commands: user/commands.md
+  - Reference:
+      - Philosophy: reference/philosophy.md
+      - Architecture: reference/architecture.md
+      - Terms & concepts: reference/terms-and-concepts.md


### PR DESCRIPTION
## Summary

Sets up the static-site build for the docs under `docs/` so we can publish to **dodot.sh** on GitHub Pages.

- `mkdocs.yml` — Material theme + [`mkdocs-lex-plugin`](https://github.com/lex-fmt/mkdocs-lex) so `.lex` files render natively, no precompilation step.
- `.github/workflows/docs.yml` — builds on push to `main` when `docs/**` or `mkdocs.yml` change, deploys via `actions/deploy-pages@v4`.
- `docs/CNAME` — `dodot.sh`. DNS for the domain lives in a Google Cloud DNS zone (apex A → GitHub Pages IPs, `www` CNAME, GitHub verification TXT).
- `docs/index.lex` + sample nav covering 4 user-guide pages + 3 reference pages. The rest of the existing `.lex` files build but aren't wired into the nav yet — that's the content phase, not this PR.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only)
- [x] Project umbrella check passes locally — `scripts/{check,pre-commit,rust-pre-commit,ci.sh}` or `cargo fmt --check && cargo clippy -- -D warnings && cargo test` (or `cargo nextest run`) — N/A, no Rust changes; mkdocs build verified locally
- [x] Tests added or updated for behavior changes — N/A, infra-only

## Notes for reviewers

- The workflow uses the modern Pages flow (`actions/upload-pages-artifact` + `actions/deploy-pages`), not `mkdocs gh-deploy` to a `gh-pages` branch. The repo's **Settings → Pages → Source** needs to be set to **GitHub Actions** before the first deploy succeeds.
- Build is **not `--strict`** yet. `lexd convert --to markdown` preserves `.lex` extensions in cross-links, so mkdocs warns ~329 times on link targets it can't resolve (since the plugin renames `.lex` → `.md` after the markdown is already emitted). Tracked separately; will tighten once link rewriting lands either in `lexd` or in the plugin.
- The `mkdocs-lex-plugin` auto-downloads `lexd` from the latest `lex-fmt/lex` release on first run into `.mkdocs_lex_cache/` (gitignored). No vendored binary, no extra step in CI.