### PR TITLE
fix: ignored packs — up/down match status output, sweep stale state (#222)

### DIFF
--- a/CHANGELOG/unreleased-fix-ignored-pack-output.md
+++ b/CHANGELOG/unreleased-fix-ignored-pack-output.md
@@ -1,0 +1,1 @@
+- `up` and `down` now report ignored packs the same way `status` does (warning + "Ignored Packs" section) instead of a bare "Packs deployed.", and sweep stale datastore state from a pack that was deployed and then marked `.dodotignore` so its files stop being sourced on shell init (#222).

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -74,17 +74,19 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         }
     }
 
-    // Sweep stale state for now-ignored packs so the regenerated init
-    // script stops sourcing them. A pack deployed before it was ignored
-    // would otherwise linger in the datastore. (#222) Counts as removal
-    // so the message reflects that something was deactivated.
+    // Sweep stale state for now-ignored packs so the regenerated
+    // (global) init script stops sourcing them. A pack deployed before
+    // it was ignored would otherwise linger in the datastore. Unfiltered
+    // — the init script covers every pack regardless of this run's
+    // filter. (#222) Counts as removal so the message reflects that
+    // something was deactivated. The count is computed in both dry-run
+    // and real runs so `down --dry-run` reports the same outcome a real
+    // run would produce; only the mutation is gated on `!dry_run`.
+    if orchestration::ignored_packs_with_state(&ignored.sweep_dir_names, ctx)? > 0 {
+        any_removed = true;
+    }
     if !ctx.dry_run {
-        for dir in &ignored.dir_names {
-            if !ctx.datastore.list_pack_handlers(dir)?.is_empty() {
-                any_removed = true;
-            }
-        }
-        orchestration::sweep_ignored_state(&ignored.dir_names, ctx)?;
+        orchestration::sweep_ignored_state(&ignored.sweep_dir_names, ctx)?;
     }
 
     // Regenerate shell init script and deployment map (now reflecting

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -41,6 +41,11 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         all_packs.retain(|p| names.iter().any(|n| n == &p.display_name || n == &p.name));
     }
 
+    // Discover `.dodotignore`-marked packs so `down` reports them in the
+    // same "Ignored Packs" section `status` shows and sweeps any stale
+    // datastore state they left behind. (issue #222)
+    let ignored = orchestration::scan_ignored(pack_filter, ctx)?;
+
     let mut affected_packs = Vec::new();
     let mut dry_run_display: Vec<DisplayPack> = Vec::new();
     let mut any_removed = false;
@@ -67,6 +72,19 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
                 ctx.datastore.remove_state(&pack.name, handler)?;
             }
         }
+    }
+
+    // Sweep stale state for now-ignored packs so the regenerated init
+    // script stops sourcing them. A pack deployed before it was ignored
+    // would otherwise linger in the datastore. (#222) Counts as removal
+    // so the message reflects that something was deactivated.
+    if !ctx.dry_run {
+        for dir in &ignored.dir_names {
+            if !ctx.datastore.list_pack_handlers(dir)?.is_empty() {
+                any_removed = true;
+            }
+        }
+        orchestration::sweep_ignored_state(&ignored.dir_names, ctx)?;
     }
 
     // Regenerate shell init script and deployment map (now reflecting
@@ -103,7 +121,7 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         warnings,
         notes: Vec::new(),
         conflicts: Vec::new(),
-        ignored_packs: Vec::new(),
+        ignored_packs: ignored.display_names,
         inactive_packs: Vec::new(),
         view_mode: ctx.view_mode.as_str().into(),
         group_mode: ctx.group_mode.as_str().into(),

--- a/crates/dodot-lib/src/commands/tests/gating.rs
+++ b/crates/dodot-lib/src/commands/tests/gating.rs
@@ -1447,6 +1447,83 @@ fn down_sweeps_state_of_pack_ignored_after_deploy() {
 }
 
 #[test]
