### PR TITLE
refactor: migrate e2e to bats.conf declarative config

### DIFF
--- a/bin/check-e2e
+++ b/bin/check-e2e
@@ -2,30 +2,75 @@
 # Canonical e2e runner. Synced from arthur-debert/release@<ref>
 # (templates/components/bats/). Do not edit by hand.
 #
-# Discovers the consumer's bats layout by convention and runs it.
-# Order matters — first match wins, so consumers with custom needs can
-# drop a `scripts/check-e2e` override that takes priority over the
-# built-in discovery.
+# Discovery order (first match wins):
 #
 #   1. ./scripts/check-e2e            consumer override (full control)
-#   2. ./live-tests/run-tests         padz pattern (explicit bats runner)
-#   3. ./live-tests/run               too pattern (umbrella e2e driver)
-#   4. ./tests/integration/run.sh     supage pattern
-#   5. bats ./tests/e2e/bats/         dodot pattern (helpers/ subdir)
-#   6. bats ./tests/e2e/              generic flat layout (any *.bats)
-#   7. bats ./live-tests/tests/       padz fallback if run-tests vanishes
+#   2. ./tests/e2e/bats.conf          canonical bats.conf layout
+#   3. ./live-tests/run-tests         padz pattern (explicit runner)
+#   4. ./live-tests/run               too pattern (umbrella driver)
+#   5. ./tests/integration/run.sh     supage pattern
+#   6. bats ./tests/e2e/bats/         bare bats (helpers/ subdir)
+#   7. bats ./tests/e2e/              generic flat layout
+#   8. bats ./live-tests/tests/       padz fallback
 #
-# Missing all: exit 0 with a notice. Repos without e2e tests should
-# not fail the umbrella `bin/check`.
+# Missing all: exit 0 with a notice.
 
 set -euo pipefail
 
 cd "$(cd "$(dirname "$0")/.." && pwd)"
 
+# --- 1. Consumer full override -------------------------------------------
+
 if [ -x scripts/check-e2e ]; then
   echo "Running e2e via scripts/check-e2e (consumer override)..."
   exec scripts/check-e2e "$@"
 fi
+
+# --- 2. bats.conf canonical layout ---------------------------------------
+
+if [ -f tests/e2e/bats.conf ]; then
+  # shellcheck source=../lib/bats-harness.bash
+  source lib/bats-harness.bash
+  harness_require_bats
+  harness_set_root "$(pwd)"
+
+  # shellcheck source=/dev/null
+  source tests/e2e/bats.conf
+
+  # Build (skip if binaries already present, e.g. CI artifact)
+  _need_build=""
+  for _entry in ${BINS:-}; do
+    _name="${_entry%%=*}"
+    _path="${_entry#*=}"
+    _var="$(echo "$_name" | tr '[:lower:]-' '[:upper:]_')_BIN"
+    if [[ -z "${!_var:-}" ]]; then
+      [[ ! -x "$_path" ]] && _need_build=1
+      export "$_var=$(pwd)/$_path"
+    fi
+  done
+  if [[ -n "$_need_build" && -n "${BUILD_CMD:-}" ]]; then
+    harness_build "$BUILD_CMD"
+  fi
+
+  # Suite mode: workspace lifecycle here, before bats
+  if [[ "${ISOLATION:-per-test}" == "suite" ]]; then
+    harness_create_workspace
+    export SANDBOX="$HARNESS_WORKSPACE"
+    harness_mkdir ${WORKSPACE_DIRS:-}
+    harness_git_init ${GIT_INIT_DIRS:-}
+    type -t e2e_env &>/dev/null && e2e_env
+    if [[ -n "${FIXTURE_SCRIPT:-}" ]]; then
+      _harness_status "Setting up fixtures..."
+      ( cd "$HARNESS_WORKSPACE" && source "$HARNESS_ROOT/$FIXTURE_SCRIPT" ) >/dev/null 2>&1
+    fi
+  fi
+
+  echo "Running bats tests/e2e/bats/ (bats.conf)..."
+  harness_bats tests/e2e/bats "$@"
+  exit $?
+fi
+
+# --- 3-5. Legacy runner scripts ------------------------------------------
 
 if [ -x live-tests/run-tests ]; then
   echo "Running e2e via live-tests/run-tests..."
@@ -41,6 +86,8 @@ if [ -x tests/integration/run.sh ]; then
   echo "Running e2e via tests/integration/run.sh..."
   exec tests/integration/run.sh "$@"
 fi
+
+# --- 6-8. Bare bats discovery --------------------------------------------
 
 if [ -d tests/e2e/bats ] && find tests/e2e/bats -maxdepth 2 -name '*.bats' -print -quit | grep -q .; then
   if ! command -v bats >/dev/null 2>&1; then
