### PR TITLE
changelog: fragment for the shipit release-pipeline cutover (unblocks the WS08 rc proof)

### DIFF
--- a/CHANGELOG/unreleased-shipit-release-cutover.md
+++ b/CHANGELOG/unreleased-shipit-release-cutover.md
@@ -1,1 +1,1 @@
-- ci: release pipeline cut over to shipit — composed `wf-release.yml@v1` caller with per-stage dispatch (ADP02-WS08, arthur-debert/shipit#841); legacy `release.yml` retired after the rc proof
+- ci: releases are now cut through the shipit release pipeline (`shipit-release.yml`, #240); the legacy `release.yml` caller is retired after the release-candidate proof

--- a/CHANGELOG/unreleased-shipit-release-cutover.md
+++ b/CHANGELOG/unreleased-shipit-release-cutover.md
@@ -1,0 +1,1 @@
+- ci: release pipeline cut over to shipit — composed `wf-release.yml@v1` caller with per-stage dispatch (ADP02-WS08, arthur-debert/shipit#841); legacy `release.yml` retired after the rc proof


### PR DESCRIPTION
The 5.2.1-release-rc dispatch was refused by prepare's empty-release invariant — no `CHANGELOG/unreleased-*.md` since 5.2.0. The cutover (#240) is itself the changelog-worthy change; this adds its fragment. For arthur-debert/shipit#841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MNAXwUJoEKdhrL7McmKWY