### PR TITLE
chore(ci): pin rust-ci.yml at @take-iii

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@feat/rust-ci-reusable-workflow
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@take-iii
     with:
       binary-name: dodot
       bats: true


### PR DESCRIPTION
## Summary
- Flip dodot's reusable rust-ci.yml ref from the merged feature branch (`@feat/rust-ci-reusable-workflow`) to `@take-iii`.
- Keeps dodot pinned to the same integration branch the rest of the rust fan-out adopters target.
- No behavioral change — same workflow file, different ref.

## Test plan
- [ ] `ci / check` and `ci / e2e` go green (job names unchanged from prior pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)