### PR TITLE
chore: drop now-dead RELEASE_CUT_MANIFEST override

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -5,10 +5,6 @@ set -euo pipefail
 # release-cut handles arg parsing, semver bump, validation, and dispatches the
 # CI release workflow. Run `release-cut --help` for usage.
 #
-# This repo's workspace-only root Cargo.toml doesn't carry the version — it
-# lives in crates/dodot-lib/Cargo.toml. Resolve the path against the repo
-# root via `git rev-parse --show-toplevel` so the shim works from any cwd.
-#
 # What CI does (all on GitHub):
 #   1. Bumps every workspace crate via `cargo set-version --workspace`
 #   2. Rolls ## [Unreleased] → ## [VERSION] - DATE in CHANGELOG.md
@@ -24,6 +20,4 @@ if ! command -v release-cut >/dev/null 2>&1; then
     exit 1
 fi
 
-repo_root=$(git rev-parse --show-toplevel)
-export RELEASE_CUT_MANIFEST="${repo_root}/crates/dodot-lib/Cargo.toml"
 exec release-cut "$@"


### PR DESCRIPTION
## Summary

[arthur-debert/release#315](https://github.com/arthur-debert/release/pull/315) made \`release-cut\` kind-aware. For Cargo workspaces whose root has no \`[workspace.package].version\`, \`release-cut\` now probes workspace members for the canonical version itself — no \`RELEASE_CUT_MANIFEST\` override needed.

This drops the override here. Verified locally: the new \`release-cut\` reads \`5.0.1-rc.1\` from \`crates/dodot-lib/Cargo.toml\` via the member-probe path.

## Test plan

- [x] No behavior change — same version is read, just via a different path.
- [ ] Validated end-to-end by the next dodot RC release (separate step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)