@@ -69,5 +116,5 @@ if find live-tests/tests -maxdepth 2 -name '*.bats' -print -quit 2>/dev/null | g
   exec bats live-tests/tests/ "$@"
 fi
 
-echo "No e2e tests found (looked at scripts/check-e2e, live-tests/run{-tests,}, tests/integration/run.sh, tests/e2e/{bats/,*.bats}, live-tests/tests/*.bats). Skipping."
+echo "No e2e tests found (looked at scripts/check-e2e, tests/e2e/bats.conf, live-tests/run{-tests,}, tests/integration/run.sh, tests/e2e/{bats/,*.bats}, live-tests/tests/*.bats). Skipping."
 exit 0

--- a/tests/e2e/bats.conf
+++ b/tests/e2e/bats.conf
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# E2E test configuration — read by the canonical bats setup.bash.
+#
+# Mirrors the TempEnvironment layout from the Rust test suite.
+
+BUILD_CMD="cargo build --release --bin dodot"
+BINS="dodot=target/release/dodot"
+
+WORKSPACE_DIRS="
+  home
+  home/dotfiles
+  home/.config
+  home/.local/share/dodot/packs
+  home/.local/share/dodot/shell
+  home/.cache/dodot
+"
+GIT_INIT_DIRS="home/dotfiles"
+
+EXTRA_HELPERS="fixtures.bash assertions.bash commands.bash"
+
+e2e_env() {
+  export HOME="$SANDBOX/home"
+  export DOTFILES_ROOT="$SANDBOX/home/dotfiles"
+  export XDG_CONFIG_HOME="$SANDBOX/home/.config"
+  export XDG_DATA_HOME="$SANDBOX/home/.local/share"
+  export XDG_CACHE_HOME="$SANDBOX/home/.cache"
+  export GIT_CEILING_DIRECTORIES="$SANDBOX"
+  export NO_COLOR=1
+  _hide_brew_from_path
+}
+
+# Muzzle Homebrew's advisory probes during tests. Without this,
+# every `brew` invocation spawns analytics curl processes and turns
+# a sub-30s CI run into a 7-minute local run.
+#
+# The shim exits non-zero so dodot's probe falls through to its
+# empty-set branch, matching CI's no-brew behavior. Tests that need
+# real brew call unhide_brew_for_test (in commands.bash).
+_hide_brew_from_path() {
+  if [[ -z "${DODOT_E2E_ORIGINAL_PATH:-}" ]]; then
+    export DODOT_E2E_ORIGINAL_PATH="$PATH"
+  fi
+  local shim_dir="$SANDBOX/.brew-muzzle"
+  mkdir -p "$shim_dir"
+  cat > "$shim_dir/brew" <<'SHIM'
+#!/bin/sh
+exit 1
+SHIM
+  chmod +x "$shim_dir/brew"
+  export PATH="$shim_dir:$PATH"
+  export HOMEBREW_NO_ANALYTICS=1
+  export HOMEBREW_NO_AUTO_UPDATE=1
+  export HOMEBREW_NO_INSTALL_FROM_API=1
+}

--- a/tests/e2e/bats/helpers/commands.bash
+++ b/tests/e2e/bats/helpers/commands.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# CLI wrapper and brew-muzzle escape hatch.
+
+dodot() {
+  "$DODOT_BIN" "$@"
+}
+
+unhide_brew_for_test() {
+  if [[ -z "${DODOT_E2E_ORIGINAL_PATH:-}" ]]; then
+    echo "unhide_brew_for_test: DODOT_E2E_ORIGINAL_PATH not set; sandbox_setup must run first" >&2
+    return 1
+  fi
+  export PATH="$DODOT_E2E_ORIGINAL_PATH"
+}

--- a/tests/e2e/bats/helpers/setup.bash
+++ b/tests/e2e/bats/helpers/setup.bash
@@ -1,157 +1,63 @@
 #!/usr/bin/env bash
-# E2E test harness — sandbox lifecycle and dodot wrapper.
+# Canonical BATS e2e setup. Synced from arthur-debert/release.
 #
-# Every BATS test gets an isolated filesystem sandbox mirroring
-# the structure that TempEnvironment creates in the Rust test suite.
+# Reads tests/e2e/bats.conf for project-specific configuration,
+# then provides sandbox_setup/sandbox_teardown for use in .bats files:
 #
-# Usage in .bats files:
 #   setup()    { load helpers/setup; sandbox_setup; }
 #   teardown() { sandbox_teardown; }
+#
+# See templates/components/bats/ in release/ for the full docs.
 
