### PR TITLE
fix: drop stale shell-quality capability (unblocks release-sync)

### DIFF
--- a/.release-sync.yaml
+++ b/.release-sync.yaml
@@ -1,7 +1,6 @@
 # Consumer override for release-sync. Adds opt-in `bats` + `mkdocs`
 # Components on top of the rust Stack defaults.
 capabilities:
-  - shell-quality
   - rust-quality
   - bats
   - mkdocs


### PR DESCRIPTION
`release-sync` currently fails here:

```
release-sync: declared Capability 'shell-quality' has no templates/components/shell-quality/ tree
```

`shell-quality` was promoted to `templates/commons/` in arthur-debert/release#320 and removed as a Capability — the shell/markdown/yaml gate now ships in commons for every consumer. This repo's `.release-sync.yaml` still declares it, so sync errors out and the repo gets no updates.

Fix: drop `shell-quality` (keep `rust-quality`, `bats`, `mkdocs`). Verified `release-sync` now resolves cleanly.

Note: a separate pre-existing conflict (`bin/release` is a real file where a managed symlink belongs) remains — not addressed here; this PR only unblocks capability resolution.

Surfaced by `release-verify-fleet` during the v2 advance.