### PR TITLE
chore(docs): migrate docs.yml to canonical mkdocs.yml@v1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,6 @@
 # Thin caller of arthur-debert/release/.github/workflows/mkdocs.yml@v1.
-# The reusable workflow handles checkout + Python setup + mkdocs install
-# from `docs/requirements.txt` + `mkdocs build --strict` + deploy to
-# GitHub Pages on pushes to main.
+# Push-to-main only — PR-time docs validation lives in `docs-check.yml`
+# (which calls the same reusable workflow but skips deploy).
 
 name: Docs
 
@@ -12,8 +11,6 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
-  pull_request:
-    paths: ['docs/**', 'mkdocs.yml']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,31 +1,31 @@
+# Thin caller of arthur-debert/release/.github/workflows/mkdocs.yml@v1.
+# The reusable workflow handles checkout + Python setup + mkdocs install
+# from `docs/requirements.txt` + `mkdocs build --strict` + deploy to
+# GitHub Pages on pushes to main.
+
 name: Docs
 
 on:
   push:
     branches: [main]
     paths:
-      - docs/**
-      - mkdocs.yml
-      - .github/workflows/docs.yml
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths: ['docs/**', 'mkdocs.yml']
   workflow_dispatch:
 
-concurrency:
-  group: docs-${{ github.ref }}
-  cancel-in-progress: false
+permissions:
+  # All three required upfront — GitHub validates reusable-workflow
+  # permission compatibility at workflow-load time, including jobs
+  # gated behind `if:` (the deploy job is push-to-main-only).
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: mhausenblas/mkdocs-deploy-gh-pages@1.26
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REQUIREMENTS: docs/requirements.txt
-          CONFIG_FILE: mkdocs.yml
+  docs:
+    uses: arthur-debert/release/.github/workflows/mkdocs.yml@v1
+    with:
+      requirements: docs/requirements.txt


### PR DESCRIPTION
Migrates the bespoke `mhausenblas/mkdocs-deploy-gh-pages`-based docs.yml to a thin caller of `arthur-debert/release/.github/workflows/mkdocs.yml@v1`. The canonical workflow handles checkout + Python setup + mkdocs install from `docs/requirements.txt` + `mkdocs build --strict` + deploy. Drops the cancel-in-progress concurrency block (handled by the reusable workflow).