-# Resolve the project root relative to BATS_TEST_DIRNAME
-_E2E_HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-_E2E_PROJECT_ROOT="$(cd "$_E2E_HELPERS_DIR/../../../.." && pwd)"
+_HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_BATS_DIR="$(cd "$_HELPERS_DIR/.." && pwd)"
+_E2E_DIR="$(cd "$_BATS_DIR/.." && pwd)"
+_PROJECT_ROOT="$(cd "$_E2E_DIR/../.." && pwd)"
 
-# Canonical harness for workspace lifecycle
 # shellcheck source=../../../../lib/bats-harness.bash
-source "$_E2E_PROJECT_ROOT/lib/bats-harness.bash"
+source "$_PROJECT_ROOT/lib/bats-harness.bash"
+harness_set_root "$_PROJECT_ROOT"
 
-# Where the compiled dodot binary lives.
-# Set DODOT_BIN externally to override (e.g. in CI or Docker).
-DODOT_BIN="${DODOT_BIN:-$_E2E_PROJECT_ROOT/target/release/dodot}"
+# Read consumer config
+_CONF="$_E2E_DIR/bats.conf"
+# shellcheck source=/dev/null
+[[ -f "$_CONF" ]] && source "$_CONF"
 
-# Source sibling helpers
-# shellcheck source=fixtures.bash
-source "$_E2E_HELPERS_DIR/fixtures.bash"
-# shellcheck source=assertions.bash
-source "$_E2E_HELPERS_DIR/assertions.bash"
+# Source consumer helpers
+for _helper in ${EXTRA_HELPERS:-}; do
+  # shellcheck source=/dev/null
+  source "$_HELPERS_DIR/$_helper"
+done
+unset _helper
 
