### PR TITLE
release: uniform plan-required secret set on every stage job (shipit#896)

### DIFF
--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -24,30 +24,30 @@ name: shipit-release
 # artifact routes the darwin tarball through the signer's archive leg
 # (shipit#800 — raw darwin CLI binary codesign+notarize).
 #
-# Secrets — exactly the plan-required set for dodot's plan:
+# Secrets — the UNIFORM plan-required set (shipit#896): preflight
+# re-validates the WHOLE release plan at every stage entry, so EVERY
+# stage job (`prepare`, `sign`, `publish`) forwards the SAME secret set
+# as `full` — no per-stage subsetting; which secrets a stage actually
+# spends is the plan's call, not this caller's. (`build` declares no
+# secrets, so it forwards none.)
 #   RELEASE_TOKEN             prepare's tag+branch push through the
 #                             ruleset (a GITHUB_TOKEN push would not
 #                             re-trigger workflows).
 #   CARGO_REGISTRY_TOKEN      the crates endpoint's registry token,
 #                             mapped from this repo's legacy-named
-#                             CRATES_IO_KEY secret (NOT renamed: the
-#                             legacy release.yml still consumes it under
-#                             that name until it is retired). Forwarded
-#                             to the stages that can publish crates
-#                             (`full`, `publish`); the RC guard drops the
-#                             crates endpoint on an -release-rc version
-#                             centrally.
+#                             CRATES_IO_KEY secret (the repo secret keeps
+#                             its legacy name; renaming it is a repo
+#                             settings change, not this caller's). The RC
+#                             guard drops the crates endpoint on an
+#                             -release-rc version centrally.
 #   HOMEBREW_TAP_TOKEN        the brew endpoint's tap push token
 #                             (arthur-debert/homebrew-tools carries
-#                             dodot.rb), forwarded beside the crates
-#                             token to `full` and `publish`.
+#                             dodot.rb).
 #   APPLE_CERTIFICATE (+PASSWORD) the mac codesign identity, mapped from
 #                             this repo's legacy-named
 #                             APPLE_CERTIFICATE_P12_BASE64 secret (NOT
 #                             renamed, same reason as CRATES_IO_KEY).
 #   ASC_API_KEY_BASE64/_ID, ASC_API_ISSUER_ID  the ASC notary trio.
-#                             The Apple set rides the stages that can
-#                             sign (`full`, `sign`).
 # gh-release rides the workflow's own GITHUB_TOKEN (no registry entry).
 
 on:
@@ -133,6 +133,13 @@ jobs:
       unsigned: ${{ inputs.unsigned }}
     secrets:
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
 
   build:
     if: inputs.stage == 'build'
@@ -147,6 +154,9 @@ jobs:
       tag: ${{ inputs.tag }}
       run-id: ${{ inputs.run-id }}
     secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
       APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
       ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
@@ -161,5 +171,11 @@ jobs:
       run-id: ${{ inputs.run-id }}
       unsigned: ${{ inputs.unsigned }}
     secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}


### PR DESCRIPTION
closes #245

Aligns `.github/workflows/shipit-release.yml` so every stage job (`prepare`, `sign`, `publish`) forwards the SAME secret set as the `full` job, per shipit#896's uniform-grants rule (preflight re-validates the whole release plan at every stage entry, so grants can't be per-stage subsets). Part of the arthur-debert/shipit#841 cutover; dodot is the fleet's end-to-end reference repo for this shape.

## Context

- **Why this approach**: one-block edit to the caller only — the plan (which secrets a stage actually *spends*) stays preflight's, computed inside the shipit blocks (ADR-0040). The caller's job is to forward the uniform set; no per-stage reasoning lives here.
- **What changed**: `prepare` gains the crates/brew/Apple set beside its existing `RELEASE_TOKEN`; `sign` and `publish` are aligned to the full 8-secret set (note: `sign` already carried `ASC_API_KEY_BASE64` on this head — the issue's mention of it as missing predates #240's landing shape; alignment to the full set is what this PR adds). `build` declares no secrets and forwards none. The header comment's secrets section is restated around the uniform-set rule (citing shipit#896) instead of the retired per-stage "rides the stages that can X" story; the stale "legacy release.yml still consumes CRATES_IO_KEY" note (retired in #244) is corrected to "the repo secret keeps its legacy name".
- **Out of scope / do NOT "fix"**: renaming the legacy-named repo secrets (`CRATES_IO_KEY`, `APPLE_CERTIFICATE_P12_BASE64`) — that's a repo-settings change, not this caller's; adding a `secrets:` block to `build` (its block declares none); any stage-to-stage wiring or plan re-derivation (ADR-0040 forbids it). The coordinator runs the staged-dispatch proof after merge — not this PR.
- **Verification**: `shipit wf test .github/workflows/shipit-release.yml --event workflow_dispatch --input stage=prepare --input version=0.0.0-release-rc --dry-run` → `WF TEST: OK`; commit/push hooks (full lint suite incl. actionlint/yamllint) green; `pixi run test` → 1302/1302 passed. Self-checked the diff against the issue's governing rules (shipit#896 uniform set, ADR-0040 routing-only, ADR-0054/workflows.lex §8 dispatch shape as stated in the header).
- **Brief-slot gap (flagged per template)**: the spawn brief did not name the epic's governing-docs list explicitly; I self-checked against the docs cited by issue #245 and the workflow header (shipit#896, shipit#841, ADR-0040, ADR-0054, workflows.lex §8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)