### PR TITLE
chore(ci): flip release/ workflow refs from @take-iii to @v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@take-iii
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v1
     with:
       binary-name: dodot
       bats: true

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   docs:
-    uses: arthur-debert/release/.github/workflows/mkdocs.yml@take-iii
+    uses: arthur-debert/release/.github/workflows/mkdocs.yml@v1
     with:
       requirements: docs/requirements.txt
       # 329 historical strict-mode warnings (broken refs, missing nav,


### PR DESCRIPTION
## Summary
- Flip release/ workflow refs from `@take-iii` to `@v1`
- take-iii has landed on main (arthur-debert/release PR #135); v1 advanced to the new HEAD
- No behavioral change expected — `@v1` now points at the same commits `@take-iii` did

## Test plan
- [ ] CI green on this PR