-# ── Sandbox lifecycle ───────────────────────────────────────────
+# Export BIN vars (skip if already set, e.g. from CI or check-e2e)
+for _entry in ${BINS:-}; do
+  _name="${_entry%%=*}"
+  _path="${_entry#*=}"
+  _var="$(echo "$_name" | tr '[:lower:]-' '[:upper:]_')_BIN"
+  if [[ -z "${!_var:-}" ]]; then
+    export "$_var=$_PROJECT_ROOT/$_path"
+  fi
+done
+unset _entry _name _path _var
 
 sandbox_setup() {
+  if [[ "${ISOLATION:-per-test}" == "per-test" ]]; then
     harness_create_workspace_notrap
-    SANDBOX="$HARNESS_WORKSPACE"
-
-    # Mirror TempEnvironment layout
-    SANDBOX_HOME="$SANDBOX/home"
-    SANDBOX_DOTFILES="$SANDBOX_HOME/dotfiles"
-    SANDBOX_CONFIG_HOME="$SANDBOX_HOME/.config"
-    SANDBOX_DATA_HOME="$SANDBOX_HOME/.local/share"
-    SANDBOX_CACHE_HOME="$SANDBOX_HOME/.cache"
-
-    mkdir -p \
-        "$SANDBOX_HOME" \
-        "$SANDBOX_DOTFILES" \
-        "$SANDBOX_CONFIG_HOME" \
-        "$SANDBOX_DATA_HOME/dodot/packs" \
-        "$SANDBOX_DATA_HOME/dodot/shell" \
-        "$SANDBOX_CACHE_HOME/dodot"
-
-    # Redirect all env vars into the sandbox
-    export HOME="$SANDBOX_HOME"
-    export DOTFILES_ROOT="$SANDBOX_DOTFILES"
-    export XDG_CONFIG_HOME="$SANDBOX_CONFIG_HOME"
-    export XDG_DATA_HOME="$SANDBOX_DATA_HOME"
-    export XDG_CACHE_HOME="$SANDBOX_CACHE_HOME"
-
-    # Prevent git from escaping the sandbox
-    export GIT_CEILING_DIRECTORIES="$SANDBOX"
-
-    # Initialize a git repo in the dotfiles root so that
-    # discover_dotfiles_root()'s git-toplevel fallback stays contained
-    git init -q "$SANDBOX_DOTFILES"
-
-    # Plain text output for reliable grep/assertion matching
-    export NO_COLOR=1
-
-    hide_brew_from_path
-}
-
-# ── Homebrew probe muzzle ───────────────────────────────────────
-#
-# Why this lives at the *base* setup level, not in individual tests:
-#
-# dodot's macOS-side advisory probes (probe::brew::list_installed_casks
-# in `crates/dodot-lib/src/probe/brew.rs`) shell out to `brew` for
-# enrichment — cask metadata in `dodot probe app`, sibling-adoption
-# tips in `dodot adopt`, missing-folder hints in `dodot up`/`status`.
-# On any host with Homebrew installed, every `brew` invocation spawns
-# two `curl` processes that phone home to Homebrew's analytics
-# endpoint with `--max-time 3`. Across the suite this turns a sub-30s
-# CI run (no brew) into a 7-minute local run.
-#
-# The shim below makes the *default* match CI: dodot's probe finds
-# `brew` on PATH, runs it, gets a non-zero exit, and falls through to
-# its empty-set branches. The probe is documented as advisory, never
-# authoritative (see `docs/reference/symlink-paths.lex` §10), so
-# correctness assertions pass without real cask data. Tests that need
-# to exercise the real brew code path call `unhide_brew_for_test`
-# explicitly — making real brew exposure opt-in, not opt-out, so the
-# next person who touches PATH handling can't accidentally re-
-# introduce the slowdown.
-#
-# Why a shim, not a PATH strip: removing the homebrew bin dir from
-# PATH wholesale also removes everything else that lives there
-# (homebrew bash 5+, gnu-coreutils on Linux, host-specific tools
-# tests rely on). The shim hides only `brew` itself.
-#
-# The HOMEBREW_NO_* env vars are belt-and-suspenders: if a future
-# test escapes the shim via its own PATH twiddling, at least the
-# analytics phone-home stays disabled.
-hide_brew_from_path() {
-    # Snapshot the original PATH for opt-in helpers (unhide_brew_for_test).
-    if [[ -z "${DODOT_E2E_ORIGINAL_PATH:-}" ]]; then
-        export DODOT_E2E_ORIGINAL_PATH="$PATH"
+    export SANDBOX="$HARNESS_WORKSPACE"
+    harness_mkdir ${WORKSPACE_DIRS:-}
+    harness_git_init ${GIT_INIT_DIRS:-}
+    if type -t e2e_env &>/dev/null; then
+      e2e_env
     fi
-
-    # Per-sandbox shim dir prepended to PATH. Lives under SANDBOX so
-    # sandbox_teardown wipes it; nothing leaks across tests.
-    local shim_dir="$SANDBOX/.brew-muzzle"
-    mkdir -p "$shim_dir"
-    cat > "$shim_dir/brew" <<'SHIM'
-#!/bin/sh
-# E2E sandbox brew shim — see helpers/setup.bash for the rationale.
-# Exits non-zero with no output so dodot's advisory brew probe falls
-# through to its empty-set branch, matching CI's no-brew behavior.
-exit 1
-SHIM
-    chmod +x "$shim_dir/brew"
-    export PATH="$shim_dir:$PATH"
-
-    export HOMEBREW_NO_ANALYTICS=1
-    export HOMEBREW_NO_AUTO_UPDATE=1
-    export HOMEBREW_NO_INSTALL_FROM_API=1
-}
-
-# Restore the pre-muzzle PATH so a single test can exercise the real
-# `brew` probe code path. The muzzle (set up in `hide_brew_from_path`)
-# prepends a non-zero `brew` shim to PATH; this helper drops that
-# prepended shim by reverting to the snapshotted original. Most tests
-# should NOT call this — see the block comment above.
-# `tests/e2e/bats/test_brew_probe.bats` is the canonical example and
-# the regression guard for the probe code.
-#
-# This explicit opt-in lives at the helper level (not inline in tests)
-# so the "I want real brew here" intent is grep-able and reviewers
-# can see at a glance which tests escape the muzzle.
-unhide_brew_for_test() {
-    if [[ -z "${DODOT_E2E_ORIGINAL_PATH:-}" ]]; then
-        echo "unhide_brew_for_test: DODOT_E2E_ORIGINAL_PATH not set; sandbox_setup must run first" >&2
-        return 1
-    fi
-    export PATH="$DODOT_E2E_ORIGINAL_PATH"
+  fi
 }
 
 sandbox_teardown() {
+  if type -t e2e_teardown &>/dev/null; then
+    e2e_teardown
+  fi
+  if [[ "${ISOLATION:-per-test}" == "per-test" ]]; then
     harness_cleanup
-}
-
-# ── dodot wrapper ───────────────────────────────────────────────
-
-# Run the dodot binary.
-# Usage:  dodot status
-#         dodot up --dry-run
-#         dodot up vim
-dodot() {
-    "$DODOT_BIN" "$@"
+  fi
 }


### PR DESCRIPTION
## Summary

- Replaces hand-written `helpers/setup.bash` with the canonical synced version from release/
- All project-specific config moves to `tests/e2e/bats.conf`: build command, binaries, workspace layout, env vars, brew muzzle
- New `helpers/commands.bash` holds `dodot()` wrapper and `unhide_brew_for_test()`
- Zero changes to `.bats` files — same interface (`sandbox_setup`/`sandbox_teardown`)
- `bin/check-e2e` updated with bats.conf discovery (pattern #2)

Refs arthur-debert/release#253

## Test plan

- [x] `bin/check-e2e` — all 311 tests pass via bats.conf discovery path

🤖 Generated with [Claude Code](https://claude.com/claude-code)