### PR TITLE
release: adopt shipit release caller — declarations + stage-choice dispatch, signed darwin (ADP02-WS08)

### DIFF
--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -1,0 +1,165 @@
+name: shipit-release
+
+# dodot's shipit release caller (ADP02-WS08, the rust fleet cutover —
+# arthur-debert/shipit#841) — the WS09 BLESSED per-stage dispatch shape
+# (ADR-0054, workflows.lex §8), copied from arthur-debert/standout's
+# shipit-release.yml (#187, the pathfinder): one workflow_dispatch caller
+# with a `stage` choice (full | prepare | build | sign | publish), one
+# job per stage, each a single `uses:` line against the matching block,
+# gated `if: inputs.stage == '...'`, forwarding
+# `version`/`tag`/`run-id`/`unsigned` verbatim. Routing ONLY (ADR-0040):
+# the release plan — matrix, live stages, the post-RC-guard endpoint set,
+# required secrets — is preflight's, computed inside the blocks; nothing
+# is re-derived or wired stage-to-stage here.
+#
+# Every ref is the FULL remote `arthur-debert/shipit/...@v1` form — never
+# `./` relative (which would resolve against THIS repo, where no blocks
+# live), never SHA-pinned (the fleet rides the advance-major-moved `v1`,
+# ADR-0010).
+#
+# dodot's release surface (.shipit.toml [artifacts]) is the legacy-parity
+# 5-asset shape: the signed-darwin archive artifact (gh-release + crates
+# + brew) and the cargo-deb leg (gh-release). Unlike standout, the plan
+# HAS a real matrix and a live sign stage: `sign = true` on the archive
+# artifact routes the darwin tarball through the signer's archive leg
+# (shipit#800 — raw darwin CLI binary codesign+notarize).
+#
+# Secrets — exactly the plan-required set for dodot's plan:
+#   RELEASE_TOKEN             prepare's tag+branch push through the
+#                             ruleset (a GITHUB_TOKEN push would not
+#                             re-trigger workflows).
+#   CARGO_REGISTRY_TOKEN      the crates endpoint's registry token,
+#                             mapped from this repo's legacy-named
+#                             CRATES_IO_KEY secret (NOT renamed: the
+#                             legacy release.yml still consumes it under
+#                             that name until it is retired). Forwarded
+#                             to the stages that can publish crates
+#                             (`full`, `publish`); the RC guard drops the
+#                             crates endpoint on an -release-rc version
+#                             centrally.
+#   HOMEBREW_TAP_TOKEN        the brew endpoint's tap push token
+#                             (arthur-debert/homebrew-tools carries
+#                             dodot.rb), forwarded beside the crates
+#                             token to `full` and `publish`.
+#   APPLE_CERTIFICATE (+PASSWORD) the mac codesign identity, mapped from
+#                             this repo's legacy-named
+#                             APPLE_CERTIFICATE_P12_BASE64 secret (NOT
+#                             renamed, same reason as CRATES_IO_KEY).
+#   ASC_API_KEY_BASE64/_ID, ASC_API_ISSUER_ID  the ASC notary trio.
+#                             The Apple set rides the stages that can
+#                             sign (`full`, `sign`).
+# gh-release rides the workflow's own GITHUB_TOKEN (no registry entry).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          The release version, consumed by `full`/`prepare`: a bare semver
+          (1.0.0, 1.0.0-release-rc) or a bump word (major|minor|patch).
+          Ignored by the tag-dispatched stages.
+        required: false
+        type: string
+      stage:
+        description: >-
+          What to dispatch: the full composed chain (default) or ONE
+          independently re-runnable stage block (per-stage dispatch,
+          ADR-0054). `prepare` dispatches on `version`; `build`, `sign`
+          and `publish` on `tag` (+ `run-id` for the artifact-consuming
+          stages).
+        required: false
+        type: choice
+        default: full
+        options:
+          - full
+          - prepare
+          - build
+          - sign
+          - publish
+      tag:
+        description: >-
+          The release tag (v<version>), consumed by the `build`/`sign`/
+          `publish` stage dispatches (ADR-0041: the version is read off
+          the tag). Ignored by `full`/`prepare`.
+        required: false
+        type: string
+      run-id:
+        description: >-
+          The SOURCE run id whose artifacts feed an artifact-consuming
+          stage dispatch (`sign`, `publish`) — one source run per dispatch
+          (workflows.lex §8). Ignored by the other stages.
+        required: false
+        type: string
+      unsigned:
+        description: >-
+          Break-glass: flip a signing plan to the unsigned path. Forwarded
+          verbatim; dodot's plan HAS a live sign stage (signed darwin), so
+          this ships unsigned darwin tarballs — break-glass only.
+        required: false
+        type: boolean
+        default: false
+
+# The standalone dispatch caller's grant (workflows.lex §8): `contents:
+# write` for prepare's push and publish's gh-release, `actions: read` for
+# the cross-run artifact downloads (`run-id` flips download-artifact onto
+# the REST API). The downloading blocks deliberately declare NO
+# `permissions:` key — a called workflow can only downgrade this token.
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  release:
+    if: inputs.stage == 'full'
+    uses: arthur-debert/shipit/.github/workflows/wf-release.yml@v1
+    with:
+      version: ${{ inputs.version }}
+      unsigned: ${{ inputs.unsigned }}
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+
+  prepare:
+    if: inputs.stage == 'prepare'
+    uses: arthur-debert/shipit/.github/workflows/wf-prepare.yml@v1
+    with:
+      version: ${{ inputs.version }}
+      unsigned: ${{ inputs.unsigned }}
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+  build:
+    if: inputs.stage == 'build'
+    uses: arthur-debert/shipit/.github/workflows/wf-build.yml@v1
+    with:
+      tag: ${{ inputs.tag }}
+
+  sign:
+    if: inputs.stage == 'sign'
+    uses: arthur-debert/shipit/.github/workflows/wf-sign-mac.yml@v1
+    with:
+      tag: ${{ inputs.tag }}
+      run-id: ${{ inputs.run-id }}
+    secrets:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+
+  publish:
+    if: inputs.stage == 'publish'
+    uses: arthur-debert/shipit/.github/workflows/wf-publish.yml@v1
+    with:
+      tag: ${{ inputs.tag }}
+      run-id: ${{ inputs.run-id }}
+      unsigned: ${{ inputs.unsigned }}
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.shipit.toml
+++ b/.shipit.toml
@@ -68,6 +68,45 @@ local = true
 [toolchains]
 "." = "rust"
 
