### PR TITLE
chore(ci): migrate release reusable-workflow callers @v2 → @v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v2
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v3
     with:
       binary-name: dodot
       bats: true

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   docs:
-    uses: arthur-debert/release/.github/workflows/mkdocs.yml@v2
+    uses: arthur-debert/release/.github/workflows/mkdocs.yml@v3
     with:
       requirements: docs/requirements.txt
       # 329 historical strict-mode warnings (broken refs, missing nav,

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# Thin caller of arthur-debert/release/.github/workflows/mkdocs.yml@v2.
+# Thin caller of arthur-debert/release/.github/workflows/mkdocs.yml@v3.
 # Push-to-main only — PR-time docs validation lives in `docs-check.yml`
 # (which calls the same reusable workflow but skips deploy).
 
@@ -23,6 +23,6 @@ permissions:
 
 jobs:
   docs:
-    uses: arthur-debert/release/.github/workflows/mkdocs.yml@v2
+    uses: arthur-debert/release/.github/workflows/mkdocs.yml@v3
     with:
       requirements: docs/requirements.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 # Thin caller — the canonical pipeline lives at
 # arthur-debert/release/.github/workflows/rust-cli.yml@v3.
 # Bug fixes and improvements to the release pipeline come in via a
-# bump of the @v1 floating ref, no changes here.
+# bump of the @v3 floating ref, no changes here.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Thin caller — the canonical pipeline lives at
-# arthur-debert/release/.github/workflows/rust-cli.yml@v2.
+# arthur-debert/release/.github/workflows/rust-cli.yml@v3.
 # Bug fixes and improvements to the release pipeline come in via a
 # bump of the @v1 floating ref, no changes here.
 
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v2
+    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v3
     with:
       version: ${{ inputs.version }}
       crates: dodot-lib,dodot

--- a/CHANGELOG/unreleased-release-v3.md
+++ b/CHANGELOG/unreleased-release-v3.md
@@ -1,0 +1,1 @@
+ci: migrate release reusable-workflow callers from @v2 to @v3 (rust-ci, rust-cli, mkdocs)


### PR DESCRIPTION
Pilot of the consumer `@v2 → @v3` migration after arthur-debert/release cut **v3.0.0**.

v3 is a MAJOR only because release removed the deprecated singular `wasm-package` input (#634). **dodot never used that input**, so this is a mechanical re-pin. The `v2` branch is frozen at v2.21.0, so staying on `@v2` would freeze dodot out of all future release fixes.

Bumped (uses + header comments):
- `rust-ci.yml` `@v2 → @v3` (ci.yml)
- `rust-cli.yml` `@v2 → @v3` (release.yml)
- `mkdocs.yml` `@v2 → @v3` (docs.yml, docs-check.yml)

## Context

- **The managed tree (CLAUDE.md stub, `bin/` mirrors, `.release/`) is intentionally NOT in this PR.** It reaches dodot via the wheel pull at the next SessionStart (`install-release-core` derives `--major` from the now-`@v3` caller pin, then `release-core init` materializes + auto-commits). Hand-pushing managed content here would fight the pull model.
- `copilot-review.yml` is left at `@v1` — it was already off the v2 line before this migration, so bumping it (a 2-major jump) is a separate standardization question, deliberately not folded into v2→v3.
- This is the first of the fleet; once its CI is green on the v3 refs (the real validation that the v3 callers work), the rest follow the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)