+fn filtered_up_sweeps_now_ignored_pack_outside_the_filter() {
+    // The init script is regenerated from the WHOLE datastore, so a
+    // filtered `dodot up vim` must still sweep a now-ignored `gpg` even
+    // though gpg isn't in the filter — otherwise gpg keeps being sourced.
+    let env = TempEnvironment::builder()
+        .pack("gpg")
+        .file("alias.zsh", "alias g='echo hi'")
+        .done()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+    assert!(!ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty());
+
+    // Ignore gpg, then run a FILTERED up that names only vim.
+    env.fs
+        .write_file(&env.dotfiles_root.join("gpg/.dodotignore"), b"")
+        .unwrap();
+    let up = commands::up::up(Some(&["vim".to_string()]), &ctx).unwrap();
+
+    assert!(
+        ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty(),
+        "filtered up must still sweep a now-ignored pack outside the filter"
+    );
+    let init = env
+        .fs
+        .read_to_string(&ctx.paths.init_script_path())
+        .unwrap();
+    assert!(
+        !init.contains("gpg/alias.zsh"),
+        "now-ignored pack must not survive a filtered up; init was:\n{init}"
+    );
+    // gpg is outside the filter, so it does NOT appear in this run's
+    // Ignored Packs section — reporting stays scoped to the request.
+    assert!(
+        !up.ignored_packs.contains(&"gpg".to_string()),
+        "filtered up should not report unrelated ignored packs"
+    );
+}
+
+#[test]
+fn down_dry_run_reports_deactivation_for_now_ignored_pack() {
+    // Gemini's dry-run discrepancy: `down --dry-run` must report the
+    // same "Packs deactivated." outcome a real run would, when a
+    // now-ignored pack still holds stale state.
+    let env = TempEnvironment::builder()
+        .pack("gpg")
+        .file("alias.zsh", "alias g='echo hi'")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+    env.fs
+        .write_file(&env.dotfiles_root.join("gpg/.dodotignore"), b"")
+        .unwrap();
+
+    let mut dry_ctx = make_ctx(&env);
+    dry_ctx.dry_run = true;
+    let down = commands::down::down(None, &dry_ctx).unwrap();
+
+    assert_eq!(
+        down.message.as_deref(),
+        Some("Packs deactivated."),
+        "dry-run must report the same outcome a real run would"
+    );
+    // Dry-run must NOT actually mutate the datastore.
+    assert!(
+        !ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty(),
+        "down --dry-run must not remove state"
+    );
+}
+
+#[test]
 fn up_mixed_selection_deploys_active_and_reports_ignored() {
     // A mixed `up vim gpg`: vim deploys, gpg is reported ignored — the
     // two outcomes coexist in one result.

--- a/crates/dodot-lib/src/commands/tests/gating.rs
+++ b/crates/dodot-lib/src/commands/tests/gating.rs
@@ -1235,3 +1235,241 @@ fn up_skips_mappings_gated_template() {
         );
     }
 }
