### PR TITLE
docs(skills): installable agent skills for dodot

### DIFF
--- a/CHANGELOG/unreleased-skills-using-dodot.md
+++ b/CHANGELOG/unreleased-skills-using-dodot.md
@@ -1,0 +1,1 @@
+- Add installable agent skills: using-dodot and dodot-templates

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,23 @@
+# dodot skills
+
+Installable agent skills for [dodot](../README.md), in the open `SKILL.md` format —
+detectable by Claude Code, Copilot, Cursor, and skill CLIs.
+
+| Skill | What it does |
+|-------|--------------|
+| [`using-dodot`](using-dodot/SKILL.md) | Operate an existing dotfiles repo with dodot: deploy packs, check what's live, add or adopt config files, undo deployments. |
+| [`dodot-templates`](dodot-templates/SKILL.md) | Author and sync dodot templates and secrets: config that varies per host/OS, value injection and whole-file encryption, and reverse-merging deployed-side edits back to source. Builds on `using-dodot`. |
+
+## Install
+
+Copy a skill directory into your agent's skills location, e.g. for Claude Code:
+
+```bash
+# project-scoped
+cp -r skills/using-dodot .claude/skills/
+
+# or user-scoped (all projects)
+cp -r skills/using-dodot ~/.claude/skills/
+```
+
+Each skill is self-contained: a `SKILL.md` plus its reference files.

