### PR TITLE
chore(docs): use mhausenblas/mkdocs-deploy-gh-pages action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,11 +7,6 @@ on:
       - docs/**
       - mkdocs.yml
       - .github/workflows/docs.yml
-  pull_request:
-    paths:
-      - docs/**
-      - mkdocs.yml
-      - .github/workflows/docs.yml
   workflow_dispatch:
 
 concurrency:
@@ -19,26 +14,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: pip
-          cache-dependency-path: docs/requirements.txt
-
-      - run: pip install -r docs/requirements.txt
-
-      - run: mkdocs build
-
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -47,12 +23,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: pip
-          cache-dependency-path: docs/requirements.txt
-
-      - run: pip install -r docs/requirements.txt
-
-      - run: mkdocs gh-deploy --force
+      - uses: mhausenblas/mkdocs-deploy-gh-pages@1.26
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIREMENTS: docs/requirements.txt
+          CONFIG_FILE: mkdocs.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Docs site infrastructure.** `mkdocs.yml` (Material theme + `mkdocs-lex-plugin`) renders the `.lex` files under `docs/` as a static site. `.github/workflows/docs.yml` builds on every push to `main` (and validates on PRs) when `docs/**` or `mkdocs.yml` change, then deploys via `mkdocs gh-deploy --force` to the `gh-pages` branch. Custom domain `dodot.sh` wired in via `docs/CNAME` (Google Cloud DNS zone, A records pointing at GitHub Pages + apex AAAA + `www` CNAME). `docs/requirements.txt` pins the build deps to exact versions for reproducibility. Content wiring is incremental — sample nav covers home + four user-guide pages + three reference pages; the rest of the existing `.lex` files build but aren't yet in the nav.
+- **Docs site infrastructure.** `mkdocs.yml` (Material theme + `mkdocs-lex-plugin`) renders the `.lex` files under `docs/` as a static site. `.github/workflows/docs.yml` deploys on every push to `main` that touches `docs/**` or `mkdocs.yml`, via the `mhausenblas/mkdocs-deploy-gh-pages` action which runs `mkdocs gh-deploy` in a container. Custom domain `dodot.sh` wired in via `docs/CNAME` (Google Cloud DNS zone, A records pointing at GitHub Pages + apex AAAA + `www` CNAME). `docs/requirements.txt` pins the build deps to exact versions for reproducibility. Content wiring is incremental — sample nav covers home + four user-guide pages + three reference pages; the rest of the existing `.lex` files build but aren't yet in the nav.
 
 ## [5.0.0] - 2026-05-15
 


### PR DESCRIPTION
## Summary

Replaces the explicit `setup-python` + `pip install` + `mkdocs gh-deploy` block with a single invocation of the [`mhausenblas/mkdocs-deploy-gh-pages`](https://github.com/marketplace/actions/deploy-mkdocs) action.

```yaml
- uses: mhausenblas/mkdocs-deploy-gh-pages@1.26
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    REQUIREMENTS: docs/requirements.txt
    CONFIG_FILE: mkdocs.yml
```

Workflow goes from ~45 lines to ~20.

## What's dropped

The separate `pull_request` build-only job. The deploy-gh-pages action only deploys; keeping a parallel build job using `setup-python` + `pip` for PR validation would have undone the whole simplification. Trade-off: doc build failures now surface at deploy time instead of PR-merge time. For markdown/lex content `mkdocs serve` already catches issues locally, so the regression risk is low.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only)
- [x] Project umbrella check passes locally — N/A, no Rust changes
- [x] Tests added or updated for behavior changes — N/A, infra-only

## Notes for reviewers

- Action's last release `v1.26` is May 2023. Stale but stable, ~50k+ repos use it. The Python + mkdocs versions baked into its image are old; we override them via `REQUIREMENTS: docs/requirements.txt`.
- `contents: write` lives on the job (only the deploy job exists now); supply-chain consideration noted explicitly here.
- Action runs in a Docker container — ~15–20s cold start overhead vs running directly on the host. Acceptable for a docs-only workflow.