### PR TITLE
chore: move app-specific scripts to app-bin/

### DIFF
--- a/app-bin/demo-errors
+++ b/app-bin/demo-errors
@@ -14,9 +14,9 @@
 #   - Adopt on a non-dotted file       → surfaces an error from the CLI
 #
 # Usage:
-#   scripts/demo-errors              # run the demo, clean up at the end
-#   scripts/demo-errors --keep       # leave the sandbox on disk and print its path
-#   scripts/demo-errors --release    # use target/release/dodot (must be built first)
+#   app-bin/demo-errors              # run the demo, clean up at the end
+#   app-bin/demo-errors --keep       # leave the sandbox on disk and print its path
+#   app-bin/demo-errors --release    # use target/release/dodot (must be built first)
 
 set -euo pipefail
 

--- a/app-bin/e2e
+++ b/app-bin/e2e
@@ -4,12 +4,12 @@ set -euo pipefail
 # E2E test runner for dodot.
 #
 # Usage:
-#   scripts/e2e                    Run all E2E tests in Docker
-#   scripts/e2e --shell            Drop into interactive container
-#   scripts/e2e --local            Run locally (no Docker, uses temp-dir isolation)
-#   scripts/e2e --rebuild          Force rebuild of Docker image
-#   scripts/e2e test_up.bats       Run a specific test file
-#   scripts/e2e --local test_up.bats   Run specific test file locally
+#   app-bin/e2e                    Run all E2E tests in Docker
+#   app-bin/e2e --shell            Drop into interactive container
+#   app-bin/e2e --local            Run locally (no Docker, uses temp-dir isolation)
+#   app-bin/e2e --rebuild          Force rebuild of Docker image
+#   app-bin/e2e test_up.bats       Run a specific test file
+#   app-bin/e2e --local test_up.bats   Run specific test file locally
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -38,7 +38,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -h|--help)
-            echo "Usage: scripts/e2e [OPTIONS] [TEST_FILE]"
+            echo "Usage: app-bin/e2e [OPTIONS] [TEST_FILE]"
             echo ""
             echo "Options:"
             echo "  --explore   Pre-built sandbox with fixtures + pre-existing home files"
@@ -48,12 +48,12 @@ while [[ $# -gt 0 ]]; do
             echo "  -h, --help  Show this help"
             echo ""
             echo "Examples:"
-            echo "  scripts/e2e                       Run all tests in Docker"
-            echo "  scripts/e2e test_up.bats           Run specific test file in Docker"
-            echo "  scripts/e2e --local                Run all tests locally"
-            echo "  scripts/e2e --local test_up.bats   Run specific test file locally"
-            echo "  scripts/e2e --explore              Explore sandbox with conflicts/adoptable files"
-            echo "  scripts/e2e --shell                Bare container shell"
+            echo "  app-bin/e2e                       Run all tests in Docker"
+            echo "  app-bin/e2e test_up.bats           Run specific test file in Docker"
+            echo "  app-bin/e2e --local                Run all tests locally"
+            echo "  app-bin/e2e --local test_up.bats   Run specific test file locally"
+            echo "  app-bin/e2e --explore              Explore sandbox with conflicts/adoptable files"
+            echo "  app-bin/e2e --shell                Bare container shell"
             exit 0
             ;;
         *.bats)


### PR DESCRIPTION
## Summary

- Moves `scripts/demo-errors` and `scripts/e2e` to `app-bin/`, separating app-specific dev/test scripts from release-sync managed infrastructure.
- `scripts/` retains only `setup-dev-env.sh` (release-managed); `bin/` is untouched (release-sync managed).
- Updates all self-referencing usage docs inside the moved scripts.

## Test plan

- [ ] Verify `app-bin/demo-errors` runs correctly from the new path
- [ ] Verify `app-bin/e2e --local` runs correctly from the new path
- [ ] Confirm `scripts/setup-dev-env.sh` is unaffected
- [ ] Confirm `bin/check-e2e` (canonical CI runner) is unaffected -- it never referenced `scripts/e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)