+
+// ── Ignored-pack parity + stale-state sweep (issue #222) ───────────
+//
+// Two contracts:
+//   1. `up`, `down`, and `status` produce the SAME view for an ignored
+//      pack — the warning + the "Ignored Packs" section — instead of
+//      `up` printing a bare "Packs deployed." with no mention of the
+//      pack.
+//   2. A pack deployed and *then* marked `.dodotignore` must have its
+//      datastore state swept on the next up/down so nothing of it is
+//      read/sourced again (the gpg `alias.zsh` regression).
+
+/// Collect the names a result surfaces in its "Ignored Packs" section.
+fn ignored_section(result: &commands::PackStatusResult) -> Vec<String> {
+    result.ignored_packs.clone()
+}
+
+/// True when `warnings` carries the "pack '<name>' is ignored" notice.
+fn warns_ignored(result: &commands::PackStatusResult, name: &str) -> bool {
+    result
+        .warnings
+        .iter()
+        .any(|w| w.contains(&format!("pack '{name}' is ignored")))
+}
+
+#[test]
+fn up_down_status_agree_for_explicitly_requested_ignored_pack() {
+    // `dodot up gpg` on an ignored pack used to print a generic
+    // "Packs deployed." with no warning and no Ignored Packs section,
+    // while `dodot status gpg` reported both. All three must agree.
+    let env = TempEnvironment::builder()
+        .pack("gpg")
+        .file("alias.zsh", "alias g='echo hi'")
+        .ignored()
+        .done()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    let filter = vec!["gpg".to_string()];
+
+    let up = commands::up::up(Some(&filter), &ctx).unwrap();
+    let down = commands::down::down(Some(&filter), &ctx).unwrap();
+    let status = commands::status::status(Some(&filter), &ctx).unwrap();
+
+    for (label, r) in [("up", &up), ("down", &down), ("status", &status)] {
+        assert_eq!(
+            ignored_section(r),
+            vec!["gpg".to_string()],
+            "{label} must list gpg in the Ignored Packs section"
+        );
+        assert!(
+            warns_ignored(r, "gpg"),
+            "{label} must warn that gpg is ignored"
+        );
+        // The ignored pack must never appear as a deployable pack row.
+        assert!(
+            r.packs.iter().all(|p| p.name != "gpg"),
+            "{label} must not render gpg as a deployable pack row"
+        );
+    }
+}
+
+#[test]
+fn up_lists_ignored_packs_in_full_run() {
+    // A bare `dodot up` (no filter) surfaces ignored packs in the same
+    // section `status` does — parity for the unfiltered case.
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .pack("disabled")
+        .file("stuff", "x")
+        .ignored()
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    let up = commands::up::up(None, &ctx).unwrap();
+    let status = commands::status::status(None, &ctx).unwrap();
+
+    assert_eq!(ignored_section(&up), vec!["disabled".to_string()]);
+    assert_eq!(
+        ignored_section(&up),
+        ignored_section(&status),
+        "up and status must surface the same ignored-pack set"
+    );
+    // The active pack still deploys normally.
+    assert!(up.packs.iter().any(|p| p.name == "vim"));
+}
+
+#[test]
+fn up_does_not_read_files_from_ignored_pack() {
+    // Nothing under a `.dodotignore` pack may be deployed: no symlink,
+    // no shell sourcing, no datastore state.
+    let env = TempEnvironment::builder()
+        .pack("gpg")
+        .file("alias.zsh", "alias g='echo hi'")
+        .file("gpgrc", "use-agent")
+        .ignored()
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+
+    // No datastore state for the ignored pack.
+    assert!(
+        ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty(),
+        "ignored pack must leave no datastore state"
+    );
+    // The init script must not source the ignored pack's shell file.
+    let init = env
+        .fs
+        .read_to_string(&ctx.paths.init_script_path())
+        .unwrap_or_default();
+    assert!(
+        !init.contains("gpg/alias.zsh"),
+        "ignored pack's shell file must not be sourced; init script was:\n{init}"
+    );
+}
+
+#[test]
+fn up_sweeps_state_of_pack_ignored_after_deploy() {
+    // The gpg regression: deploy a pack, then mark it ignored. The next
+    // `up` must tear down its stale datastore state so the regenerated
+    // init script stops sourcing it.
+    let env = TempEnvironment::builder()
+        .pack("gpg")
+        .file("alias.zsh", "alias g='echo hi'")
+        .done()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+
+    // First up: gpg deploys normally and its shell file is sourced.
+    commands::up::up(None, &ctx).unwrap();
+    assert!(
+        !ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty(),
+        "precondition: gpg should have state after first up"
+    );
+    let init_before = env
+        .fs
+        .read_to_string(&ctx.paths.init_script_path())
+        .unwrap();
+    assert!(
+        init_before.contains("gpg/alias.zsh"),
+        "precondition: gpg's shell file should be sourced before ignore"
+    );
+
+    // Now mark gpg ignored and run up again.
+    env.fs
+        .write_file(&env.dotfiles_root.join("gpg/.dodotignore"), b"")
+        .unwrap();
+    let up = commands::up::up(None, &ctx).unwrap();
+
+    // Stale state is gone …
+    assert!(
+        ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty(),
+        "up must sweep datastore state for a now-ignored pack"
+    );
+    // … the regenerated init script no longer sources it …
+    let init_after = env
+        .fs
+        .read_to_string(&ctx.paths.init_script_path())
+        .unwrap();
+    assert!(
+        !init_after.contains("gpg/alias.zsh"),
+        "init script must stop sourcing a now-ignored pack; was:\n{init_after}"
+    );
+    // … and it now appears in the Ignored Packs section.
+    assert_eq!(ignored_section(&up), vec!["gpg".to_string()]);
+}
+
+#[test]
+fn down_sweeps_state_of_pack_ignored_after_deploy() {
+    // Same sweep contract for `down`.
+    let env = TempEnvironment::builder()
+        .pack("gpg")
+        .file("alias.zsh", "alias g='echo hi'")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+    assert!(!ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty());
+
+    env.fs
+        .write_file(&env.dotfiles_root.join("gpg/.dodotignore"), b"")
+        .unwrap();
+    let down = commands::down::down(Some(&["gpg".to_string()]), &ctx).unwrap();
+
+    assert!(
+        ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty(),
+        "down must sweep datastore state for a now-ignored pack"
+    );
+    let init_after = env
+        .fs
+        .read_to_string(&ctx.paths.init_script_path())
+        .unwrap();
+    assert!(!init_after.contains("gpg/alias.zsh"));
+    assert_eq!(ignored_section(&down), vec!["gpg".to_string()]);
+    // Sweeping leftover state counts as deactivation.
+    assert_eq!(down.message.as_deref(), Some("Packs deactivated."));
+}
+
+#[test]
+fn up_mixed_selection_deploys_active_and_reports_ignored() {
+    // A mixed `up vim gpg`: vim deploys, gpg is reported ignored — the
+    // two outcomes coexist in one result.
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .pack("gpg")
+        .file("alias.zsh", "alias g='echo hi'")
+        .ignored()
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    let filter = vec!["vim".to_string(), "gpg".to_string()];
+    let up = commands::up::up(Some(&filter), &ctx).unwrap();
+    let status = commands::status::status(Some(&filter), &ctx).unwrap();
+
+    assert!(
+        up.packs.iter().any(|p| p.name == "vim"),
+        "vim should deploy in a mixed selection"
+    );
+    assert_eq!(ignored_section(&up), vec!["gpg".to_string()]);
+    assert_eq!(ignored_section(&up), ignored_section(&status));
+    assert!(warns_ignored(&up, "gpg"));
+}

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -52,6 +52,21 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         "starting up command"
     );
 