--- a/skills/dodot-templates/SECRETS.md
+++ b/skills/dodot-templates/SECRETS.md
@@ -1,0 +1,122 @@
+# Secrets reference
+
+dodot keeps secrets out of git two ways. It does **not** own encryption or vault
+custody — it delegates to tools you already use and only ensures plaintext doesn't
+land in git or sit in cleartext on disk longer than necessary.
+
+- **Value injection** — a template references one secret via
+  `{{ secret("scheme:reference") }}`, resolved at deploy through a provider and
+  substituted into the rendered output. Source stays committable; deployed file has
+  the real value. Single-line only — multi-line values are refused at render time.
+- **Whole-file decryption** — a `.age`/`.gpg` file is encrypted at rest; `dodot up`
+  decrypts to a 0600 datastore file and the symlink handler links it. No template
+  expansion; the whole bytestream is the secret.
+
+Pick value-injection when the secret is one line inside a config with readable
+non-secret fields; pick whole-file when the secret *is* the file (SSH key, cert,
+service-account JSON).
+
+## The six providers
+
+| Scheme        | Tool                       | Reference syntax                  |
+|---------------|----------------------------|-----------------------------------|
+| `pass`        | password-store             | `pass:path/to/entry`              |
+| `op`          | 1Password CLI              | `op://Vault/Item/Field`           |
+| `bw`          | Bitwarden CLI              | `bw:item-name[#field]`            |
+| `sops`        | Mozilla SOPS               | `sops:file.yaml#dot.path`         |
+| `keychain`    | macOS Keychain             | `keychain:service[/account]`      |
+| `secret-tool` | freedesktop Secret Service | `secret-tool:service[/account]`   |
+
+Enable per scheme (all default to `enabled = false` so a fresh install never shells
+out unprompted):
+
+```toml
+[secret]
+enabled = true
+
+[secret.providers.pass]
+enabled = true
+```
+
+The TOML key for the freedesktop provider is `secret_tool` (underscore); the
+reference prefix is `secret-tool:` (hyphen).
+
+Provider quirks:
+
+- **pass** — returns the first line of `~/.password-store/<entry>.gpg`; override with
+  `[secret.providers.pass] store_dir`.
+- **op** — requires `OP_SERVICE_ACCOUNT_TOKEN`; the desktop-app fallback is
+  deliberately disabled (would pop a biometric prompt mid-render).
+- **bw** — needs an unlocked vault (`bw unlock`, export `BW_SESSION`).
+  `bw:item#field` picks password/username/notes/totp/uri.
+- **sops** — file paths anchored at the dotfiles root; the dot path becomes SOPS
+  `--extract` bracket-notation.
+- **keychain** (macOS) — `keychain:Service[/account]`; never calls
+  `unlock-keychain` itself.
+- **secret-tool** (Linux) — libsecret lookup against the session keyring; the
+  session daemon handles unlocking.
+
+## Whole-file: `.age` / `.gpg`
+
+```toml
+[preprocessor.age]
+enabled = true     # identity defaults to ~/.config/age/identity.txt
+
+[preprocessor.gpg]
+enabled = true     # picks up keys from gpg-agent / ~/.gnupg
+```
+
+Decrypted output lands at mode 0600 atomically. `.asc` is **not** in the default gpg
+extension list (it's conventionally armored public keys/signatures); opt in with
+`extensions = ["gpg", "asc"]` only if your repo stores armored payloads as `.asc`.
+gpg runs with `--batch` (never prompts) — use a smartcard/YubiKey key or pre-cache
+the passphrase in `gpg-agent`.
+
+## The edit loop
+
+- **Value injection** — same as any template: edit source, `dodot up`, the value
+  re-resolves. Your vault is the source of truth; rotating a value flows in on the
+  next `up`.
+- **Whole-file** — dodot deliberately has **no `dodot secret edit`**. Do it by hand:
+
+  ```bash
+  age -d -i ~/.config/age/identity.txt ssh/id_ed25519.age > /tmp/key
+  $EDITOR /tmp/key
+  age -e -r age1... -o ssh/id_ed25519.age /tmp/key
+  rm /tmp/key && git add ssh/id_ed25519.age && git commit
+  ```
+
+  Hand-editing the *deployed* plaintext is preserved with a "preserved" warning on
+  next `up` (no auto-merge) — re-encrypt the source instead.
+
+## Inspecting (read-only — never triggers auth prompts)
+
+- `dodot secret list` — every `secret(...)` reference across the repo, flagging
+  schemes with no provider enabled. Run before the first `up` to inventory needs.
+- `dodot secret probe` — runs `probe()` on each enabled provider:
+  ok / not installed / not authenticated / misconfigured. Run when something fails.
+- `dodot transform status` — shows which secrets each cached baseline depends on.
+
+`dodot up` runs one preflight pass over enabled providers and aggregates all
+failures into a single error. Repeated references to the same secret in one `up`
+resolve once. `--dry-run` and `status` skip preflight (they read the cached
+baseline, never touching providers).
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `provider 'op' is not authenticated` | set `OP_SERVICE_ACCOUNT_TOKEN` (no desktop fallback) |
+| `provider 'pass' is not installed` | install `pass`, or disable the provider |
+| `provider 'pass' is misconfigured` | `pass init <gpg-key>`, or set `store_dir` |
+| `secret '…' resolved to a multi-line value` | value injection is single-line; use whole-file `.age`/`.gpg` |
+| `gpg: bad passphrase / session key` | `--batch` won't prompt; pre-cache passphrase in gpg-agent |
+| `key path 'a.b' not found in …` | SOPS dot path wrong; verify with `sops -d file \| yq` |
+| `secret(...)` silently doesn't render | need both `[secret] enabled` and `[secret.providers.<scheme>] enabled` |
+
+## Trust boundary
+
+dodot's property is "don't ship plaintext to git." It does **not** promise an
+attacker with code execution as your user can't read secrets — the rendered file is
+plaintext on disk by design. Encryption, key custody, and runtime security are the
+provider tools' job, not dodot's.

--- a/skills/dodot-templates/SKILL.md
+++ b/skills/dodot-templates/SKILL.md
@@ -46,14 +46,17 @@ Two separate problems, two separate commands. Don't conflate them:
    so `git status` shows nothing. `dodot refresh` walks the baseline cache, finds
    deployed files whose bytes diverged, and touches the *source* mtime so git
    re-reads. It does **not** change source content — only visibility.
-2. **The source content is still stale.** `dodot transform check` actually
-   reverse-merges the deployed bytes back into the `.tmpl` source on disk. Where it
-   can't merge cleanly it inserts `dodot-conflict` markers for you to resolve.
-   `--strict` makes it exit 1 while markers remain (how the pre-commit hook blocks
-   bad commits). **It writes to your source files** — use `--dry-run` to preview.
+2. **The source content is still stale.** `dodot transform check` reverse-merges
+   the deployed bytes back into the `.tmpl` source on disk for any block it *can*
+   merge cleanly. Where the deployed edit overlaps a template expression it
+   **can't** merge: it prints a `dodot-conflict` block to its output, leaves that
+   block in the source **untouched**, and (under `--strict`) exits 1 — resolve the
+   source by hand. **It writes to your source files** for the clean parts — use
+   `--dry-run` to preview.
 
-`dodot transform status` is the read-only map: `synced` / `output_changed` (deployed
-edited) / `input_changed` (source edited) / `both` / `missing`.
+`dodot transform status` is the read-only map. States (snake_case, as printed):
+`synced`, `output_changed` (deployed edited), `input_changed` (source edited),
+`both_changed`, `missing_source`, `missing_deployed`.
 
 The canonical setup wires both into git so this is automatic:
 
@@ -115,8 +118,8 @@ commit by hand. See `SECRETS.md`.
 ```bash
 dodot transform status                 # confirm the file shows output-changed / both
 dodot transform check --dry-run        # preview the reverse-merge
-dodot transform check                  # write it back into the .tmpl source
-# resolve any dodot-conflict markers in the source, then commit
+dodot transform check                  # write clean merges back into the .tmpl source
+# for any dodot-conflict block it reports, edit that block in the source by hand, then commit
 ```
 
 ## Going deeper

--- a/skills/dodot-templates/SKILL.md
+++ b/skills/dodot-templates/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: dodot-templates
+description: Author and sync dodot templates and secrets — render config that varies per host/OS, inject secret values or encrypt whole files, and reverse-merge deployed-side edits back to source. Use when the user wants a dotfile to vary between machines, references Jinja/{{ }} in dotfiles, wants to keep a token/password out of git, encrypts a file with age/gpg, edits a rendered/deployed file and needs it back in source, or sets up the dodot git pre-commit hook for templates.
+---
+
+# dodot templates & secrets
+
+dodot **preprocesses** some pack files at deploy time: `.tmpl`/`.template` files are
+rendered as Jinja2, and secrets are resolved from your password manager or decrypted
+from `.age`/`.gpg`. This skill is for authoring that content and keeping it in sync.
+
+Prerequisite mental model: packs, handlers, `up`/`down`/`status`, and the
+datastore — see the **using-dodot** skill. This skill assumes it.
+
+## The one inversion that matters: source ≠ live
+
+For an ordinary symlinked file, the source and the live (deployed) file are the
+*same bytes*. **Preprocessing breaks that.** The source is a `.tmpl`/`.age`/`.gpg`
+file; the live file is the *rendered* / *decrypted* output, written to the
+datastore (`~/.local/share/dodot/packs/<pack>/preprocessed/<name>`) and symlinked
+into place. They are **different bytes**, and that drives everything below.
+
+Two consequences you must hold:
+
+- **Rendering is forward-only and automatic.** Every `dodot up` re-renders from
+  source. Edit the template or change a variable → it picks up on the next `up`.
+  There is no separate render step.
+- **Editing the *live* file does not flow back to source on its own.** If you edit
+  the rendered `~/.gitconfig` directly, the `.tmpl` source still has the old
+  content, and the next `up` overwrites your edit. Getting it back to source is the
+  reverse-sync (below).
+
+## The rule for an agent: edit the source, not the output
+
+When changing a templated file, **find and edit the `.tmpl` source**, then
+`dodot up` and verify the rendered output. This sidesteps reverse-sync entirely.
+
+Only reach for the reverse-sync when the user has *already* edited the deployed
+file in place, or explicitly wants the git-augmentation installed.
+
+## Reverse-sync: getting deployed-side edits back to source
+
+Two separate problems, two separate commands. Don't conflate them:
+
+1. **git can't see the edit.** git's stat-cache says the source mtime is unchanged,
+   so `git status` shows nothing. `dodot refresh` walks the baseline cache, finds
+   deployed files whose bytes diverged, and touches the *source* mtime so git
+   re-reads. It does **not** change source content — only visibility.
+2. **The source content is still stale.** `dodot transform check` actually
+   reverse-merges the deployed bytes back into the `.tmpl` source on disk. Where it
+   can't merge cleanly it inserts `dodot-conflict` markers for you to resolve.
+   `--strict` makes it exit 1 while markers remain (how the pre-commit hook blocks
+   bad commits). **It writes to your source files** — use `--dry-run` to preview.
+
+`dodot transform status` is the read-only map: `synced` / `output_changed` (deployed
+edited) / `input_changed` (source edited) / `both` / `missing`.
+
+The canonical setup wires both into git so this is automatic:
+
+```bash
+dodot git-install-alias        # git wrapper runs `dodot refresh --quiet` first → git sees deployed edits
+dodot transform install-hook   # pre-commit runs refresh + `transform check --strict`
+```
+
+## Workflows
+
+### Add a templated file (vary content per host)
+
+```bash
+# 1. Author the source with the .tmpl extension, referencing variables in {{ }}:
+#      git/gitconfig.tmpl   ->   name = {{ name }}
+# 2. Define the variable(s) in .dodot.toml (root for all packs, or pack-local):
+#      [preprocessor.template.vars]
+#      name = "Alice"
+dodot up git
+cat ~/.config/git/gitconfig            # verify rendered output (status shows the *stripped* name)
+```
+
+Undefined variables are a hard error — `up` refuses the pack. Mark genuinely
+optional values with Jinja's `default`: `{{ env.EDITOR | default("nvim") }}`.
+Built-in namespaces: `dodot.*` (os, arch, hostname, …), `env.*`, and your bare vars.
+See `TEMPLATES.md`.
+
+### Template vs gate — pick the right tool
+
+A template is for when the file *always deploys* but its **content** varies. When
+the question is binary — *does this file deploy on this host at all?* — use a
+**gate** (`Brewfile._darwin`, `install._darwin.sh`, `[pack] os = ["darwin"]`), not
+a whole file wrapped in `{% if dodot.os %}`. They compose:
+`aliases._darwin.sh.tmpl` gates first, renders second.
+
+### Inject a secret value (keep a token out of git)
+
+```bash
+dodot secret list                      # inventory which providers the repo references
+# enable in .dodot.toml: [secret] enabled = true  +  [secret.providers.<scheme>] enabled = true
+# reference in a template:  token = "{{ secret('pass:dodot/api_token') }}"
+dodot secret probe                     # confirm the provider authenticates
+dodot up <pack>                        # source keeps {{ secret(...) }}; deployed gets the real value
+```
+
+Six providers (`pass`, `op`, `bw`, `sops`, `keychain`, `secret-tool`), each with its
+own reference syntax — see `SECRETS.md`. Multi-line secrets are refused here; use
+whole-file instead.
+
+### Encrypt a whole file
+
+Drop a `.age` or `.gpg` file in the pack, enable `[preprocessor.age]` /
+`[preprocessor.gpg]`; `dodot up` decrypts to a 0600 datastore file and symlinks it.
+There is **no `dodot secret edit`** — the edit loop is decrypt → edit → re-encrypt →
+commit by hand. See `SECRETS.md`.
+
+### Sync a deployed-side edit back to source
+
+```bash
+dodot transform status                 # confirm the file shows output-changed / both
+dodot transform check --dry-run        # preview the reverse-merge
+dodot transform check                  # write it back into the .tmpl source
+# resolve any dodot-conflict markers in the source, then commit
+```
+
+## Going deeper
+
+- **`TEMPLATES.md`** — the three namespaces and built-ins, strict-mode errors and
+  `default`, custom extensions, collision rules, where rendered output lives.
+- **`SECRETS.md`** — the six providers with reference syntax and quirks, value
+  injection vs whole-file, the manual edit loop, `secret probe`/`list`,
+  troubleshooting.
+
+Per-command help is authoritative: `dodot transform --help`, `dodot refresh --help`,
+`dodot secret --help`.

--- a/skills/dodot-templates/TEMPLATES.md
+++ b/skills/dodot-templates/TEMPLATES.md
@@ -1,0 +1,92 @@
+# Templates reference
+
+Any pack file ending in `.tmpl` or `.template` is rendered as a Jinja2 template at
+deploy time. The extension is stripped and the result flows to the normal handler
+pipeline: `git/gitconfig.tmpl` renders and symlinks as `~/.gitconfig`. `dodot
+status` shows the **stripped** name. Every `dodot up` re-renders — no `dodot render`
+step.
+
+## What you can reference
+
+Three namespaces are always available:
+
+- **`dodot.*`** — built-ins describing the machine:
+  `dodot.os` (`"linux"`/`"macos"`), `dodot.arch` (`"aarch64"`/`"x86_64"`),
+  `dodot.hostname`, `dodot.username`, `dodot.home`, `dodot.dotfiles_root`.
+  `os`/`arch`/`home`/`dotfiles_root` are always set; `hostname`/`username` are
+  best-effort (the key is *omitted* if undetectable, not blanked).
+- **`env.*`** — process environment at render time. `{{ env.EDITOR }}` reads
+  `$EDITOR` as `dodot up` runs.
+- **bare names** — your own vars from `[preprocessor.template.vars]`.
+
+## Defining variables
+
+```toml
+# .dodot.toml — root (all packs) or pack (that pack only)
+[preprocessor.template.vars]
+editor = "nvim"
+host_tier = "workstation"
+```
+
+Values are strings, referenced by bare name (`{{ editor }}`). Pack-level vars
+override root-level of the same name (replace, no merge). `dodot` and `env` are
+reserved — using them as var names is a startup error.
+
+## Strict mode — undefined is an error
+
+Referencing a variable that doesn't exist is a render error and `up` refuses to
+deploy that pack (deliberate: no silent empty-string substitution). Mark genuinely
+optional values with Jinja's `default` filter — works across all three namespaces:
+
+```jinja
+editor = {{ env.EDITOR | default("nvim") }}
+host   = {{ dodot.hostname | default("unknown") }}
+tier   = {{ host_tier | default("unspecified") }}
+```
+
+## Branching
+
+Standard Jinja `{% if %}` / `{% else %}` / `{% endif %}`:
+
+```jinja
+{% if dodot.os == "macos" %}
+export HOMEBREW_PREFIX=/opt/homebrew
+{% else %}
+export HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
+{% endif %}
+```
+
+For anything past OS/hostname, define a classifier var (`host_role = "work"`) and
+branch on it. For *deploy-or-not* questions, prefer a gate over a whole-file `{% if
+%}` — see the main skill's "template vs gate" note.
+
+## Disabling preprocessing
+
+```toml
+[preprocessor]
+enabled = false        # .tmpl files deploy verbatim, extension intact
+```
+
+The same key in a pack's `.dodot.toml` overrides the root — enable globally, disable
+for one pack.
+
+## Custom extensions
+
+```toml
+[preprocessor.template]
+extensions = ["j2", "jinja"]    # leading dot optional; longest match wins on overlap
+```
+
+## Collisions
+
+A pack can't hold both `config.toml` and `config.toml.tmpl` — they'd deploy to the
+same name. dodot refuses the pack with a collision error rather than picking
+silently. Same if two preprocessors produce the same output name.
+
+## Where rendered output lives
+
+`$XDG_DATA_HOME/dodot/packs/<pack>/preprocessed/<stripped-name>` (directory
+structure preserved). That file is what the handlers see and what `refresh` /
+`transform` hash. The install handler's completion sentinel hashes the **rendered**
+script, so changing a variable (or moving machines, changing `dodot.hostname`)
+re-triggers the install step even when the `.tmpl` source is unchanged.

--- a/skills/using-dodot/CLI.md
+++ b/skills/using-dodot/CLI.md
@@ -7,9 +7,12 @@ supports `--dry-run`.
 
 ### `dodot status [PACKS...]`
 
-Read-only. Per-file: handler symbol, live target, state (`pending` / `deployed` /
-`error`), plus `skipped` files. Symbols: `➞` symlink · `⚙` shell/homebrew · `+`
-`$PATH` · `×` install.
+Read-only. Per-file: handler symbol, live target, and a **handler-specific** label —
+`pending`/`deployed` (symlink), `sourced`/`not sourced` (shell), `in PATH` (path),
+`installed`/`never run`/`older version` (provisioning), `skipped`, `gated out`. Only
+the **pack-level rollup** is constrained to `pending`/`deployed`/`error`. Symbols:
+`➞` symlink · `⚙` shell/homebrew/nix · `+` `$PATH` · `×` install · `·` skip/gate
+(not deployed). The icon set in `status --help` lists only the first four.
 
 - `--check-drift` — hash deployed external files, report divergence (opt-in, slow).
 - `--diff` — for provisioning files reporting "older version", show the unified diff.

--- a/skills/using-dodot/CLI.md
+++ b/skills/using-dodot/CLI.md
@@ -1,0 +1,116 @@
+# CLI reference
+
+Per-command help is authoritative: `dodot <cmd> --help`. Every mutating command
+supports `--dry-run`.
+
+## Daily commands
+
+### `dodot status [PACKS...]`
+
+Read-only. Per-file: handler symbol, live target, state (`pending` / `deployed` /
+`error`), plus `skipped` files. Symbols: `➞` symlink · `⚙` shell/homebrew · `+`
+`$PATH` · `×` install.
+
+- `--check-drift` — hash deployed external files, report divergence (opt-in, slow).
+- `--diff` — for provisioning files reporting "older version", show the unified diff.
+- `--full` / `--short` — per-file detail vs one line per pack (default `--full`).
+- `--by-name` / `--by-status` — sort order (default `--by-name`).
+
+### `dodot up [PACKS...]`
+
+Deploy: materialize symlinks, register shell sources and `bin/` on `$PATH`, run
+provisioning when its content hash changed. Phases: plan → detect cross-pack
+conflicts (stops if any) → execute (wipe each pack's stored state, re-apply from
+source). Idempotent.
+
+- `--dry-run` — preview only.
+- `--no-provision` — skip install scripts and Brewfile.
+- `--provision-rerun` — force-rerun provisioning even if the sentinel matches.
+- `--force` — overwrite pre-existing files at target locations.
+
+### `dodot down [PACKS...]`
+
+Remove deployments: delete symlinks, clear shell-source and `$PATH` registrations,
+remove provisioning sentinels. The dotfiles repo is untouched.
+
+- `--dry-run`.
+
+## Pack management
+
+### `dodot list`
+
+List discovered packs (display names; ordering prefixes stripped). Skips dirs with
+`.dodotignore` and the default ignore globs (`.git`, `node_modules`, `.DS_Store`, …).
+
+### `dodot init <PACK>`
+
+Create `<root>/<PACK>/` and a commented starter `.dodot.toml`. No handler files
+(use `fill`). Errors if the dir exists.
+
+### `dodot fill <PACK>`
+
+Add starter handler files to an existing pack — `install.sh` (0755), `aliases.sh`,
+`Brewfile` — each substituting the pack name. Never overwrites existing files.
+
+### `dodot adopt <FILES...>`
+
+Move existing config into a pack and replace the original with a symlink back.
+
+- `--into <PACK>` — force the destination pack (must exist; overrides inference).
+- `--force` — overwrite existing destination files in the pack.
+- `--no-follow` — move the symlink itself, not its target.
+- `--dry-run`.
+Pack is inferred from the source path when `--into` is omitted: `$XDG_CONFIG_HOME/X/…`
+→ pack `X`; bare `~/.X` files/dirs generally require `--into`.
+
+### `dodot addignore <PACK>`
+
+Drop a zero-byte `.dodotignore` so the directory stops being discovered as a pack.
+Idempotent; reverse with `rm <pack>/.dodotignore`.
+
+## Shell integration
+
+- `dodot init-sh` — print the shell init script; add `eval "$(dodot init-sh)"` to
+  `~/.zshrc` / `~/.bashrc`.
+- `dodot git-show-alias` / `dodot git-install-alias` [`--shell SHELL`] — the git
+  wrapper alias that runs `dodot refresh --quiet` so `git status`/`git diff` see
+  deployed-side template edits (show vs write-to-rc).
+
+## Introspection — `dodot probe`
+
+Read-only, lower-level than `status`.
+
+- `deployment-map` — every symlink dodot created (source → live); machine-readable,
+  supports `--output json`.
+- `show-data-dir [--depth N]` — tree of the datastore (`~/.local/share/dodot`), by
+  pack + handler (default depth 4).
+- `shell-init [<PACK[/FILE]>] [--runs [N]] [--history] [--errors-only]` — per-source
+  shell-startup timings, exit codes, stderr.
+- `app <PACK> [--refresh]` (macOS) — app-support folders, matching cask, bundle id.
+
+## Configuration — `dodot config`
+
+- `list` — resolved config values · `get <KEY>` — one key with its docs · `set
+  <KEY> <VALUE>` · `unset <KEY>` · `gen [-o FILE]` — print/write a fully-commented
+  `.dodot.toml` starter.
+
+`.dodot.toml` lives at the repo root (all packs) and/or per-pack (that pack only);
+pack config layers over root. Key sections: `[mappings]` (handler dispatch),
+`[symlink]` (target routing), `[path]`, `[preprocessor.template.vars]`, `[secret]`,
+`[gates]`, `[pack]`.
+
+## Templates, secrets & their git integration
+
+Out of scope here — these are a separate concern with their own footguns (the
+source is **not** the deployed bytes). If a repo uses `*.tmpl`/`*.template`,
+`{{ secret(...) }}`, or `*.age`/`*.gpg` files, or you need `dodot refresh` /
+`dodot transform` / `dodot secret`, use the **dodot-templates** skill.
+
+`dodot plist clean|smudge` + `git-install-filters` (binary↔XML plist git filters,
+macOS) are git plumbing — install once per clone and ignore; `dodot
+git-install-filters` writes them.
+
+## Misc
+
+- `dodot tutorial [--reset] [--from STEP]` — interactive walkthrough on the real repo.
+- `dodot prompts list` / `reset [KEY] [--all]` — manage one-shot CLI prompts.

--- a/skills/using-dodot/HANDLERS.md
+++ b/skills/using-dodot/HANDLERS.md
@@ -1,0 +1,101 @@
+# Handlers reference
+
+A **handler** is what dodot does with a file once a **rule** matches it. Rules are
+pattern → handler mappings with a priority; checked highest-first, first match wins.
+
+## Default rules (highest priority first)
+
+| Prio | Handler  | Matches (at pack root)                                  |
+|------|----------|--------------------------------------------------------|
+| 100  | ignore   | (empty by default)                                     |
+| 50   | skip     | README, LICENSE, CHANGELOG, CONTRIBUTING, AUTHORS, NOTICE, COPYING (case-insensitive) |
+| 20   | install  | `install.sh`, `install.bash`, `install.zsh`            |
+| 10   | homebrew | `Brewfile`                                             |
+| 10   | nix      | `packages.nix`                                         |
+| 10   | path     | `bin/`                                                 |
+| 10   | shell    | `*.sh`, `*.bash`, `*.zsh`                              |
+| 0    | symlink  | catch-all — anything not claimed above                 |
+
+Override dispatch per-pack or repo-wide in `.dodot.toml` under `[mappings]`
+(e.g. `shell = ["aliases.sh"]`, `ignore = ["scratch.txt"]`).
+
+## Deploy handlers
+
+These produce filesystem work. Each entry notes its **liveness** — what propagates
+on its own vs what needs another `dodot up`.
+
+### symlink (catch-all)
+
+Links the source file to its live target.
+
+- **Default target:** `~/.config/<pack>/<file>` for XDG-style config, else `~/.<file>`.
+- **Routing prefixes** (override the target, applied at pack root):
+  - File-level (skip the pack namespace): `home.X` → `~/.X` · `xdg.X` →
+    `$XDG_CONFIG_HOME/X` · `app.X` → app-support dir · `lib.X` → `~/Library/X` (macOS).
+  - Directory-level (route a whole subtree): `_home/<rest>` → `~/.<rest>` ·
+    `_xdg/<rest>` → `$XDG_CONFIG_HOME/<rest>` · `_app/<rest>` → app-support ·
+    `_lib/<rest>` → `~/Library/<rest>` (macOS).
+- **Liveness:** edits to the source are live immediately (live path *is* the source
+  via the link). File-watching editors reload at once; startup-only programs
+  (window managers, daemons, X resources) need their own reload. **Adding or
+  removing a source file needs another `dodot up`.**
+
+### shell
+
+Arranges for a `*.sh`/`*.bash`/`*.zsh` file to be sourced at login.
+
+- **Liveness:** editing the script is live for the *next* shell session — no second
+  `up` needed; re-source or open a new shell. **Adding or removing a script needs
+  another `dodot up`** (staging registers it for new shells).
+
+### path
+
+Puts a `bin/` directory on `$PATH`.
+
+- **Liveness:** new executables dropped into the directory are immediately runnable
+  in shells that already have it on `$PATH` (the directory is staged, not each
+  file). New files need the execute bit (`auto_chmod_exec = true` sets it on the
+  next `up`). **Adding a new pack with `bin/`, or removing one, needs another `up`.**
+
+### install / homebrew / nix (provisioning)
+
+One-shot setup, tracked by a sentinel so it doesn't re-run:
+
+- **install** — runs `install.sh` once.
+- **homebrew** — runs `brew bundle` on a `Brewfile`.
+- **nix** — runs `nix profile install` on a `packages.nix`.
+- **Liveness:** editing the script does **not** auto-rerun (conservative — it could
+  be destructive). `dodot status` reports `never run` / `installed` / `older
+  version (N lines ±)`; `dodot status --diff` shows the change. Apply edits with
+  `dodot up --provision-rerun`. Skip provisioning entirely with `dodot up --no-provision`.
+
+## Filter handlers
+
+These drop a match *without* deploying it.
+
+- **ignore** — silent drop, like `.gitignore`. Empty by default; add globs via
+  `[mappings] ignore`.
+- **skip** — drops but surfaces as `skipped` in `dodot status` (so you can see it
+  was deliberately not deployed). Defaults cover README/LICENSE/etc.
+- **gate** — drops on hosts where a predicate doesn't match. Driven by filename
+  suffix `._<label>` (e.g. `install._darwin.sh`, `home.bashrc._linux`) or a
+  `_<label>/` directory at pack root. Built-in labels: `darwin`, `linux`, `macos`,
+  `arm64`, `aarch64`, `x86_64`; define more under `[gates]`.
+
+## Not the same as `.dodotignore`
+
+`.dodotignore` is a **zero-byte marker inside a directory** that stops the whole
+directory from being discovered as a pack. The `ignore`/`skip` handlers act on
+*individual files within* a pack. Don't conflate them.
+
+## Extensions that preprocess before the handler runs
+
+Applied before dispatch; the extension is stripped and the result flows to the
+normal handler:
+
+- `.tmpl` / `.template` — rendered as a Jinja2 template at deploy time.
+- `.age` / `.gpg` — decrypted at deploy time to a 0600 file in the datastore, then
+  symlinked.
+
+For both, the source is **not** the deployed bytes — a different editing model. See
+the **dodot-templates** skill.

--- a/skills/using-dodot/SKILL.md
+++ b/skills/using-dodot/SKILL.md
@@ -15,8 +15,10 @@ from scratch.
 Four leading words carry everything:
 
 - **pack** — a top-level directory in the dotfiles repo (`vim/`, `git/`, `work/`).
-  The unit `up`/`down`/`status` act on. Every top-level dir is a pack unless it
-  holds a `.dodotignore` file.
+  The unit `up`/`down`/`status` act on. Every top-level dir is a pack *except*
+  hidden dirs (e.g. `.git/`), names matching the default ignore globs
+  (`node_modules`, `.DS_Store`, …), invalid pack names, and any dir holding a
+  `.dodotignore` marker. `dodot list` shows exactly what's discovered.
 - **handler** — what dodot does with a file once a rule matches it. The filename
   decides the handler (a `*.sh` is sourced, `bin/` joins `$PATH`, anything else is
   symlinked). See `HANDLERS.md`.
@@ -37,8 +39,10 @@ Always **status → act → status**. Never hand-create symlinks or edit the
 datastore; let dodot do the work and verify with `status`.
 
 1. **Orient.** Confirm the dotfiles root (`$DOTFILES_ROOT`, else the git toplevel,
-   else cwd). Run `dodot status` to see packs and their deployment state
-   (`pending` / `deployed` / `error`, plus `skipped` files).
+   else cwd). Run `dodot status` to see each pack's rollup
+   (`pending` / `deployed` / `error`) and its per-file labels — which are
+   handler-specific (`sourced`, `in PATH`, `installed`, `older version`,
+   `skipped`, `gated out`, …), not the same three words.
 2. **Act.** Run the workflow below. When unsure of the effect, run with
    `--dry-run` first — every mutating command supports it.
 3. **Verify.** Run `dodot status` again and confirm the change landed (`deployed`,

--- a/skills/using-dodot/SKILL.md
+++ b/skills/using-dodot/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: using-dodot
+description: Manage dotfiles with dodot — deploy packs, check what's live, add or adopt config files, undo deployments. Use when the user wants to deploy/update their dotfiles, run dodot up/down/status, add a file to a pack, adopt an existing config file into dodot, check what dodot has deployed, or undo a deployment.
+---
+
+# Using dodot
+
+dodot is a convention-based dotfiles manager. You operate an **existing** dotfiles
+repo with it: deploy packs, inspect what's live, bring new files under management,
+and tear deployments down. This skill is for *using* dodot, not authoring a repo
+from scratch.
+
+## Mental model
+
+Four leading words carry everything:
+
+- **pack** — a top-level directory in the dotfiles repo (`vim/`, `git/`, `work/`).
+  The unit `up`/`down`/`status` act on. Every top-level dir is a pack unless it
+  holds a `.dodotignore` file.
+- **handler** — what dodot does with a file once a rule matches it. The filename
+  decides the handler (a `*.sh` is sourced, `bin/` joins `$PATH`, anything else is
+  symlinked). See `HANDLERS.md`.
+- **up / down** — `up` deploys a pack (creates symlinks, registers shell sources
+  and `$PATH` entries, runs install scripts). `down` removes the deployment. Your
+  repo is never touched by either — only the **datastore** (`~/.local/share/dodot/`)
+  and the live targets in `$HOME`.
+- **source vs live** — the repo file is the **source**; the deployed path is the
+  **live** file. dodot links live → source, so for symlinked files *they are the
+  same bytes*. This distinction drives the one rule you must not get wrong (below).
+
+dodot has **no apply database and no drift**: the filesystem *is* the state. git is
+the source of truth; `up` is idempotent — re-run it freely.
+
+## The core loop
+
+Always **status → act → status**. Never hand-create symlinks or edit the
+datastore; let dodot do the work and verify with `status`.
+
+1. **Orient.** Confirm the dotfiles root (`$DOTFILES_ROOT`, else the git toplevel,
+   else cwd). Run `dodot status` to see packs and their deployment state
+   (`pending` / `deployed` / `error`, plus `skipped` files).
+2. **Act.** Run the workflow below. When unsure of the effect, run with
+   `--dry-run` first — every mutating command supports it.
+3. **Verify.** Run `dodot status` again and confirm the change landed (`deployed`,
+   no `error`).
+
+## The one rule: when does a re-run of `up` happen?
+
+Editing an already-deployed file → **no `dodot up` needed**. The live path is the
+source via symlink; the edit is already live. (Programs that only read config at
+startup still need their own reload — that's the program's behavior, not dodot's.)
+
+**Adding or removing a source file → run `dodot up` again.** `up` reconciles
+per-pack state: new sources get linked, removed sources get their stale links
+cleaned. This is the mistake to avoid — dropping a file into a pack and assuming
+it's live. It isn't until the next `up`.
+
+Install / Homebrew / Nix scripts are the exception in the other direction: editing
+them does **not** auto-rerun (too destructive to do silently). `status` flags them
+as "older version"; apply with `dodot up --provision-rerun`.
+
+## Workflows
+
+### Deploy (or redeploy after a git pull)
+
+```bash
+dodot status                 # see current state
+dodot up --dry-run           # preview when unsure
+dodot up                     # deploy all packs (or: dodot up <pack>...)
+dodot status                 # confirm deployed
+```
+
+### Add a new file to a pack
+
+Put the file in the pack directory, named so the right handler claims it (see the
+table below / `HANDLERS.md`), then re-run `up`:
+
+```bash
+cp ~/some/config ~/dotfiles/nvim/        # source now in the pack
+dodot up nvim                            # link it live
+dodot status nvim
+```
+
+### Adopt an existing live config into dodot
+
+`adopt` moves a real file into a pack and replaces the original with a symlink back
+— the inverse of dropping a file in by hand. Use it to bring already-existing
+config under management without losing the live file:
+
+```bash
+dodot adopt ~/.gitconfig --into git      # explicit pack
+dodot adopt ~/.config/helix/             # pack inferred from path
+dodot status
+```
+
+### Undo a deployment
+
+```bash
+dodot down nvim                          # remove links/registrations for one pack
+dodot down                               # or all packs; repo stays intact
+dodot up nvim                            # redeploy later, any time
+```
+
+### Create a pack scaffold
+
+```bash
+dodot init <pack>                        # make the dir + starter .dodot.toml
+dodot fill <pack>                        # add starter install.sh/aliases.sh/Brewfile
+```
+
+## How filenames map to handlers (the essentials)
+
+| At pack root            | Handler  | Result                                  |
+|-------------------------|----------|-----------------------------------------|
+| `*.sh` `*.bash` `*.zsh` | shell    | sourced at login                        |
+| `bin/`                  | path     | directory added to `$PATH`              |
+| `install.sh`            | install  | run once (tracked; won't re-run)        |
+| `Brewfile`              | homebrew | `brew bundle`                           |
+| `packages.nix`          | nix      | `nix profile install`                   |
+| `README` `LICENSE` …    | skip     | not deployed; shown as `skipped`        |
+| anything else           | symlink  | linked to `~/.<name>` or `~/.config/<pack>/` |
+
+Routing prefixes on a symlinked file override the default target: `home.X` →
+`~/.X`, `xdg.X` → `$XDG_CONFIG_HOME/X`, `app.X` → app-support dir; the directory
+forms `_home/`, `_xdg/`, `_app/` route a whole subtree. Full handler behavior,
+filter handlers (ignore/skip/gate), and per-handler liveness are in `HANDLERS.md`.
+
+## Going deeper
+
+- **`HANDLERS.md`** — every handler, the default rules and priorities, filter
+  handlers, routing prefixes, and what propagates live vs needs another `up`.
+- **`CLI.md`** — full command and flag reference, including `probe`
+  (introspection) and `config`. Reach for it when a command or flag here isn't enough.
+- **dodot-templates skill** — if the repo uses `*.tmpl` templates, `{{ secret(...) }}`,
+  or `*.age`/`*.gpg` files. There the source is **not** the deployed bytes, which
+  changes the editing rules; don't treat those files like ordinary symlinks.
+
+When behavior is ambiguous, the per-command help is authoritative: `dodot <cmd> --help`.


### PR DESCRIPTION
Adds two model-invoked agent skills under `skills/`, in the open `SKILL.md` format (installable by Claude Code, Copilot, Cursor, skill CLIs).

- **`using-dodot`** — operate an existing dotfiles repo: packs/handlers mental model, the `status → act → status` loop, the add-vs-edit "one rule", with full handler + CLI reference disclosed to `HANDLERS.md` / `CLI.md`.
- **`dodot-templates`** — author and sync templates & secrets: the **source ≠ live** inversion, forward render vs reverse-merge (`refresh`/`transform`), the six secret providers, whole-file `.age`/`.gpg`, disclosed to `TEMPLATES.md` / `SECRETS.md`.

Plus `skills/README.md` (install instructions + index) and a changelog fragment.

## Context

**Why two skills, not one.** Scope was deliberately split. `using-dodot` is for *operating* an existing repo (the user's chosen scope). Templates earned a separate skill on two axes: a distinct trigger surface (`template`, `secret`, `{{ }}`, `.age`) and a real multi-step *process* (the reverse-sync edit loop) with ordering footguns — too heavy to inline without bloating the operating skill. The rest of the advanced CLI (`probe`, `config`, plist filters) did **not** earn a split; it stayed as flat reference. Please don't suggest merging them back or splitting further.

**Why the heavy emphasis on "source vs live."** That's the #1 thing an agent gets wrong that a human wouldn't (editing the rendered/deployed file vs the source). It's load-bearing in both skills by design, not redundancy.

**Verification.** The documented surface was checked against a release build of HEAD (not the brew binary, which is stale and lacks `transform`/`refresh`/`secret`), the e2e bats suite, and live sandbox runs (template render + `transform check` reverse-merge). Two explorer-reported items were corrected out: `adopt --only-os` (doesn't exist) and `transform status` state names (underscored, not hyphenated). Separately filing a dodot issue for `--help`/behavior mismatches found during this pass — out of scope for this PR.

**Out of scope:** no doc-site (mkdocs) wiring, no top-level README pointer — these are static skill files only.