+# [artifacts] — dodot's declared Artifact set for the shipit release pipeline
+# (ADP02-WS08, arthur-debert/shipit#841; modeled on padz's WS06-proven
+# consumer map — the exact same 5-asset shape). The legacy surface it
+# replaces is release.yml → rust-cli.yml@v3 (`crates: dodot-lib,dodot`,
+# `bin-name: dodot`, defaults: darwin arm64 + linux gnu x86_64/aarch64,
+# brew, apt, signed darwin via `secrets: inherit`).
+#   - [artifacts.dodot] is the binary-tarball artifact (the brew formula
+#     subject): archive composition over the same three native-runner
+#     platforms the legacy matrix built, distributed to gh-release + crates
+#     (dodot-lib then dodot — shipit derives the workspace topo order
+#     itself) + brew (the tap is shipit's portfolio constant,
+#     arthur-debert/homebrew-tools, which already carries dodot.rb — same
+#     as legacy).
+#   - [artifacts.dodot-deb] is the legacy `apt: true` leg: cargo-deb against
+#     the pre-built release binary (the same `cargo deb -p dodot --no-build
+#     --no-strip` contract as legacy build-deb, riding the
+#     [package.metadata.deb] variants in crates/dodot-cli/Cargo.toml),
+#     linux platforms only, gh-release only (legacy attached the .debs to
+#     the GH release; there is no apt repository endpoint).
+# `sign = true` on the archive artifact — the one deliberate divergence
+# from padz's map: dodot ships SIGNED darwin (legacy parity), routed
+# through the signer's archive leg (shipit#800: raw darwin CLI binaries
+# codesigned + notarized in-place, tarballs re-emitted under their
+# original filenames; padz went unsigned by owner decision, THIS repo
+# signs). The bare flag derives the Apple cert pair + either-notary-trio
+# secret requirements in preflight.
+[artifacts.dodot]
+build = [{ toolchain = "rust", package = "dodot" }]
+platforms = ["darwin-arm64", "linux-x86_64", "linux-arm64"]
+bundle = { composition = "archive" }
+sign = true
+endpoints = ["gh-release", "crates", "brew"]
+
+[artifacts.dodot-deb]
+build = [{ toolchain = "rust", package = "dodot" }]
+platforms = ["linux-x86_64", "linux-arm64"]
+bundle = { composition = "deb" }
+endpoints = ["gh-release"]
+
 [shipit]
 version = "c8ef2189cc57f58af425afcd383ef44575108b88"
 


### PR DESCRIPTION
Closes #239. Workstream `for arthur-debert/shipit#841` (ADP02-WS08, non-closing — the umbrella closes the epic's issues).

## What

