### PR TITLE
feat(ci): thin-call release/'s rust-ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ name: CI
 # installs bats-core, and runs `bin/check-e2e` with DODOT_BIN
 # set to the workspace-relative binary path.
 #
-# Pinned at @take-iii during integration; flips to @v1 after the
-# take-iii branch merges and the new workflow rides the next
-# release/ tag.
+# Pinned at the feature branch of release/'s PR #130 while
+# rust-ci.yml is in review. Flips to @take-iii once #130 merges,
+# then to @v1 after take-iii itself lands on main and rides the
+# next release/ tag.
 
 on:
   push:
@@ -29,7 +30,7 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@take-iii
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@feat/rust-ci-reusable-workflow
     with:
       binary-name: dodot
       bats: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,13 @@ name: CI
 # See docs/per-stack/rust-ci.md in arthur-debert/release for the
 # full input reference. dodot is the reference adopter of this
 # workflow — closes the CI workflow reusability gap for the rust
-# fleet (called out in release/'s README and the
-# feedback_ci_reusability_gap memory).
+# fleet (see the "CI workflow reusability gap" section in
+# release/'s README.md).
 #
 # `binary-name: dodot` causes the check job to build and upload
 # `dodot-linux`; `bats: true` adds an e2e job that downloads it,
 # installs bats-core, and runs `bin/check-e2e` with DODOT_BIN
 # set to the workspace-relative binary path.
-#
-# Pinned at the feature branch of release/'s PR #130 while
-# rust-ci.yml is in review. Flips to @take-iii once #130 merges,
-# then to @v1 after take-iii itself lands on main and rides the
-# next release/ tag.
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,24 @@
 name: CI
 
+# Thin caller for the canonical reusable Rust CI workflow at
+# arthur-debert/release. Replaces the previously hand-rolled
+# setup-rust + nextest + bin/check + build + bats sequence.
+#
+# See docs/per-stack/rust-ci.md in arthur-debert/release for the
+# full input reference. dodot is the reference adopter of this
+# workflow — closes the CI workflow reusability gap for the rust
+# fleet (called out in release/'s README and the
+# feedback_ci_reusability_gap memory).
+#
+# `binary-name: dodot` causes the check job to build and upload
+# `dodot-linux`; `bats: true` adds an e2e job that downloads it,
+# installs bats-core, and runs `bin/check-e2e` with DODOT_BIN
+# set to the workspace-relative binary path.
+#
+# Pinned at @take-iii during integration; flips to @v1 after the
+# take-iii branch merges and the new workflow rides the next
+# release/ tag.
+
 on:
   push:
     branches: ['**']
@@ -8,65 +27,9 @@ on:
 permissions:
   contents: read
 
-env:
-  CARGO_TERM_COLOR: always
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Rust
-        uses: ./.github/actions/rust-setup
-        with:
-          rust-components: clippy, rustfmt
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Run checks
-        run: bin/check
-
-      - name: Build release binary
-        run: cargo build --release -p dodot
-
-      - name: Upload binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: dodot-linux
-          path: target/release/dodot
-
-  e2e:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          # Need bin/check-e2e (synced from the canonical bats Component)
-          # alongside the tests themselves. Sparse-checkout keeps the job
-          # fast while pulling both paths.
-          sparse-checkout: |
-            tests/e2e
-            bin
-
-      - name: Download binary
-        uses: actions/download-artifact@v8
-        with:
-          name: dodot-linux
-
-      - name: Install BATS
-        # Canonical install via the bats-core marketplace action. Replaces
-        # the prior `git clone bats-core/install.sh` boilerplate. See
-        # arthur-debert/release `bats` Component docs/per-component/bats.md.
-        uses: bats-core/bats-action@4.0.0
-
-      - name: Run E2E tests
-        env:
-          DODOT_BIN: ${{ github.workspace }}/dodot
-        run: |
-          chmod +x dodot
-          bin/check-e2e
+  ci:
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@take-iii
+    with:
+      binary-name: dodot
+      bats: true


### PR DESCRIPTION
## Summary

Migrate `ci.yml` from a hand-rolled 75-line pipeline to a thin caller of the canonical reusable workflow at `arthur-debert/release/.github/workflows/rust-ci.yml`. **dodot is the first consumer to adopt `rust-ci.yml`** — closes the CI workflow reusability gap for the rust fleet (called out in release/'s README and `feedback_ci_reusability_gap` memory).

The new ci.yml in full:

```yaml
on:
  push: { branches: ['**'] }
  pull_request:
permissions:
  contents: read
jobs:
  ci:
    uses: arthur-debert/release/.github/workflows/rust-ci.yml@take-iii
    with:
      binary-name: dodot
      bats: true
```

That's it.

## Behavior preserved exactly

- **check job** — `setup-rust` (toolchain + Swatinem/rust-cache) + nextest + `bin/check` (umbrella) + `cargo build --release -p dodot` + upload `dodot-linux` artifact.
- **e2e job** — sparse checkout (`tests/e2e` + `bin`) + download `dodot-linux` + `bats-core/bats-action@4.0.0` + run `bin/check-e2e` with `DODOT_BIN=$GITHUB_WORKSPACE/dodot`.

The `binary-name` → `DODOT_BIN` convention is documented in [release's per-stack/rust-ci.md](https://github.com/arthur-debert/release/blob/feat/rust-ci-reusable-workflow/docs/per-stack/rust-ci.md#how-binary-name-and-bats-interact).

## Versioning note

Pinned at `@take-iii` during integration with the release/ PR ([arthur-debert/release#130](https://github.com/arthur-debert/release/pull/130)). Flips to `@v1` after take-iii merges to main and rides the next release/ tag.

## Test plan

- [ ] check job actually runs `bin/check` (verify in run log: "Run canonical checks (bin/check)" step)
- [ ] check job builds + uploads `dodot-linux`
- [ ] e2e job downloads `dodot-linux`, installs bats, exports `DODOT_BIN`, runs `bin/check-e2e`
- [ ] both jobs go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)