+    // Validate names up front so an explicitly-requested ignored pack
+    // surfaces the same "pack '…' is ignored, skipping" warning that
+    // `status`/`down` emit — prepare_packs discards these. (issue #222)
+    let mut planning_warnings: Vec<String> = match pack_filter {
+        Some(names) => orchestration::validate_pack_names(names, ctx)?,
+        None => Vec::new(),
+    };
+
+    // Discover `.dodotignore`-marked packs so we can both report them in
+    // the same "Ignored Packs" section `status` shows and sweep any
+    // stale datastore state they left behind. Without the sweep, a pack
+    // deployed before it was ignored keeps getting sourced from the
+    // regenerated init script. (issue #222)
+    let ignored = orchestration::scan_ignored(pack_filter, ctx)?;
+
     // Phase 1: Discover packs and collect intents
     let packs = orchestration::prepare_packs(pack_filter, ctx)?;
 
@@ -77,7 +92,6 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
 
     let mut pack_intents: Vec<(String, Vec<HandlerIntent>)> = Vec::with_capacity(packs.len());
     let mut intent_errors: Vec<PackResult> = Vec::new();
-    let mut planning_warnings: Vec<String> = Vec::new();
 
     for pack in &packs {
         // Active when actually deploying; Passive on `--dry-run`. The
@@ -188,6 +202,9 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
 
     // Regenerate shell init script and deployment map
     if !ctx.dry_run {
+        // Tear down any stale state for packs that are now ignored, so
+        // the regenerated init script below stops sourcing them. (#222)
+        orchestration::sweep_ignored_state(&ignored.dir_names, ctx)?;
         info!("regenerating shell init script");
         let root_config = ctx.config_manager.root_config()?;
         shell::write_init_script(
@@ -305,7 +322,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         warnings: planning_warnings,
         notes,
         conflicts: Vec::new(),
-        ignored_packs: Vec::new(),
+        ignored_packs: ignored.display_names,
         inactive_packs: Vec::new(),
         view_mode: ctx.view_mode.as_str().into(),
         group_mode: ctx.group_mode.as_str().into(),

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -203,8 +203,10 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     // Regenerate shell init script and deployment map
     if !ctx.dry_run {
         // Tear down any stale state for packs that are now ignored, so
-        // the regenerated init script below stops sourcing them. (#222)
-        orchestration::sweep_ignored_state(&ignored.dir_names, ctx)?;
+        // the regenerated (global) init script below stops sourcing
+        // them — unfiltered, since the init script covers every pack
+        // regardless of this run's filter. (#222)
+        orchestration::sweep_ignored_state(&ignored.sweep_dir_names, ctx)?;
         info!("regenerating shell init script");
         let root_config = ctx.config_manager.root_config()?;
         shell::write_init_script(

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -203,6 +203,80 @@ pub fn prepare_packs(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> 
     Ok(configured)
 }
 
+/// Result of [`scan_ignored`]: the raw on-disk directory names of
+/// pack-shaped directories skipped via `.dodotignore`, optionally
+/// narrowed to a name filter, plus those same names mapped to their
+/// user-facing display form.
+pub struct IgnoredScan {
+    /// Raw on-disk directory names (e.g. `gpg`, `010-old`). This is the
+    /// datastore key, used by [`sweep_ignored_state`].
+    pub dir_names: Vec<String>,
+    /// Display names (prefix stripped) for the rendered "Ignored Packs"
+    /// section — same form `status` surfaces.
+    pub display_names: Vec<String>,
+}
+
+/// Scan the dotfiles root for `.dodotignore`-marked packs, applying the
+/// same name filter the active-pack path uses.
+///
+/// Centralises the ignored-pack discovery that `up`, `down`, and
+/// `status` all need so the three commands report (and sweep) the same
+/// set — the divergence that let `dodot up <ignored>` print a generic
+/// "Packs deployed." while `dodot status <ignored>` showed the pack in
+/// its "Ignored Packs" section (issue #222).
+pub fn scan_ignored(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<IgnoredScan> {
+    let root_config = ctx.config_manager.root_config()?;
+    let mut ignored = packs::scan_packs(
+        ctx.fs.as_ref(),
+        ctx.paths.dotfiles_root(),
+        &root_config.pack.ignore,
+    )?
+    .ignored;
+
+    if let Some(names) = pack_filter {
+        ignored.retain(|dir| {
+            names
+                .iter()
+                .any(|n| n == dir || n == packs::display_name_for(dir))
+        });
+    }
+
+    let display_names = ignored
+        .iter()
+        .map(|d| packs::display_name_for(d).to_string())
+        .collect();
+
+    Ok(IgnoredScan {
+        dir_names: ignored,
+        display_names,
+    })
+}
+
+/// Tear down any leftover datastore state for `.dodotignore`-marked
+/// packs.
+///
+/// A pack that was deployed and *then* marked ignored leaves its shell /
+/// path / symlink state in the datastore. Because the regenerated
+/// init script is driven entirely off the datastore `packs/` tree, that
+/// stale state keeps getting sourced on every shell startup even though
+/// the pack now reports as ignored — exactly the gpg `alias.zsh` error
+/// in issue #222. Removing the state here, before the caller regenerates
+/// the init script, makes "ignored" mean "nothing of this pack is read
+/// or deployed" across up/down.
+///
+/// Datastore is keyed by on-disk directory name (`dir_names`), so this
+/// takes the raw names from [`scan_ignored`], not display names.
+pub fn sweep_ignored_state(dir_names: &[String], ctx: &ExecutionContext) -> Result<()> {
+    for dir in dir_names {
+        let handlers = ctx.datastore.list_pack_handlers(dir)?;
+        for handler in handlers {
+            debug!(pack = %dir, %handler, "sweeping state for now-ignored pack");
+            ctx.datastore.remove_state(dir, &handler)?;
+        }
+    }
+    Ok(())
+}
+
 /// Execute a pre-collected set of intents.
 ///
 /// This is the second half of the two-phase execution model.

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -203,51 +203,56 @@ pub fn prepare_packs(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> 
     Ok(configured)
 }
 
-/// Result of [`scan_ignored`]: the raw on-disk directory names of
-/// pack-shaped directories skipped via `.dodotignore`, optionally
-/// narrowed to a name filter, plus those same names mapped to their
-/// user-facing display form.
+/// Result of [`scan_ignored`]: the `.dodotignore`-marked packs split by
+/// the two distinct jobs they serve.
+///
+/// Reporting (the "Ignored Packs" section) is scoped to what the user
+/// asked about, so it respects `pack_filter`. The stale-state sweep is
+/// **not** — the init script is regenerated from the *whole* datastore,
+/// so a filtered `dodot up <other-pack>` must still tear down every
+/// now-ignored pack's leftover state, or it would keep getting sourced.
 pub struct IgnoredScan {
-    /// Raw on-disk directory names (e.g. `gpg`, `010-old`). This is the
-    /// datastore key, used by [`sweep_ignored_state`].
-    pub dir_names: Vec<String>,
-    /// Display names (prefix stripped) for the rendered "Ignored Packs"
-    /// section — same form `status` surfaces.
+    /// Raw on-disk directory names (datastore keys) for **every** ignored
+    /// pack, ignoring `pack_filter`. Used by [`sweep_ignored_state`] so
+    /// the global init regeneration never re-sources a stale pack.
+    pub sweep_dir_names: Vec<String>,
+    /// Display names (prefix stripped) of the ignored packs that match
+    /// `pack_filter`, for the rendered "Ignored Packs" section — same
+    /// form and scope `status` surfaces.
     pub display_names: Vec<String>,
 }
 
-/// Scan the dotfiles root for `.dodotignore`-marked packs, applying the
-/// same name filter the active-pack path uses.
+/// Scan the dotfiles root for `.dodotignore`-marked packs.
 ///
 /// Centralises the ignored-pack discovery that `up`, `down`, and
 /// `status` all need so the three commands report (and sweep) the same
 /// set — the divergence that let `dodot up <ignored>` print a generic
 /// "Packs deployed." while `dodot status <ignored>` showed the pack in
-/// its "Ignored Packs" section (issue #222).
+/// its "Ignored Packs" section (issue #222). The returned
+/// [`IgnoredScan`] separates the filtered reporting set from the
+/// unfiltered sweep set; see its docs for why they differ.
 pub fn scan_ignored(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<IgnoredScan> {
     let root_config = ctx.config_manager.root_config()?;
-    let mut ignored = packs::scan_packs(
+    let all_ignored = packs::scan_packs(
         ctx.fs.as_ref(),
         ctx.paths.dotfiles_root(),
         &root_config.pack.ignore,
     )?
     .ignored;
 
-    if let Some(names) = pack_filter {
-        ignored.retain(|dir| {
-            names
-                .iter()
-                .any(|n| n == dir || n == packs::display_name_for(dir))
-        });
-    }
-
-    let display_names = ignored
+    let display_names = all_ignored
         .iter()
+        .filter(|dir| match pack_filter {
+            None => true,
+            Some(names) => names
+                .iter()
+                .any(|n| n == *dir || n == packs::display_name_for(dir)),
+        })
         .map(|d| packs::display_name_for(d).to_string())
         .collect();
 
     Ok(IgnoredScan {
-        dir_names: ignored,
+        sweep_dir_names: all_ignored,
         display_names,
     })
 }
@@ -264,17 +269,39 @@ pub fn scan_ignored(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> R
 /// the init script, makes "ignored" mean "nothing of this pack is read
 /// or deployed" across up/down.
 ///
-/// Datastore is keyed by on-disk directory name (`dir_names`), so this
-/// takes the raw names from [`scan_ignored`], not display names.
-pub fn sweep_ignored_state(dir_names: &[String], ctx: &ExecutionContext) -> Result<()> {
+/// Pass the **unfiltered** [`IgnoredScan::sweep_dir_names`]: the init
+/// script is global, so even a filtered `up`/`down` must sweep every
+/// ignored pack or a now-ignored pack outside the filter would still be
+/// sourced. Datastore is keyed by on-disk directory name, not display
+/// name. Returns the dir names that actually had state removed, so the
+/// caller can reflect "something was deactivated" in its message.
+pub fn sweep_ignored_state(dir_names: &[String], ctx: &ExecutionContext) -> Result<Vec<String>> {
+    let mut swept = Vec::new();
     for dir in dir_names {
         let handlers = ctx.datastore.list_pack_handlers(dir)?;
+        if handlers.is_empty() {
+            continue;
+        }
+        swept.push(dir.clone());
         for handler in handlers {
             debug!(pack = %dir, %handler, "sweeping state for now-ignored pack");
             ctx.datastore.remove_state(dir, &handler)?;
         }
     }
-    Ok(())
+    Ok(swept)
+}
+
+/// Count of ignored packs that currently hold datastore state, without
+/// removing anything. Lets `down --dry-run` report "would deactivate"
+/// consistently with what a real run would sweep.
+pub fn ignored_packs_with_state(dir_names: &[String], ctx: &ExecutionContext) -> Result<usize> {
+    let mut n = 0;
+    for dir in dir_names {
+        if !ctx.datastore.list_pack_handlers(dir)?.is_empty() {
+            n += 1;
+        }
+    }
+    Ok(n)
 }
 
 /// Execute a pre-collected set of intents.


### PR DESCRIPTION
Fixes #222.

## Root cause

Two coupled bugs around `.dodotignore` packs:

1. **Output divergence.** `dodot up <ignored>` / `dodot down <ignored>` printed a generic `Packs deployed.` with no warning and no "Ignored Packs" section, while `dodot status <ignored>` showed both. `up` discarded the `validate_pack_names` warnings (`prepare_packs` threw them away) and hardcoded `ignored_packs: Vec::new()`; `down` did the same for `ignored_packs`.

2. **Stale ignored state still sourced.** The shell init script is generated entirely from the datastore `packs/` tree. A pack deployed and *then* marked ignored is never re-discovered by `up`/`down` (they only walk active packs), so its shell/path/symlink datastore state lingered and kept being sourced on every shell startup — exactly the `gpg/alias.zsh` error in the issue (the pack reports ignored, yet its file still runs at shell init).

## What changed

- New `orchestration::scan_ignored` — shared ignored-pack discovery (raw dir names for the datastore key + display names for rendering), honoring the same name filter the active-pack path uses.
- New `orchestration::sweep_ignored_state` — tears down datastore state for `.dodotignore` packs.
- `up` and `down` now call both: surface the warning + "Ignored Packs" section like `status`, and sweep stale state **before** regenerating the init script. `down` counts a swept pack as a deactivation (`Packs deactivated.`).

All three commands (`up`/`down`/`status`) now share the same ignored-pack discovery and reporting path.

## Files changed

- `crates/dodot-lib/src/packs/orchestration/mod.rs` — `scan_ignored` + `sweep_ignored_state`
- `crates/dodot-lib/src/commands/up.rs`
- `crates/dodot-lib/src/commands/down.rs`
- `crates/dodot-lib/src/commands/tests/gating.rs` — tests
- `CHANGELOG/unreleased-fix-ignored-pack-output.md`

## Test plan

New tests in `gating.rs`:
- `up_down_status_agree_for_explicitly_requested_ignored_pack` — all three report the warning + Ignored Packs section, none render the ignored pack as a deployable row.
- `up_lists_ignored_packs_in_full_run` — unfiltered `up` matches `status`.
- `up_mixed_selection_deploys_active_and_reports_ignored` — `up vim gpg`: vim deploys, gpg reported ignored.
- `up_does_not_read_files_from_ignored_pack` — ignored pack leaves no datastore state and is not sourced in the init script.
- `up_sweeps_state_of_pack_ignored_after_deploy` / `down_sweeps_state_of_pack_ignored_after_deploy` — the gpg regression: deploy → ignore → up/down sweeps state and stops sourcing the file.

Full suite green (`cargo test --workspace`, 1266+ tests), `lefthook run pre-commit --all-files` green, manually verified the original repro (`up gpg`, `status gpg`, `down gpg` now agree; deploy-then-ignore no longer sources `gpg/alias.zsh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)