### PR TITLE
ci: bump release reusable workflows to @v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v1
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v2
     with:
       binary-name: dodot
       bats: true

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v1
+    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v2
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   docs:
-    uses: arthur-debert/release/.github/workflows/mkdocs.yml@v1
+    uses: arthur-debert/release/.github/workflows/mkdocs.yml@v2
     with:
       requirements: docs/requirements.txt
       # 329 historical strict-mode warnings (broken refs, missing nav,

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# Thin caller of arthur-debert/release/.github/workflows/mkdocs.yml@v1.
+# Thin caller of arthur-debert/release/.github/workflows/mkdocs.yml@v2.
 # Push-to-main only — PR-time docs validation lives in `docs-check.yml`
 # (which calls the same reusable workflow but skips deploy).
 
@@ -23,6 +23,6 @@ permissions:
 
 jobs:
   docs:
-    uses: arthur-debert/release/.github/workflows/mkdocs.yml@v1
+    uses: arthur-debert/release/.github/workflows/mkdocs.yml@v2
     with:
       requirements: docs/requirements.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Thin caller — the canonical pipeline lives at
-# arthur-debert/release/.github/workflows/rust-cli.yml@v1.
+# arthur-debert/release/.github/workflows/rust-cli.yml@v2.
 # Bug fixes and improvements to the release pipeline come in via a
 # bump of the @v1 floating ref, no changes here.
 
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v1
+    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v2
     with:
       version: ${{ inputs.version }}
       crates: dodot-lib,dodot


### PR DESCRIPTION
Moves onto release/'s v2 major line (v2.0.0 = strict lint gate). Reusable workflows unchanged v1→v2; behavior-neutral. Admin-merged without the review loop per maintainer direction.