- **`.shipit.toml` `[artifacts]`** — dodot's declared release surface, modeled on padz's WS06-proven consumer map: `[artifacts.dodot]` (rust build of the `dodot` package, archive composition over darwin-arm64 + linux gnu x86_64/arm64, endpoints gh-release + crates + brew) and `[artifacts.dodot-deb]` (deb composition, linux only, gh-release only). This reproduces the LEGACY ASSET PARITY set exactly: `dodot-aarch64-apple-darwin.tar.gz`, `dodot-{aarch64,x86_64}-unknown-linux-gnu.tar.gz`, `dodot_<v>-1_{amd64,arm64}.deb`.
- **`sign = true`** on the archive artifact — the one deliberate divergence from padz's map: dodot ships signed darwin (legacy parity via `secrets: inherit` into rust-cli.yml@v3), routed through the signer's archive leg (shipit#800: raw darwin CLI binary codesign+notarize, tarball re-emitted under its original filename). Note per the issue: the first of the dodot/rustloc/burgertocow rc dispatches carries the owed remote proof of this leg.
- **`.github/workflows/shipit-release.yml`** — the blessed WS09 stage-choice caller, copied VERBATIM from arthur-debert/standout (#187); adapted ONLY the header facts and the plan-required secrets. Routing only (ADR-0040): no plan logic, no stage wiring, no companion workflow; full remote `arthur-debert/shipit/.github/workflows/wf-*.yml@v1` refs. Secrets forwarded: `RELEASE_TOKEN`; `CARGO_REGISTRY_TOKEN` ← legacy-named `CRATES_IO_KEY` (full, publish); `HOMEBREW_TAP_TOKEN` (full, publish — brew endpoint verified: legacy caller rides rust-cli.yml@v3 brew default and arthur-debert/homebrew-tools carries `dodot.rb`); the mac sign set on full + sign: `APPLE_CERTIFICATE` ← legacy-named `APPLE_CERTIFICATE_P12_BASE64`, `APPLE_CERTIFICATE_PASSWORD`, and the ASC notary trio `ASC_API_KEY_BASE64`/`ASC_API_KEY_ID`/`ASC_API_ISSUER_ID` — all names verified against `gh secret list`; no legacy-named secret renamed.
- **Legacy `release.yml` UNTOUCHED** (removal is a later coordinator-driven step after this repo's rc proof).

## Verification (each verify command the issue names, run at the pin)

- `shipit release preflight 5.2.1-release-rc --json` — rc plan sane: registry endpoints DROPPED by the central RC guard (`endpoints: ["gh-release"]` only), 5-leg matrix matching the parity set with `sign: true` on the darwin-arm64 leg, live stages `preflight→prepare→bundle→assert-bundle→sign→publish`, required secrets = `RELEASE_TOKEN` + Apple cert pair + either-notary-trio. (Preflight validates secrets from the process env, so the plan was emitted with dummy env values; the FIRST run without them doubled as a check that the bare `sign` flag derives the Apple requirement set, and the real repo secret names were verified via `gh secret list`.)
- `shipit release preflight 5.2.1 --json` — non-rc control plan: full endpoint set (`gh-release`, `crates`, `brew`) and full secret set INCLUDING the sign stage + Apple set (`RELEASE_TOKEN`, `CARGO_REGISTRY_TOKEN`, `HOMEBREW_TAP_TOKEN`, `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, notary either-trio) — exactly the set the caller forwards.
- `shipit wf test .github/workflows/shipit-release.yml --event workflow_dispatch --input stage=prepare --input version=5.2.1-release-rc --dry-run` — WF TEST: OK.
- `pixi run test` — 1302 passed, 0 skipped. Lint gate green via the commit hook (LINT: OK, 13 checks).

Self-checked against the issue's fixed doctrine: ADR-0040 (routing only — nothing re-derived in YAML), ADR-0041 (tag-dispatched stages read the version off the tag), ADR-0054/workflows.lex §8 (the blessed per-stage dispatch shape, unsampled), ADR-0010 (`@v1` floating refs, never SHA-pinned), shipit#800 (archive-leg sign declaration surface).

## Context

- **Why this approach**: fixed by the issue's doctrine — declarations copied from the padz model (the proven consumer with this exact asset shape), caller copied from the standout model (the blessed stage-choice shape, pathfinder-proven on standout's rc). No design latitude was taken beyond the mandated header-facts + secrets adaptation and the mandated `sign = true`.
- **Out of scope / do NOT "fix"**: legacy `release.yml` (stays until the post-rc-proof cleanup step); dispatching or tagging anything (the coordinator fires the rc after merge); renaming the legacy-named secrets (`CRATES_IO_KEY`, `APPLE_CERTIFICATE_P12_BASE64` — legacy still consumes them); the e2e.yml/checks.yml CI surface (WS05, already merged).
- **Derived-vs-legacy mismatches**: none found — matrix, endpoints, crate order (workspace-topo dodot-lib→dodot), deb variants, and secret names all line up with the legacy caller + rust-cli.yml@v3 defaults.
- **Brief-gap note (role contract)**: the spawn brief itself did not enumerate the BRIEF TEMPLATE slots; the issue body carried them all (verify commands, governing docs, decision boundaries), so I worked from those — flagged for completeness, no guessing was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)