### PR TITLE
caller: per-stage secret sets = plan-required ∩ block-declared (fix startup_failure)

### DIFF
--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -154,9 +154,6 @@ jobs:
       tag: ${{ inputs.tag }}
       run-id: ${{ inputs.run-id }}
     secrets:
-      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
-      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
       APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
       ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
@@ -171,11 +168,5 @@ jobs:
       run-id: ${{ inputs.run-id }}
       unsigned: ${{ inputs.unsigned }}
     secrets:
-      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
-      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
-      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}


### PR DESCRIPTION
The #246 caller edit both over-forwarded (undeclared secrets in sign/publish) and duplicated the ASC keys in four jobs — GitHub rejects the file at dispatch startup (run 29247215245, startup_failure, zero jobs). Rebuilt the four secrets blocks: prepare mirrors full; sign = wf-sign-mac's declared Apple set; publish = wf-publish's declared registry set. actionlint clean. For arthur-debert/shipit#896 — the model-fix rule there needs the same ∩-declared correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MNAXwUJoEKdhrL7McmKWY