### PR TITLE
Clean up comment sediment across maintained source and configuration

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,36 +1,18 @@
 name: Checks
 
-# Thin caller of shipit's wf-checks quality-checks block (ADP02-WS05, #236;
-# ADR-0010/0039/0040: consumer CI is routing-only YAML over shipit-published
-# reusable workflows). Modeled on the proven first-consumer cutover,
-# lex-fmt/lex#829. Replaces the quality-check half of the legacy caller of
-# arthur-debert/release/.github/workflows/rust-ci.yml@v3 (ci.yml): the lane
-# planner (`shipit ci plan`) reads .shipit.toml [lanes] and emits the
-# lint + test matrix, and each job runs `pixi run --locked <run>` — the same
-# implementation a laptop runs. The block is consumed by the floating major
-# ref @v1, per the ADR-0010 publishing convention.
+# The lane planner reads `.shipit.toml` and routes lint and test through
+# shipit's reusable workflow (ADR-0010/0039/0040).
 #
-# The bats e2e suite lives on in the companion e2e.yml (the run needs the
-# release-built `dodot` binary artifact, bats-core, and the shared
-# `bin/check-e2e` harness — surface the wf-checks block deliberately doesn't
-# carry), keeping the required `ci / e2e` context stable across the cutover.
-# Docs stay on their own callers (docs-check.yml PR-time build, docs.yml
-# main-branch deploy); release.yml stays on the legacy release path.
+# E2E remains separate because it needs a release-built binary and supporting
+# tools that the lane workflow does not provide.
 
 on:
   push:
     branches: ['**']
   pull_request:
 
-# Superseded-run hygiene (shipit#645): a branch with an open PR gets BOTH a
-# push run and a pull_request run per push. The group is scoped per EVENT and
-# per ref/PR: `github.event_name` keeps the push run and the PR run of the
-# same head in separate groups (both verdicts are legit), while within one
-# event a new push cancels the now-superseded in-flight run for the same
-# branch (push: github.ref) or the same PR (pull_request: PR number). A
-# cancelled-because-superseded run belongs to an old head, and the `check`
-# job below turns cancellation into a SKIP, so it is never the surviving
-# verdict on the current head.
+# Keep push and pull-request verdicts in separate concurrency groups while
+# cancelling older runs for the same event and branch or PR.
 concurrency:
   group: checks-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -41,16 +23,9 @@ permissions:
 jobs:
   checks:
     uses: arthur-debert/shipit/.github/workflows/wf-checks.yml@v1
-  # The merge-blocking verdict under ONE stable name: the main ruleset
-  # requires `check`, and a called workflow's jobs report as
-  # "checks / <lane>" — so this aggregator keeps one stable `check` context
-  # alive, succeeding iff the block succeeded. Result propagation with one
-  # deliberate hole (shipit#645): a CANCELLED block means the run was
-  # superseded (the concurrency group above cancelled it for a newer head),
-  # and the new head's run carries the verdict — so cancellation SKIPS this
-  # job (a skipped required check counts as satisfied, i.e. neutral) instead
-  # of failing it. Every completed result stays explicit via `if: always()`:
-  # success passes, anything else — including a skipped block — fails.
+  # The ruleset requires one stable `check` context, while reusable-workflow
+  # jobs report lane-specific names. A cancelled run is superseded, so its
+  # aggregator is skipped and the newer head supplies the verdict.
   check:
     needs: checks
     if: always() && needs.checks.result != 'cancelled'

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,15 +1,7 @@
 name: Docs check
 
-# PR-time docs validation via the canonical mkdocs Component reusable
-# workflow at arthur-debert/release. Build-only (deploy is handled by
-# the existing docs.yml on push to main).
-#
-# Migration path: when dodot's Pages source is flipped from
-# "Deploy from a branch" → "GitHub Actions", this workflow should
-# absorb the deploy responsibility (set `deploy: true`) and the
-# legacy docs.yml gets removed. Until then, the two workflows split:
-#   - docs-check.yml: PR validation
-#   - docs.yml: main-branch deploy (legacy 3rd-party action)
+# When Pages moves from branch deployment to GitHub Actions, enable deployment
+# here and remove the main-branch-only `docs.yml` workflow.
 
 on:
   pull_request:
@@ -30,10 +22,8 @@ jobs:
     uses: arthur-debert/release/.github/workflows/mkdocs.yml@v3
     with:
       requirements: docs/requirements.txt
-      # 329 historical strict-mode warnings (broken refs, missing nav,
-      # etc.) — opt out during initial adoption. Flip to `true` after
-      # the cleanup pass.
+      # Strict mode remains disabled while 329 broken-reference and missing-nav
+      # warnings remain.
       strict: false
-      # Build-only here; main-branch docs.yml handles the deploy until
-      # dodot's Pages source flips from legacy/branch to "GitHub Actions".
+      # `docs.yml` owns deployment until Pages moves to GitHub Actions.
       deploy: 'false'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,3 @@
-# Thin caller of arthur-debert/release/.github/workflows/mkdocs.yml@v3.
-# Push-to-main only — PR-time docs validation lives in `docs-check.yml`
-# (which calls the same reusable workflow but skips deploy).
-
 name: Docs
 
 on:
@@ -14,9 +10,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  # All three required upfront — GitHub validates reusable-workflow
-  # permission compatibility at workflow-load time, including jobs
-  # gated behind `if:` (the deploy job is push-to-main-only).
+  # GitHub validates reusable-workflow permissions at load time, including
+  # jobs gated by `if:`.
   contents: read
   pages: write
   id-token: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,5 @@
+# Main-branch deployment; pull requests build through docs-check.yml without deploying.
+
 name: Docs
 
 on:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,40 +1,17 @@
 name: E2E
 
-# Companion e2e workflow (ADP02-WS05, #236) — the disposition the cutover
-# issue asked for: the bats e2e suite STAYS a caller of release's reusable
-# rust-ci.yml block rather than becoming a declared shipit lane, the same way
-# lexed#169 kept its packaged-Electron Playwright run a companion. The run
-# needs what the wf-checks block deliberately doesn't carry: a release build
-# of the `dodot` binary uploaded/downloaded as an artifact, bats-core + the
-# helper libs, and the shared `bin/check-e2e` harness (arm-gate installs it —
-# it is an untracked release-core mirror, never in the checkout). This file
-# is the slimmed remainder of the legacy ci.yml, whose quality-check half
-# (the `bin/check` umbrella verdict) now lives in checks.yml (the wf-checks
-# lanes).
+# E2E uses the reusable Rust workflow because it needs a release-built binary,
+# Bats and helper libraries, and a `bin/check-e2e` harness supplied at run time.
 #
-# The caller job id stays `ci` ON PURPOSE: the ruleset-required context is
-# `ci / e2e`, and keeping the job id keeps that context stable across the
-# cutover — no window where a required check is unreportable. The block's
-# internal `check` job (`ci / check`, bin/check + the release build that
-# produces the e2e binary) still runs as the e2e job's prerequisite — the
-# reusable workflow hard-wires `e2e: needs: check`, and the artifact the e2e
-# job downloads is built there. Its verdict is NO LONGER ruleset-required
-# (the wf-checks lanes carry the required quality verdict); the overlap with
-# the lanes is an acknowledged prerequisite cost, not a second gate.
-#
-# `binary-name: dodot` causes the check job to build and upload
-# `dodot-linux`; `bats: true` adds the e2e job that downloads it, installs
-# bats-core, and runs `bin/check-e2e` with DODOT_BIN set to the
-# workspace-relative binary path. See docs/per-stack/rust-ci.md in
-# arthur-debert/release for the full input reference.
+# The `ci` job id preserves the ruleset context `ci / e2e`. Its internal
+# `check` prerequisite builds the binary consumed by the E2E job.
 
 on:
   push:
     branches: ['**']
   pull_request:
 
-# Superseded-run hygiene, same shape as checks.yml (shipit#645): per-event,
-# per-ref/PR group; a new push cancels the superseded in-flight run.
+# Match the per-event, per-ref/PR concurrency scope in `checks.yml`.
 concurrency:
   group: e2e-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -1,54 +1,21 @@
 name: shipit-release
 
-# dodot's shipit release caller (ADP02-WS08, the rust fleet cutover —
-# arthur-debert/shipit#841) — the WS09 BLESSED per-stage dispatch shape
-# (ADR-0054, workflows.lex §8), copied from arthur-debert/standout's
-# shipit-release.yml (#187, the pathfinder): one workflow_dispatch caller
-# with a `stage` choice (full | prepare | build | sign | publish), one
-# job per stage, each a single `uses:` line against the matching block,
-# gated `if: inputs.stage == '...'`, forwarding
-# `version`/`tag`/`run-id`/`unsigned` verbatim. Routing ONLY (ADR-0040):
-# the release plan — matrix, live stages, the post-RC-guard endpoint set,
-# required secrets — is preflight's, computed inside the blocks; nothing
-# is re-derived or wired stage-to-stage here.
+# This routing-only caller forwards dispatch inputs to the matching reusable
+# workflow. The reusable blocks own the release plan, matrix, live stages,
+# endpoints, and required secrets (ADR-0040/0054, workflows.lex §8).
 #
-# Every ref is the FULL remote `arthur-debert/shipit/...@v1` form — never
-# `./` relative (which would resolve against THIS repo, where no blocks
-# live), never SHA-pinned (the fleet rides the advance-major-moved `v1`,
-# ADR-0010).
+# Keep full remote `arthur-debert/shipit/...@v1` refs: relative refs resolve
+# against this repository, which does not contain the reusable blocks, and the
+# floating major follows ADR-0010.
 #
-# dodot's release surface (.shipit.toml [artifacts]) is the legacy-parity
-# 5-asset shape: the signed-darwin archive artifact (gh-release + crates
-# + brew) and the cargo-deb leg (gh-release). Unlike standout, the plan
-# HAS a real matrix and a live sign stage: `sign = true` on the archive
-# artifact routes the darwin tarball through the signer's archive leg
-# (shipit#800 — raw darwin CLI binary codesign+notarize).
+# The artifact and signing plan is declared in `.shipit.toml`; `sign = true`
+# gives this repository a live macOS signing stage (shipit#800).
 #
-# Secrets — the UNIFORM plan-required set (shipit#896): preflight
-# re-validates the WHOLE release plan at every stage entry, so EVERY
-# stage job (`prepare`, `sign`, `publish`) forwards the SAME secret set
-# as `full` — no per-stage subsetting; which secrets a stage actually
-# spends is the plan's call, not this caller's. (`build` declares no
-# secrets, so it forwards none.)
-#   RELEASE_TOKEN             prepare's tag+branch push through the
-#                             ruleset (a GITHUB_TOKEN push would not
-#                             re-trigger workflows).
-#   CARGO_REGISTRY_TOKEN      the crates endpoint's registry token,
-#                             mapped from this repo's legacy-named
-#                             CRATES_IO_KEY secret (the repo secret keeps
-#                             its legacy name; renaming it is a repo
-#                             settings change, not this caller's). The RC
-#                             guard drops the crates endpoint on an
-#                             -release-rc version centrally.
-#   HOMEBREW_TAP_TOKEN        the brew endpoint's tap push token
-#                             (arthur-debert/homebrew-tools carries
-#                             dodot.rb).
-#   APPLE_CERTIFICATE (+PASSWORD) the mac codesign identity, mapped from
-#                             this repo's legacy-named
-#                             APPLE_CERTIFICATE_P12_BASE64 secret (NOT
-#                             renamed, same reason as CRATES_IO_KEY).
-#   ASC_API_KEY_BASE64/_ID, ASC_API_ISSUER_ID  the ASC notary trio.
-# gh-release rides the workflow's own GITHUB_TOKEN (no registry entry).
+# `CRATES_IO_KEY` and `APPLE_CERTIFICATE_P12_BASE64` retain their repository
+# names but map to the reusable workflows' canonical secret names. GitHub
+# releases use the workflow's `GITHUB_TOKEN`.
+# Preflight validates the whole release plan at every stage entry; each
+# standalone caller forwards the secret subset accepted by its reusable block.
 
 on:
   workflow_dispatch:
@@ -99,11 +66,8 @@ on:
         type: boolean
         default: false
 
-# The standalone dispatch caller's grant (workflows.lex §8): `contents:
-# write` for prepare's push and publish's gh-release, `actions: read` for
-# the cross-run artifact downloads (`run-id` flips download-artifact onto
-# the REST API). The downloading blocks deliberately declare NO
-# `permissions:` key — a called workflow can only downgrade this token.
+# `contents: write` permits prepare and publish; `actions: read` permits
+# cross-run artifact downloads. Called workflows can only downgrade this grant.
 permissions:
   contents: write
   actions: read

--- a/.release-sync.yaml
+++ b/.release-sync.yaml
@@ -1,5 +1,4 @@
-# Consumer override for release-sync. Adds opt-in `bats` + `mkdocs`
-# Components on top of the rust Stack defaults.
+# Extends release-sync's Rust defaults with Bats and MkDocs.
 capabilities:
   - rust-quality
   - bats

--- a/.shipit.toml
+++ b/.shipit.toml
@@ -1,31 +1,17 @@
-# [secrets] — repo Actions secrets. Each table key is the GitHub secret NAME; the
-# value names exactly one source ({ doppler = "KEY" } / { env = "VAR" } /
-# { prompt = true }). Seeded with shipit's local-reviewer (codex/agy) GitHub App
-# credentials, each sourced from Doppler github/prd. `shipit gh-setup` only pushes
-# a secret when its source resolves, so these are safe before the App is installed.
+# `shipit gh-setup` pushes a secret only when its configured source resolves.
 [secrets]
 CODEX_REVIEW_APP_PRIVATE_KEY = { doppler = "CODEX_REVIEW_APP_PRIVATE_KEY" }
 CODEX_REVIEW_APP_ID          = { doppler = "CODEX_REVIEW_APP_ID" }
 AGY_REVIEW_APP_PRIVATE_KEY   = { doppler = "AGY_REVIEW_APP_PRIVATE_KEY" }
 AGY_REVIEW_APP_ID            = { doppler = "AGY_REVIEW_APP_ID" }
 
-# [reviewers] — the required-reviewer SET for this repo's PRs (the map KEYS are
-# required; ALL must be DONE to flip Ready). Seeded with shipit's shipped default
-# (Copilot, review-once), rendered from the single source in
-# `prstate.reviewers_config.DEFAULT_REVIEWERS`. codex/agy are NOT seeded by default —
-# their review GitHub Apps are not installed on an arbitrary repo, so requiring them
-# would park PRs at REVIEWS_PENDING; a repo that HAS the Apps opts them in here (e.g.
-# `codex = {}`). Review-once: `rerun` defaults OFF (token-billed; opt in per reviewer
-# with e.g. `copilot = { rerun = true }`).
+# All configured reviewers must finish before the PR can become ready. Review
+# reruns are opt-in with `{ rerun = true }`.
 [reviewers]
 copilot = {}
 
-# [lint].ignore — paths the managed lint gate must SKIP. Seeded with common
-# generated/assembled files (a built CHANGELOG, package lockfiles) that are not
-# hand-written prose, so a freshly-onboarded repo does not take a latent gate
-# failure on them. Gitignore-style globs. You OWN this list and may extend it —
-# it is reconcile-safe: `shipit install` seeds [lint] only when absent and never
-# clobbers a table you have edited.
+# Gitignore-style globs skipped by the lint gate. This table is consumer-owned
+# and reconcile-safe.
 [lint]
 ignore = [
   "CHANGELOG.md",
@@ -34,27 +20,10 @@ ignore = [
   "pnpm-lock.yaml",
 ]
 
-# [lanes] — the declared PR-time check units (ADP02-WS05, #236; modeled on
-# lex#829/lexed#169). The lane planner (`shipit ci plan`) maps these + the CI
-# event + a path-diff to the job matrix the wf-checks workflow block runs
-# (`pixi run --locked <run>` per job). Both lanes' tasks SELF-PROVISION,
-# because on a hosted runner nothing outside pixi is provisioned:
-#   - `lint-full` (NOT the managed bare `lint` task, which runs in the default
-#     env where no lint tool exists) resolves into the pixi lint env and
-#     provisions lexd inline (this repo tracks `.lex` docs, so the lex Lang of
-#     `shipit lint` runs) — see its definition in pixi.toml
-#     [feature.lint.tasks].
-#   - The test lane runs the managed `test` task (-> ./bin/shipit test ->
-#     cargo nextest over the rust workspace; a real task, so the #444
-#     POSIX-`test` trap does not apply). No extra inline provisioning needed —
-#     this repo has no submodules (shipit#759 n/a); cargo + cargo-nextest +
-#     uv (for bin/shipit) ride pixi's default env ([dependencies] in
-#     pixi.toml).
-# The bats e2e suite is NOT a lane: it stays on the companion e2e.yml caller
-# of release's rust-ci.yml (the run needs the release-built `dodot` binary
-# artifact handed to `bin/check-e2e` — a build/download/bats surface the
-# wf-checks block deliberately doesn't carry), keeping the required
-# `ci / e2e` context stable across the cutover (the lexed#169 pattern).
+# `shipit ci plan` maps these lanes and the path diff to the reusable workflow's
+# job matrix. `lint-full` resolves in the lint environment; `test` resolves in
+# the default environment. E2E stays separate because it consumes a
+# release-built binary.
 [lanes.lint]
 run = "lint-full"
 required = true
@@ -68,32 +37,9 @@ local = true
 [toolchains]
 "." = "rust"
 
-# [artifacts] — dodot's declared Artifact set for the shipit release pipeline
-# (ADP02-WS08, arthur-debert/shipit#841; modeled on padz's WS06-proven
-# consumer map — the exact same 5-asset shape). The legacy surface it
-# replaces is release.yml → rust-cli.yml@v3 (`crates: dodot-lib,dodot`,
-# `bin-name: dodot`, defaults: darwin arm64 + linux gnu x86_64/aarch64,
-# brew, apt, signed darwin via `secrets: inherit`).
-#   - [artifacts.dodot] is the binary-tarball artifact (the brew formula
-#     subject): archive composition over the same three native-runner
-#     platforms the legacy matrix built, distributed to gh-release + crates
-#     (dodot-lib then dodot — shipit derives the workspace topo order
-#     itself) + brew (the tap is shipit's portfolio constant,
-#     arthur-debert/homebrew-tools, which already carries dodot.rb — same
-#     as legacy).
-#   - [artifacts.dodot-deb] is the legacy `apt: true` leg: cargo-deb against
-#     the pre-built release binary (the same `cargo deb -p dodot --no-build
-#     --no-strip` contract as legacy build-deb, riding the
-#     [package.metadata.deb] variants in crates/dodot-cli/Cargo.toml),
-#     linux platforms only, gh-release only (legacy attached the .debs to
-#     the GH release; there is no apt repository endpoint).
-# `sign = true` on the archive artifact — the one deliberate divergence
-# from padz's map: dodot ships SIGNED darwin (legacy parity), routed
-# through the signer's archive leg (shipit#800: raw darwin CLI binaries
-# codesigned + notarized in-place, tarballs re-emitted under their
-# original filenames; padz went unsigned by owner decision, THIS repo
-# signs). The bare flag derives the Apple cert pair + either-notary-trio
-# secret requirements in preflight.
+# Shipit derives workspace crate publication order for the archive artifact.
+# The deb artifact reuses the release binary and the Cargo metadata variants;
+# signed macOS archives pass through code-signing and notarization (shipit#800).
 [artifacts.dodot]
 build = [{ toolchain = "rust", package = "dodot" }]
 platforms = ["darwin-arm64", "linux-x86_64", "linux-arm64"]

--- a/crates/dodot-cli/Cargo.toml
+++ b/crates/dodot-cli/Cargo.toml
@@ -28,7 +28,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dodot-lib = { version = "5.2.2-rc.1", path = "../dodot-lib", features = ["test-utils"] }
 tempfile = "3"
 
-# cargo-deb configuration. Driven by `cargo deb -p dodot` in CI.
 # No maintainer scripts (debian/postinst, debian/prerm) — dodot has no
 # `completion --shell X print` CLI to register completions on configure,
 # and no other post-install state to manage. When that lands, add

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -44,10 +44,6 @@ fn verbose_from(matches: &clap::ArgMatches) -> bool {
 }
 
 /// Build an ExecutionContext from the current environment.
-///
-/// Uses `ExecutionContext::production()` with the dotfiles root
-/// discovered from env/git. Reads CLI flags when present, defaulting
-/// to false for flags not defined on the current subcommand.
 fn build_ctx(matches: &clap::ArgMatches) -> Result<ExecutionContext, anyhow::Error> {
     let dotfiles_root = discover_dotfiles_root()?;
     let mut ctx = ExecutionContext::production(&dotfiles_root, verbose_from(matches))?;
@@ -96,7 +92,6 @@ fn pack_filter(matches: &clap::ArgMatches) -> Option<Vec<String>> {
 
 /// Discover the dotfiles root directory.
 fn discover_dotfiles_root() -> Result<PathBuf, anyhow::Error> {
-    // DOTFILES_ROOT env var
     if let Ok(root) = std::env::var("DOTFILES_ROOT") {
         let path = PathBuf::from(root);
         if path.exists() {
@@ -104,7 +99,6 @@ fn discover_dotfiles_root() -> Result<PathBuf, anyhow::Error> {
         }
     }
 
-    // Git toplevel
     if let Ok(output) = std::process::Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .output()
@@ -117,7 +111,6 @@ fn discover_dotfiles_root() -> Result<PathBuf, anyhow::Error> {
         }
     }
 
-    // CWD fallback
     let cwd = std::env::current_dir()?;
     Ok(cwd)
 }
@@ -291,10 +284,7 @@ pub fn probe_app_handler(
 /// §6 and `docs/proposals/magic.lex`. Exit code 0 = clean, 1 = at
 /// least one Patched / Conflict / Missing finding (or, in `--strict`
 /// mode, any unresolved dodot-conflict markers in template sources).
-///
-/// The non-zero exit code is set via [`PENDING_EXIT_CODE`] so the
-/// rendered report still prints normally; `main.rs` consults the
-/// atomic after dispatch and `std::process::exit`s if it's non-zero.
+/// The non-zero code is threaded out through [`PENDING_EXIT_CODE`].
 pub fn transform_check_handler(
     matches: &clap::ArgMatches,
     _ctx: &CommandContext,
@@ -527,7 +517,6 @@ pub fn config_passthrough(matches: &clap::ArgMatches) -> Result<(), anyhow::Erro
         .no_env()
         .handle_to_string(&action)?;
 
-    // Clean up clapfig's Debug-format leak: String("value") → "value"
     let cleaned = clean_debug_format(&output);
     print!("{cleaned}");
     Ok(())
@@ -537,7 +526,6 @@ pub fn config_passthrough(matches: &clap::ArgMatches) -> Result<(), anyhow::Erro
 /// Replaces `String("value")` with `"value"` in config list output.
 fn clean_debug_format(input: &str) -> String {
     let mut result = input.to_string();
-    // Iteratively replace String("...") with "..."
     while let Some(start) = result.find("String(\"") {
         let after_prefix = start + 8; // skip 'String("'
         if let Some(end_quote) = result[after_prefix..].find("\")") {
@@ -619,11 +607,10 @@ pub fn git_show_filters_handler(
 
 /// Post-`up` consolidated installer ladder.
 ///
-/// Replaces three sequential prompts (plist filter, hook, template
-/// filter) with a single Y/n covering whichever rungs apply. Spec:
-/// `docs/proposals/magic.lex` §"What This Costs the User" promises
-/// "one Y/n to install the clean/smudge filters and the pre-commit
-/// hook"; this function is the implementation.
+/// A single Y/n covering whichever of the three rungs (plist filter,
+/// hook, template filter) apply. Spec: `docs/proposals/magic.lex`
+/// §"What This Costs the User" — "one Y/n to install the clean/smudge
+/// filters and the pre-commit hook".
 ///
 /// Behavior:
 /// - **Yes** installs every applicable rung whose component dismissal
@@ -717,10 +704,9 @@ fn try_prompt_install_ladder() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    // A rung enters the ladder only when applicable AND its
-    // component dismissal isn't set. The component check lets the
-    // user opt out of a single rung (via `dodot prompts <key>`) while
-    // still hearing about the others.
+    // The per-component dismissal check lets the user opt out of a
+    // single rung (via `dodot prompts <key>`) while still hearing
+    // about the others.
     let mut active_rungs: Vec<&LadderRung> = Vec::new();
     if hook_applicable && !registry.is_dismissed(RUNG_HOOK.component_key) {
         active_rungs.push(&RUNG_HOOK);
@@ -735,9 +721,6 @@ fn try_prompt_install_ladder() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    // Build the prompt body. Header summarises detection; bullet list
-    // enumerates what would be installed; closing line frames the
-    // ask.
     let mut body: Vec<String> = Vec::new();
     body.push("dodot can wire git up to handle the files in this repo:".into());
     for rung in &active_rungs {
@@ -766,11 +749,11 @@ fn try_prompt_install_ladder() -> Result<(), anyhow::Error> {
             // will offer the same prompt.
         }
         crate::interactive::YesNoShow::No => {
-            // Per #112: "no" dismisses every component key so
-            // subsequent `up` runs don't re-prompt. The umbrella
-            // `magic.install_ladder` key is also dismissed so a
-            // future rung becoming applicable doesn't unilaterally
-            // re-open the ladder against the user's wishes.
+            // "no" dismisses every component key so subsequent `up`
+            // runs don't re-prompt. The umbrella `magic.install_ladder`
+            // key is also dismissed so a future rung becoming
+            // applicable doesn't unilaterally re-open the ladder
+            // against the user's wishes.
             for rung in &active_rungs {
                 registry.dismiss(rung.component_key);
             }
@@ -806,14 +789,12 @@ fn install_ladder_yes(
         .any(|r| r.component_key == RUNG_TEMPLATE_FILTER.component_key);
 
     // Each rung is soft-fail: an error in one installer must not
-    // skip the others. The pre-three-prompts UX let the user
-    // accept/reject each rung independently; the consolidated
-    // ladder needs to preserve that "approved means tried" contract,
-    // because the rungs are operationally unrelated (the plist
-    // filter doesn't care whether the hook installed). Surface each
-    // failure to stderr so the user knows what didn't land, and
-    // only dismiss the catalog key on the success path so a failed
-    // rung re-prompts on the next `up`.
+    // skip the others. "Approved means tried" for every rung, because
+    // the rungs are operationally unrelated (the plist filter doesn't
+    // care whether the hook installed). Surface each failure to
+    // stderr so the user knows what didn't land, and only dismiss the
+    // catalog key on the success path so a failed rung re-prompts on
+    // the next `up`.
     if install_hook {
         match commands::transform::install_hook(ctx) {
             Ok(r) => {
@@ -939,7 +920,6 @@ pub fn maybe_prompt_invalidate_cfprefsd() {
 fn try_prompt_invalidate_cfprefsd() -> Result<(), anyhow::Error> {
     use dodot_lib::prompts::PromptRegistry;
 
-    // cfprefsd is macOS-only.
     if !cfg!(target_os = "macos") {
         return Ok(());
     }

--- a/crates/dodot-cli/src/help.rs
+++ b/crates/dodot-cli/src/help.rs
@@ -153,11 +153,9 @@ pub fn lookup(path: &str) -> &'static str {
     {
         return text;
     }
-    // Try shorter prefixes
     if let Some((parent, _)) = path.rsplit_once('.') {
         return lookup(parent);
     }
-    // Fall back to the top-level help
     HELP_TEXTS
         .iter()
         .find_map(|(k, v)| k.is_empty().then_some(*v))

--- a/crates/dodot-cli/src/help.rs
+++ b/crates/dodot-cli/src/help.rs
@@ -231,7 +231,6 @@ mod tests {
 
     #[test]
     fn lookup_falls_back_to_parent() {
-        // Unknown probe subcommand -> falls back to "probe"
         let got = lookup("probe.unknown-thing");
         let probe_text = HELP_TEXTS
             .iter()
@@ -249,8 +248,6 @@ mod tests {
 
     #[test]
     fn every_registered_command_has_help() {
-        // Sanity: each known command path resolves to its own text,
-        // not a parent fallback.
         for (path, expected) in HELP_TEXTS {
             assert_eq!(lookup(path), *expected, "path {path:?} should self-match");
         }
@@ -266,7 +263,6 @@ mod tests {
         for (name, body) in HELP_TEXTS {
             let display_name = if name.is_empty() { "<top-level>" } else { name };
             let rendered = render(body, OutputMode::TermDebug);
-            // Any `[foo?]` indicates a tag the theme doesn't know.
             for (lineno, line) in rendered.lines().enumerate() {
                 assert!(
                     !line.contains("?]"),

--- a/crates/dodot-cli/src/interactive.rs
+++ b/crates/dodot-cli/src/interactive.rs
@@ -10,8 +10,8 @@ use std::io::{self, BufRead, IsTerminal, Write};
 pub enum YesNoShow {
     /// User wants to proceed.
     Yes,
-    /// User declined; caller should NOT mark the prompt dismissed
-    /// (so it fires again next time).
+    /// User declined. What that means for dismissal is the caller's
+    /// policy, documented per prompt.
     No,
     /// User wants to inspect the underlying config without committing.
     Show,

--- a/crates/dodot-cli/src/logging.rs
+++ b/crates/dodot-cli/src/logging.rs
@@ -33,7 +33,6 @@ pub enum Verbosity {
 /// Returns a `WorkerGuard` that must be kept alive until process exit to
 /// ensure buffered log lines are flushed on shutdown.
 pub fn init(log_dir: &Path, verbosity: Verbosity) -> tracing_appender::non_blocking::WorkerGuard {
-    // Ensure the log directory exists; fall back to a temp dir on failure.
     let log_dir = if fs::create_dir_all(log_dir).is_ok() {
         log_dir.to_path_buf()
     } else {
@@ -102,7 +101,6 @@ fn cleanup_old_logs(log_dir: &Path, max_age_days: u64) {
     for entry in entries.flatten() {
         let path = entry.path();
 
-        // Only clean up dodot log files
         let name = match path.file_name().and_then(|n| n.to_str()) {
             Some(n) if n.starts_with("dodot.log") => n,
             _ => continue,

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -71,7 +71,6 @@ fn main() {
         }
     }
 
-    // Initialize logging based on CLI flags
     let verbosity = if matches.get_flag("debug") {
         logging::Verbosity::Debug
     } else if matches.get_flag("verbose") {
@@ -86,8 +85,8 @@ fn main() {
 
     // Passthrough: config (clapfig handles its own output)
     if let Some(("config", sub_matches)) = matches.subcommand() {
-        // If no config subcommand given, show config help instead of
-        // falling through to config list (#20)
+        // With no config subcommand, show config help instead of
+        // falling through to config list.
         if sub_matches.subcommand().is_none() {
             let cmd = build_clap_command();
             let config_cmd = cmd
@@ -143,28 +142,16 @@ fn main() {
             println!("{output}");
             // Post-up nudges. Both fire only after a successful `up`
             // and are soft (failures land in the debug log, never
-            // stderr).
-            //
-            // - `maybe_prompt_install_ladder`: single Y/n covering
-            //   the pre-commit hook + plist filter + template filter
-            //   (whichever apply). Replaces the earlier three
-            //   sequential prompts. See magic.lex §"What This Costs
-            //   the User" and #112.
-            //
-            // - `maybe_prompt_invalidate_cfprefsd` (macOS only):
-            //   fires when `up` detected a plist change relative to
-            //   the previous run. Offers `killall cfprefsd` so
-            //   running apps re-read the new values. See plists.lex
-            //   §6.4 and #109.
+            // stderr); each handler's docstring covers what it offers
+            // and when it applies.
             if subcommand.as_deref() == Some("up") {
                 handlers::maybe_prompt_install_ladder();
                 handlers::maybe_prompt_invalidate_cfprefsd();
             }
             // `dodot transform check` may have set a non-zero exit code
-            // via PENDING_EXIT_CODE: the report still rendered above,
-            // but findings are present and the pre-commit hook (R4) is
-            // counting on the process to exit 1. Read after print so
-            // the user sees the report even when we're about to exit.
+            // via PENDING_EXIT_CODE; the pre-commit hook counts on the
+            // process exiting 1. Read after print so the user still
+            // sees the rendered report when we're about to exit.
             let pending = handlers::PENDING_EXIT_CODE.load(std::sync::atomic::Ordering::Relaxed);
             if pending != 0 {
                 std::process::exit(pending);
@@ -172,7 +159,6 @@ fn main() {
         }
         standout::cli::RunResult::Silent => {}
         standout::cli::RunResult::NoMatch(_) => {
-            // No subcommand given — show help
             let _ = build_clap_command().print_help();
             println!();
         }
@@ -183,13 +169,11 @@ fn main() {
             );
             std::process::exit(1);
         }
-        // Handler / hook / output-write errors. standout 7.6.2's
-        // `RunResult::Error` carries the formatted error string; we
-        // print to stderr and exit non-zero so scripts piping with `&&`
-        // and CI invocations see failure correctly. Pre-7.6.2 these
-        // were misclassified as `Handled`, silently exiting 0 — fixes
-        // every standout-dispatched subcommand at once
-        // (status, up, down, list, init, fill, adopt, addignore, probe …).
+        // Handler / hook / output-write errors. standout's
+        // `RunResult::Error` carries the formatted error string; print
+        // it to stderr and exit non-zero so scripts piping with `&&`
+        // and CI invocations see the failure. Needs standout >= 7.6.2 —
+        // earlier versions reported these as `Handled` and exited 0.
         standout::cli::RunResult::Error(msg) => {
             eprintln!("{msg}");
             std::process::exit(1);

--- a/crates/dodot-cli/src/tutorial.rs
+++ b/crates/dodot-cli/src/tutorial.rs
@@ -895,7 +895,6 @@ mod tests {
 
         let out = String::from_utf8(buf).unwrap();
 
-        // The driver visited every step we expected.
         assert!(out.contains("Welcome to dodot"), "missing intro: {out}");
         assert!(
             out.contains("Step 1 — find your dotfiles repo"),
@@ -915,14 +914,12 @@ mod tests {
         );
         assert!(out.contains("You're set up."), "missing outro: {out}");
 
-        // No prompt answers should be left over.
         assert_eq!(
             prompts.remaining(),
             0,
             "tutorial consumed fewer prompts than scripted"
         );
 
-        // Pack actually got deployed — symlink chain exists.
         let user_target = temp.config_home.join("vim").join("vimrc");
         assert!(
             temp.fs.is_symlink(&user_target),
@@ -949,7 +946,6 @@ mod tests {
         let mut buf: Vec<u8> = Vec::new();
         run_with_prompts(&env, opts_text(), &prompts, &mut buf).unwrap();
 
-        // Pack was not deployed.
         let user_target = temp.config_home.join("vim").join("vimrc");
         assert!(
             !temp.fs.exists(&user_target),

--- a/crates/dodot-lib/src/commands/addignore.rs
+++ b/crates/dodot-lib/src/commands/addignore.rs
@@ -36,7 +36,6 @@ pub fn addignore(pack_name: &str, ctx: &ExecutionContext) -> Result<AddIgnoreRes
 
     ctx.fs.write_file(&ignore_path, b"")?;
 
-    // Check if pack is currently deployed and warn (#18)
     let handlers = ctx.datastore.list_pack_handlers(&pack_dir)?;
     let mut details = vec![format!("Created {}", ignore_path.display())];
     if !handlers.is_empty() {

--- a/crates/dodot-lib/src/commands/adopt/infer.rs
+++ b/crates/dodot-lib/src/commands/adopt/infer.rs
@@ -23,7 +23,7 @@
 //! - `$HOME/.<X>` (file) — in-pack `home.<X>` (round-trips via Priority 1).
 //! - `$HOME/.<X>/...` (dir) — in-pack `_home/<X>/...` (round-trips via
 //!   Priority 2's `_home/` directory prefix).
-//! - `~/Library/Application Support/<X>/<rest>` (macOS, future) — pack
+//! - `~/Library/Application Support/<X>/<rest>` (macOS) — pack
 //!   `<X>`, in-pack `_app/<X>/<rest>` (round-trips via Priority 2's
 //!   `_app/` prefix per `docs/proposals/macos-paths.lex`).
 //!
@@ -41,7 +41,7 @@
 //! - HOME source: the `home.X` and `_home/X/` prefixes are pack-name
 //!   independent already, so the override-aware path equals the natural
 //!   path. Override changes only the *pack* the file lands in.
-//! - AppSupport source, override differs (future): use `_app/<X>/<rest>`.
+//! - AppSupport source, override differs: use `_app/<X>/<rest>`.
 //!
 //! ## Why HOME sources don't infer a pack name
 //!
@@ -409,8 +409,7 @@ fn resolve_app_support_relative(
 
     if rest_path.as_os_str().is_empty() {
         // Sole component: source IS the app's top-level Application
-        // Support directory. A directory expands; a loose file is
-        // refused (same shape as XDG's LooseXdgFile case).
+        // Support directory.
         if is_dir {
             return Ok(InferredTarget {
                 natural_pack: Some(first.clone()),
@@ -460,9 +459,6 @@ fn resolve_library_relative(rel: &Path, is_dir: bool) -> Result<InferredTarget, 
 
     let in_pack = PathBuf::from("_lib").join(rel);
     Ok(InferredTarget {
-        // No natural pack name to mine — bundle IDs and folder names
-        // like `Preferences`, `LaunchAgents` are not pack-shaped.
-        // Caller must supply `--into <pack>`.
         natural_pack: None,
         in_pack_natural: in_pack.clone(),
         in_pack_override: in_pack,
@@ -516,9 +512,6 @@ fn resolve_home_relative(
 
     // Delegate to the string-shaped helper so both inference and the
     // round-trip property test go through the same convention table.
-    // `derive_home_in_pack` returns `force_home`-bare-name, `home.X`,
-    // `_home/X`, or a "non-dotted refused" error — exactly the shape we
-    // need here.
     let stripped = first.strip_prefix('.').unwrap_or(&first);
     let in_pack_str = derive_home_in_pack(&first, is_dir, force_home).map_err(|_| {
         InferenceError::NonDottedHome {
@@ -610,7 +603,6 @@ pub(crate) fn is_gui_app_folder(name: &str) -> bool {
     if name.contains(' ') {
         return true;
     }
-    // Reverse-DNS: ≥2 dotted segments, every segment non-empty.
     let segments: Vec<&str> = name.split('.').collect();
     if segments.len() >= 2 && segments.iter().all(|s| !s.is_empty()) {
         return true;
@@ -628,8 +620,7 @@ pub(crate) fn is_gui_app_folder(name: &str) -> bool {
 /// Returns `Err(reason)` when the source has no automatic round-trip
 /// path — currently the non-dotted-non-force_home case. The inference
 /// entry point translates the same situation into a richer
-/// `InferenceError::NonDottedHome`; this thinner string-error variant
-/// matches the original `derive_pack_filename` shape.
+/// `InferenceError::NonDottedHome`.
 pub(crate) fn derive_home_in_pack(
     file_name: &str,
     is_dir: bool,

--- a/crates/dodot-lib/src/commands/adopt/infer.rs
+++ b/crates/dodot-lib/src/commands/adopt/infer.rs
@@ -845,7 +845,6 @@ mod tests {
         // an XDG-rooted source's path also starts with HOME. Inference
         // must pick the *more specific* root (XDG) — checking HOME
         // first would produce a useless "nested under $HOME" verdict.
-        // This test pins that ordering as a regression guard.
         let p = pather("/u", "/u/.config");
         let t = infer_target(Path::new("/u/.config/nvim/init.lua"), false, &p, &[]).unwrap();
         assert_eq!(t.source_root, SourceRoot::XdgConfig);

--- a/crates/dodot-lib/src/commands/adopt/mod.rs
+++ b/crates/dodot-lib/src/commands/adopt/mod.rs
@@ -77,7 +77,6 @@ pub(crate) use self::infer::derive_home_in_pack as derive_pack_filename;
 struct AdoptPlan {
     /// The resolved source (post --no-follow handling).
     source: PathBuf,
-    /// Destination inside the pack.
     pack_dest: PathBuf,
     /// `true` if the source is a directory (after --no-follow resolution).
     is_dir: bool,
@@ -98,11 +97,10 @@ struct AdoptPlan {
 /// `None` lets per-source inference decide. See the module-level docs
 /// for the inference rules and two-phase failure semantics.
 ///
-/// `only_os` is `Some(label)` when the user passed `--only-os <label>`
-/// (Phase C5 of the conditional-running proposal). Each source's
-/// in-pack path is prepended with a `_<label>/` gate-dir segment so
-/// re-deploying via `dodot up` will only land the symlink on hosts
-/// matching the gate predicate. The label is validated against the
+/// `only_os` is `Some(label)` when the user passed `--only-os <label>`.
+/// Each source's in-pack path is prepended with a `_<label>/` gate-dir
+/// segment so re-deploying via `dodot up` will only land the symlink on
+/// hosts matching the gate predicate. The label is validated against the
 /// gate table (built-ins + user `[gates]`) at the root level.
 pub fn adopt(
     pack_override: Option<&str>,
@@ -136,16 +134,9 @@ pub fn adopt(
 
     // ── Resolve pack: per-source inference, then aggregate ───────────
     //
-    // Each source contributes a candidate pack name (its naturally-inferred
-    // pack, or None if the source root has no pack structure). We require
-    // exactly one pack per adopt invocation:
-    //
-    //   - All sources agree on a single inferred name → use it.
-    //   - Sources disagree → refuse; ask the user to split or use --into.
-    //   - All sources decline (HOME-only) → require --into.
-    //   - --into supplied → it wins regardless of inference.
-    //
-    // The single-pack constraint keeps the result shape (one
+    // Exactly one pack per adopt invocation (see
+    // `resolve_pack_for_sources` for how candidates aggregate). The
+    // single-pack constraint keeps the result shape (one
     // PackStatusResult) and the conflict-check semantics simple. Future
     // work can lift this to multi-pack invocations once the result
     // structure supports it.
@@ -157,10 +148,8 @@ pub fn adopt(
 
     // ── Auto-create the pack if inferred and missing ─────────────────
     //
-    // Inferred-but-absent packs are created as empty directories. The
-    // explicit `--into` path goes through `resolve_pack_dir_name` and
-    // errors on miss instead — that's the typo-guard the user opted
-    // into by naming a specific pack.
+    // Only inferred names reach here: an explicit `--into` naming a
+    // missing pack already errored in `resolve_pack_for_sources`.
     if !ctx.fs.exists(&pack_path) {
         ctx.fs.mkdir_all(&pack_path)?;
     }
@@ -225,17 +214,12 @@ pub fn adopt(
         result.warnings.push(msg);
     }
 
-    // M5 capitalization-heuristic advisory + M6 brew enrichment.
+    // Capitalization-heuristic advisory (M5) + brew enrichment (M6).
     //
     // Both gate on the same precondition (at least one AppSupport
     // source) and consume the same brew probe data (the matching
-    // installed-cask token for the pack name). They were separate
-    // blocks pre-cask-aware-rename — the consolidation here lets the
-    // M5 rename suggestion *prefer the cask token* over a
-    // whitespace-stripped-lowercase folder name, which matters for
-    // reverse-DNS bundle IDs (`com.colliderli.iina` → `iina`, not
-    // `comcolliderliiina`). See `docs/proposals/macos-paths.lex`
-    // §8.1–§8.2.
+    // installed-cask token for the pack name). See
+    // `docs/proposals/macos-paths.lex` §8.1–§8.2.
     //
     // Resolver/pack-tree state is unaffected throughout — these are
     // purely user-facing strings on `PackStatusResult.warnings`.
@@ -563,7 +547,7 @@ fn preflight(
         // Already-adopted detection: source is a symlink whose target lives
         // inside the dotfiles root or the data dir.
         //
-        // #44: distinguish two sub-cases so the user knows what to do next:
+        // Two sub-cases, distinguished so the user knows what to do next:
         //
         // - `target.starts_with(&data_dir)` — fully managed via dodot's
         //   chain (`user_path → data_link → source`). Nothing to do.
@@ -614,21 +598,20 @@ fn preflight(
             smeta.is_dir
         };
 
-        // ── Inference: source-root match + in-pack path computation ──
         let inferred =
             infer_target(&abs, is_dir, ctx.paths.as_ref(), &force_home).map_err(|reason| {
                 DodotError::Other(format!("refusing to adopt {}: {reason}", abs.display()))
             })?;
 
         // Pick the override-aware encoding when --into changed the pack
-        // name. This keeps `_xdg/<X>/...` (and the future `_app/<X>/...`)
+        // name. This keeps `_xdg/<X>/...` and `_app/<X>/...`
         // round-trip-correct even when the user reroutes the file into
         // a different pack than its source-root segment suggests.
         let in_pack = match (&inferred.natural_pack, pack_override) {
             (Some(natural), Some(over)) if natural != over => inferred.in_pack_override.clone(),
             _ => inferred.in_pack_natural.clone(),
         };
-        // C5: `--only-os <label>` wraps the entry in a `_<label>/`
+        // `--only-os <label>` wraps the entry in a `_<label>/`
         // gate dir so the deployed symlink only lands on matching
         // hosts. The wrap composes with routing prefixes (`_home/`,
         // `_xdg/`, ...) — those still work after the gate dir strips
@@ -640,9 +623,9 @@ fn preflight(
         };
 
         if inferred.expand_children {
-            // Source IS a pack-root directory under XDG (or AppSupport
-            // future) — enumerate children and adopt each as a top-level
-            // pack entry. This is the "I want this whole `~/.config/nvim/`
+            // Source IS a pack-root directory under XDG (or AppSupport)
+            // — enumerate children and adopt each as a top-level pack
+            // entry. This is the "I want this whole `~/.config/nvim/`
             // to become the `nvim` pack" ergonomic.
             //
             // Override-aware: if `--into` rerouted the destination pack
@@ -658,7 +641,7 @@ fn preflight(
             let entries = fs.read_dir(&abs)?;
             for entry in entries {
                 let child_in_pack = expand_child_in_pack(&inferred, &entry.name, override_differs);
-                // C5: same gate-dir wrap as the single-source path.
+                // Same gate-dir wrap as the single-source path.
                 let child_in_pack = if let Some(label) = only_os {
                     std::path::PathBuf::from(format!("_{label}")).join(&child_in_pack)
                 } else {
@@ -718,9 +701,9 @@ fn preflight(
 /// When `override_differs` is false (no override, or override matches
 /// inferred name), the natural-pack encoding wins: bare `<child>` for
 /// XDG (default rule routes back via the matching pack name), and
-/// `_app/<X>/<child>` for AppSupport (default rule routes through
-/// `$XDG`, not `app_support_dir`, so the prefix is mandatory even at
-/// natural pack name — see `docs/proposals/macos-paths.lex` §7.2).
+/// `_app/<X>/<child>` for AppSupport (the `_app/` prefix is mandatory
+/// even at natural pack name — see `docs/proposals/macos-paths.lex`
+/// §7.2).
 fn expand_child_in_pack(
     parent: &InferredTarget,
     child_name: &str,
@@ -739,9 +722,8 @@ fn expand_child_in_pack(
         }
         SourceRoot::AppSupport => {
             // `parent.in_pack_override` is `_app/<X>` for the dir itself.
-            // AppSupport always needs the prefix (see §7.2 note), so the
-            // override flag doesn't change behavior here. Reserved for
-            // when Pather exposes app_support_dir() per macos-paths M1.
+            // AppSupport always needs the prefix, so the override flag
+            // doesn't change behavior here.
             parent.in_pack_override.join(child_name)
         }
         SourceRoot::Home => {
@@ -837,8 +819,8 @@ fn push_plan(
 }
 
 /// Resolve a possibly-relative path to an absolute, lexically-normalized one.
-/// Mirrors the original adopt behavior: relative inputs resolve against
-/// CWD, then `..` and `.` are collapsed without touching the filesystem.
+/// Relative inputs resolve against CWD, then `..` and `.` are collapsed
+/// without touching the filesystem.
 fn absolutize(raw: &Path) -> Result<PathBuf> {
     let abs = if raw.is_absolute() {
         raw.to_path_buf()
@@ -904,7 +886,6 @@ fn copy_all(plans: &[AdoptPlan], fs: &dyn Fs) -> Result<()> {
                 return Err(e);
             }
         } else {
-            // No existing destination: copy directly.
             copy_tree(&plan.source, &plan.pack_dest, fs)?;
         }
     }
@@ -1036,7 +1017,6 @@ fn swap_file_atomic(source: &Path, pack_dest: &Path, fs: &dyn Fs) -> Result<()> 
     let tmp = temp_sibling(source, "tmp");
     fs.symlink(pack_dest, &tmp)?;
     if let Err(e) = fs.rename(&tmp, source) {
-        // Clean up temp link before returning.
         let _ = fs.remove_file(&tmp);
         return Err(e);
     }
@@ -1050,12 +1030,10 @@ fn swap_dir(source: &Path, pack_dest: &Path, fs: &dyn Fs) -> Result<()> {
     fs.rename(source, &backup)?;
     match fs.symlink(pack_dest, source) {
         Ok(()) => {
-            // Best-effort cleanup of the backup directory.
             let _ = fs.remove_dir_all(&backup);
             Ok(())
         }
         Err(e) => {
-            // Restore original on failure.
             let _ = fs.rename(&backup, source);
             Err(e)
         }

--- a/crates/dodot-lib/src/commands/adopt/mod.rs
+++ b/crates/dodot-lib/src/commands/adopt/mod.rs
@@ -674,7 +674,7 @@ fn preflight(
 
     // Permission pre-flight. We do this after planning so every error up to
     // this point gives precise guidance; perms check catches late issues.
-    let _ = pack_name; // reserved for future per-pack perm messages
+    let _ = pack_name;
     check_writable(fs, pack_path)?;
     for plan in &plans {
         // Pass the plan's `is_dir` (already resolved with `--no-follow`

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -23,7 +23,6 @@ use crate::Result;
 pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<PackStatusResult> {
     info!(dry_run = ctx.dry_run, "starting down command");
 
-    // Validate pack names before doing anything
     let mut warnings = Vec::new();
     if let Some(names) = pack_filter {
         warnings = orchestration::validate_pack_names(names, ctx)?;
@@ -89,8 +88,6 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         orchestration::sweep_ignored_state(&ignored.sweep_dir_names, ctx)?;
     }
 
-    // Regenerate shell init script and deployment map (now reflecting
-    // the removed state).
     if !ctx.dry_run {
         info!("regenerating shell init script");
         shell::write_init_script(

--- a/crates/dodot-lib/src/commands/fill.rs
+++ b/crates/dodot-lib/src/commands/fill.rs
@@ -1,7 +1,7 @@
 //! `fill` command — add placeholder files to an existing pack.
 //!
 //! Creates template files for each configured handler pattern so the
-//! user has a starting point. Files that already exist are skipped.
+//! user has a starting point.
 
 use serde::Serialize;
 
@@ -75,8 +75,6 @@ echo "Installing PACK_NAME..."
 /// Skips files that already exist. Replaces `PACK_NAME` in templates
 /// with the actual pack name.
 pub fn fill(pack_name: &str, ctx: &ExecutionContext) -> Result<FillResult> {
-    // Resolve the user's input (display or raw on-disk name) to the
-    // actual directory.
     let pack_dir = orchestration::resolve_pack_dir_name(pack_name, ctx)?;
     let pack_path = ctx.paths.pack_path(&pack_dir);
 
@@ -104,7 +102,6 @@ pub fn fill(pack_name: &str, ctx: &ExecutionContext) -> Result<FillResult> {
         let content = template.content.replace("PACK_NAME", display);
         ctx.fs.write_file(&file_path, content.as_bytes())?;
 
-        // Make install.sh executable
         if template.filename.ends_with(".sh") {
             ctx.fs.set_permissions(&file_path, 0o755)?;
         }

--- a/crates/dodot-lib/src/commands/fill.rs
+++ b/crates/dodot-lib/src/commands/fill.rs
@@ -184,7 +184,6 @@ mod tests {
         env.assert_exists(&env.dotfiles_root.join("vim/aliases.sh"));
         env.assert_exists(&env.dotfiles_root.join("vim/Brewfile"));
 
-        // install.sh should contain pack name
         let content = env
             .fs
             .read_to_string(&env.dotfiles_root.join("vim/install.sh"))
@@ -203,14 +202,12 @@ mod tests {
         let ctx = make_ctx(&env);
 
         let result = fill("vim", &ctx).unwrap();
-        // Only 2 created (aliases.sh + Brewfile), install.sh skipped
         assert!(result.message.contains("2 template"));
         assert!(result
             .details
             .iter()
             .any(|d| d.contains("install.sh") && d.contains("skipped")));
 
-        // Original content preserved
         let content = env
             .fs
             .read_to_string(&env.dotfiles_root.join("vim/install.sh"))

--- a/crates/dodot-lib/src/commands/git_alias.rs
+++ b/crates/dodot-lib/src/commands/git_alias.rs
@@ -310,10 +310,8 @@ pub fn resolve_shell(explicit: Option<&str>) -> Result<Shell> {
     })
 }
 
-/// Cheap "is this rc file already wrapping git via our alias?"
-/// check, used by the future post-`up` prompt. Reads the rc file
-/// and looks for the guard. Doesn't error out if the file is
-/// missing — that's a normal "not installed" state.
+/// Checks whether this shell's rc file already wraps git via dodot's alias.
+/// A missing file is the normal "not installed" state.
 pub fn is_installed(ctx: &ExecutionContext, shell: Shell) -> bool {
     let rc_path = ctx.paths.home_dir().join(shell.rc_relative_path());
     if !ctx.fs.exists(&rc_path) {

--- a/crates/dodot-lib/src/commands/git_alias.rs
+++ b/crates/dodot-lib/src/commands/git_alias.rs
@@ -1,10 +1,10 @@
 //! `dodot git-show-alias` and `dodot git-install-alias` — the
 //! Tier 2 shell-side glue for the template-magic flow.
 //!
-//! Tier 1 (R4) gets you commit-time correctness via the pre-commit
+//! Tier 1 gets you commit-time correctness via the pre-commit
 //! hook. Tier 2 makes interactive `git status` and `git diff` show
 //! the truth between commits too, by wrapping git in a shell alias
-//! that runs `dodot refresh --quiet` first. The clean filter (R6)
+//! that runs `dodot refresh --quiet` first. The clean filter
 //! does the heavy lifting once the source mtime is fresh; this
 //! alias is what nudges the mtime on every interactive git
 //! invocation.
@@ -53,11 +53,6 @@ impl Shell {
     /// or names a shell we don't support — the caller (typically
     /// [`resolve_shell`]) surfaces a clear error rather than
     /// silently writing a bashrc snippet for a fish/nu user.
-    ///
-    /// Why fail explicitly: silently falling back to `Bash` means
-    /// `dodot git-install-alias` happily writes `~/.bashrc` for a
-    /// fish user, who then never sees the alias take effect.
-    /// Better to refuse with a message that points at `--shell`.
     pub fn detect() -> Option<Self> {
         std::env::var("SHELL").ok().and_then(|s| {
             if s.ends_with("/zsh") || s == "zsh" {

--- a/crates/dodot-lib/src/commands/git_alias.rs
+++ b/crates/dodot-lib/src/commands/git_alias.rs
@@ -400,8 +400,6 @@ mod tests {
 
     #[test]
     fn alias_line_runs_refresh_then_command_git() {
-        // Both shells use the same alias body for now; pin the
-        // exact form so a stray edit doesn't break the wrap.
         for sh in [Shell::Bash, Shell::Zsh] {
             assert_eq!(
                 sh.alias_line(),
@@ -427,14 +425,8 @@ mod tests {
         assert_eq!(resolve_shell(Some("Zsh")).unwrap(), Shell::Zsh);
     }
 
-    // Env-driven detect/resolve_shell tests use the shared
-    // `ShellEnvGuard` from `crate::testing`. The guard is RAII
-    // (restores `$SHELL` on drop, including on panic) AND holds a
-    // process-wide mutex, so any test in the binary touching
-    // `$SHELL` is serialised. We can split these into one
-    // `#[test]` per scenario again, since the guard handles both
-    // the panic-safety and cross-test-races concerns Copilot
-    // raised on R8.
+    // `ShellEnvGuard` restores `$SHELL` on drop and serialises all tests
+    // in the binary that mutate it.
 
     use crate::testing::ShellEnvGuard;
 
@@ -452,17 +444,14 @@ mod tests {
 
     #[test]
     fn detect_returns_none_for_unknown_shell() {
-        // fish/nu/etc. don't auto-detect — the caller must `--shell`.
         let _g = ShellEnvGuard::set("/usr/bin/fish");
         assert_eq!(Shell::detect(), None);
     }
 
     #[test]
     fn resolve_shell_no_explicit_unsupported_shell_errors() {
-        // The PR-review fix from R7: a fish/nu user running
-        // `dodot git-show-alias` (no --shell) gets a clear error
-        // pointing at `--shell bash|zsh`, NOT a silent fall-
-        // through to bash that writes a useless ~/.bashrc.
+        // Unsupported shells require an explicit supported `--shell`
+        // instead of silently falling through to bash.
         let _g = ShellEnvGuard::set("/usr/bin/fish");
         let err = resolve_shell(None).unwrap_err();
         let msg = format!("{err}");
@@ -472,8 +461,6 @@ mod tests {
 
     #[test]
     fn resolve_shell_no_explicit_unset_shell_errors() {
-        // $SHELL unset entirely. Same disposition: clear pointer
-        // at --shell.
         let _g = ShellEnvGuard::unset();
         let err = resolve_shell(None).unwrap_err();
         let msg = format!("{err}");
@@ -593,12 +580,9 @@ mod tests {
         assert!(matches!(r.outcome, InstallAliasOutcome::Updated));
 
         let body = env.fs.read_to_string(&rc_path).unwrap();
-        // New shape:
         assert!(body.contains(Shell::Zsh.alias_line()));
-        // User content (before AND after the block) survived:
         assert!(body.contains("export PATH"));
         assert!(body.contains("alias ll='ls -l'"));
-        // Exactly one managed block.
         assert_eq!(body.matches(ALIAS_GUARD_START).count(), 1);
     }
 
@@ -609,7 +593,6 @@ mod tests {
         assert!(!is_installed(&ctx, Shell::Bash));
         install_alias(&ctx, Shell::Bash).unwrap();
         assert!(is_installed(&ctx, Shell::Bash));
-        // The other shell's state is independent.
         assert!(!is_installed(&ctx, Shell::Zsh));
     }
 
@@ -626,7 +609,6 @@ mod tests {
         assert!(r.alias_block.contains(Shell::Zsh.alias_line()));
         assert_eq!(r.rc_path_display, "~/.zshrc");
         assert!(!r.already_installed);
-        // Critically: file must NOT have been created.
         assert!(!env.fs.exists(&rc_path));
     }
 

--- a/crates/dodot-lib/src/commands/git_filters.rs
+++ b/crates/dodot-lib/src/commands/git_filters.rs
@@ -642,7 +642,6 @@ mod tests {
 
     #[test]
     fn normalize_plist_extensions_strips_lowercases_dedupes_and_filters() {
-        // Trims, strips a leading `.`, lowercases.
         assert_eq!(
             normalize_plist_extensions(&[
                 "plist".into(),
@@ -655,7 +654,6 @@ mod tests {
              to a single canonical entry"
         );
 
-        // Filters empty / whitespace-only.
         assert!(normalize_plist_extensions(&["".into(), "   ".into(), ".".into()]).is_empty());
 
         // Rejects shell metacharacters, path separators, glob chars,
@@ -676,7 +674,6 @@ mod tests {
             "metacharacter-bearing entries must be dropped"
         );
 
-        // Real-world mix passes through cleanly.
         assert_eq!(
             normalize_plist_extensions(&[
                 "plist".into(),

--- a/crates/dodot-lib/src/commands/init.rs
+++ b/crates/dodot-lib/src/commands/init.rs
@@ -24,7 +24,6 @@ pub fn init(pack_name: &str, ctx: &ExecutionContext) -> Result<InitResult> {
 
     ctx.fs.mkdir_all(&pack_path)?;
 
-    // Write default .dodot.toml
     let config_content = format!(
         r#"# dodot configuration for {pack_name}
 # See: dodot config gen --help

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -185,7 +185,6 @@ pub struct DisplayNote {
 /// One claimant of a cross-pack conflict, formatted for display.
 #[derive(Debug, Clone, Serialize)]
 pub struct DisplayClaimant {
-    /// Pack name.
     pub pack: String,
     /// Short, pack-relative source description (e.g. `git/env.sh`).
     pub source: String,
@@ -251,7 +250,6 @@ fn pack_relative_source(source: &std::path::Path, pack: &str) -> String {
         let rel = &s[idx + 1..];
         return rel.to_string();
     }
-    // Fallback: pack/filename
     let fname = source
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())

--- a/crates/dodot-lib/src/commands/probe/mod.rs
+++ b/crates/dodot-lib/src/commands/probe/mod.rs
@@ -133,7 +133,6 @@ pub fn app(pack_name: &str, refresh: bool, ctx: &ExecutionContext) -> Result<Pro
                     folders.push((e.name.clone(), "force_app"));
                 }
             }
-            // _app/<X>/ subtree
             let app_dir = pack_path.join("_app");
             if ctx.fs.exists(&app_dir) {
                 if let Ok(children) = ctx.fs.read_dir(&app_dir) {

--- a/crates/dodot-lib/src/commands/probe/render.rs
+++ b/crates/dodot-lib/src/commands/probe/render.rs
@@ -64,9 +64,6 @@ pub(super) fn flatten_tree(
         return;
     }
 
-    // Extend the prefix for children. The root contributes no prefix
-    // characters; a last-child contributes "   "; an inner child
-    // contributes "│  ".
     let child_prefix = if is_root {
         String::new()
     } else if is_last {

--- a/crates/dodot-lib/src/commands/probe/shell_init.rs
+++ b/crates/dodot-lib/src/commands/probe/shell_init.rs
@@ -199,8 +199,6 @@ fn target_matches_filter(target: &str, filter: &str) -> bool {
             .file_name()
             .is_some_and(|s| s == std::ffi::OsStr::new(filter));
     }
-    // Subpath form: must end at a path boundary so `dir/env.sh` doesn't
-    // accidentally match `otherdir/env.sh`.
     target.ends_with(&format!("/{filter}")) || target == filter
 }
 
@@ -340,7 +338,6 @@ pub fn shell_init_errors(ctx: &ExecutionContext, runs: usize) -> Result<ProbeRes
     for profile in &profiles {
         let when = format_unix_ts(parse_unix_ts_from_filename(&profile.filename));
         for entry in &profile.entries {
-            // Errors-only: skip clean runs entirely.
             if entry.exit_status == 0 {
                 continue;
             }

--- a/crates/dodot-lib/src/commands/probe/shell_init.rs
+++ b/crates/dodot-lib/src/commands/probe/shell_init.rs
@@ -503,16 +503,13 @@ mod tests {
 
     #[test]
     fn format_unix_ts_handles_zero_and_out_of_range() {
-        // Sentinel for parse-failure → empty, not a date.
         assert_eq!(format_unix_ts(0), "");
-        // Real timestamp → formatted.
         assert_eq!(format_unix_ts(1_714_000_000), "2024-04-24 23:06");
         // Past year 9999 → empty (defensive ceiling so a tampered
         // filename doesn't produce a nonsense date or risk overflow
         // during the i64 cast on `days`).
         assert_eq!(format_unix_ts(u64::MAX), "");
         assert_eq!(format_unix_ts(253_402_300_800), ""); // 1s past year 9999.
-                                                         // Right below the ceiling still renders.
         assert_eq!(format_unix_ts(253_402_300_799), "9999-12-31 23:59");
     }
 }

--- a/crates/dodot-lib/src/commands/prompts.rs
+++ b/crates/dodot-lib/src/commands/prompts.rs
@@ -62,7 +62,7 @@ pub fn list(ctx: &ExecutionContext) -> Result<PromptsListResult> {
 
     // Surface any unknown keys lurking in the registry so they can be
     // reset. Catalog absence is not an error — older dodot versions
-    // may have written them. One pass over the dismissed map; cheap.
+    // may have written them.
     for (key, record) in registry.dismissed() {
         if catalog::lookup(key).is_none() {
             rows.push(PromptRow {

--- a/crates/dodot-lib/src/commands/refresh.rs
+++ b/crates/dodot-lib/src/commands/refresh.rs
@@ -271,7 +271,6 @@ mod tests {
 
     #[test]
     fn clean_state_is_a_noop() {
-        // baseline + source + deployed all line up. No mtime touched.
         let env = TempEnvironment::builder().build();
         let (src, _) = stage_one(&env, "app", "cfg.toml.tmpl", b"rendered", b"src");
         // Capture the source mtime before refresh; a no-op must not
@@ -288,14 +287,10 @@ mod tests {
 
     #[test]
     fn divergent_deployed_touches_source_mtime() {
-        // The core scenario: user edits the deployed file → source
-        // mtime gets bumped to match.
         let env = TempEnvironment::builder().build();
         let (src, deployed) = stage_one(&env, "app", "cfg.toml.tmpl", b"rendered", b"src");
 
-        // Edit the deployed file to a divergent value AFTER the
-        // baseline. Sleep briefly so the deployed mtime is strictly
-        // later than the source's.
+        // Ensure the deployed mtime is strictly later than the source.
         std::thread::sleep(std::time::Duration::from_millis(20));
         env.fs.write_file(&deployed, b"rendered EDITED").unwrap();
         let deployed_mtime = env.fs.modified(&deployed).unwrap();
@@ -306,7 +301,6 @@ mod tests {
         assert!(matches!(r.entries[0].action, RefreshAction::Touched));
         assert!(r.touched_any);
 
-        // Source mtime now equals the deployed mtime.
         let new_src_mtime = env.fs.modified(&src).unwrap();
         assert_eq!(new_src_mtime, deployed_mtime);
     }
@@ -330,7 +324,6 @@ mod tests {
         assert!(matches!(r.entries[0].action, RefreshAction::Touched));
         assert!(r.touched_any);
 
-        // mtime unchanged.
         assert_eq!(env.fs.modified(&src).unwrap(), before_src);
     }
 
@@ -357,7 +350,6 @@ mod tests {
         // removed the .tmpl). Refresh keeps going; the entry is
         // surfaced so the user knows the cache is stale.
         let env = TempEnvironment::builder().build();
-        // Stage a baseline whose source path doesn't exist on disk.
         let baseline = Baseline::build(
             &env.dotfiles_root.join("app/missing.toml.tmpl"),
             b"rendered",
@@ -374,7 +366,6 @@ mod tests {
                 "missing.toml",
             )
             .unwrap();
-        // Deployed file exists.
         let deployed = env
             .paths
             .data_dir()
@@ -405,7 +396,6 @@ mod tests {
                 "cfg.toml",
             )
             .unwrap();
-        // Don't lay down the deployed file.
 
         let ctx = make_ctx(&env);
         let r = refresh(&ctx, RefreshMode::Report).unwrap();
@@ -445,18 +435,14 @@ mod tests {
 
     #[test]
     fn divergent_with_equal_mtimes_still_bumps_source() {
-        // Edge case from PR review: if the deployed mtime happens to
-        // equal the source mtime (coarse FS, rapid edits within the
-        // same second), `set_modified(source, deployed_mtime)` would
+        // Coarse filesystems or rapid edits can leave deployed and
+        // source mtimes equal. `set_modified(source, deployed_mtime)` would
         // be a no-op — git's stat-cache wouldn't invalidate, and
         // refresh would silently fail at its core purpose. We bump
         // by 1s in that case so the source mtime *strictly* changes.
         let env = TempEnvironment::builder().build();
         let (src, deployed) = stage_one(&env, "app", "cfg.toml.tmpl", b"rendered", b"src");
 
-        // Force the deployed mtime to exactly match the current
-        // source mtime, then mutate the deployed bytes so refresh
-        // sees a divergence to act on.
         let pinned = env.fs.modified(&src).unwrap();
         env.fs.write_file(&deployed, b"rendered EDITED").unwrap();
         env.fs.set_modified(&deployed, pinned).unwrap();
@@ -466,8 +452,6 @@ mod tests {
         let r = refresh(&ctx, RefreshMode::Report).unwrap();
         assert!(matches!(r.entries[0].action, RefreshAction::Touched));
 
-        // Source mtime must STRICTLY exceed the original (no-op
-        // behaviour would leave it unchanged).
         let after = env.fs.modified(&src).unwrap();
         assert!(
             after > pinned,

--- a/crates/dodot-lib/src/commands/secret.rs
+++ b/crates/dodot-lib/src/commands/secret.rs
@@ -1,4 +1,4 @@
-//! `dodot secret` subcommands — Phase S5 ergonomics surface.
+//! `dodot secret` subcommands.
 //!
 //! Two read-only commands for inspecting the secrets configuration
 //! and template references without running `dodot up`:
@@ -12,9 +12,9 @@
 //!   invokes a provider.
 //!
 //! Both commands take an [`ExecutionContext`] (already built by the
-//! CLI handler), build the registry from root config (Phase S4
-//! contract: `[secret]` is root-only — see `SecretSection` docs),
-//! and return a serializable result for the standout renderer.
+//! CLI handler), build the registry from root config (`[secret]` is
+//! root-only — see `SecretSection` docs), and return a serializable
+//! result for the standout renderer.
 
 use serde::Serialize;
 

--- a/crates/dodot-lib/src/commands/secret.rs
+++ b/crates/dodot-lib/src/commands/secret.rs
@@ -608,7 +608,7 @@ c = "{{ secret("bw:gh-token") }}""#;
         // Malformed input shouldn't crash the scanner; the user
         // would get a MiniJinja parse error at render time.
         let text = r#"x = {{ secret("unterminated"#;
-        let _ = scan_secret_calls(text); // doesn't panic; we don't care what comes back
+        let _ = scan_secret_calls(text);
     }
 
     #[test]
@@ -628,9 +628,7 @@ c = "{{ secret("bw:gh-token") }}""#;
 
     #[test]
     fn list_skips_basename_gated_template() {
-        // Round-2 review feedback: `secret list` must skip files
-        // whose filename gate evaluates false on this host. Same
-        // posture as `dodot status`.
+        // Secret discovery follows the same host-gating posture as status.
         let gated = if cfg!(target_os = "macos") {
             "linux"
         } else if cfg!(target_os = "linux") {
@@ -660,7 +658,6 @@ enabled = true
         );
 
         let result = list(&ctx).unwrap();
-        // Only the unconditional template's reference should surface.
         let refs: Vec<&str> = result.rows.iter().map(|r| r.reference.as_str()).collect();
         assert!(
             refs.contains(&"pass:other"),
@@ -674,10 +671,7 @@ enabled = true
 
     #[test]
     fn list_recognises_gate_suffixed_template_extension() {
-        // Round-2 review feedback: `gitconfig.tmpl._darwin` should be
-        // recognised as a template (after stripping the gate
-        // suffix). Without the strip, the rightmost extension would
-        // be `_darwin`, not `tmpl`, and the file would be skipped.
+        // The gate suffix must be stripped before recognizing the template extension.
         let passing = if cfg!(target_os = "macos") {
             "darwin"
         } else if cfg!(target_os = "linux") {

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -51,8 +51,8 @@ enum Health {
     /// Run-once handler (install / homebrew) recorded a successful run
     /// for a *different* content hash than the file currently has on
     /// disk. The script has not been re-run automatically — the
-    /// notify-don't-rerun policy (#169 PR C) leaves the prior state in
-    /// place until the user passes `--provision-rerun`. `label` is the
+    /// notify-don't-rerun policy leaves the prior state in place
+    /// until the user passes `--provision-rerun`. `label` is the
     /// short status-column text (carries the per-handler "older
     /// version" copy plus a `(N+ M-)` line summary when a snapshot is
     /// on disk).
@@ -210,10 +210,10 @@ fn intent_display_name(
 /// Verify symlink handler chain for a single file.
 ///
 /// `user_target` is the resolved deploy path — provided by the caller
-/// (typically a [`HandlerIntent::Link`] from the planner). Status no
-/// longer re-derives it; doing so used to drift from the planner for
+/// (typically a [`HandlerIntent::Link`] from the planner). Status must
+/// not re-derive it: a second derivation drifts from the planner for
 /// escape-prefix dirs (`_home/`/`_xdg/`/`_app/`/`_lib/`), producing
-/// permanent "pending" rows for files the planner had successfully
+/// permanent "pending" rows for files the planner successfully
 /// deployed under a *different* path. Source of truth lives in
 /// `resolve_target`, called once per intent in the planner.
 ///
@@ -235,7 +235,6 @@ fn verify_symlink(
         .handler_data_dir(pack, HANDLER_SYMLINK)
         .join(filename);
 
-    // Step 1: Does the data link exist and is it a symlink?
     if !ctx.fs.is_symlink(&data_link) {
         if ctx.fs.exists(&data_link) {
             return Health::Broken("broken: data link exists but is not a symlink".into());
@@ -266,7 +265,6 @@ fn verify_symlink(
         return Health::Pending;
     }
 
-    // Step 2: Does data link point to the correct source?
     match ctx.fs.readlink(&data_link) {
         Ok(target) if target == source => {}
         Ok(target) => {
@@ -275,12 +273,10 @@ fn verify_symlink(
         Err(_) => return Health::Broken("broken: cannot read data link".into()),
     }
 
-    // Step 3: Does the source file still exist?
     if !ctx.fs.exists(source) {
         return Health::Broken("broken: source file missing".into());
     }
 
-    // Step 4: Check user link at the intent's target
     if ctx.fs.is_symlink(user_target) {
         match ctx.fs.readlink(user_target) {
             Ok(link_target) if link_target == data_link => {
@@ -303,8 +299,8 @@ fn verify_symlink(
             Health::Broken("conflict: non-symlink file at target path".into())
         }
     } else {
-        // No user link — data link exists but user link missing.
-        // This happens when config changed (drift) or deployment was interrupted.
+        // Data link exists but the user link is missing — config drift
+        // or an interrupted deployment.
         Health::Stale("stale: user link missing, re-deploy to fix".into())
     }
 }
@@ -454,9 +450,9 @@ fn run_once_health(
                 }
                 _ => {
                     // No snapshot on disk — sentinel predates the
-                    // snapshot convention (#169 PR C). Render the
-                    // state without a line summary so the user knows
-                    // a re-run is pending but not what changed.
+                    // snapshot convention. Render the state without a
+                    // line summary so the user knows a re-run is
+                    // pending but not what changed.
                     format!("{} (no diff data)", messages.ran_different)
                 }
             };
@@ -614,7 +610,6 @@ fn truncate_for_footnote(stderr: &str, budget: usize) -> String {
 pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<PackStatusResult> {
     info!("starting status command");
 
-    // Validate pack names before doing anything
     let mut warnings = Vec::new();
     if let Some(names) = pack_filter {
         warnings = orchestration::validate_pack_names(names, ctx)?;
@@ -651,7 +646,6 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
     // when `ctx.show_diff` is true and the row's snapshot is on disk.
     let mut diffs: Vec<DisplayDiff> = Vec::new();
 
-    // Collect intents across all packs for conflict detection
     let mut pack_intents = Vec::new();
     // Capture the active packs (post-filter, post-OS-gate) so the
     // optional `--check-drift` pass at the end of status() respects
@@ -664,7 +658,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;
         pack.config = pack_config.to_handler_config();
 
-        // C3: pack-level OS gate. Inactive packs surface in their own
+        // Pack-level OS gate. Inactive packs surface in their own
         // section ("inactive on this OS") and skip the per-file
         // walk/preprocess/match cycle entirely.
         if !crate::gates::pack_os_active(&pack_config.pack.os, host) {
@@ -768,13 +762,13 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         )?;
 
         // Collect intents for conflict detection AND drive symlink
-        // rendering off the same intents the executor sees. Without
-        // this, status re-walked matches and re-resolved targets in
-        // parallel — and drifted for escape-prefix dirs (`_app/` etc.),
-        // since matches are top-level entries but the planner expands
-        // those per-leaf. Driving display off intents collapses the
-        // two paths into one and makes "render through status" actually
-        // truthful for every file the executor touched.
+        // rendering off the same intents the executor sees. Re-walking
+        // matches and re-resolving targets in parallel drifts for
+        // escape-prefix dirs (`_app/` etc.), since matches are
+        // top-level entries but the planner expands those per-leaf.
+        // Driving display off intents collapses the two paths into one
+        // and makes "render through status" actually truthful for
+        // every file the executor touched.
         //
         // The first tuple element is the user-facing label that
         // surfaces in any resulting `DisplayConflict.claimants` entry,
@@ -910,9 +904,9 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         // recurses per-leaf, so this produces N rows where the matches
         // loop would have produced 1 wrongly-targeted row. For wholesale
         // dirs (`nvim`) and plain top-level files the planner produces
-        // exactly one intent, matching the old per-match output. `_lib/`
-        // on non-macOS yields zero intents (`Resolution::Skip`), so the
-        // old explicit `_lib/`-suppress branch is no longer needed.
+        // exactly one intent. `_lib/` on non-macOS yields zero intents
+        // (`Resolution::Skip`), so those rows drop out without an
+        // explicit suppress branch here.
         let home = ctx.paths.home_dir();
         let preprocessed_dir = ctx.paths.handler_data_dir(&pack.name, "preprocessed");
         for intent in &intents_for_pack {
@@ -952,7 +946,6 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         display_packs.push(DisplayPack::new(pack.display_name.clone(), files));
     }
 
-    // Detect and surface cross-pack conflicts as structured display data
     let detected_conflicts = conflicts::detect_cross_pack_conflicts(&pack_intents, ctx.fs.as_ref());
     let home = ctx.paths.home_dir();
     let display_conflicts: Vec<DisplayConflict> = detected_conflicts

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -1236,8 +1236,6 @@ mod tests {
             .build();
         let ctx = ctx_for(&env);
         let abs = env.dotfiles_root.join("vim/install.sh");
-        // Pre-create a sentinel for the *current* hash so did_run
-        // returns RanCurrent.
         let checksum = crate::handlers::run_once::file_checksum(env.fs.as_ref(), &abs).unwrap();
         let dir = env.paths.handler_data_dir("vim", HANDLER_INSTALL);
         env.fs.mkdir_all(&dir).unwrap();
@@ -1263,8 +1261,6 @@ mod tests {
         let ctx = ctx_for(&env);
         let abs = env.dotfiles_root.join("vim/install.sh");
 
-        // Previous-run sentinel for a different hash, plus its
-        // snapshot sibling — exactly what `run_and_record` writes.
         let dir = env.paths.handler_data_dir("vim", HANDLER_INSTALL);
         env.fs.mkdir_all(&dir).unwrap();
         env.fs
@@ -1292,7 +1288,6 @@ mod tests {
             }
             _ => panic!("expected RanOlderVersion"),
         }
-        // show_diff was false → no diff rows emitted.
         assert!(diffs.is_empty());
     }
 
@@ -1306,7 +1301,6 @@ mod tests {
         let ctx = ctx_for(&env);
         let abs = env.dotfiles_root.join("vim/install.sh");
 
-        // Pre-snapshot-era sentinel: no .snapshot sibling.
         let dir = env.paths.handler_data_dir("vim", HANDLER_INSTALL);
         env.fs.mkdir_all(&dir).unwrap();
         env.fs
@@ -1324,7 +1318,6 @@ mod tests {
             }
             _ => panic!("expected RanOlderVersion"),
         }
-        // Even with show_diff=true, no snapshot ⇒ no diff payload.
         assert!(
             diffs.is_empty(),
             "no snapshot should yield no diff entry, got {} entries",

--- a/crates/dodot-lib/src/commands/template_clean.rs
+++ b/crates/dodot-lib/src/commands/template_clean.rs
@@ -4,7 +4,7 @@
 //! This is what makes `git status` / `git diff` / `git log -p` show
 //! the truth between commits, even when the user has only edited the
 //! deployed file. Git invokes us when reading a working-tree file
-//! whose mtime suggests it might have changed (refresh — R5 — is the
+//! whose mtime suggests it might have changed (`dodot refresh` is the
 //! thing that nudges those mtimes); we look up the cached baseline,
 //! compare the deployed bytes to the baseline's rendered hash, and:
 //!
@@ -17,12 +17,12 @@
 //! 2. **Slow path**: if the deployed file diverges, rehydrate the
 //!    cached `TrackedRender::from_tracked_string` and run
 //!    `burgertocow::generate_diff_with_markers` (with our
-//!    `MARKER_*` constants from R2) against the deployed bytes.
+//!    `MARKER_*` constants) against the deployed bytes.
 //!    Apply the resulting diff to the template via diffy and emit
 //!    the patched form. Conflict blocks land inline.
 //!
 //! No provider calls, ever. The whole point of caching
-//! `tracked_render` in R1 is so this filter never re-renders — that
+//! `tracked_render` is so this filter never re-renders — that
 //! would re-trigger any `secret(...)` provider auth on every
 //! `git status`, the auth-fatigue scenario magic.lex specifically
 //! rules out.
@@ -137,8 +137,7 @@ pub fn template_clean(
     // deployed file would land as a diff that rewrites the template
     // expression to the literal new value — defeating the
     // `secret(...)` abstraction. See `secrets.lex` §3.3 +
-    // burgertocow#13. Absent sidecar = empty mask = byte-identical
-    // to pre-Phase-S2 behavior.
+    // burgertocow#13.
     let secret_ranges = SecretsSidecar::load(fs, paths, &pack, &handler, &filename)?
         .map(|s| s.secret_line_ranges)
         .unwrap_or_default();

--- a/crates/dodot-lib/src/commands/template_clean.rs
+++ b/crates/dodot-lib/src/commands/template_clean.rs
@@ -235,10 +235,7 @@ mod tests {
     use crate::testing::TempEnvironment;
     use burgertocow::Tracker;
 
-    /// Render a template through burgertocow the way R1's pipeline
-    /// does, so we get a tracked-render string that the filter will
-    /// be able to rehydrate. Mirrors the test helper in the
-    /// reverse_merge module.
+    /// Render a template and return the tracked string cached for rehydration.
     fn render(src: &str, ctx: serde_json::Value) -> (String, String) {
         let mut tracker = Tracker::new();
         tracker.add_template("t", src).unwrap();
@@ -246,9 +243,7 @@ mod tests {
         (tracked.output().to_string(), tracked.tracked().to_string())
     }
 
-    /// Stage a baseline + matching pack source + matching deployed
-    /// file. Returns the absolute paths so the test can edit either
-    /// side. Same shape as the helper in `commands::refresh::tests`.
+    /// Stage matching baseline, source, and deployed files.
     fn stage(
         env: &TempEnvironment,
         pack: &str,
@@ -473,12 +468,10 @@ mod tests {
         env.fs.write_file(&deployed, b"* a\n+ b\n- c\n").unwrap();
 
         let out = template_clean(env.fs.as_ref(), env.paths.as_ref(), template, &src, &[]).unwrap();
-        // Original template still present.
         assert!(
             out.contains("{% for i in items %}"),
             "original template must be retained: {out:?}"
         );
-        // Conflict block appended.
         assert!(
             out.contains(MARKER_START),
             "conflict block missing: {out:?}"
@@ -542,7 +535,6 @@ mod tests {
         env.fs.mkdir_all(deployed.parent().unwrap()).unwrap();
         env.fs.write_file(&deployed, b"name = EDITED\n").unwrap();
 
-        // Baseline with an empty tracked_render.
         let baseline = Baseline::build(&src, b"name = Alice\n", template.as_bytes(), None, None);
         baseline
             .write(
@@ -608,7 +600,6 @@ mod tests {
         let template = "name = {{ name }}\n";
         env.fs.write_file(&src, template.as_bytes()).unwrap();
 
-        // Lay down a corrupt baseline JSON (parse failure on load).
         let cache_path = env
             .paths
             .preprocessor_baseline_path("app", "preprocessed", "cfg");
@@ -617,7 +608,6 @@ mod tests {
 
         let mut stdin = std::io::Cursor::new(template.as_bytes().to_vec());
         let mut stdout: Vec<u8> = Vec::new();
-        // Must succeed — the inner Err is swallowed.
         template_clean_stdio(
             env.fs.as_ref(),
             env.paths.as_ref(),
@@ -627,7 +617,6 @@ mod tests {
             &mut stdout,
         )
         .expect("stdio must soft-fail to echo, not propagate Err");
-        // And the echoed bytes must equal the input verbatim.
         assert_eq!(stdout, template.as_bytes());
     }
 
@@ -655,9 +644,6 @@ mod tests {
             .write_file(&deployed, b"unrelated content\n")
             .unwrap();
 
-        // Baseline with a tracked_render that doesn't correspond to
-        // the template — burgertocow will see them as totally
-        // different.
         let baseline = Baseline::build(
             &src,
             b"different",
@@ -675,8 +661,6 @@ mod tests {
             )
             .unwrap();
 
-        // Must succeed (output may be anything; just not a panic or
-        // an Err).
         let _ = template_clean(env.fs.as_ref(), env.paths.as_ref(), template, &src, &[]).unwrap();
     }
 }

--- a/crates/dodot-lib/src/commands/template_install_filter.rs
+++ b/crates/dodot-lib/src/commands/template_install_filter.rs
@@ -27,9 +27,8 @@ use crate::commands::MessageResult;
 use crate::packs::orchestration::ExecutionContext;
 use crate::{DodotError, Result};
 
-/// The `.git/config` snippet this command writes. Public so
-/// `dodot template show-filter` can print it for users who want to
-/// install by hand.
+/// The `.git/config` snippet this command writes. Public so the
+/// post-`up` prompt can print it for users who want to install by hand.
 pub fn config_block_text() -> String {
     [
         "[filter \"dodot-template\"]",

--- a/crates/dodot-lib/src/commands/template_install_filter.rs
+++ b/crates/dodot-lib/src/commands/template_install_filter.rs
@@ -28,8 +28,8 @@ use crate::packs::orchestration::ExecutionContext;
 use crate::{DodotError, Result};
 
 /// The `.git/config` snippet this command writes. Public so
-/// `dodot template show-filter` (future) can print it for users
-/// who want to install by hand.
+/// `dodot template show-filter` can print it for users who want to
+/// install by hand.
 pub fn config_block_text() -> String {
     [
         "[filter \"dodot-template\"]",

--- a/crates/dodot-lib/src/commands/tests/adopt.rs
+++ b/crates/dodot-lib/src/commands/tests/adopt.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the `adopt` command (and the related "adopt: pack not found hint" UX section).
+//! Integration tests for the `adopt` command.
 
 #![allow(unused_imports)]
 
@@ -42,17 +42,13 @@ fn adopt_moves_file_and_creates_symlink() {
     )
     .unwrap();
 
-    // File should have moved into pack with the `home.` prefix (post-#48
-    // adopt rename — preserves the round-trip back to ~/.vimrc on `up`),
-    // content preserved.
+    // The `home.` prefix preserves the round-trip back to ~/.vimrc on `up`.
     env.assert_regular_file(
         &env.dotfiles_root.join("vim/home.vimrc"),
         "set nocompatible",
     );
-    // Symlink should exist at original location
     assert!(env.fs.is_symlink(&source));
 
-    // Status output should include the vim pack with the adopted file
     assert!(result.packs.iter().any(|p| p.name == "vim"));
     let vim = result.packs.iter().find(|p| p.name == "vim").unwrap();
     assert!(vim.files.iter().any(|f| f.name == "home.vimrc"));
@@ -62,9 +58,8 @@ fn adopt_moves_file_and_creates_symlink() {
 fn adopt_preserves_executable_permissions() {
     use std::os::unix::fs::PermissionsExt;
 
-    // Uses a dotted file (post-#2: non-dotted $HOME entries are
-    // refused for round-trip safety). The test's intent is exec-bit
-    // preservation, not the dot-or-not policy.
+    // A dotted source isolates executable-bit preservation from the
+    // separate refusal of non-dotted $HOME entries.
     let env = TempEnvironment::builder()
         .pack("tools")
         .file("placeholder", "")
@@ -73,7 +68,6 @@ fn adopt_preserves_executable_permissions() {
         .build();
 
     let source = env.home.join(".script.sh");
-    // Mark source as executable
     let perms = std::fs::Permissions::from_mode(0o755);
     std::fs::set_permissions(&source, perms).unwrap();
 
@@ -98,9 +92,8 @@ fn adopt_preserves_executable_permissions() {
     );
 }
 
-/// Regression for review item #2 on PR #49: a non-dotted entry in
-/// $HOME has no automatic round-trip path under the post-#48 XDG
-/// default — adopt must refuse rather than silently relocate.
+/// A non-dotted entry in $HOME has no automatic round-trip path under
+/// the XDG default, so adopt must refuse rather than silently relocate.
 #[test]
 fn adopt_refuses_non_dotted_home_entry() {
     let env = TempEnvironment::builder()
@@ -132,16 +125,13 @@ fn adopt_refuses_non_dotted_home_entry() {
         msg.contains("[symlink.targets]"),
         "refusal should point at [symlink.targets] escape hatch, got: {msg}"
     );
-    // Source untouched, no pack copy created.
     env.assert_regular_file(&source, "#!/bin/sh\necho hi");
     env.assert_not_exists(&env.dotfiles_root.join("tools/script.sh"));
 }
 
 #[test]
 fn adopt_destination_conflict_refused_without_force() {
-    // Destination conflict: pack already has `home.vimrc`. Adopt of
-    // `~/.vimrc` derives `home.vimrc` as the pack filename (post-#48
-    // adopt rename), so the existing file blocks the adoption.
+    // Adopt derives `home.vimrc`, so the existing pack file is a conflict.
     let env = TempEnvironment::builder()
         .pack("vim")
         .file("home.vimrc", "existing content")
@@ -167,7 +157,6 @@ fn adopt_destination_conflict_refused_without_force() {
         "expected SymlinkConflict, got: {err}"
     );
 
-    // Original file untouched; existing pack file untouched.
     env.assert_regular_file(&source, "new content");
     env.assert_regular_file(
         &env.dotfiles_root.join("vim/home.vimrc"),
@@ -204,11 +193,11 @@ fn adopt_destination_conflict_resolved_with_force() {
 
 #[test]
 fn adopt_directory_creates_symlink_and_preserves_contents() {
-    // Dotted-directory adoption from $HOME directly: contents move to
+    // Dotted-directory contents move to
     // pack/_home/<stripped>/, which round-trips back via the `_home/`
     // subtree-escape (Priority 2) on `dodot up`. We use a non-XDG
     // dotted dir so the test stays decoupled from the XDG-source
-    // inference rules — adopting `~/.config/` itself is now refused
+    // inference rules — adopting `~/.config/` itself is refused
     // explicitly (see `adopt_xdg_root_itself_refused`).
     let env = TempEnvironment::builder()
         .pack("editor")
@@ -237,14 +226,13 @@ fn adopt_directory_creates_symlink_and_preserves_contents() {
     env.assert_regular_file(&pack_dir.join("vimrc"), "set nocompatible");
     env.assert_regular_file(&pack_dir.join("colors/scheme.vim"), "\" colors");
 
-    // Original path is now a symlink to the pack copy.
     assert!(env.fs.is_symlink(&source));
     let target = env.fs.readlink(&source).unwrap();
     assert_eq!(target, pack_dir);
 }
 
-/// Regression for review item #1 on PR #49: a dotted directory adopted
-/// from $HOME (not in force_home) must round-trip back via the
+/// A dotted directory adopted from $HOME (not in force_home) must
+/// round-trip via the
 /// `_home/` escape hatch on `dodot up`. Without this, the file would
 /// silently move from $HOME/.X to $XDG_CONFIG_HOME/<pack>/X.
 #[test]
@@ -270,14 +258,10 @@ fn adopt_dotted_dir_from_home_round_trips_via_home_escape() {
     )
     .unwrap();
 
-    // Adopted under chats/_home/weechat (the `_home/` per-subtree
-    // routing tells the symlink handler to deploy back to $HOME/.X).
     let pack_dir = env.dotfiles_root.join("chats/_home/weechat");
     env.assert_dir_exists(&pack_dir);
     env.assert_regular_file(&pack_dir.join("weechat.conf"), "[server]");
 
-    // Re-deploying with `dodot up` puts the symlink back at $HOME/.weechat
-    // — the round-trip the rename was designed to preserve.
     commands::up::up(Some(&["chats".into()]), &ctx).unwrap();
     let user_path = env.home.join(".weechat");
     assert!(
@@ -410,10 +394,8 @@ fn pack_filename_round_trips_through_resolve_target() {
 
 #[test]
 fn adopt_preserves_inner_symlinks_as_symlinks() {
-    // Uses a dotted directory (post-#2: non-dotted $HOME entries are
-    // refused). Test intent: inner symlinks are preserved during the
-    // copy phase. The `_home/` path comes from #1's dotted-dir
-    // round-trip rename.
+    // A dotted directory isolates inner-symlink preservation from the
+    // separate refusal of non-dotted $HOME entries.
     let env = TempEnvironment::builder()
         .pack("shell")
         .file("placeholder", "")
@@ -421,7 +403,6 @@ fn adopt_preserves_inner_symlinks_as_symlinks() {
         .home_file(".mydir/real.txt", "hello")
         .build();
 
-    // Create an inner symlink: .mydir/alias -> .mydir/real.txt
     let inner_target = env.home.join(".mydir/real.txt");
     let inner_link = env.home.join(".mydir/alias");
     env.fs.symlink(&inner_target, &inner_link).unwrap();
@@ -439,7 +420,6 @@ fn adopt_preserves_inner_symlinks_as_symlinks() {
     )
     .unwrap();
 
-    // The inner link should still be a symlink inside the pack copy.
     let copied_link = env.dotfiles_root.join("shell/_home/mydir/alias");
     assert!(
         env.fs.is_symlink(&copied_link),
@@ -447,12 +427,11 @@ fn adopt_preserves_inner_symlinks_as_symlinks() {
     );
 }
 
-/// `~/.config/<X>/<rest>` is now a recognized adopt source: the first
+/// `~/.config/<X>/<rest>` is a recognized adopt source: the first
 /// segment under `$XDG_CONFIG_HOME` is the inferred pack name, and the
 /// remainder is the in-pack path. Round-trip is the resolver's default
 /// rule — pack `nvim` containing `init.lua` deploys to
-/// `$XDG_CONFIG_HOME/nvim/init.lua` on `dodot up`. (Pre-inference, this
-/// case was refused as a nested source.)
+/// `$XDG_CONFIG_HOME/nvim/init.lua` on `dodot up`.
 #[test]
 fn adopt_xdg_nested_file_lands_at_pack_root() {
     let env = TempEnvironment::builder()
@@ -509,7 +488,6 @@ fn adopt_xdg_source_infers_pack_and_auto_creates() {
     )
     .unwrap();
 
-    // Pack auto-created at `<dotfiles>/ghostty/`, file landed at root.
     let pack_dir = env.dotfiles_root.join("ghostty");
     env.assert_dir_exists(&pack_dir);
     env.assert_regular_file(&pack_dir.join("config"), "theme = dark");
@@ -541,20 +519,13 @@ fn adopt_xdg_pack_root_directory_expands_to_children() {
     )
     .unwrap();
 
-    // Each top-level child of `~/.config/helix/` became its own pack
-    // entry — `config.toml` (file) and `themes/` (dir) — both at pack
-    // root, not nested under another `helix/`.
     let pack_dir = env.dotfiles_root.join("helix");
     env.assert_regular_file(&pack_dir.join("config.toml"), "theme = \"onedark\"");
     env.assert_regular_file(&pack_dir.join("themes/extra.toml"), "fg = \"white\"");
-    // Original entries are now symlinks at their original paths
-    // (one per top-level child, not one for the whole helix/ dir).
     assert!(env
         .fs
         .is_symlink(&env.home.join(".config/helix/config.toml")));
     assert!(env.fs.is_symlink(&env.home.join(".config/helix/themes")));
-    // Parent directory `~/.config/helix/` itself stays a real directory
-    // — only its children became symlinks.
     assert!(!env.fs.is_symlink(&source));
 }
 
@@ -589,8 +560,7 @@ fn adopt_xdg_root_itself_refused() {
 /// `_xdg/<X>/` prefix on each child so the round-trip survives the
 /// pack-name change. Without this, expanded children would land at
 /// pack root and `dodot up` would deploy them to `$XDG/<override>/...`
-/// instead of the original `$XDG/<X>/...`. (Regression for Copilot
-/// review on PR #85.)
+/// instead of the original `$XDG/<X>/...`.
 #[test]
 fn adopt_xdg_pack_root_expansion_with_override_uses_xdg_prefix() {
     let env = TempEnvironment::builder()
@@ -615,9 +585,6 @@ fn adopt_xdg_pack_root_expansion_with_override_uses_xdg_prefix() {
     )
     .unwrap();
 
-    // Each expanded child lives under `toolbox/_xdg/lazygit/...` so the
-    // resolver's Priority 2 `_xdg/` prefix routes back to
-    // `~/.config/lazygit/<child>` regardless of the override pack name.
     env.assert_regular_file(
         &env.dotfiles_root.join("toolbox/_xdg/lazygit/config.yml"),
         "gui:\n  theme: dark",
@@ -626,8 +593,6 @@ fn adopt_xdg_pack_root_expansion_with_override_uses_xdg_prefix() {
         &env.dotfiles_root.join("toolbox/_xdg/lazygit/themes/x.yml"),
         "fg: white",
     );
-    // Each original child is now a symlink (per-child expansion); the
-    // pack-root dir itself stays a real directory.
     assert!(env
         .fs
         .is_symlink(&env.home.join(".config/lazygit/config.yml")));
@@ -706,9 +671,6 @@ fn adopt_app_support_source_round_trips_through_app_prefix() {
     let pack_file = env.dotfiles_root.join("Code/_app/Code/User/settings.json");
     env.assert_regular_file(&pack_file, "{\"editor.fontSize\": 14}");
 
-    // Original deploy location is now a symlink — and the symlink
-    // chain points (eventually) back at the pack copy. Resolve via
-    // resolve_target_full to confirm round-trip.
     assert!(env.fs.is_symlink(&source));
 
     use crate::handlers::symlink::{resolve_target_full, Resolution};
@@ -755,21 +717,15 @@ fn adopt_app_support_pack_root_directory_expands_to_children() {
     )
     .unwrap();
 
-    // The pack-root directory expanded: the single child of `Cursor/`
-    // is `User/`, so the pack contains `_app/Cursor/User/` (a
-    // directory whose contents come along).
     let pack_dir = env.dotfiles_root.join("Cursor");
     env.assert_dir_exists(&pack_dir);
     env.assert_regular_file(&pack_dir.join("_app/Cursor/User/settings.json"), "{}");
     env.assert_regular_file(&pack_dir.join("_app/Cursor/User/keybindings.json"), "[]");
-    // The expanded child (`User/`) at the original AppSupport
-    // location is now a symlink, but the parent `Cursor/` itself
-    // stays a real directory.
     assert!(env.fs.is_symlink(&env.app_support.join("Cursor/User")));
     assert!(!env.fs.is_symlink(&source));
 }
 
-/// M5 capitalization-heuristic advisory: when a user adopts an
+/// When a user adopts an
 /// AppSupport source whose folder name passes the GUI-app heuristic
 /// (`Code`, uppercase), adopt emits a tip pointing at the
 /// `app_aliases` ergonomic. The pack tree itself is unaffected — the
@@ -806,9 +762,9 @@ fn adopt_app_support_emits_capitalization_hint() {
 
 /// Reverse-DNS bundle-ID folders (`com.colliderli.iina`,
 /// `dev.warp.Warp-Stable`) get a much better rename suggestion when
-/// the M6 brew probe identifies a matching cask: prefer the cask
+/// the brew probe identifies a matching cask: prefer the cask
 /// token (`iina`) over the awful whitespace-strip-lowercase fallback
-/// (`comcolliderliiina`). Real IINA case from user testing on PR #91.
+/// (`comcolliderliiina`).
 #[test]
 #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only enrichment paths")]
 fn adopt_app_support_reverse_dns_uses_cask_token_in_tip() {
@@ -854,19 +810,14 @@ fn adopt_app_support_reverse_dns_uses_cask_token_in_tip() {
         .find(|w| w.contains("app_aliases"))
         .unwrap_or_else(|| panic!("expected an app_aliases tip, got: {:?}", result.warnings));
 
-    // The good outcome: tip suggests `iina` as the rename target.
     assert!(
         tip.contains("renaming the pack to `iina`"),
         "expected cask-token-based rename suggestion (`iina`), got: {tip}"
     );
-    // And explicitly NOT the whitespace-strip-lowercase fallback,
-    // which would be `comcolliderliiina` for this folder.
     assert!(
         !tip.contains("comcolliderliiina"),
         "rename suggestion fell back to lowercase mangling instead of cask token: {tip}"
     );
-    // The tip credits the cask so the user knows where the
-    // recommendation came from.
     assert!(
         tip.contains("matches homebrew cask"),
         "tip should credit the cask source, got: {tip}"
@@ -874,10 +825,7 @@ fn adopt_app_support_reverse_dns_uses_cask_token_in_tip() {
 }
 
 /// When no installed cask matches the folder, the tip falls back to
-/// the original whitespace-strip-lowercase suggestion. Pins the
-/// fallback so a refactor doesn't accidentally regress the no-cask
-/// path (the heuristic still triggers on uppercase folders even when
-/// brew has nothing to say).
+/// the whitespace-strip-lowercase suggestion when brew has no match.
 #[test]
 #[cfg_attr(not(target_os = "macos"), ignore = "macOS-only enrichment paths")]
 fn adopt_app_support_falls_back_to_lowercase_when_no_cask_match() {
@@ -910,8 +858,6 @@ fn adopt_app_support_falls_back_to_lowercase_when_no_cask_match() {
         .find(|w| w.contains("app_aliases"))
         .unwrap_or_else(|| panic!("expected an app_aliases tip, got: {:?}", result.warnings));
 
-    // Fallback suggestion: lowercased pack name (no spaces here, but
-    // the casing transformation still applies).
     assert!(
         tip.contains("renaming the pack to `tinkerbell`"),
         "expected fallback rename suggestion, got: {tip}"
@@ -1036,15 +982,13 @@ fn adopt_home_source_without_into_requires_pack() {
 
 #[test]
 fn adopt_already_adopted_source_is_skipped() {
-    // Direct symlink to pack source — adopt skips with a #44 message
-    // pointing the user at `dodot up` to upgrade to the full chain.
+    // A direct source link is unmanaged until `dodot up` upgrades it to the full chain.
     let env = TempEnvironment::builder()
         .pack("vim")
         .file("vimrc", "content")
         .done()
         .build();
 
-    // Pre-link home file to the pack.
     let source = env.home.join(".vimrc");
     let pack_file = env.dotfiles_root.join("vim/vimrc");
     env.fs.symlink(&pack_file, &source).unwrap();
@@ -1074,14 +1018,13 @@ fn adopt_already_adopted_source_is_skipped() {
         warning.contains("dodot up vim"),
         "warning should point user at `dodot up vim`, got: {warning}"
     );
-    // Source still a symlink, pack file untouched.
     assert!(env.fs.is_symlink(&source));
     env.assert_regular_file(&pack_file, "content");
 }
 
-/// Regression for #44: when the source is fully managed (the user
-/// symlink points at dodot's data_dir), adopt skips with the original
-/// "already managed by dodot" wording — no upgrade needed.
+/// When the source is fully managed (the user
+/// symlink points at dodot's data_dir), adopt reports it as already
+/// managed rather than suggesting an upgrade.
 #[test]
 fn adopt_fully_managed_source_keeps_original_skip_message() {
     let env = TempEnvironment::builder()
@@ -1091,8 +1034,6 @@ fn adopt_fully_managed_source_keeps_original_skip_message() {
         .build();
 
     let ctx = make_ctx(&env);
-    // First, deploy normally so user_path goes through the dodot chain.
-    // Under #48 the default deploy target is $XDG_CONFIG_HOME/<pack>/<file>.
     commands::up::up(Some(&["vim".into()]), &ctx).unwrap();
 
     let source = env.home.join(".config/vim/vimrc");
@@ -1124,7 +1065,7 @@ fn adopt_fully_managed_source_keeps_original_skip_message() {
     );
 }
 
-/// Regression for #44: `dodot up` auto-replaces a pre-existing regular
+/// `dodot up` auto-replaces a pre-existing regular
 /// file whose content is byte-identical to the pack source — no
 /// `--force` needed, no conflict reported.
 #[test]
@@ -1133,7 +1074,6 @@ fn up_auto_replaces_content_equivalent_pre_existing_file() {
         .pack("git")
         .file("home.gitconfig", "[user]\n  name = test")
         .done()
-        // Same content as the pack source.
         .home_file(".gitconfig", "[user]\n  name = test")
         .build();
 
@@ -1146,24 +1086,21 @@ fn up_auto_replaces_content_equivalent_pre_existing_file() {
         "no errors expected for content-equivalent file, got: {:?}",
         result.message
     );
-    // ~/.gitconfig is now a symlink (the dodot chain), not a regular file.
     let user_path = env.home.join(".gitconfig");
     assert!(
         env.fs.is_symlink(&user_path),
         "user file should now be a symlink"
     );
-    // Content reaching the user is unchanged.
     assert_eq!(
         env.fs.read_to_string(&user_path).unwrap(),
         "[user]\n  name = test"
     );
-    // And status agrees: deployed, not a conflict.
     let status = commands::status::status(None, &ctx).unwrap();
     let file = &status.packs[0].files[0];
     assert_eq!(file.status, "deployed");
 }
 
-/// Regression for #44: `dodot up` still refuses (without `--force`) when
+/// `dodot up` still refuses (without `--force`) when
 /// the pre-existing file's content differs from the source. The
 /// auto-replace only kicks in for content-equivalent files.
 #[test]
@@ -1184,11 +1121,10 @@ fn up_still_refuses_content_different_pre_existing_file() {
         "different content should still conflict, got: {:?}",
         result.message
     );
-    // Original content preserved.
     env.assert_file_contents(&env.home.join(".gitconfig"), "[user]\n  name = old");
 }
 
-/// Regression for #44: `status` does NOT flag a content-equivalent
+/// `status` does not flag a content-equivalent
 /// pre-existing file as PendingConflict (since `up` will handle it
 /// without `--force`). Stays plain `pending`, no footnote.
 #[test]
@@ -1231,7 +1167,6 @@ fn adopt_relative_path_with_curdir_normalizes() {
         .home_file(".vimrc", "content")
         .build();
 
-    // Run with CWD = HOME so the relative path resolves naturally.
     let prev_cwd = std::env::current_dir().unwrap();
     std::env::set_current_dir(&env.home).unwrap();
     let ctx = make_ctx(&env);
@@ -1343,7 +1278,6 @@ fn adopt_broken_pack_blocks_conflict_check() {
         "expected the broken pack's error to surface, got: {err}"
     );
 
-    // Home untouched; no pack copy left behind.
     env.assert_regular_file(&source, "content");
     env.assert_not_exists(&env.dotfiles_root.join("target/vimrc"));
 }
@@ -1380,9 +1314,7 @@ fn adopt_deploy_conflict_refused() {
         "expected CrossPackConflict, got: {err}"
     );
 
-    // Home untouched.
     env.assert_regular_file(&source, "new");
-    // Pack copy rolled back.
     env.assert_not_exists(&env.dotfiles_root.join("work/bashrc"));
 }
 
@@ -1440,10 +1372,8 @@ fn adopt_dry_run_makes_no_changes() {
     .unwrap();
     assert!(result.dry_run);
 
-    // Nothing changed at home.
     env.assert_regular_file(&source, "content");
     assert!(!env.fs.is_symlink(&source));
-    // No copy in pack.
     env.assert_not_exists(&env.dotfiles_root.join("vim/home.vimrc"));
 }
 
@@ -1456,7 +1386,6 @@ fn adopt_no_follow_keeps_source_symlink_as_symlink() {
         .home_file("real_vimrc", "real content")
         .build();
 
-    // ~/.vimrc is a symlink to ~/real_vimrc
     let real = env.home.join("real_vimrc");
     let source = env.home.join(".vimrc");
     env.fs.symlink(&real, &source).unwrap();
@@ -1473,13 +1402,11 @@ fn adopt_no_follow_keeps_source_symlink_as_symlink() {
     )
     .unwrap();
 
-    // The pack copy should be a symlink (not a regular file with copied content).
     let pack_copy = env.dotfiles_root.join("vim/home.vimrc");
     assert!(
         env.fs.is_symlink(&pack_copy),
         "--no-follow should preserve source symlink as a symlink in the pack"
     );
-    // Home path replaced with a symlink into the pack.
     assert!(env.fs.is_symlink(&source));
 }
 
@@ -1487,8 +1414,7 @@ fn adopt_no_follow_keeps_source_symlink_as_symlink() {
 #[test]
 fn adopt_force_preserves_old_content_when_copy_fails() {
     // With --force, the old destination must remain intact if the copy of
-    // the new source fails. Previously copy_all removed the dest before
-    // copying, so a copy failure silently lost the old content.
+    // the new source fails.
     use std::os::unix::fs::PermissionsExt;
 
     // Skip when DAC permissions don't block this process (e.g. running as
@@ -1537,11 +1463,8 @@ fn adopt_force_preserves_old_content_when_copy_fails() {
         result.is_err(),
         "adopt should fail when the source is unreadable"
     );
-    // The old pack content must survive the failed --force adoption.
     env.assert_regular_file(&env.dotfiles_root.join("vim/home.vimrc"), "OLD");
-    // Home file also untouched.
     env.assert_regular_file(&source, "NEW");
-    // No lingering stage file in the pack.
     let leftover = env.fs.read_dir(&env.dotfiles_root.join("vim")).unwrap();
     for entry in leftover {
         assert!(
@@ -1556,15 +1479,13 @@ fn adopt_force_preserves_old_content_when_copy_fails() {
 fn adopt_no_follow_on_dangling_symlink_succeeds() {
     // A dangling symlink under --no-follow: readability check must inspect
     // the link itself (lstat), not try to follow it into a non-existent
-    // target. Regression test: check_readable previously used fs.is_dir +
-    // fs.stat, both of which follow symlinks and would fail here.
+    // target.
     let env = TempEnvironment::builder()
         .pack("vim")
         .file("placeholder", "")
         .done()
         .build();
 
-    // Create ~/.dangling -> /does/not/exist (target intentionally missing).
     let source = env.home.join(".dangling");
     env.fs
         .symlink(std::path::Path::new("/does/not/exist"), &source)
@@ -1582,8 +1503,6 @@ fn adopt_no_follow_on_dangling_symlink_succeeds() {
     )
     .expect("adopt with --no-follow on a dangling symlink should succeed");
 
-    // The pack copy should itself be a symlink (preserving the dangling link).
-    // Post-#48 adopt rename: ~/.dangling → vim/home.dangling.
     let pack_copy = env.dotfiles_root.join("vim/home.dangling");
     assert!(env.fs.is_symlink(&pack_copy));
     let target = env.fs.readlink(&pack_copy).unwrap();

--- a/crates/dodot-lib/src/commands/tests/gating.rs
+++ b/crates/dodot-lib/src/commands/tests/gating.rs
@@ -1,4 +1,4 @@
-//! Integration tests for gating behaviour: §7.4 passive-command contract (#121), cross-pack conflict detection, and the C3/C5/gate-before-preprocess regression suite.
+//! Integration tests for passive commands, cross-pack conflicts, and gating.
 
 #![allow(unused_imports)]
 
@@ -17,11 +17,11 @@ use standout_render::OutputMode;
 
 use super::support::{make_ctx, make_ctx_with_runner, CannedRunner};
 
-// ── §7.4 passive-command contract (#121) ───────────────────
+// ── §7.4 passive-command contract ───────────────────────────
 
 #[test]
 fn status_does_not_write_to_datastore() {
-    // §7.4: passive commands MUST NOT mutate the datastore.
+    // §7.4: passive commands must not mutate the datastore.
     // Running `up` once primes the data dir; running `status`
     // afterwards must leave that state byte-identical.
     let env = TempEnvironment::builder()
@@ -36,7 +36,6 @@ fn status_does_not_write_to_datastore() {
 
     let snapshot = snapshot_dir_contents(&env, env.paths.data_dir());
 
-    // Two consecutive status runs must leave data_dir unchanged.
     commands::status::status(None, &ctx).unwrap();
     commands::status::status(None, &ctx).unwrap();
 
@@ -50,7 +49,6 @@ fn status_does_not_write_to_datastore() {
 
 #[test]
 fn up_dry_run_does_not_write_to_datastore() {
-    // Pin the same §7.4 contract for `up --dry-run`.
     let env = TempEnvironment::builder()
         .pack("app")
         .file("config.toml.tmpl", "name = {{ name }}")
@@ -75,11 +73,9 @@ fn up_dry_run_does_not_write_to_datastore() {
 
 #[test]
 fn install_template_dry_run_emits_correct_sentinel_without_writing_rendered_file() {
-    // The §7.4 unblocker: in Passive mode the rendered file isn't
-    // on disk, so the install handler used to fail to compute its
-    // sentinel. With `rendered_bytes` threaded through, dry-run now
-    // emits a Run intent with the same sentinel as the active path
-    // would — without ever writing the rendered file. (#121)
+    // In Passive mode the rendered file is not on disk, so the
+    // install handler computes the active-path sentinel from
+    // `rendered_bytes` without writing the file.
     let env = TempEnvironment::builder()
         .pack("app")
         .file("install.sh.tmpl", "#!/bin/sh\necho hello {{ name }}")
@@ -87,16 +83,13 @@ fn install_template_dry_run_emits_correct_sentinel_without_writing_rendered_file
         .done()
         .build();
 
-    // First up establishes the baseline so Passive mode has
-    // something to read. no_provision = false so the install
+    // no_provision = false ensures the install
     // handler actually plans Run intents (the default test ctx
     // suppresses code-execution handlers).
     let mut ctx = make_ctx(&env);
     ctx.no_provision = false;
     commands::up::up(None, &ctx).unwrap();
 
-    // Capture the active sentinel (it lives in the executed
-    // RunCommand operation).
     let active_intents = crate::packs::orchestration::collect_pack_intents(
         &crate::packs::Pack::new(
             "app".into(),
@@ -117,9 +110,6 @@ fn install_template_dry_run_emits_correct_sentinel_without_writing_rendered_file
         })
         .expect("active path must produce a Run intent for install.sh");
 
-    // Snapshot the rendered datastore file's existence — Passive
-    // must not modify it, but it should already exist from the
-    // earlier active up.
     let rendered_path = env
         .paths
         .handler_data_dir("app", "preprocessed")
@@ -130,9 +120,7 @@ fn install_template_dry_run_emits_correct_sentinel_without_writing_rendered_file
     );
     let rendered_before = ctx.fs.read_file(&rendered_path).unwrap();
 
-    // Now plan via dry-run; the install handler must produce the
-    // same sentinel from in-memory bytes. Same no_provision = false
-    // so the handler actually emits intents.
+    // Keep provisioning enabled so dry-run emits the in-memory intent.
     let mut dry_ctx = make_ctx(&env);
     dry_ctx.no_provision = false;
     dry_ctx.dry_run = true;
@@ -172,13 +160,11 @@ fn install_template_dry_run_emits_correct_sentinel_without_writing_rendered_file
 
 #[test]
 fn up_dry_run_first_time_pack_with_install_template_does_not_error() {
-    // Regression for Copilot review on PR #126: a first-time pack
+    // A first-time pack
     // containing `install.sh.tmpl` (no baseline yet, no rendered
     // file on disk) must not crash dry-run intent collection. The
-    // install handler used to read `m.absolute_path` unconditionally
-    // and propagate an Fs error; now it skips intent generation for
-    // the placeholder match instead. Same shape for `Brewfile.tmpl`
-    // / homebrew handler.
+    // install handler must skip intent generation for the placeholder
+    // match. The same applies to `Brewfile.tmpl` and the homebrew handler.
     let env = TempEnvironment::builder()
         .pack("setup")
         .file("install.sh.tmpl", "#!/bin/sh\necho hello {{ name }}")
@@ -191,10 +177,6 @@ fn up_dry_run_first_time_pack_with_install_template_does_not_error() {
     dry_ctx.no_provision = false;
     dry_ctx.dry_run = true;
 
-    // The fix: this returns Ok and emits zero Run intents (the
-    // placeholders skip intent generation cleanly). Pre-fix, the
-    // install/homebrew handlers tried to read missing rendered
-    // files and propagated an Fs error.
     let result = commands::up::up(None, &dry_ctx).unwrap();
     assert!(result.dry_run);
 }
@@ -204,7 +186,7 @@ fn passive_first_time_pack_surfaces_pending_placeholder() {
     // §7.4 acceptance: a passive command on a brand-new pack with
     // no baseline cache yet must surface a coherent placeholder
     // (template stripped name, status pending), never panic, never
-    // fall through to template evaluation. (#121)
+    // fall through to template evaluation.
     let env = TempEnvironment::builder()
         .pack("app")
         .file("greet.tmpl", "hello {{ name }}")
@@ -292,7 +274,6 @@ fn up_halts_on_cross_pack_symlink_conflict() {
         "expected CrossPackConflict, got: {err}"
     );
 
-    // Error message should include both packs and the target
     let msg = err.to_string();
     assert!(msg.contains("pack-a"), "msg: {msg}");
     assert!(msg.contains("pack-b"), "msg: {msg}");
@@ -301,8 +282,7 @@ fn up_halts_on_cross_pack_symlink_conflict() {
 
 #[test]
 fn up_halts_no_partial_deployment_on_conflict() {
-    // When a conflict is detected, NO packs should be deployed —
-    // not even the non-conflicting ones.
+    // A conflict blocks even otherwise independent packs.
     let env = TempEnvironment::builder()
         .pack("conflict-a")
         .file("home.aliases", "a")
@@ -318,7 +298,6 @@ fn up_halts_no_partial_deployment_on_conflict() {
     let ctx = make_ctx(&env);
     let _err = commands::up::up(None, &ctx).unwrap_err();
 
-    // Nothing should be deployed — check the innocent pack
     env.assert_no_handler_state("innocent", "symlink");
     env.assert_no_handler_state("conflict-a", "symlink");
     env.assert_no_handler_state("conflict-b", "symlink");
@@ -373,12 +352,10 @@ fn up_dry_run_still_detects_cross_pack_conflict() {
     );
 }
 
-/// Regression: `dodot up` on a cross-pack conflict must render the full
+/// `dodot up` on a cross-pack conflict must render the full
 /// per-pack listing, notes, and ignored-pack section — not a bare
-/// conflicts dump. Before the fix, the CLI handler hardcoded
-/// `packs: Vec::new()` on the `CrossPackConflict` branch, so users only
-/// saw the trailing conflicts section and lost all context about what
-/// *would* have been deployed.
+/// conflicts dump, so users retain the context of what would have been
+/// deployed.
 #[test]
 fn up_with_cross_pack_conflict_renders_full_status_view() {
     let env = TempEnvironment::builder()
@@ -398,7 +375,6 @@ fn up_with_cross_pack_conflict_renders_full_status_view() {
     let result = commands::up::up_or_status_for_conflict(None, &ctx)
         .expect("status fallback should produce Ok on cross-pack conflict");
 
-    // Top-level message explains why nothing deployed.
     assert_eq!(
         result.message.as_deref(),
         Some("Cross-pack conflicts prevent deployment."),
@@ -406,7 +382,6 @@ fn up_with_cross_pack_conflict_renders_full_status_view() {
         result.message
     );
 
-    // Full per-pack listing is present — the regression was this being empty.
     assert!(
         !result.packs.is_empty(),
         "up-with-conflict must render pack rows, not a bare conflicts dump"
@@ -428,7 +403,6 @@ fn up_with_cross_pack_conflict_renders_full_status_view() {
         pack_names
     );
 
-    // Conflicts section is still populated — same data the old branch showed.
     assert!(
         !result.conflicts.is_empty(),
         "expected conflicts section to be populated"
@@ -440,7 +414,6 @@ fn up_with_cross_pack_conflict_renders_full_status_view() {
         conflict.target
     );
 
-    // Nothing was actually deployed — rows should report pending, not deployed.
     for pack in &result.packs {
         for file in &pack.files {
             assert_ne!(
@@ -680,7 +653,6 @@ fn up_three_packs_partial_conflict() {
         "should detect the conflict even if not all packs are involved"
     );
 
-    // Verify nothing was deployed
     env.assert_no_handler_state("a", "symlink");
     env.assert_no_handler_state("b", "symlink");
     env.assert_no_handler_state("c", "symlink");
@@ -701,12 +673,9 @@ fn up_error_message_includes_all_conflict_details() {
     let err = commands::up::up(None, &ctx).unwrap_err();
 
     let msg = err.to_string();
-    // Should mention both packs
     assert!(msg.contains("alpha"), "msg: {msg}");
     assert!(msg.contains("beta"), "msg: {msg}");
-    // Should mention the handler
     assert!(msg.contains("symlink"), "msg: {msg}");
-    // Should mention the target path
     assert!(msg.contains(".aliases"), "msg: {msg}");
 }
 
@@ -778,14 +747,12 @@ fn status_shows_conflict_even_when_not_deployed() {
     let ctx = make_ctx(&env);
     let result = commands::status::status(None, &ctx).unwrap();
 
-    // Both packs should show as pending
     for pack in &result.packs {
         for file in &pack.files {
             assert_eq!(file.status, "pending");
         }
     }
 
-    // Conflict data should still be emitted.
     assert!(
         !result.conflicts.is_empty(),
         "should flag potential conflict even when undeployed"
@@ -934,7 +901,6 @@ fn pack_os_inactive_pack_emits_no_operations_in_up() {
 
     let ctx = make_ctx(&env);
     let result = commands::up::up(None, &ctx).unwrap();
-    // No deployed pack rows.
     assert!(result.packs.is_empty(), "packs: {:?}", result.packs);
 }
 
@@ -1031,11 +997,11 @@ fn adopt_only_os_user_defined_label_works() {
     env.assert_regular_file(&env.dotfiles_root.join("vim/_laptop/home.vimrc"), "x");
 }
 
-// ── Gate-before-preprocess regression ───────────────────────────
+// ── Gate-before-preprocess contract ─────────────────────────────
 
 #[test]
 fn gate_failed_template_does_not_render_at_up() {
-    // Regression guard: a gate-failed template (e.g.
+    // A gate-failed template (e.g.
     // `aliases._linux.sh.tmpl` on a darwin host) must NOT be expanded by
     // the template preprocessor. If the gate check ran AFTER preprocessing,
     // MiniJinja would render the template and fire secret-provider calls and
@@ -1064,8 +1030,7 @@ fn gate_failed_template_does_not_render_at_up() {
     let env = TempEnvironment::builder()
         .pack("p")
         .file(&template_name, "alias x={{ undefined_variable }}")
-        // Co-located plain file. Its deployment proves pack planning
-        // didn't abort because of the gated template.
+        // A co-located plain file detects an aborted pack plan.
         .file("home.profile", "export PATH=$PATH:~/.local/bin")
         .done()
         .build();
@@ -1073,7 +1038,6 @@ fn gate_failed_template_does_not_render_at_up() {
     let ctx = make_ctx(&env);
     commands::up::up(None, &ctx).unwrap();
 
-    // (1) The plain file must be deployed.
     let profile_link = env.home.join(".profile");
     assert!(
         env.fs.exists(&profile_link),
@@ -1081,7 +1045,6 @@ fn gate_failed_template_does_not_render_at_up() {
          because the gated template still reached the template engine: {profile_link:?}"
     );
 
-    // (2) No baseline cache for the gated source.
     let baseline_dir = ctx.paths.cache_dir().join("preprocessor/p/template");
     if env.fs.exists(&baseline_dir) {
         let baselines = env.fs.read_dir(&baseline_dir).unwrap_or_default();
@@ -1093,13 +1056,11 @@ fn gate_failed_template_does_not_render_at_up() {
         );
     }
 
-    // No rendered output in the preprocessed dir for the gated template.
     let preprocessed = ctx.paths.data_dir().join("packs/p/preprocessed/aliases.sh");
     assert!(
         !env.fs.exists(&preprocessed),
         "gated-out template was rendered to datastore at {preprocessed:?}"
     );
-    // And no shell stage link.
     let shell_link = ctx.paths.data_dir().join("packs/p/shell/aliases.sh");
     assert!(
         !env.fs.exists(&shell_link),
@@ -1109,11 +1070,10 @@ fn gate_failed_template_does_not_render_at_up() {
 
 #[test]
 fn up_catches_mappings_gates_filename_conflict() {
-    // Round-2 review feedback (orchestration.rs:637): the `up` path
-    // strips basename gates BEFORE match_entries, so the
+    // The `up` path strips basename gates before match_entries, so the
     // [mappings.gates] vs filename-gate conflict needs to fire in
-    // filter_basename_gates rather than match_entries. Without the
-    // fix, this combination would silently pass through `up`.
+    // filter_basename_gates rather than match_entries; otherwise this
+    // combination would silently pass through `up`.
     let env = TempEnvironment::builder()
         .pack("p")
         .file("install._darwin.sh", "echo x")
@@ -1130,9 +1090,7 @@ fn up_catches_mappings_gates_filename_conflict() {
 
 #[test]
 fn up_rejects_invalid_mappings_gates_glob() {
-    // Round-2 review feedback (rules/mod.rs:387): invalid glob
-    // patterns in [mappings.gates] used to be silently dropped via
-    // `.ok()`. They now hard-error so a typo is loud, not silent.
+    // Invalid [mappings.gates] globs hard-error so typos cannot be dropped.
     let env = TempEnvironment::builder()
         .pack("p")
         .file("vimrc", "x")
@@ -1150,8 +1108,7 @@ fn up_rejects_invalid_mappings_gates_glob() {
 
 #[test]
 fn status_surfaces_gated_template_under_original_name() {
-    // Round-3 review feedback (status.rs:545): without pre-preprocess
-    // gate filtering in the status path, a gated template would get
+    // Without pre-preprocess gate filtering, a gated template would get
     // partitioned by `preprocess_pack` and replaced by a virtual
     // entry whose path is the *stripped* virtual name (e.g.
     // `aliases.sh`), losing the on-disk source name (`aliases._linux.sh.tmpl`).
@@ -1190,9 +1147,8 @@ fn status_surfaces_gated_template_under_original_name() {
 
 #[test]
 fn up_skips_mappings_gated_template() {
-    // Round-3 review feedback (orchestration.rs:645): a
-    // `[mappings.gates]`-gated template must not reach the
-    // preprocessor. Like the basename-gate regression, we use a
+    // A `[mappings.gates]`-gated template must not reach the
+    // preprocessor. Like the basename-gate case, we use a
     // template that would error if rendered to prove the engine
     // never fired.
     let gated = if cfg!(target_os = "macos") {
@@ -1215,7 +1171,6 @@ fn up_skips_mappings_gated_template() {
     let ctx = make_ctx(&env);
     commands::up::up(None, &ctx).unwrap();
 
-    // Plain co-located file deployed → pack planning succeeded.
     let profile_link = env.home.join(".profile");
     assert!(
         env.fs.exists(&profile_link),
@@ -1223,7 +1178,6 @@ fn up_skips_mappings_gated_template() {
          likely reached the engine: {profile_link:?}"
     );
 
-    // No baseline cache for the gated template.
     let baseline_dir = ctx.paths.cache_dir().join("preprocessor/p/template");
     if env.fs.exists(&baseline_dir) {
         let baselines = env.fs.read_dir(&baseline_dir).unwrap_or_default();
@@ -1236,7 +1190,7 @@ fn up_skips_mappings_gated_template() {
     }
 }
 
-// ── Ignored-pack parity + stale-state sweep (issue #222) ───────────
+// ── Ignored-pack parity + stale-state sweep ────────────────────────
 //
 // Two contracts:
 //   1. `up`, `down`, and `status` produce the SAME view for an ignored
@@ -1245,14 +1199,12 @@ fn up_skips_mappings_gated_template() {
 //      pack.
 //   2. A pack deployed and *then* marked `.dodotignore` must have its
 //      datastore state swept on the next up/down so nothing of it is
-//      read/sourced again (the gpg `alias.zsh` regression).
+//      read/sourced again (the gpg `alias.zsh` scenario).
 
-/// Collect the names a result surfaces in its "Ignored Packs" section.
 fn ignored_section(result: &commands::PackStatusResult) -> Vec<String> {
     result.ignored_packs.clone()
 }
 
-/// True when `warnings` carries the "pack '<name>' is ignored" notice.
 fn warns_ignored(result: &commands::PackStatusResult, name: &str) -> bool {
     result
         .warnings
@@ -1262,9 +1214,7 @@ fn warns_ignored(result: &commands::PackStatusResult, name: &str) -> bool {
 
 #[test]
 fn up_down_status_agree_for_explicitly_requested_ignored_pack() {
-    // `dodot up gpg` on an ignored pack used to print a generic
-    // "Packs deployed." with no warning and no Ignored Packs section,
-    // while `dodot status gpg` reported both. All three must agree.
+    // `up`, `down`, and `status` must agree on ignored-pack reporting.
     let env = TempEnvironment::builder()
         .pack("gpg")
         .file("alias.zsh", "alias g='echo hi'")
@@ -1292,7 +1242,6 @@ fn up_down_status_agree_for_explicitly_requested_ignored_pack() {
             warns_ignored(r, "gpg"),
             "{label} must warn that gpg is ignored"
         );
-        // The ignored pack must never appear as a deployable pack row.
         assert!(
             r.packs.iter().all(|p| p.name != "gpg"),
             "{label} must not render gpg as a deployable pack row"
@@ -1302,8 +1251,6 @@ fn up_down_status_agree_for_explicitly_requested_ignored_pack() {
 
 #[test]
 fn up_lists_ignored_packs_in_full_run() {
-    // A bare `dodot up` (no filter) surfaces ignored packs in the same
-    // section `status` does — parity for the unfiltered case.
     let env = TempEnvironment::builder()
         .pack("vim")
         .file("vimrc", "set nocompatible")
@@ -1324,14 +1271,11 @@ fn up_lists_ignored_packs_in_full_run() {
         ignored_section(&status),
         "up and status must surface the same ignored-pack set"
     );
-    // The active pack still deploys normally.
     assert!(up.packs.iter().any(|p| p.name == "vim"));
 }
 
 #[test]
 fn up_does_not_read_files_from_ignored_pack() {
-    // Nothing under a `.dodotignore` pack may be deployed: no symlink,
-    // no shell sourcing, no datastore state.
     let env = TempEnvironment::builder()
         .pack("gpg")
         .file("alias.zsh", "alias g='echo hi'")
@@ -1343,12 +1287,10 @@ fn up_does_not_read_files_from_ignored_pack() {
     let ctx = make_ctx(&env);
     commands::up::up(None, &ctx).unwrap();
 
-    // No datastore state for the ignored pack.
     assert!(
         ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty(),
         "ignored pack must leave no datastore state"
     );
-    // The init script must not source the ignored pack's shell file.
     let init = env
         .fs
         .read_to_string(&ctx.paths.init_script_path())
@@ -1361,7 +1303,7 @@ fn up_does_not_read_files_from_ignored_pack() {
 
 #[test]
 fn up_sweeps_state_of_pack_ignored_after_deploy() {
-    // The gpg regression: deploy a pack, then mark it ignored. The next
+    // After a deployed pack becomes ignored, the next
     // `up` must tear down its stale datastore state so the regenerated
     // init script stops sourcing it.
     let env = TempEnvironment::builder()
@@ -1375,7 +1317,6 @@ fn up_sweeps_state_of_pack_ignored_after_deploy() {
 
     let ctx = make_ctx(&env);
 
-    // First up: gpg deploys normally and its shell file is sourced.
     commands::up::up(None, &ctx).unwrap();
     assert!(
         !ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty(),
@@ -1390,18 +1331,15 @@ fn up_sweeps_state_of_pack_ignored_after_deploy() {
         "precondition: gpg's shell file should be sourced before ignore"
     );
 
-    // Now mark gpg ignored and run up again.
     env.fs
         .write_file(&env.dotfiles_root.join("gpg/.dodotignore"), b"")
         .unwrap();
     let up = commands::up::up(None, &ctx).unwrap();
 
-    // Stale state is gone …
     assert!(
         ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty(),
         "up must sweep datastore state for a now-ignored pack"
     );
-    // … the regenerated init script no longer sources it …
     let init_after = env
         .fs
         .read_to_string(&ctx.paths.init_script_path())
@@ -1410,13 +1348,11 @@ fn up_sweeps_state_of_pack_ignored_after_deploy() {
         !init_after.contains("gpg/alias.zsh"),
         "init script must stop sourcing a now-ignored pack; was:\n{init_after}"
     );
-    // … and it now appears in the Ignored Packs section.
     assert_eq!(ignored_section(&up), vec!["gpg".to_string()]);
 }
 
 #[test]
 fn down_sweeps_state_of_pack_ignored_after_deploy() {
-    // Same sweep contract for `down`.
     let env = TempEnvironment::builder()
         .pack("gpg")
         .file("alias.zsh", "alias g='echo hi'")
@@ -1442,7 +1378,6 @@ fn down_sweeps_state_of_pack_ignored_after_deploy() {
         .unwrap();
     assert!(!init_after.contains("gpg/alias.zsh"));
     assert_eq!(ignored_section(&down), vec!["gpg".to_string()]);
-    // Sweeping leftover state counts as deactivation.
     assert_eq!(down.message.as_deref(), Some("Packs deactivated."));
 }
 
@@ -1464,7 +1399,6 @@ fn filtered_up_sweeps_now_ignored_pack_outside_the_filter() {
     commands::up::up(None, &ctx).unwrap();
     assert!(!ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty());
 
-    // Ignore gpg, then run a FILTERED up that names only vim.
     env.fs
         .write_file(&env.dotfiles_root.join("gpg/.dodotignore"), b"")
         .unwrap();
@@ -1492,7 +1426,7 @@ fn filtered_up_sweeps_now_ignored_pack_outside_the_filter() {
 
 #[test]
 fn down_dry_run_reports_deactivation_for_now_ignored_pack() {
-    // Gemini's dry-run discrepancy: `down --dry-run` must report the
+    // `down --dry-run` must report the
     // same "Packs deactivated." outcome a real run would, when a
     // now-ignored pack still holds stale state.
     let env = TempEnvironment::builder()
@@ -1516,7 +1450,6 @@ fn down_dry_run_reports_deactivation_for_now_ignored_pack() {
         Some("Packs deactivated."),
         "dry-run must report the same outcome a real run would"
     );
-    // Dry-run must NOT actually mutate the datastore.
     assert!(
         !ctx.datastore.list_pack_handlers("gpg").unwrap().is_empty(),
         "down --dry-run must not remove state"
@@ -1525,8 +1458,6 @@ fn down_dry_run_reports_deactivation_for_now_ignored_pack() {
 
 #[test]
 fn up_mixed_selection_deploys_active_and_reports_ignored() {
-    // A mixed `up vim gpg`: vim deploys, gpg is reported ignored — the
-    // two outcomes coexist in one result.
     let env = TempEnvironment::builder()
         .pack("vim")
         .file("vimrc", "set nocompatible")

--- a/crates/dodot-lib/src/commands/tests/mod.rs
+++ b/crates/dodot-lib/src/commands/tests/mod.rs
@@ -1,10 +1,4 @@
-//! Integration tests for command API.
-//!
-//! Big tests — adopt, probe + shell-init, gating — live in sibling
-//! files so each per-command suite stays under its own roof and
-//! `cargo test commands::tests::adopt::` can target a single
-//! command's coverage without compiling the rest of the suite.
-//! Shared test fixtures live in [`mod@support`].
+//! Integration tests for the command API.
 
 mod adopt;
 mod gating;
@@ -51,7 +45,6 @@ fn status_shows_pending_before_up() {
     assert_eq!(result.packs[0].name, "vim");
     assert!(!result.packs[0].files.is_empty());
 
-    // All should be pending
     for file in &result.packs[0].files {
         assert_eq!(
             file.status, "pending",
@@ -65,7 +58,7 @@ fn status_shows_pending_before_up() {
 /// in the planner. Status must suppress the corresponding row and
 /// only surface the warning — otherwise the user sees a confusing
 /// "pending symlink" row alongside a "skipping on this platform"
-/// warning. Regression for review feedback on PR #90.
+/// warning.
 #[test]
 fn status_suppresses_lib_prefix_rows_when_skipped() {
     let env = TempEnvironment::builder()
@@ -175,13 +168,11 @@ fn status_renders_with_standout() {
     let ctx = make_ctx(&env);
     let result = commands::status::status(None, &ctx).unwrap();
 
-    // Render as text
     let output = render::render("pack-status", &result, OutputMode::Text).unwrap();
     assert!(output.contains("vim"), "output: {output}");
     assert!(output.contains("vimrc"), "output: {output}");
     assert!(output.contains("pending"), "output: {output}");
 
-    // Render as JSON
     let json = render::render("pack-status", &result, OutputMode::Json).unwrap();
     assert!(json.contains("\"packs\""), "json: {json}");
 }
@@ -274,8 +265,6 @@ fn status_shows_xdg_target_for_subdirectory() {
 
 #[test]
 fn status_lists_top_level_dirs_wholesale() {
-    // Top-level dirs now appear as single entries (linked wholesale),
-    // not expanded into one entry per nested file.
     let env = TempEnvironment::builder()
         .pack("nvim")
         .file("nvim/init.lua", "-- nvim config")
@@ -295,11 +284,11 @@ fn status_lists_top_level_dirs_wholesale() {
     );
 }
 
-/// Regression: status must follow the planner's intent expansion for
+/// Status must follow the planner's intent expansion for
 /// escape-prefix directories (`_home/`, `_xdg/`, `_app/`, `_lib/`).
 ///
-/// Before this was fixed, status iterated raw scanner matches and
-/// rendered `_app` as a single row resolving to the default rule
+/// Iterating raw scanner matches would render `_app` as a single row
+/// resolving to the default rule
 /// (`$XDG_CONFIG_HOME/<pack>/_app`) — a path the planner never deploys
 /// to. Because the data link for that bogus target never exists,
 /// verification reported "pending" indefinitely, even after a
@@ -307,7 +296,7 @@ fn status_lists_top_level_dirs_wholesale() {
 /// `<app_support>/...` per the `_app/<rest>` rule) didn't appear in
 /// status output at all.
 ///
-/// The fix has status drive its deployable rows from
+/// Status drives its deployable rows from
 /// `orchestration::plan_pack` (the same intents the executor runs),
 /// not from raw matches. This test pins that contract end-to-end:
 /// after `up`, status must show the per-leaf row deployed at the
@@ -402,7 +391,6 @@ fn up_deploys_packs() {
     assert!(!result.packs.is_empty());
     assert!(result.message.is_some());
 
-    // After up, status should show deployed
     let status = commands::status::status(None, &ctx).unwrap();
     let deployed_count = status.packs[0]
         .files
@@ -412,11 +400,9 @@ fn up_deploys_packs() {
     assert!(deployed_count > 0, "some files should be deployed after up");
 }
 
-/// Regression for #42 (unify status rendering): `up` and `status` must
+/// `up` and `status` must
 /// produce identical per-file status_label strings for the same handler
-/// state. Before #42, `up` reported "staged bin" while `status` reported
-/// "in PATH" for the same path-handler state — confusing duplicate
-/// vocabulary.
+/// state, using steady-state vocabulary.
 #[test]
 fn up_and_status_produce_matching_labels() {
     let env = TempEnvironment::builder()
@@ -434,7 +420,6 @@ fn up_and_status_produce_matching_labels() {
     let up_result = commands::up::up(None, &ctx).unwrap();
     let status_result = commands::status::status(None, &ctx).unwrap();
 
-    // Build (pack, file_name) -> status_label maps for both.
     let to_map = |packs: &[commands::DisplayPack]| {
         let mut map = std::collections::HashMap::new();
         for p in packs {
@@ -478,7 +463,7 @@ fn up_and_status_produce_matching_labels() {
     );
 }
 
-/// Regression for #42: `down` should likewise render through status, not
+/// `down` should likewise render through status, not
 /// hand-rolled "removed" / "state removed" labels.
 #[test]
 fn down_and_status_produce_matching_labels() {
@@ -515,7 +500,6 @@ fn down_and_status_produce_matching_labels() {
         "down and status should report identical status_labels for the same files"
     );
 
-    // After down, files should be in handler-specific pending vocabulary.
     let labels: Vec<&str> = down_labels.values().map(String::as_str).collect();
     assert!(
         labels.iter().all(|l| !l.contains("removed")),
@@ -534,7 +518,6 @@ fn up_generates_shell_init() {
     let ctx = make_ctx(&env);
     commands::up::up(None, &ctx).unwrap();
 
-    // Shell init script should exist
     env.assert_exists(&env.paths.init_script_path());
     let init_content = env
         .fs
@@ -575,7 +558,7 @@ fn status_surfaces_syntax_error_sidecar_for_deployed_shell_file() {
     ctx.syntax_checker = Arc::new(FlagAliases);
     commands::up::up(None, &ctx).unwrap();
 
-    // Now run status — should flag aliases.sh as broken and leave
+    // Status flags aliases.sh as broken and leaves
     // env.sh as plain deployed.
     let result = commands::status::status(None, &ctx).unwrap();
     let pack = &result.packs[0];
@@ -782,13 +765,11 @@ fn up_writes_syntax_error_sidecar_when_check_fails() {
     ctx.syntax_checker = Arc::new(FlagAliases);
     commands::up::up(None, &ctx).unwrap();
 
-    // Sidecar present for the failing file…
     let bad = crate::shell::error_sidecar_path(env.paths.as_ref(), "vim", "aliases.sh");
     assert!(env.fs.exists(&bad), "expected sidecar at {}", bad.display());
     let body = env.fs.read_to_string(&bad).unwrap();
     assert!(body.contains("unexpected token"), "sidecar:\n{body}");
 
-    // …and not for the clean file.
     let good = crate::shell::error_sidecar_path(env.paths.as_ref(), "vim", "env.sh");
     assert!(!env.fs.exists(&good));
 }
@@ -807,7 +788,6 @@ fn up_dry_run_no_changes() {
     let result = commands::up::up(None, &ctx).unwrap();
     assert!(result.dry_run);
 
-    // Nothing should be deployed
     let status_ctx = make_ctx(&env); // fresh non-dry-run ctx
     let status = commands::status::status(None, &status_ctx).unwrap();
     for file in &status.packs[0].files {
@@ -845,7 +825,7 @@ fn up_dry_run_does_not_write_preprocessing_baselines() {
     );
 }
 
-// ── cfprefsd drift marker (#109) ────────────────────────────
+// ── cfprefsd drift marker ───────────────────────────────────
 
 #[cfg(target_os = "macos")]
 #[test]
@@ -918,7 +898,7 @@ fn up_with_pack_filter_does_not_write_cfprefsd_marker_for_unrelated_pack_plists(
 
 #[test]
 fn up_reports_conflict_when_file_exists() {
-    // home.gitconfig (post-#48 per-file home opt-in) routes to ~/.gitconfig,
+    // home.gitconfig routes to ~/.gitconfig,
     // which already exists in the home_file fixture. That collision
     // exercises the conflict path the test cares about.
     let env = TempEnvironment::builder()
@@ -931,14 +911,12 @@ fn up_reports_conflict_when_file_exists() {
     let ctx = make_ctx(&env);
     let result = commands::up::up(None, &ctx).unwrap();
 
-    // Should report errors
     assert!(
         result.message.as_deref() == Some("Packs deployed with errors."),
         "msg: {:?}",
         result.message
     );
 
-    // The conflict file should show as error
     let error_files: Vec<&commands::DisplayFile> = result.packs[0]
         .files
         .iter()
@@ -948,7 +926,7 @@ fn up_reports_conflict_when_file_exists() {
         !error_files.is_empty(),
         "should have error files for conflicts"
     );
-    // The conflict message now lives in the notes section, referenced by
+    // The conflict message lives in the notes section, referenced by
     // the error row's note_ref. status_label stays a short "error" keyword
     // so the column layout is preserved.
     let note_idx = error_files[0]
@@ -960,8 +938,7 @@ fn up_reports_conflict_when_file_exists() {
         "note should mention conflict: {}",
         result.notes[note_idx].body
     );
-    // Error rows must identify the failing file in the left column,
-    // not render with an empty name (regression: PR #45 review).
+    // Error rows identify the failing file in the left column.
     assert!(
         !error_files[0].name.is_empty(),
         "error row should name the failing file, got empty name"
@@ -972,12 +949,11 @@ fn up_reports_conflict_when_file_exists() {
         error_files[0].name
     );
 
-    // Original file should be untouched
     env.assert_file_contents(&env.home.join(".gitconfig"), "[user]\n  name = old");
 
     // Status should NOT show deployed. The conflicted file should surface
     // as `warning` (PendingConflict) with a footnote pointing at the
-    // pre-existing user file — see #43.
+    // pre-existing user file.
     let status = commands::status::status(None, &ctx).unwrap();
     for file in &status.packs[0].files {
         assert!(
@@ -1026,20 +1002,16 @@ fn up_force_overwrites_existing_files() {
     ctx.force = true;
     let result = commands::up::up(None, &ctx).unwrap();
 
-    // Should succeed
     assert_eq!(result.message.as_deref(), Some("Packs deployed."));
 
-    // File should now be a symlink with new content
     let content = env.fs.read_to_string(&env.home.join(".gitconfig")).unwrap();
     assert_eq!(content, "[user]\n  name = new");
 }
 
-// ── up: reconcile non-provisioning state (#58) ─────────────
+// ── up: reconcile non-provisioning state ────────────────────
 
-/// `dodot up` was additive only: a deleted source file would leave its
-/// datastore entry behind, so the regenerated init script kept sourcing
-/// a now-missing path. The fix wipes configuration-handler state per
-/// pack at the start of `up` and re-applies from current source.
+/// `dodot up` wipes configuration-handler state per pack before
+/// reapplying current sources, so deleted entries cannot remain sourced.
 #[test]
 fn up_reconciles_deleted_shell_source() {
     let env = TempEnvironment::builder()
@@ -1057,7 +1029,6 @@ fn up_reconciles_deleted_shell_source() {
     before.sort();
     assert_eq!(before, vec!["aliases.sh", "profile.sh"]);
 
-    // Delete one source from the pack and re-run up.
     env.fs
         .remove_file(&env.dotfiles_root.join("gh/profile.sh"))
         .unwrap();
@@ -1126,7 +1097,6 @@ fn up_reconciles_deleted_path_dir() {
     let path_dir = env.paths.handler_data_dir("tools", "path");
     assert_eq!(env.list_dir_names(&path_dir), vec!["bin"]);
 
-    // Drop the bin/ directory entirely.
     env.fs
         .remove_dir_all(&env.dotfiles_root.join("tools/bin"))
         .unwrap();
@@ -1177,8 +1147,6 @@ fn up_preserves_install_sentinel_when_source_persists() {
     );
     let original = sentinels_before.into_iter().next().unwrap();
 
-    // Re-run up with no source change. The sentinel must persist —
-    // wiping it would force the script to re-execute every time.
     commands::up::up(None, &ctx).unwrap();
     let sentinels_after: Vec<_> = env
         .list_dir_names(&install_dir)
@@ -1244,23 +1212,20 @@ fn down_removes_deployed_state() {
 
     let ctx = make_ctx(&env);
 
-    // Deploy first
     commands::up::up(None, &ctx).unwrap();
 
-    // Verify something is deployed
     let status = commands::status::status(None, &ctx).unwrap();
     let has_deployed = status.packs[0].files.iter().any(|f| f.status == "deployed");
     assert!(has_deployed, "should have deployed files after up");
 
-    // Down
     let down_result = commands::down::down(None, &ctx).unwrap();
     assert!(down_result.message.is_some());
 
     // After down, all files should be plain pending. The user-side
     // symlinks left dangling by `down` are NOT conflicts — the executor's
-    // create_user_link gracefully replaces them on the next `up`. (#43
-    // refines `PendingConflict` to only fire when the executor would
-    // actually refuse: non-symlink + exists.)
+    // create_user_link gracefully replaces them on the next `up`.
+    // `PendingConflict` only fires when the executor would
+    // actually refuse: non-symlink + exists.
     let status = commands::status::status(None, &ctx).unwrap();
     for file in &status.packs[0].files {
         assert_eq!(
@@ -1299,7 +1264,6 @@ fn list_shows_all_packs() {
     let disabled = result.packs.iter().find(|p| p.name == "disabled").unwrap();
     assert!(disabled.ignored);
 
-    // Render as text
     let output = render::render("list", &result, OutputMode::Text).unwrap();
     assert!(output.contains("vim"), "output: {output}");
     assert!(output.contains("(ignored)"), "output: {output}");
@@ -1412,7 +1376,6 @@ fn down_on_already_down_pack_says_nothing_to_do() {
         .build();
 
     let ctx = make_ctx(&env);
-    // vim was never deployed — should not print misleading output
     let result = commands::down::down(None, &ctx).unwrap();
     assert_eq!(
         result.message.as_deref(),
@@ -1433,10 +1396,8 @@ fn addignore_on_deployed_pack_warns() {
         .build();
 
     let ctx = make_ctx(&env);
-    // Deploy first
     commands::up::up(None, &ctx).unwrap();
 
-    // Now addignore should warn
     let result = commands::addignore::addignore("git", &ctx).unwrap();
     assert!(result.message.contains("ignored"));
     let has_warning = result
@@ -1465,7 +1426,6 @@ fn full_lifecycle_up_status_down_status() {
 
     let ctx = make_ctx(&env);
 
-    // 1. Status before up — all pending
     let s1 = commands::status::status(None, &ctx).unwrap();
     assert_eq!(s1.packs.len(), 2);
     for pack in &s1.packs {
@@ -1474,11 +1434,9 @@ fn full_lifecycle_up_status_down_status() {
         }
     }
 
-    // 2. Up — deploy
     let up = commands::up::up(None, &ctx).unwrap();
     assert!(!up.packs.is_empty());
 
-    // 3. Status after up — deployed
     let s2 = commands::status::status(None, &ctx).unwrap();
     let total_deployed: usize = s2
         .packs
@@ -1488,11 +1446,10 @@ fn full_lifecycle_up_status_down_status() {
         .count();
     assert!(total_deployed > 0);
 
-    // 4. Down — remove
     commands::down::down(None, &ctx).unwrap();
 
-    // 5. Status after down — pending again. Dangling user-side symlinks
-    // left by `down` are not conflicts (executor handles them on
+    // Dangling user-side symlinks left by `down` are not conflicts
+    // (the executor handles them on
     // re-deploy), so they stay plain pending.
     let s3 = commands::status::status(None, &ctx).unwrap();
     for pack in &s3.packs {
@@ -1505,7 +1462,6 @@ fn full_lifecycle_up_status_down_status() {
         }
     }
 
-    // 6. Up again — idempotent
     commands::up::up(None, &ctx).unwrap();
     let s4 = commands::status::status(None, &ctx).unwrap();
     let deployed_again: usize = s4
@@ -1517,7 +1473,7 @@ fn full_lifecycle_up_status_down_status() {
     assert_eq!(total_deployed, deployed_again, "idempotent re-deploy");
 }
 
-/// Regression for #43: status must distinguish "pending — clear to
+/// Status must distinguish "pending — clear to
 /// deploy" from "pending — would conflict with a pre-existing file".
 /// Both render under the `pending` *label*, but the conflict case gets
 /// a `warning` status (so themes can color it differently) plus a
@@ -1525,7 +1481,7 @@ fn full_lifecycle_up_status_down_status() {
 #[test]
 fn status_surfaces_pre_existing_conflict_as_warning_with_footnote() {
     // Use `home.X` so the deploy targets ~/.X and collides with the
-    // home_file fixture (under #48 the default deploy target is
+    // home_file fixture (the default deploy target is
     // $XDG_CONFIG_HOME/<pack>/X, which wouldn't collide).
     let env = TempEnvironment::builder()
         .pack("ghostty")
@@ -1582,7 +1538,6 @@ fn status_surfaces_pre_existing_conflict_as_warning_with_footnote() {
         result.notes[ghostty_note].body
     );
 
-    // vim has no pre-existing ~/.vimrc — should be plain pending, no note.
     let vim_file = &vim.files[0];
     assert_eq!(
         vim_file.status, "pending",
@@ -1595,12 +1550,10 @@ fn status_surfaces_pre_existing_conflict_as_warning_with_footnote() {
     );
 }
 
-/// Negative regression for #43: pre-existing symlinks at the user-target
+/// Pre-existing symlinks at the user-target
 /// path are NOT conflicts. The executor's `create_user_link` gracefully
 /// replaces them (correct ones are no-ops, wrong/dangling ones are
 /// removed and recreated), so flagging them would be a false positive.
-/// Issue #44 may add an informational note for the equivalent-symlink
-/// case, but that's separate from the conflict detection #43 introduces.
 #[test]
 fn status_does_not_flag_pre_existing_symlinks_as_conflict() {
     let env = TempEnvironment::builder()
@@ -1612,12 +1565,10 @@ fn status_does_not_flag_pre_existing_symlinks_as_conflict() {
         .done()
         .build();
 
-    // Equivalent symlink: ~/.kittyrc already points at dodot's source.
     let source = env.dotfiles_root.join("kitty/kittyrc");
     let kitty_target = env.home.join(".kittyrc");
     env.fs.symlink(&source, &kitty_target).unwrap();
 
-    // Non-equivalent symlink: ~/.ghostrc points somewhere else entirely.
     let ghostty_target = env.home.join(".ghostrc");
     env.fs
         .symlink(std::path::Path::new("/tmp/elsewhere"), &ghostty_target)
@@ -1712,7 +1663,6 @@ fn status_detects_broken_user_link_removed() {
     let ctx = make_ctx(&env);
     commands::up::up(None, &ctx).unwrap();
 
-    // Remove the user link (under #48: $XDG_CONFIG_HOME/vim/vimrc).
     let user_path = env.home.join(".config/vim/vimrc");
     env.fs.remove_file(&user_path).unwrap();
 
@@ -1741,9 +1691,9 @@ fn status_detects_conflict_at_user_path() {
     let ctx = make_ctx(&env);
     commands::up::up(None, &ctx).unwrap();
 
-    // Replace user symlink (under #48: $XDG_CONFIG_HOME/vim/vimrc) with a
+    // Replace the user symlink with a
     // regular file whose content does NOT match source — that's a real
-    // conflict (#44 auto-replace would only kick in for matching content).
+    // conflict; auto-replace only applies to matching content.
     let user_path = env.home.join(".config/vim/vimrc");
     env.fs.remove_file(&user_path).unwrap();
     env.fs.write_file(&user_path, b"manual file").unwrap();
@@ -1797,18 +1747,12 @@ fn status_shell_handler_detects_broken_source() {
     let ctx = make_ctx(&env);
     commands::up::up(None, &ctx).unwrap();
 
-    // Delete source but keep data link
     let source = env.dotfiles_root.join("vim/aliases.sh");
     env.fs.remove_file(&source).unwrap();
 
-    // Scanner won't find the deleted file, so pack will have no matches.
-    // Recreate the source so scanner finds it, but break the chain differently.
-    // Instead, test that the data link pointing to missing source is detected.
-    // We need the file in the pack for the scanner, so write a new one and
-    // then break the data link.
+    // Recreate the source so the scanner sees it, then break the data link.
     env.fs.write_file(&source, b"alias vi=vim").unwrap();
 
-    // Now manually break the data link by pointing it elsewhere
     let data_link = env
         .paths
         .handler_data_dir("vim", "shell")
@@ -1858,7 +1802,6 @@ fn status_path_handler_verified_deployed() {
 
 #[test]
 fn up_succeeds_after_resolving_conflict() {
-    // Set up conflicting packs
     let env = TempEnvironment::builder()
         .pack("pack-a")
         .file("home.aliases", "a")
@@ -1870,16 +1813,13 @@ fn up_succeeds_after_resolving_conflict() {
 
     let ctx = make_ctx(&env);
 
-    // First attempt fails
     let err = commands::up::up(None, &ctx).unwrap_err();
     assert!(matches!(err, crate::DodotError::CrossPackConflict { .. }));
 
-    // "Resolve" conflict by deploying only one pack
     let filter = vec!["pack-a".into()];
     let result = commands::up::up(Some(&filter), &ctx).unwrap();
     assert_eq!(result.message.as_deref(), Some("Packs deployed."));
 
-    // pack-a should be deployed
     let status = commands::status::status(Some(&filter), &ctx).unwrap();
     assert!(status.packs[0].files.iter().any(|f| f.status == "deployed"));
 }
@@ -1908,7 +1848,6 @@ fn up_conflict_with_home_prefix_convention() {
 
 #[test]
 fn up_multiple_simultaneous_conflicts() {
-    // Two conflict groups at the same time
     let env = TempEnvironment::builder()
         .pack("a")
         .file("home.aliases", "a-aliases")
@@ -1981,7 +1920,7 @@ fn up_conflict_xdg_path_both_packs_subdir() {
     // hatch — skips the pack name in the path) → both resolve to
     // ~/.config/nvim/init.lua, conflict.
     //
-    // (Without `_xdg/`, the new default would namespace each pack
+    // (Without `_xdg/`, the default would namespace each pack
     // under its own dir — `~/.config/nvim-base/...` vs `~/.config/
     // nvim-custom/...` — and they wouldn't collide.)
     let env = TempEnvironment::builder()
@@ -2013,14 +1952,12 @@ fn up_auto_chmod_makes_bin_files_executable() {
 
     let ctx = make_ctx(&env);
 
-    // Verify the file starts non-executable
     let tool_path = env.dotfiles_root.join("tools/bin/deploy");
     let meta_before = env.fs.stat(&tool_path).unwrap();
     assert_eq!(meta_before.mode & 0o111, 0, "should start non-executable");
 
     commands::up::up(None, &ctx).unwrap();
 
-    // After up, file should be executable
     let meta_after = env.fs.stat(&tool_path).unwrap();
     assert_ne!(
         meta_after.mode & 0o111,
@@ -2037,7 +1974,6 @@ fn up_auto_chmod_disabled_via_config() {
         .done()
         .build();
 
-    // Write root config disabling auto_chmod_exec
     env.fs
         .write_file(
             &env.dotfiles_root.join(".dodot.toml"),
@@ -2048,7 +1984,6 @@ fn up_auto_chmod_disabled_via_config() {
     let ctx = make_ctx(&env);
     commands::up::up(None, &ctx).unwrap();
 
-    // File should remain non-executable
     let tool_path = env.dotfiles_root.join("tools/bin/deploy");
     let meta = env.fs.stat(&tool_path).unwrap();
     assert_eq!(
@@ -2062,10 +1997,8 @@ fn up_auto_chmod_disabled_via_config() {
 
 #[test]
 fn status_reports_template_under_stripped_name() {
-    // Regression guard: before the fix, status used the raw scanner
-    // output (pre-preprocessing) for its file list, so a `greet.tmpl`
-    // template would be listed as `greet.tmpl` and wrongly reported as
-    // "pending" even after `dodot up` deployed the rendered `greet`.
+    // Status uses post-preprocessing entries so a deployed `greet.tmpl`
+    // appears as `greet`, not a pending source template.
     let env = TempEnvironment::builder()
         .pack("app")
         .file("greet.tmpl", "hello {{ name }}")
@@ -2075,7 +2008,6 @@ fn status_reports_template_under_stripped_name() {
 
     let ctx = make_ctx(&env);
 
-    // Run up first so the deployment state is "deployed".
     commands::up::up(None, &ctx).unwrap();
 
     let result = commands::status::status(None, &ctx).unwrap();
@@ -2084,7 +2016,6 @@ fn status_reports_template_under_stripped_name() {
     let files = &result.packs[0].files;
     assert_eq!(files.len(), 1, "files: {files:?}");
 
-    // The display name must be the stripped name, not the .tmpl source.
     assert_eq!(files[0].name, "greet", "file name: {}", files[0].name);
     assert_eq!(
         files[0].status, "deployed",
@@ -2094,7 +2025,6 @@ fn status_reports_template_under_stripped_name() {
 
 #[test]
 fn status_reports_template_pending_before_up() {
-    // Even without running up, status should use the stripped name.
     let env = TempEnvironment::builder()
         .pack("app")
         .file("greet.tmpl", "hello {{ name }}")
@@ -2156,7 +2086,6 @@ fn summary_rolls_up_error_over_pending_over_deployed() {
         note_ref: None,
     };
 
-    // error beats pending beats deployed
     let pack = DisplayPack::new(
         "mixed".into(),
         vec![mk("error"), mk("pending"), mk("deployed")],
@@ -2164,17 +2093,14 @@ fn summary_rolls_up_error_over_pending_over_deployed() {
     assert_eq!(pack.summary_status, "error");
     assert_eq!(pack.summary_count, 1);
 
-    // broken rolls into error bucket
     let pack = DisplayPack::new("b".into(), vec![mk("broken"), mk("deployed")]);
     assert_eq!(pack.summary_status, "error");
 
-    // stale and warning roll into pending bucket
     let pack = DisplayPack::new("s".into(), vec![mk("stale"), mk("deployed")]);
     assert_eq!(pack.summary_status, "pending");
     let pack = DisplayPack::new("w".into(), vec![mk("warning"), mk("deployed")]);
     assert_eq!(pack.summary_status, "pending");
 
-    // count counts only files in the winning bucket
     let pack = DisplayPack::new(
         "counts".into(),
         vec![
@@ -2206,7 +2132,6 @@ fn short_mode_renders_one_line_per_pack_with_count() {
 
     let output = render::render("pack-status", &result, OutputMode::Text).unwrap();
 
-    // Short mode: one line per pack, count + status word, no per-file rows
     assert!(output.contains("vim"), "output: {output}");
     assert!(output.contains("nvim"), "output: {output}");
     assert!(output.contains("(1) pending"), "output: {output}");
@@ -2237,7 +2162,6 @@ fn by_status_groups_packs_under_banners() {
 
     let output = render::render("pack-status", &result, OutputMode::Text).unwrap();
 
-    // All packs pending, so only the Pending banner appears
     assert!(output.contains("Pending Packs"), "output: {output}");
     assert!(
         !output.contains("Deployed Packs"),
@@ -2247,7 +2171,6 @@ fn by_status_groups_packs_under_banners() {
         !output.contains("Error Packs"),
         "no error packs — error banner should be hidden: {output}"
     );
-    // Pack names still render within the group
     assert!(output.contains("vim"), "output: {output}");
     assert!(output.contains("nvim"), "output: {output}");
 }

--- a/crates/dodot-lib/src/commands/tests/probe.rs
+++ b/crates/dodot-lib/src/commands/tests/probe.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the `probe` command family (probe summary, deployment-map, shell-init in all modes, and the macOS app-advisory probes).
+//! Integration tests for the `probe` command family.
 
 #![allow(unused_imports)]
 
@@ -73,7 +73,6 @@ fn probe_show_data_dir_renders_tree_with_sizes() {
     assert!(output.contains("packs"), "output:\n{output}");
     assert!(output.contains("vim"), "output:\n{output}");
     assert!(output.contains("shell"), "output:\n{output}");
-    // Tree should use box-drawing glyphs somewhere.
     assert!(
         output.contains("├") || output.contains("└"),
         "expected branch glyphs in tree; got:\n{output}"
@@ -91,7 +90,7 @@ fn probe_deployment_map_json_mode_is_kind_tagged() {
     assert!(parsed["entries"].is_array());
 }
 
-// ── probe shell-init Phase 3 (--runs / --history) ─────────────────
+// ── probe shell-init (--runs / --history) ─────────────────────────
 
 fn write_fake_profile(env: &TempEnvironment, name: &str, lines: &[&str]) {
     let dir = env.paths.probes_shell_init_dir();
@@ -147,7 +146,6 @@ fn probe_shell_init_aggregate_warns_when_fewer_runs_than_requested() {
         "profile-1714000001-1-1.tsv",
         &["source\tvim\tshell\t/x.sh\t1.000000\t1.000100\t0"],
     );
-    // Asked for 10, only 1 on disk.
     let result = commands::probe::shell_init_aggregate(&ctx, 10).unwrap();
     let output = render::render("probe", &result, OutputMode::Text).unwrap();
     assert!(
@@ -196,19 +194,16 @@ fn probe_shell_init_history_renders_one_row_per_run_newest_first() {
         output.contains("2024-04-24"),
         "date missing; got:\n{output}"
     );
-    // Three rendered rows; ordering check via JSON because the text
-    // template's column padding makes substring offsets fragile.
+    // Use JSON for ordering because text-column padding makes offsets fragile.
     let json = render::render("probe", &result, OutputMode::Json).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
     let rows = parsed["rows"].as_array().unwrap();
     assert_eq!(rows.len(), 3);
-    // Newest unix_ts first, oldest last (descending).
     let timestamps: Vec<u64> = rows
         .iter()
         .map(|r| r["unix_ts"].as_u64().unwrap_or(0))
         .collect();
     assert_eq!(timestamps, vec![1714007200, 1714003600, 1714000000]);
-    // Middle row had a non-zero exit_status.
     assert_eq!(rows[1]["failed_entries"].as_u64().unwrap(), 1);
     assert_eq!(rows[0]["failed_entries"].as_u64().unwrap(), 0);
     assert_eq!(rows[2]["failed_entries"].as_u64().unwrap(), 0);
@@ -272,7 +267,7 @@ fn probe_shell_init_errors_json_is_kind_tagged() {
     assert!(parsed["targets"].is_array());
 }
 
-// ── probe shell-init: staleness banner (#59) ────────────────
+// ── probe shell-init: staleness banner ──────────────────────
 
 /// Plant a `last-up-at` marker at the given unix timestamp so tests
 /// don't depend on real wall-clock writes.
@@ -308,7 +303,6 @@ fn probe_shell_init_banner_when_profile_predates_last_up() {
         text.contains("warning:"),
         "expected staleness banner, got:\n{text}"
     );
-    // Banner mentions both timestamps so the user can verify the comparison.
     assert!(
         text.contains("2024-04-24") && text.contains("2024-04-25"),
         "banner should reference both capture and up timestamps, got:\n{text}"
@@ -627,7 +621,6 @@ fn probe_shell_init_filter_supports_nested_subpaths() {
         ],
     );
 
-    // Subpath filter narrows to the matching nested file only.
     let result = commands::probe::shell_init_filter(
         &ctx,
         "gpg/sub/dir/env.sh",
@@ -641,7 +634,6 @@ fn probe_shell_init_filter_supports_nested_subpaths() {
     assert_eq!(view.targets.len(), 1);
     assert_eq!(view.targets[0].target, "/p/gpg/sub/dir/env.sh");
 
-    // Bare basename still matches both nested files.
     let result_basename = commands::probe::shell_init_filter(
         &ctx,
         "gpg/env.sh",
@@ -657,7 +649,6 @@ fn probe_shell_init_filter_supports_nested_subpaths() {
 
 #[test]
 fn probe_shell_init_filter_basename_does_not_partial_match() {
-    // Boundary check: `env.sh` filter must not match `nvenv.sh`.
     let env = TempEnvironment::builder().build();
     let ctx = make_ctx(&env);
     write_fake_profile(
@@ -719,7 +710,6 @@ fn probe_shell_init_errors_only_keeps_only_failed_runs() {
         commands::probe::ProbeResult::ShellInitErrors(v) => v,
         other => panic!("expected ShellInitErrors, got {other:?}"),
     };
-    // vim/aliases.sh succeeded — must not appear. Only gpg/env.sh.
     assert_eq!(view.targets.len(), 1);
     assert_eq!(view.targets[0].display_target, "env.sh");
     assert_eq!(view.targets[0].failure_count, 1);
@@ -761,8 +751,6 @@ fn probe_shell_init_errors_only_sorts_by_failure_count_desc() {
 
 #[test]
 fn probe_shell_init_errors_only_clean_window_says_so() {
-    // Only successful runs in the window — view shows 0 targets and
-    // the renderer surfaces a cheerful "no failed sources" line.
     let env = TempEnvironment::builder().build();
     let ctx = make_ctx(&env);
     write_fake_profile(
@@ -812,7 +800,6 @@ fn up_writes_last_up_marker() {
 
     let raw = env.fs.read_to_string(&env.paths.last_up_path()).unwrap();
     let parsed: u64 = raw.trim().parse().expect("marker should be a unix ts");
-    // Sanity: post-2023.
     assert!(parsed > 1_700_000_000, "ts should look recent: {parsed}");
 }
 
@@ -856,7 +843,6 @@ fn down_refreshes_deployment_map_to_empty() {
 
     let ctx = make_ctx(&env);
     commands::up::up(None, &ctx).unwrap();
-    // Precondition: map has a row.
     let content_before = env
         .fs
         .read_to_string(&env.paths.deployment_map_path())
@@ -869,7 +855,6 @@ fn down_refreshes_deployment_map_to_empty() {
         .fs
         .read_to_string(&env.paths.deployment_map_path())
         .unwrap();
-    // Header stays; data rows are gone.
     assert!(content_after.starts_with("# dodot deployment map v1"));
     assert!(
         !content_after.contains("aliases.sh"),
@@ -889,7 +874,6 @@ fn up_dry_run_does_not_touch_deployment_map() {
     ctx.dry_run = true;
     commands::up::up(None, &ctx).unwrap();
 
-    // Map file should not have been written for a dry-run.
     env.assert_not_exists(&env.paths.deployment_map_path());
 }
 
@@ -916,7 +900,7 @@ fn by_status_folds_ignored_packs_into_ignored_group() {
     assert!(output.contains("Pending Packs"), "output: {output}");
 }
 
-// ── M6: probe::app + advisory probes ─────────────────────────
+// ── probe::app + advisory probes ─────────────────────────────
 
 /// `dodot probe app <pack>` collects every folder this pack would
 /// route to (alias, force_app, _app/), checks each against the
@@ -999,7 +983,6 @@ fn probe_app_collects_alias_force_and_underscore_entries() {
         Some("com.todesktop.Cursor")
     );
 
-    // Sibling-adoption suggestions surfaced from cask zap.
     assert!(
         view.suggested_adoptions
             .iter()
@@ -1012,8 +995,7 @@ fn probe_app_collects_alias_force_and_underscore_entries() {
 /// `dodot probe app ..` (or any other path-traversing input) must
 /// not let `pack_path` traversal escape the dotfiles root. Probe
 /// validates that `pack_name` is a single-component path before
-/// passing it to `Pather::pack_path`. Regression for review feedback
-/// on PR #91.
+/// passing it to `Pather::pack_path`.
 #[test]
 fn probe_app_rejects_path_traversal_input() {
     let env = TempEnvironment::builder().build();
@@ -1026,8 +1008,6 @@ fn probe_app_rejects_path_traversal_input() {
             commands::probe::ProbeResult::App(v) => v,
             other => panic!("expected App variant, got {other:?}"),
         };
-        // Empty-but-named view: the pack name echoes back, but no
-        // entries are surfaced (filesystem traversal was skipped).
         assert_eq!(view.pack, evil, "input echoed back unchanged");
         assert!(
             view.entries.is_empty(),
@@ -1062,7 +1042,6 @@ fn probe_app_non_macos_returns_minimal_view() {
         other => panic!("expected App variant, got {other:?}"),
     };
     assert!(!view.macos);
-    // No brew enrichment.
     for entry in &view.entries {
         assert!(entry.cask.is_none(), "row: {entry:?}");
         assert!(entry.app_bundle.is_none(), "row: {entry:?}");
@@ -1121,7 +1100,6 @@ fn plan_pack_emits_missing_target_hint_with_cask_enrichment() {
         ctx.command_runner.as_ref(),
     );
 
-    // Synthesize a Pack matching the on-disk pack we built.
     let pack_path = env.dotfiles_root.join("vscode");
     let pack_config = ctx.config_manager.config_for_pack(&pack_path).unwrap();
     let pack = Pack {
@@ -1144,8 +1122,8 @@ fn plan_pack_emits_missing_target_hint_with_cask_enrichment() {
         hint_text.contains("visual-studio-code"),
         "expected cask-enriched hint, got: {hint_text}"
     );
-    // Per review feedback: the cask is installed (we read it from
-    // `brew list`), so the message must NOT claim it isn't installed.
+    // Casks from `brew list` are installed, so the message must not
+    // claim otherwise.
     assert!(
         !hint_text.contains("isn't installed"),
         "hint should not falsely claim the cask is uninstalled, got: {hint_text}"

--- a/crates/dodot-lib/src/commands/tests/support.rs
+++ b/crates/dodot-lib/src/commands/tests/support.rs
@@ -1,10 +1,4 @@
-//! Shared test fixtures for the commands integration tests.
-//!
-//! Holds the mock `CommandRunner` impls and the `make_ctx` /
-//! `make_ctx_with_runner` builders that every per-command test module
-//! reaches for. Visibility is `pub(super)` so other test files within
-//! the `tests/` directory can reuse them without exposing the helpers
-//! to the broader crate.
+//! Shared command-test fixtures.
 
 use std::sync::Arc;
 
@@ -27,9 +21,7 @@ impl CommandRunner for MockCommandRunner {
     }
 }
 
-/// CommandRunner test double that returns canned outputs per `(exe,
-/// args...)` key. Used by probe::app integration tests so the brew /
-/// mdls / mdfind subprocesses don't actually run.
+/// Returns canned command outputs without spawning subprocesses.
 pub(super) struct CannedRunner {
     responses: std::sync::Mutex<std::collections::HashMap<Vec<String>, CommandOutput>>,
 }
@@ -97,9 +89,6 @@ pub(super) fn make_ctx(env: &TempEnvironment) -> ExecutionContext {
     }
 }
 
-/// Variant of make_ctx that swaps in a [`CannedRunner`] so probe
-/// tests can exercise the brew/mdls/mdfind enrichment paths without
-/// spawning processes.
 pub(super) fn make_ctx_with_runner(
     env: &TempEnvironment,
     runner: Arc<dyn CommandRunner>,

--- a/crates/dodot-lib/src/commands/transform/install_hook.rs
+++ b/crates/dodot-lib/src/commands/transform/install_hook.rs
@@ -40,8 +40,8 @@ pub enum InstallHookOutcome {
 }
 
 /// Result returned by [`install_hook`]. Renders through the
-/// `transform-install-hook.jinja` template; CLI exits 0 in all three
-/// outcomes (every state is a success).
+/// `transform-install-hook.jinja` template; CLI exits 0 for every
+/// outcome (they are all successes).
 #[derive(Debug, Clone, Serialize)]
 pub struct InstallHookResult {
     pub outcome: InstallHookOutcome,
@@ -61,8 +61,10 @@ pub struct InstallHookResult {
 ///
 /// - If `<dotfiles_root>/.git/hooks/pre-commit` does not exist:
 ///   create it with `#!/bin/sh` + our guarded block, mode `0o755`.
-/// - If it exists and already contains [`HOOK_GUARD_START`]:
+/// - If it exists and already carries an up-to-date managed block:
 ///   no-op, return [`InstallHookOutcome::AlreadyInstalled`].
+/// - If it exists with a stale managed block: rewrite the block in
+///   place, leaving everything outside the guards untouched.
 /// - If it exists without our guard: append our block (preserving
 ///   existing content), ensure executable bit is set.
 ///
@@ -91,9 +93,6 @@ pub fn install_hook(ctx: &ExecutionContext) -> Result<InstallHookResult> {
     let outcome = if ctx.fs.exists(&hook_path) {
         let existing = ctx.fs.read_to_string(&hook_path)?;
         if let Some((start_byte, end_byte)) = find_managed_block(&existing) {
-            // A managed block exists. Decide whether it matches the
-            // current `block` exactly (no-op) or is stale and needs
-            // replacing.
             let current_block = &existing[start_byte..end_byte];
             if current_block == block {
                 InstallHookOutcome::AlreadyInstalled
@@ -153,23 +152,20 @@ pub fn hook_is_installed(ctx: &ExecutionContext) -> Result<bool> {
     Ok(existing.contains(HOOK_GUARD_START))
 }
 
-/// Public for `dodot transform show-hook` (future) and for the
-/// onboarding prompt in `commands::up` to surface what would be
-/// installed. Includes the guard lines so callers can grep-detect
-/// the block in arbitrary contexts.
+/// Public so the onboarding prompt in `commands::up` can surface what
+/// would be installed. Includes the guard lines so callers can
+/// grep-detect the block in arbitrary contexts.
 ///
 /// The block runs two commands:
 ///
 /// 1. `dodot refresh --quiet` — touch source mtimes for any
 ///    deployed-side edits so git's stat-cache invalidates. Without
-///    this, the clean filter (R6) wouldn't fire on the upcoming
-///    commit, and the commit could include stale template content.
+///    this, the clean filter wouldn't fire on the upcoming commit,
+///    and the commit could include stale template content.
 /// 2. `dodot transform check --strict` — run the 4-state matrix and
 ///    refuse the commit on any finding (Conflict, missing,
 ///    unresolved markers, NeedsRebaseline). `Patched` outcomes don't
-///    refuse — burgertocow's auto-merge already produced a clean
-///    unified patch and rewrote the source; the user `git add`s and
-///    commits the follow-up if they want a clean history.
+///    refuse; see `TransformCheckResult::has_findings`.
 ///
 /// Each step short-circuits with `|| exit 1`; a failure in either
 /// aborts the commit (with exit code 1 — the inner command's exit
@@ -216,7 +212,6 @@ pub(crate) const HOOK_COMMAND: &str = "dodot refresh --quiet && dodot transform 
 /// non-managed content the user has in their hook.
 fn find_managed_block(text: &str) -> Option<(usize, usize)> {
     let start = text.find(HOOK_GUARD_START)?;
-    // Find the end guard after `start`.
     let after_start = start + HOOK_GUARD_START.len();
     let end_rel = text[after_start..].find(HOOK_GUARD_END)?;
     let end_guard_start = after_start + end_rel;

--- a/crates/dodot-lib/src/commands/transform/install_hook.rs
+++ b/crates/dodot-lib/src/commands/transform/install_hook.rs
@@ -252,7 +252,6 @@ mod tests {
     fn install_hook_creates_new_pre_commit_when_absent() {
         let env = TempEnvironment::builder().build();
         fake_git_dir(&env);
-        // Make sure the hooks dir exists but the hook file does not.
         let hook_path = env.dotfiles_root.join(".git/hooks/pre-commit");
         assert!(!env.fs.exists(&hook_path));
 
@@ -319,7 +318,6 @@ mod tests {
             body_after_first, body_after_second,
             "body changed on second call"
         );
-        // Exactly one occurrence of the guard line.
         assert_eq!(body_after_second.matches(HOOK_GUARD_START).count(), 1);
     }
 
@@ -342,15 +340,11 @@ mod tests {
         fake_git_dir(&env);
         let ctx = make_ctx(&env);
 
-        // No hook yet → not installed.
         assert!(!hook_is_installed(&ctx).unwrap());
 
-        // Install it → reported as installed.
         install_hook(&ctx).unwrap();
         assert!(hook_is_installed(&ctx).unwrap());
 
-        // A user-written hook without our guard → not installed
-        // (from our perspective).
         let hook_path = env.dotfiles_root.join(".git/hooks/pre-commit");
         env.fs
             .write_file(&hook_path, b"#!/bin/sh\necho hello\n")
@@ -371,8 +365,7 @@ mod tests {
 
         let hook_path = env.dotfiles_root.join(".git/hooks/pre-commit");
         let mode = std::fs::metadata(&hook_path).unwrap().permissions().mode();
-        // owner-execute bit must be set; we test for any execute
-        // rather than exact 0o755 because the OS may apply umask.
+        // Test for any execute bit because the OS may apply umask.
         assert!(
             mode & 0o100 != 0,
             "hook is not executable, mode = {:o}",
@@ -399,15 +392,14 @@ mod tests {
 
     #[test]
     fn install_hook_replaces_a_stale_managed_block() {
-        // An older R4-shape block (single check command, no refresh
+        // An older block (single check command, no refresh
         // line) must be detected and rewritten to the new two-line
         // form when `install-hook` runs again. Existing non-managed
         // content is preserved.
         let env = TempEnvironment::builder().build();
         fake_git_dir(&env);
 
-        // Stage an old-style block manually. This is what an R4-era
-        // install-hook would have produced: the same guards, but the
+        // Stage an old-style block manually: the same guards, but the
         // single old `dodot transform check --strict || exit 1`
         // command line and the older comment.
         let stale = format!(
@@ -433,14 +425,10 @@ mod tests {
         assert!(matches!(result.outcome, InstallHookOutcome::Updated));
 
         let body = env.fs.read_to_string(&hook_path).unwrap();
-        // New shape: both refresh + check lines, comment matches the
-        // current block.
         assert!(body.contains(HOOK_COMMAND_REFRESH), "body: {body:?}");
         assert!(body.contains(HOOK_COMMAND_CHECK), "body: {body:?}");
-        // User content (before AND after the managed block) survived.
         assert!(body.contains("user-installed pre-commit step"));
         assert!(body.contains("trailing user step"));
-        // Exactly one managed block — no duplicates.
         assert_eq!(body.matches(HOOK_GUARD_START).count(), 1);
         assert_eq!(body.matches(HOOK_GUARD_END).count(), 1);
     }
@@ -454,7 +442,6 @@ mod tests {
         fake_git_dir(&env);
         let ctx = make_ctx(&env);
 
-        // Install fresh.
         let r1 = install_hook(&ctx).unwrap();
         assert!(matches!(r1.outcome, InstallHookOutcome::Created));
         let body_after_first = env
@@ -462,7 +449,6 @@ mod tests {
             .read_to_string(&env.dotfiles_root.join(".git/hooks/pre-commit"))
             .unwrap();
 
-        // Re-install — current block is up to date, no change.
         let r2 = install_hook(&ctx).unwrap();
         assert!(matches!(r2.outcome, InstallHookOutcome::AlreadyInstalled));
         let body_after_second = env

--- a/crates/dodot-lib/src/commands/transform/mod.rs
+++ b/crates/dodot-lib/src/commands/transform/mod.rs
@@ -25,8 +25,8 @@
 //!
 //! # Strict mode
 //!
-//! `check(ctx, strict=true)` is the form used by the pre-commit hook
-//! (R4). On top of the matrix work above, it scans every source file
+//! `check(ctx, strict=true)` is the form used by the pre-commit hook.
+//! On top of the matrix work above, it scans every source file
 //! for unresolved [`crate::preprocessing::conflict`] markers — if any
 //! are found, the result reports them and the command exits non-zero
 //! so a commit is blocked until the user resolves them.
@@ -146,12 +146,11 @@ pub struct TransformStatusEntry {
     /// References this file resolved through `secret(...)` on its
     /// last successful render. Populated from
     /// `<baseline>.secret.json` (per `secrets.lex` §3.3); empty
-    /// when the file has no sidecar (which is also the common
-    /// case for templates that don't use secrets, and for
-    /// pre-Phase-S1 baselines that pre-date sidecar tracking).
-    /// Phase S5 surfaces this in the rendered status so users can
-    /// see *which* secret references each baseline depends on
-    /// without re-rendering. JSON consumers see the same field.
+    /// when the file has no sidecar (the common case for templates
+    /// that don't use secrets, and for baselines written before
+    /// sidecar tracking existed). Surfaced in the rendered status so
+    /// users can see *which* secret references each baseline depends
+    /// on without re-rendering. JSON consumers see the same field.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub secret_references: Vec<String>,
 }
@@ -293,10 +292,8 @@ pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResul
                 TransformAction::MissingDeployed
             }
             DivergenceState::OutputChanged | DivergenceState::BothChanged if no_reverse => {
-                // Opted out — leave source untouched, surface as
-                // Synced. The user has explicitly chosen "detect
-                // divergence but don't auto-merge"; `transform
-                // status` still shows the real state.
+                // Opted out — surface as Synced without touching the
+                // source.
                 TransformAction::Synced
             }
             DivergenceState::OutputChanged | DivergenceState::BothChanged => {
@@ -314,17 +311,16 @@ pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResul
                     has_findings = true;
                     TransformAction::NeedsRebaseline
                 } else {
-                    // Run the reverse-merge engine. Unchanged → variable-
-                    // only edit, no action. Patched → write back to source.
-                    // Conflict → report the block, leave source alone.
+                    // Run the reverse-merge engine. `Unchanged` means the
+                    // deployed edit touched only variable values, so the
+                    // template source needs no change.
                     let template_src = ctx.fs.read_to_string(&report.source_path)?;
                     let deployed = ctx.fs.read_to_string(&report.deployed_path)?;
                     // Load the per-render secrets sidecar so the
                     // reverse-merge masks lines whose source-of-truth
                     // is a vault, not the deployed bytes. Absence of
-                    // the sidecar = empty mask = byte-identical to
-                    // pre-Phase-S2 behavior. See secrets.lex §3.3 and
-                    // burgertocow#13.
+                    // the sidecar = empty mask = unmasked merge. See
+                    // secrets.lex §3.3 and burgertocow#13.
                     let secret_ranges = crate::preprocessing::baseline::SecretsSidecar::load(
                         ctx.fs.as_ref(),
                         ctx.paths.as_ref(),
@@ -345,15 +341,9 @@ pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResul
                             if !ctx.dry_run {
                                 ctx.fs.write_file(&report.source_path, patched.as_bytes())?;
                             }
-                            // `Patched` is the auto-merge happy path:
-                            // burgertocow + diffy produced an
-                            // unambiguous unified patch, the source
-                            // is now in sync with the user's edit.
-                            // Nothing for the user to review →
-                            // `has_findings` stays false. The patched
-                            // source surfaces as modified on the next
-                            // `git status` for a follow-up commit.
-                            // See #113.
+                            // The auto-merge happy path: `has_findings`
+                            // deliberately stays false (see
+                            // `TransformCheckResult::has_findings`).
                             TransformAction::Patched
                         }
                         ReverseMergeOutcome::Conflict(block) => {

--- a/crates/dodot-lib/src/commands/transform/mod.rs
+++ b/crates/dodot-lib/src/commands/transform/mod.rs
@@ -481,14 +481,12 @@ mod tests {
         template_body: &str,
         config_toml: &str,
     ) -> std::path::PathBuf {
-        // Write the template source.
         let src_path = env.dotfiles_root.join(pack).join(template_name);
         env.fs.mkdir_all(src_path.parent().unwrap()).unwrap();
         env.fs
             .write_file(&src_path, template_body.as_bytes())
             .unwrap();
 
-        // Write a root .dodot.toml carrying the desired vars.
         if !config_toml.is_empty() {
             env.fs
                 .write_file(
@@ -498,7 +496,6 @@ mod tests {
                 .unwrap();
         }
 
-        // Deploy via `dodot up`.
         let ctx = make_ctx(env);
         let _ = crate::commands::up::up(None, &ctx).unwrap();
 
@@ -526,8 +523,6 @@ mod tests {
 
     #[test]
     fn synced_files_report_synced_and_no_findings() {
-        // Run `dodot up` on a template, immediately run `transform
-        // check`. Nothing edited → all entries are Synced, no findings.
         let env = TempEnvironment::builder().build();
         deploy_template(
             &env,
@@ -545,9 +540,6 @@ mod tests {
 
     #[test]
     fn output_changed_static_edit_patches_source() {
-        // Edit the deployed file's static content. The source file's
-        // template variable should be preserved; the static edit
-        // should land in the template via diffy.
         let env = TempEnvironment::builder().build();
         let src_path = deploy_template(
             &env,
@@ -556,9 +548,6 @@ mod tests {
             "name = {{ name }}\nport = 5432\n",
             "[preprocessor.template.vars]\nname = \"Alice\"\n",
         );
-        // Edit the deployed file (the rendered content in the
-        // datastore — that's what the user-side symlink dereferences
-        // to). Change the static `port` line.
         let deployed = deployed_path(&env, "app", "config.toml");
         env.fs
             .write_file(&deployed, b"name = Alice\nport = 9999\n")
@@ -572,15 +561,9 @@ mod tests {
             "got: {:?}",
             result.entries[0].action
         );
-        // Patched is the auto-merge happy path: clean unified diff,
-        // source rewritten, nothing for the user to review. The
-        // pre-commit hook lets the commit proceed; the user does a
-        // follow-up `git add` + commit on the patched source. See #113.
         assert!(!result.has_findings);
         assert_eq!(result.exit_code(), 0);
 
-        // Source was rewritten: the static line is updated, the
-        // variable-bearing line is preserved verbatim.
         let new_src = env.fs.read_to_string(&src_path).unwrap();
         assert!(new_src.contains("port = 9999"), "src: {new_src:?}");
         assert!(new_src.contains("name = {{ name }}"), "src: {new_src:?}");
@@ -608,7 +591,6 @@ mod tests {
         let result = check(&ctx, false).unwrap();
         assert_eq!(result.entries.len(), 1);
         assert!(matches!(result.entries[0].action, TransformAction::Synced));
-        // Source must be byte-identical to the original.
         assert_eq!(env.fs.read_to_string(&src_path).unwrap(), original_src);
     }
 
@@ -633,7 +615,6 @@ mod tests {
         );
         let original_src = env.fs.read_to_string(&src_path).unwrap();
 
-        // Edit the deployed file the same way the patching test does.
         let deployed = deployed_path(&env, "app", "config.toml");
         env.fs
             .write_file(&deployed, b"name = Alice\nport = 9999\n")
@@ -649,7 +630,6 @@ mod tests {
         );
         assert!(!result.has_findings);
         assert_eq!(result.exit_code(), 0);
-        // Source untouched on disk.
         assert_eq!(env.fs.read_to_string(&src_path).unwrap(), original_src);
     }
 
@@ -706,23 +686,15 @@ mod tests {
         ctx.dry_run = true;
         let result = check(&ctx, false).unwrap();
         assert!(matches!(result.entries[0].action, TransformAction::Patched));
-        // Source unchanged on disk despite the action label.
         assert_eq!(env.fs.read_to_string(&src_path).unwrap(), original_src);
     }
 
     #[test]
     fn needs_rebaseline_when_tracked_render_is_empty_and_deployed_edited() {
-        // Forward-compat surface: a baseline written before
-        // tracked_render existed (or by a future preprocessor that
-        // opts in without producing a marker stream) is unable to
-        // drive burgertocow. If the deployed file has been edited,
-        // the action MUST be NeedsRebaseline — never silently
-        // reported as Synced. This test pins that contract because
-        // the bug existed in the first cut: empty tracked_render
-        // produced reverse_merge → Unchanged → mapped to Synced,
-        // hiding real divergence from the user.
+        // A baseline without a marker stream cannot drive burgertocow.
+        // Edited deployed content must be reported as NeedsRebaseline,
+        // never silently as Synced.
         let env = TempEnvironment::builder().build();
-        // Stage a baseline by hand with an empty tracked_render.
         let src_path = env.dotfiles_root.join("app/config.toml.tmpl");
         env.fs.mkdir_all(src_path.parent().unwrap()).unwrap();
         env.fs.write_file(&src_path, b"name = {{ name }}").unwrap();
@@ -742,7 +714,6 @@ mod tests {
                 "config.toml",
             )
             .unwrap();
-        // Lay down a deployed file that DIVERGES from the baseline.
         let deployed = deployed_path(&env, "app", "config.toml");
         env.fs.mkdir_all(deployed.parent().unwrap()).unwrap();
         env.fs
@@ -763,8 +734,6 @@ mod tests {
         );
         assert_eq!(result.exit_code(), 1);
 
-        // Source must NOT have been mutated (we couldn't compute a
-        // safe diff without the marker stream).
         let src_after = env.fs.read_to_string(&src_path).unwrap();
         assert_eq!(src_after, "name = {{ name }}");
     }
@@ -775,7 +744,6 @@ mod tests {
         // (Easier than going through `dodot up` and then deleting
         // the file.)
         let env = TempEnvironment::builder().build();
-        // Build a minimal baseline by hand at the cache path.
         let baseline = crate::preprocessing::baseline::Baseline::build(
             &env.dotfiles_root.join("app/missing.toml.tmpl"),
             b"rendered",
@@ -792,8 +760,6 @@ mod tests {
                 "missing.toml",
             )
             .unwrap();
-        // Also lay down a deployed file so we don't conflate
-        // MissingSource with MissingDeployed.
         let deployed = deployed_path(&env, "app", "missing.toml");
         env.fs.mkdir_all(deployed.parent().unwrap()).unwrap();
         env.fs.write_file(&deployed, b"rendered").unwrap();
@@ -809,9 +775,7 @@ mod tests {
 
     #[test]
     fn strict_mode_flags_unresolved_marker_in_source() {
-        // Deploy a template, then write dodot-conflict markers into
-        // the source file (simulating a previous `transform check`
-        // run that emitted them). Strict mode catches it.
+        // Strict mode catches dodot-conflict markers left in the source.
         let env = TempEnvironment::builder().build();
         let src_path = deploy_template(
             &env,
@@ -828,12 +792,9 @@ mod tests {
         env.fs.write_file(&src_path, dirty.as_bytes()).unwrap();
 
         let ctx = make_ctx(&env);
-        // Non-strict: no marker scan, so no findings (the source
-        // change makes it InputChanged, which is fine).
         let lax = check(&ctx, false).unwrap();
         assert!(lax.unresolved_markers.is_empty());
 
-        // Strict: scan picks up the markers, has_findings=true.
         let strict = check(&ctx, true).unwrap();
         assert_eq!(strict.unresolved_markers.len(), 1);
         assert_eq!(strict.unresolved_markers[0].line_numbers, vec![2, 4]);
@@ -843,8 +804,6 @@ mod tests {
 
     #[test]
     fn strict_mode_clean_repo_is_zero_findings() {
-        // No source has markers → strict mode reports zero unresolved
-        // markers and (assuming no divergence either) no findings.
         let env = TempEnvironment::builder().build();
         deploy_template(
             &env,
@@ -876,7 +835,6 @@ mod tests {
         );
         let ctx = make_ctx(&env);
         let result = check(&ctx, false).unwrap();
-        // At least one of source/deployed should start with `~/`.
         let entry = &result.entries[0];
         assert!(
             entry.source_path.starts_with("~/") || entry.deployed_path.starts_with("~/"),
@@ -921,9 +879,6 @@ mod tests {
             "name = {{ name }}\n",
             "[preprocessor.template.vars]\nname = \"Alice\"\n",
         );
-        // Drop a sidecar next to the baseline. (In production
-        // the renderer writes this; tests can build it
-        // directly since the file shape is stable.)
         let sidecar = crate::preprocessing::baseline::SecretsSidecar::new(vec![
             crate::preprocessing::SecretLineRange {
                 start: 0,

--- a/crates/dodot-lib/src/commands/transform/test_support.rs
+++ b/crates/dodot-lib/src/commands/transform/test_support.rs
@@ -1,9 +1,4 @@
-//! Shared test fixture for the `transform` command suites.
-//!
-//! `make_ctx` wires a no-op `CommandRunner` into a `FilesystemDataStore`
-//! pointed at the test's `TempEnvironment`. Both the check / status
-//! tests in `mod.rs` and the install-hook tests in `install_hook.rs`
-//! use it via `super::test_support::make_ctx`.
+//! Shared context fixture for `transform` command tests.
 
 use std::sync::Arc;
 

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -200,7 +200,6 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         }
     }
 
-    // Regenerate shell init script and deployment map
     if !ctx.dry_run {
         // Tear down any stale state for packs that are now ignored, so
         // the regenerated (global) init script below stops sourcing
@@ -655,13 +654,11 @@ fn extract_op_info(
             user_path,
             ..
         } => {
-            // Name: filename from the datastore path (pack-relative name)
             let name = datastore_path
                 .file_name()
                 .unwrap_or_else(|| user_path.file_name().unwrap_or_default())
                 .to_string_lossy()
                 .into_owned();
-            // Target: user_path displayed relative to ~ for readability
             let target = if let Ok(rel) = user_path.strip_prefix(home) {
                 format!("~/{}", rel.display())
             } else {

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -310,7 +310,7 @@ pub struct PreprocessorGpgSection {
 pub struct ProfilingSection {
     /// Whether the generated `dodot-init.sh` carries the timing wrapper
     /// around each `source` and PATH line. When false, the init script
-    /// is byte-identical to the pre-Phase-2 form. When true, bash 5+ /
+    /// carries no timing instrumentation at all. When true, bash 5+ /
     /// zsh sessions emit one TSV per shell startup under
     /// `<data_dir>/probes/shell-init/`; older shells fall through to
     /// the no-op path even with the wrapper present.
@@ -612,7 +612,7 @@ impl DodotConfig {
 /// Generate rules from the mappings section.
 ///
 /// This produces the default rule set that maps filename patterns to
-/// handlers, matching the Go implementation's `GenerateRulesFromMapping`.
+/// handlers.
 pub fn mappings_to_rules(mappings: &MappingsSection) -> Vec<Rule> {
     use std::collections::HashMap;
 
@@ -652,7 +652,6 @@ pub fn mappings_to_rules(mappings: &MappingsSection) -> Vec<Rule> {
         }
     }
 
-    // Shell handler
     for pattern in &mappings.shell {
         if !pattern.is_empty() {
             rules.push(Rule {
@@ -665,7 +664,6 @@ pub fn mappings_to_rules(mappings: &MappingsSection) -> Vec<Rule> {
         }
     }
 
-    // Homebrew handler
     if !mappings.homebrew.is_empty() {
         rules.push(Rule {
             pattern: mappings.homebrew.clone(),

--- a/crates/dodot-lib/src/config/mod.rs
+++ b/crates/dodot-lib/src/config/mod.rs
@@ -829,7 +829,6 @@ mod tests {
 
     #[test]
     fn default_config_has_expected_values() {
-        // Load with no files — should use compiled defaults
         let env = TempEnvironment::builder().build();
         let mgr = ConfigManager::new(&env.dotfiles_root).unwrap();
         let cfg = mgr.root_config().unwrap();
@@ -937,7 +936,6 @@ mod tests {
     fn root_config_overrides_defaults() {
         let env = TempEnvironment::builder().build();
 
-        // Write a root .dodot.toml
         env.fs
             .write_file(
                 &env.dotfiles_root.join(".dodot.toml"),
@@ -954,7 +952,6 @@ homebrew = "MyBrewfile"
 
         assert_eq!(cfg.mappings.install, vec!["setup.sh"]);
         assert_eq!(cfg.mappings.homebrew, "MyBrewfile");
-        // Unset fields keep defaults
         assert_eq!(cfg.mappings.path, "bin");
     }
 
@@ -975,7 +972,6 @@ install = ["vim-setup.sh"]
             .done()
             .build();
 
-        // Root config
         env.fs
             .write_file(
                 &env.dotfiles_root.join(".dodot.toml"),
@@ -989,11 +985,9 @@ homebrew = "RootBrewfile"
 
         let mgr = ConfigManager::new(&env.dotfiles_root).unwrap();
 
-        // Root config
         let root_cfg = mgr.root_config().unwrap();
         assert_eq!(root_cfg.mappings.install, vec!["install.sh"]);
 
-        // Pack config merges root + pack
         let pack_path = env.dotfiles_root.join("vim");
         let pack_cfg = mgr.config_for_pack(&pack_path).unwrap();
         assert_eq!(pack_cfg.mappings.install, vec!["vim-setup.sh"]); // overridden
@@ -1017,7 +1011,6 @@ homebrew = "RootBrewfile"
 
         let rules = mappings_to_rules(&mappings);
 
-        // path + 2 install + 2 shell + homebrew + nix + externals + ignore + catchall = 10
         assert_eq!(rules.len(), 10, "rules: {rules:#?}");
 
         let handler_names: Vec<&str> = rules.iter().map(|r| r.handler.as_str()).collect();
@@ -1037,7 +1030,6 @@ homebrew = "RootBrewfile"
         assert!(!ignore.pattern.starts_with('!'));
         assert!(!ignore.case_insensitive);
 
-        // Catchall should be lowest priority
         let catchall = rules.iter().find(|r| r.pattern == "*").unwrap();
         assert_eq!(catchall.priority, 0);
     }

--- a/crates/dodot-lib/src/conflicts.rs
+++ b/crates/dodot-lib/src/conflicts.rs
@@ -222,7 +222,6 @@ mod tests {
         }
     }
 
-    /// Helper: create a mock Fs for tests that don't need real filesystem.
     fn dummy_fs() -> std::sync::Arc<crate::fs::OsFs> {
         std::sync::Arc::new(crate::fs::OsFs::new())
     }
@@ -589,7 +588,6 @@ mod tests {
         let conflicts = detect_cross_pack_conflicts(&pack_intents, env.fs.as_ref());
         assert_eq!(conflicts.len(), 1);
 
-        // Claimant sources should point to the actual files, not the directories
         for claimant in &conflicts[0].claimants {
             assert!(
                 claimant.source.to_string_lossy().contains("deploy"),

--- a/crates/dodot-lib/src/conflicts.rs
+++ b/crates/dodot-lib/src/conflicts.rs
@@ -50,13 +50,11 @@ pub enum ConflictKind {
 /// A cross-pack conflict: multiple packs claim the same effective target.
 #[derive(Debug, Clone)]
 pub struct Conflict {
-    /// The kind of collision.
     pub kind: ConflictKind,
     /// For [`ConflictKind::SymlinkTarget`]: the resolved filesystem path.
     /// For [`ConflictKind::PathExecutable`]: a sentinel path
     /// `<path-executable>/<name>` — read `.file_name()` for the bare name.
     pub target: PathBuf,
-    /// Every pack that claims this target.
     pub claimants: Vec<Claimant>,
 }
 
@@ -151,7 +149,6 @@ pub fn detect_cross_pack_conflicts(
     let mut conflicts: Vec<Conflict> = targets
         .into_iter()
         .filter(|(_, claimants)| {
-            // Only flag when at least two *different* packs claim the target.
             let first = &claimants[0].pack;
             claimants.len() > 1 && claimants.iter().any(|c| c.pack != *first)
         })

--- a/crates/dodot-lib/src/datastore/filesystem.rs
+++ b/crates/dodot-lib/src/datastore/filesystem.rs
@@ -16,8 +16,8 @@ use crate::{DodotError, Result};
 /// can delete the sentinel + snapshot pair to roll a file back to
 /// `NeverRan`.
 ///
-/// Old sentinels predating PR C of #169 have no sibling — `did_run`
-/// surfaces `previous_snapshot: None` in that case so `dodot status`
+/// Sentinels written before snapshots existed have no sibling —
+/// `did_run` surfaces `previous_snapshot: None` then, so `dodot status`
 /// can render the `ran older version` state without diff details
 /// (and `dodot status --diff` can omit the entry from its output).
 pub(crate) const SNAPSHOT_SUFFIX: &str = ".snapshot";
@@ -162,14 +162,12 @@ impl DataStore for FilesystemDataStore {
 
         self.fs.mkdir_all(&link_dir)?;
 
-        // Idempotent: if the link already points to the correct source, skip.
         if self.fs.is_symlink(&link_path) {
             if let Ok(current_target) = self.fs.readlink(&link_path) {
                 if current_target == source_file {
                     return Ok(link_path);
                 }
             }
-            // Wrong target — remove and re-create.
             self.fs.remove_file(&link_path)?;
         }
 
@@ -178,23 +176,18 @@ impl DataStore for FilesystemDataStore {
     }
 
     fn create_user_link(&self, datastore_path: &Path, user_path: &Path) -> Result<()> {
-        // Create parent directory
         if let Some(parent) = user_path.parent() {
             self.fs.mkdir_all(parent)?;
         }
 
-        // If something already exists at user_path, handle it
         if self.fs.is_symlink(user_path) {
-            // Existing symlink — check if it's correct
             if let Ok(current_target) = self.fs.readlink(user_path) {
                 if current_target == datastore_path {
-                    return Ok(()); // Already correct
+                    return Ok(());
                 }
             }
-            // Wrong target — remove and re-create
             self.fs.remove_file(user_path)?;
         } else if self.fs.exists(user_path) {
-            // Exists but is not a symlink — conflict
             return Err(crate::DodotError::SymlinkConflict {
                 path: user_path.to_path_buf(),
             });
@@ -212,7 +205,6 @@ impl DataStore for FilesystemDataStore {
         sentinel: &str,
         force: bool,
     ) -> Result<()> {
-        // Idempotent: skip if sentinel exists
         if !force && self.has_sentinel(pack, handler, sentinel)? {
             return Ok(());
         }
@@ -266,7 +258,6 @@ impl DataStore for FilesystemDataStore {
         }
         result?;
 
-        // Record sentinel
         let sentinel_dir = self.paths.handler_data_dir(pack, handler);
         self.fs.mkdir_all(&sentinel_dir)?;
 
@@ -280,13 +271,12 @@ impl DataStore for FilesystemDataStore {
 
         // Snapshot the file we just ran so that a future `did_run`
         // can return its previous content for diff display when the
-        // current file's hash differs (notify-don't-rerun, #169 PR
-        // C). The path of the file ran is the last argument by
-        // convention — same as the header-block read above. Snapshot
-        // writes are best-effort: if the read or write fails, log
-        // and move on. The sentinel itself is already recorded, so
-        // the user's run state is correct; only the diff capability
-        // is lost.
+        // current file's hash differs. The path of the file ran is
+        // the last argument by convention — same as the header-block
+        // read above. Snapshot writes are best-effort: if the read or
+        // write fails, log and move on. The sentinel itself is
+        // already recorded, so the user's run state is correct; only
+        // the diff capability is lost.
         if let Some(path_str) = script_path.as_deref() {
             let snapshot_path = sentinel_dir.join(format!("{sentinel}{SNAPSHOT_SUFFIX}"));
             match self.fs.read_file(Path::new(path_str)) {
@@ -352,19 +342,14 @@ impl DataStore for FilesystemDataStore {
             return Ok(DidRunStatus::NeverRan);
         }
 
-        // RanCurrent if any sentinel records the current hash.
         if matches.iter().any(|(_, h)| h == current_hash) {
             return Ok(DidRunStatus::RanCurrent);
         }
 
-        // For tie-break between multiple non-matching sentinels, pick
-        // the sentinel with the most recent `completed|<unix-ts>`
-        // payload (written by `run_and_record`). This is the closest
-        // signal we have to "most recent prior run" without needing
-        // mtime access through the Fs trait. Sentinels whose payload
-        // doesn't parse fall to the bottom of the ranking (timestamp
-        // 0); ties on timestamp break by lexical order on the
-        // sentinel filename for determinism.
+        // Tie-break on the `completed|<unix-ts>` payload rather than
+        // mtime, which the Fs trait doesn't expose. Sentinels whose
+        // payload doesn't parse fall to the bottom (timestamp 0); the
+        // lexical fallback keeps ties deterministic.
         let prior = matches
             .into_iter()
             .map(|(name, hash)| {

--- a/crates/dodot-lib/src/datastore/filesystem.rs
+++ b/crates/dodot-lib/src/datastore/filesystem.rs
@@ -606,13 +606,11 @@ mod tests {
         let source = env.dotfiles_root.join("vim/vimrc");
         let link_path = ds.create_data_link("vim", "symlink", &source).unwrap();
 
-        // Link should be in the handler data dir
         assert_eq!(
             link_path,
             env.paths.handler_data_dir("vim", "symlink").join("vimrc")
         );
 
-        // Link should point to source
         env.assert_symlink(&link_path, &source);
     }
 
@@ -647,14 +645,11 @@ mod tests {
         let source1 = env.dotfiles_root.join("vim/vimrc");
         let source2 = env.dotfiles_root.join("vim/vimrc-new");
 
-        // Create initial link to source1
         let link_dir = env.paths.handler_data_dir("vim", "symlink");
         env.fs.mkdir_all(&link_dir).unwrap();
-        // Manually create a link named "vimrc-new" pointing to source1 (wrong target)
         let wrong_link = link_dir.join("vimrc-new");
         env.fs.symlink(&source1, &wrong_link).unwrap();
 
-        // Now create_data_link should fix it to point at source2
         let link_path = ds.create_data_link("vim", "symlink", &source2).unwrap();
         env.assert_symlink(&link_path, &source2);
     }
@@ -669,7 +664,6 @@ mod tests {
         let datastore_path = env.data_dir.join("packs/vim/symlink/vimrc");
         let user_path = env.home.join(".vimrc");
 
-        // Create the datastore file so the symlink target exists
         env.fs.mkdir_all(datastore_path.parent().unwrap()).unwrap();
         env.fs.write_file(&datastore_path, b"link target").unwrap();
 
@@ -703,7 +697,6 @@ mod tests {
         let datastore_path = env.data_dir.join("packs/vim/symlink/vimrc");
         let user_path = env.home.join(".vimrc");
 
-        // Create a regular file at the user path
         env.fs.write_file(&user_path, b"existing content").unwrap();
 
         let err = ds
@@ -728,10 +721,8 @@ mod tests {
         env.fs.write_file(&wrong_target, b"wrong").unwrap();
         env.fs.write_file(&correct_target, b"right").unwrap();
 
-        // Create wrong symlink
         env.fs.symlink(&wrong_target, &user_path).unwrap();
 
-        // Should fix it
         ds.create_user_link(&correct_target, &user_path).unwrap();
         env.assert_symlink(&user_path, &correct_target);
     }
@@ -750,16 +741,12 @@ mod tests {
         let source = env.dotfiles_root.join("vim/vimrc");
         let user_path = env.home.join(".vimrc");
 
-        // Step 1: data link
         let datastore_path = ds.create_data_link("vim", "symlink", &source).unwrap();
 
-        // Step 2: user link
         ds.create_user_link(&datastore_path, &user_path).unwrap();
 
-        // Verify the full chain
         env.assert_double_link("vim", "symlink", "vimrc", &source, &user_path);
 
-        // Reading through the chain should yield the original content
         let content = env.fs.read_to_string(&user_path).unwrap();
         assert_eq!(content, "set nocompatible");
     }
@@ -786,7 +773,6 @@ mod tests {
         assert!(ds.has_sentinel("vim", "install", "install.sh-abc").unwrap());
         assert_eq!(runner.calls(), vec!["echo hello"]);
 
-        // Sentinel file should contain "completed|..."
         let sentinel_path = env
             .paths
             .handler_data_dir("vim", "install")
@@ -805,7 +791,6 @@ mod tests {
         ds.run_and_record("vim", "install", "echo", &["second".into()], "s1", false)
             .unwrap();
 
-        // Command only ran once
         assert_eq!(runner.calls(), vec!["echo first"]);
     }
 
@@ -824,7 +809,6 @@ mod tests {
             "expected CommandFailed, got: {err}"
         );
 
-        // No sentinel should be created on failure
         assert!(!ds.has_sentinel("vim", "install", "s1").unwrap());
     }
 
@@ -852,7 +836,6 @@ mod tests {
         let env = TempEnvironment::builder().build();
         let (ds, _) = make_datastore(&env);
 
-        // Should not error
         ds.remove_state("nonexistent", "handler").unwrap();
     }
 
@@ -1026,7 +1009,6 @@ mod tests {
         let env = TempEnvironment::builder().build();
         let (ds, _) = make_datastore(&env);
 
-        // handler_data_dir doesn't exist yet — write_rendered_file should create it
         let handler_dir = env.paths.handler_data_dir("newpack", "preprocessed");
         assert!(!env.fs.exists(&handler_dir));
 
@@ -1143,18 +1125,13 @@ mod tests {
 
     #[test]
     fn extract_sentinel_hash_rejects_non_sentinels() {
-        // No dash.
         assert_eq!(extract_sentinel_hash("install.sh"), None);
-        // Hash too short.
         assert_eq!(extract_sentinel_hash("install.sh-abc"), None);
-        // Hash has uppercase (we expect lowercase).
         assert_eq!(extract_sentinel_hash("install.sh-ABCDEF0123456789"), None);
-        // Snapshot sibling files — the suffix is ".snapshot", not 16 hex chars.
         assert_eq!(
             extract_sentinel_hash("install.sh-abcdef0123456789.snapshot"),
             None
         );
-        // Hash contains non-hex.
         assert_eq!(extract_sentinel_hash("install.sh-abcdef012345xyz9"), None);
     }
 
@@ -1198,7 +1175,6 @@ mod tests {
             .build();
         let (ds, _) = make_datastore(&env);
 
-        // Run with one hash, then ask about a different one.
         ds.run_and_record(
             "vim",
             "install",
@@ -1232,8 +1208,7 @@ mod tests {
 
     #[test]
     fn did_run_different_without_snapshot_returns_none() {
-        // Pre-PR-C sentinel: no .snapshot sibling. did_run should
-        // still classify as RanDifferent but with previous_snapshot=None.
+        // Legacy sentinels without snapshots still classify as RanDifferent.
         let env = TempEnvironment::builder().build();
         let (ds, _) = make_datastore(&env);
 
@@ -1245,7 +1220,6 @@ mod tests {
                 b"completed|12345",
             )
             .unwrap();
-        // No .snapshot file written — simulates pre-upgrade state.
 
         let status = ds
             .did_run("vim", "install", "install.sh", "bbbbbbbbbbbbbbbb")
@@ -1269,7 +1243,6 @@ mod tests {
 
         let sentinel_dir = env.paths.handler_data_dir("vim", "install");
         env.fs.mkdir_all(&sentinel_dir).unwrap();
-        // Sentinel for a *different* filename.
         env.fs
             .write_file(
                 &sentinel_dir.join("install.bash-aaaaaaaaaaaaaaaa"),
@@ -1298,14 +1271,12 @@ mod tests {
         let sentinel_dir = env.paths.handler_data_dir("vim", "install");
         env.fs.mkdir_all(&sentinel_dir).unwrap();
 
-        // Older run, hash sorts LATER lexically.
         env.fs
             .write_file(
                 &sentinel_dir.join("install.sh-ffffffffffffffff"),
                 b"completed|100",
             )
             .unwrap();
-        // Newer run, hash sorts EARLIER lexically.
         env.fs
             .write_file(
                 &sentinel_dir.join("install.sh-1111111111111111"),
@@ -1424,11 +1395,9 @@ mod tests {
         )
         .unwrap();
 
-        // Sentinel exists.
         assert!(ds
             .has_sentinel("vim", "install", "missing.sh-abcdef0123456789")
             .unwrap());
-        // Snapshot does not.
         let snapshot_path = env
             .paths
             .handler_data_dir("vim", "install")

--- a/crates/dodot-lib/src/datastore/mod.rs
+++ b/crates/dodot-lib/src/datastore/mod.rs
@@ -16,11 +16,10 @@ use crate::Result;
 /// been run by a handler, and if so, whether the recorded run matches
 /// the current file content.
 ///
-/// Mirrors the spec in #169: run-once handlers consult this to decide
-/// between *first-time-run* (NeverRan → execute), *already up to
-/// date* (RanCurrent → skip silently), and *file edited since last
-/// run* (RanDifferent → skip with notice, user runs `--force` to
-/// apply).
+/// Run-once handlers consult this to decide between
+/// *first-time-run* (NeverRan → execute), *already up to date*
+/// (RanCurrent → skip silently), and *file edited since last run*
+/// (RanDifferent → skip with notice, user runs `--force` to apply).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DidRunStatus {
     /// No sentinel exists for this filename in this pack/handler.
@@ -29,10 +28,11 @@ pub enum DidRunStatus {
     RanCurrent,
     /// A sentinel exists for a *different* content hash — the file
     /// has changed since the last successful run. `previous_hash` is
-    /// the hex hash recorded in the existing sentinel; if the
-    /// `<sentinel>.snapshot` sibling file exists (created on or after
-    /// PR C of #169) its raw bytes are returned in `previous_snapshot`
-    /// so callers can render a diff.
+    /// the hex hash recorded in the existing sentinel; when the
+    /// `<sentinel>.snapshot` sibling file exists its raw bytes are
+    /// returned in `previous_snapshot` so callers can render a diff.
+    /// Sentinels written before snapshots existed have no sibling and
+    /// yield `previous_snapshot: None`.
     RanDifferent {
         previous_hash: String,
         previous_snapshot: Option<Vec<u8>>,
@@ -396,8 +396,6 @@ impl CommandRunner for ShellCommandRunner {
             })
         };
 
-        // Read stdout on the main thread: capture, scan for `# status:`,
-        // optionally passthrough.
         let mut stdout_buf = String::new();
         {
             let mut reader = BufReader::new(stdout_pipe);
@@ -461,12 +459,10 @@ impl CommandRunner for ShellCommandRunner {
         })
     }
 
-    /// Override of the default trait impl: reads stdout as raw
-    /// bytes (no `from_utf8_lossy` decode), so binary payloads
-    /// from age / gpg whole-file decryption survive verbatim.
-    /// Stderr is still buffered as text via the same drainer
-    /// pattern `run` uses — gpg and age both emit
-    /// human-readable diagnostics.
+    /// Reads stdout as raw bytes from the start, as
+    /// [`CommandRunner::run_bytes`] requires. Stderr is still
+    /// buffered as text via the same drainer pattern `run` uses —
+    /// gpg and age both emit human-readable diagnostics.
     fn run_bytes(&self, executable: &str, arguments: &[String]) -> Result<CommandOutputBytes> {
         use std::io::{Read, Write};
         use std::process::{Command, Stdio};
@@ -506,8 +502,7 @@ impl CommandRunner for ShellCommandRunner {
             })
         };
 
-        // Read stdout as raw bytes on the main thread. No
-        // line-by-line passthrough / status-line parsing here —
+        // No line-by-line passthrough / status-line parsing here —
         // those are install-script ergonomics and have no place in
         // a binary-payload pipe.
         let mut stdout_buf: Vec<u8> = Vec::new();
@@ -534,9 +529,6 @@ impl CommandRunner for ShellCommandRunner {
         let exit_code = status.code().unwrap_or(-1);
 
         if !status.success() && !stderr_text.is_empty() && !self.verbose {
-            // Mirror `run`'s "surface stderr on failure when not
-            // verbose" pattern so a quiet failure is still
-            // debuggable.
             let host_stderr = std::io::stderr();
             let mut h = host_stderr.lock();
             let _ = h.write_all(stderr_text.as_bytes());

--- a/crates/dodot-lib/src/datastore/mod.rs
+++ b/crates/dodot-lib/src/datastore/mod.rs
@@ -19,7 +19,8 @@ use crate::Result;
 /// Run-once handlers consult this to decide between
 /// *first-time-run* (NeverRan → execute), *already up to date*
 /// (RanCurrent → skip silently), and *file edited since last run*
-/// (RanDifferent → skip with notice, user runs `--force` to apply).
+/// (RanDifferent → skip with notice, user runs `--provision-rerun` to
+/// apply).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DidRunStatus {
     /// No sentinel exists for this filename in this pack/handler.

--- a/crates/dodot-lib/src/equivalence.rs
+++ b/crates/dodot-lib/src/equivalence.rs
@@ -77,22 +77,18 @@ pub fn normalize_path(path: &Path) -> PathBuf {
 /// See module-level docs for the exact equivalence rules.
 pub fn is_equivalent(user_path: &Path, source: &Path, fs: &dyn Fs) -> bool {
     if fs.is_symlink(user_path) {
-        // Single-hop direct symlink to source. Resolve relative targets
-        // against the symlink's parent so e.g. `~/.vimrc -> ../foo/vimrc`
-        // is recognised. Multi-hop chains and links pointing elsewhere
-        // fall through to false.
+        // Single hop only: a multi-hop chain never compares equal here,
+        // even when its realpath is `source`.
         match fs.readlink(user_path) {
             Ok(target) => resolve_symlink_target(user_path, &target) == source,
             Err(_) => false,
         }
     } else if fs.exists(user_path) && !fs.is_dir(user_path) {
-        // Regular file: byte equality with source.
         match (fs.read_file(user_path), fs.read_file(source)) {
             (Ok(a), Ok(b)) => a == b,
             _ => false,
         }
     } else {
-        // Absent, directory, or unreadable.
         false
     }
 }

--- a/crates/dodot-lib/src/equivalence.rs
+++ b/crates/dodot-lib/src/equivalence.rs
@@ -100,10 +100,6 @@ mod tests {
 
     #[test]
     fn relative_direct_symlink_to_source_is_equivalent() {
-        // Regression for PR #47 review: `~/.vimrc -> ../dotfiles/vim/vimrc`
-        // (relative target) must resolve to the same absolute source path,
-        // not be mis-classified as "points elsewhere".
-        //
         // TempEnvironment lays out dotfiles_root inside home (as
         // `<home>/dotfiles`), so a symlink at `<home>/.vimrc` reaches
         // the source via the relative path `dotfiles/vim/vimrc`.

--- a/crates/dodot-lib/src/execution/fetch.rs
+++ b/crates/dodot-lib/src/execution/fetch.rs
@@ -1168,12 +1168,10 @@ mod tests {
         assert!(results.iter().all(|r| r.success), "{results:#?}");
         assert_eq!(fetcher.calls(), vec!["https://example.com/aliases.sh"]);
 
-        // The user-visible link exists and resolves to the bytes we fed in.
         assert!(env.fs.is_symlink(&user_path));
         let content = env.fs.read_to_string(&user_path).unwrap();
         assert_eq!(content.as_bytes(), known_body());
 
-        // Sentinel was recorded.
         let sentinel = super::file_sentinel("aliases", &known_sha());
         env.assert_sentinel("shared", "external", &sentinel);
     }
@@ -1208,7 +1206,6 @@ mod tests {
         .with_fetcher(&fetcher);
         let _ = executor.execute(vec![intent.clone()]).unwrap();
 
-        // Second run: no calls because sentinel matches.
         let results = executor.execute(vec![intent]).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].success);
@@ -1217,7 +1214,6 @@ mod tests {
             "msg: {}",
             results[0].message
         );
-        // Mock pops responses on use; only the first execute consumed it.
         assert_eq!(fetcher.calls(), vec!["https://example.com/aliases.sh"]);
     }
 
@@ -1249,19 +1245,16 @@ mod tests {
         )
         .with_fetcher(&fetcher);
 
-        // Initial deploy: fetch + link.
         executor.execute(vec![intent.clone()]).unwrap();
         assert!(env.fs.is_symlink(&user_path));
 
-        // User (or a stray `rm`) deletes the deployed symlink.
         env.fs.remove_file(&user_path).unwrap();
         assert!(!env.fs.exists(&user_path));
 
         // Re-running `up` with the sentinel still present must
         // restore the symlink even though the sha hasn't changed and
         // --force is off. The fetcher's only canned response was
-        // already consumed — so a regression here would surface as
-        // "no response configured for ...".
+        // already consumed, so an unexpected fetch would fail.
         let results = executor.execute(vec![intent]).unwrap();
         assert!(
             results.iter().all(|r| r.success),
@@ -1275,7 +1268,6 @@ mod tests {
             env.fs.read_to_string(&user_path).unwrap(),
             "#!/bin/sh\nexport SHARED=1\n"
         );
-        // The repair must not re-fetch from upstream.
         assert_eq!(fetcher.calls(), vec!["https://example.com/aliases.sh"]);
     }
 
@@ -1285,7 +1277,6 @@ mod tests {
         let (ds, _) = make_datastore(&env);
         let fetcher = MockFetcher::new().with("https://example.com/aliases.sh", known_body());
 
-        // Place a regular file at the target path before deploying.
         let user_path = env.home.join(".config/shared/aliases.sh");
         env.fs.mkdir_all(user_path.parent().unwrap()).unwrap();
         env.fs
@@ -1325,12 +1316,10 @@ mod tests {
             "msg: {}",
             results[0].message
         );
-        // Original file untouched.
         assert_eq!(
             env.fs.read_to_string(&user_path).unwrap(),
             "hand-written by the user"
         );
-        // No fetch happened (we pre-checked the conflict).
         assert!(fetcher.calls().is_empty());
     }
 
@@ -1372,7 +1361,6 @@ mod tests {
             "msg: {}",
             results[0].message
         );
-        // Nothing was written.
         assert!(!env.fs.exists(&user_path));
         env.assert_no_handler_state("shared", "external");
     }
@@ -1494,7 +1482,6 @@ mod tests {
             "msg: {}",
             results[0].message
         );
-        // No fetch call, no symlink, no sentinel.
         assert!(fetcher.calls().is_empty());
         assert!(!env.fs.exists(&user_path));
         env.assert_no_handler_state("shared", "external");
@@ -1538,7 +1525,6 @@ mod tests {
         )
         .with_git(&git);
 
-        // First run: clone happens.
         let first = executor.execute(vec![intent.clone()]).unwrap();
         assert_eq!(first.len(), 2);
         assert!(first.iter().all(|r| r.success), "{first:#?}");
@@ -1549,7 +1535,6 @@ mod tests {
         );
         assert!(env.fs.is_symlink(&user_path));
 
-        // Second run: clone exists, ls-remote matches local → no fetch.
         let calls_before = git.calls().len();
         let second = executor.execute(vec![intent]).unwrap();
         assert!(second.iter().all(|r| r.success), "{second:#?}");
@@ -1592,7 +1577,6 @@ mod tests {
         )
         .with_git(&git);
 
-        // Initial clone.
         executor.execute(vec![intent.clone()]).unwrap();
 
         // Upstream moves; next run must fetch+reset.
@@ -1604,7 +1588,6 @@ mod tests {
             "{:?}",
             git.calls()
         );
-        // The marker file should reflect the refresh.
         let datastore_path = env
             .paths
             .handler_data_dir("frameworks", "external")
@@ -1632,7 +1615,6 @@ mod tests {
         )
         .with_git(&git);
 
-        // Initial clone succeeds.
         executor.execute(vec![intent.clone()]).unwrap();
 
         // Network goes down. ls-remote fails transiently; we must
@@ -1681,10 +1663,8 @@ mod tests {
         )
         .with_git(&git);
 
-        // First run clones.
         executor.execute(vec![intent.clone()]).unwrap();
 
-        // Move upstream; fetch fails transiently.
         git.set_upstream_sha(&"b".repeat(40));
         git.set_fetch_offline(true);
         let results = executor.execute(vec![intent]).unwrap();
@@ -1756,8 +1736,6 @@ mod tests {
             .join("p10k");
         let resolved = env.fs.readlink(&user_path).unwrap();
         assert_eq!(resolved, clone_root.join("themes"));
-        // And the marker file (which the mock writes under subpath)
-        // is reachable through the symlink.
         let content = env.fs.read_to_string(&user_path.join("README.md")).unwrap();
         assert!(content.contains("# themes"));
     }
@@ -1788,7 +1766,6 @@ mod tests {
         )
         .with_git(&git);
 
-        // First run clones --branch v1.20.0.
         executor.execute(vec![intent.clone()]).unwrap();
         assert!(
             git.calls()
@@ -1798,7 +1775,6 @@ mod tests {
             git.calls()
         );
 
-        // Second run: ls-remote uses the configured ref, not HEAD.
         let calls_before = git.calls().len();
         executor.execute(vec![intent]).unwrap();
         let new_calls = &git.calls()[calls_before..];
@@ -1894,7 +1870,6 @@ mod tests {
             "msg: {}",
             results[0].message
         );
-        // No clone calls, no symlink, no datastore tree.
         assert!(git.calls().is_empty());
         assert!(!env.fs.exists(&user_path));
         env.assert_no_handler_state("frameworks", "external");
@@ -2002,7 +1977,6 @@ mod tests {
             .unwrap();
         assert!(results.iter().all(|r| r.success), "{results:#?}");
         assert!(env.fs.is_symlink(&user_path));
-        // Two files materialised under the entry dir.
         let theme = user_path.join("themes/alpha.zsh");
         let script = user_path.join("scripts/setup.sh");
         assert!(env.fs.exists(&theme));
@@ -2108,7 +2082,6 @@ mod tests {
             .unwrap();
         assert!(results.iter().all(|r| r.success), "{results:#?}");
         assert!(env.fs.is_symlink(&user_path));
-        // The deployed file's content matches the archive member.
         assert_eq!(
             env.fs.read_to_string(&user_path).unwrap(),
             "#!/bin/sh\necho setup\n"

--- a/crates/dodot-lib/src/execution/fetch.rs
+++ b/crates/dodot-lib/src/execution/fetch.rs
@@ -321,7 +321,6 @@ impl<'a> Executor<'a> {
         // needs to handle "remove existing dodot symlink and re-create".
         self.create_external_user_link(&datastore_path, user_path)?;
 
-        // Record sentinel so subsequent up's are no-ops.
         self.write_sentinel(pack, handler, &sentinel)?;
 
         let create_link = Operation::CreateUserLink {
@@ -449,8 +448,7 @@ impl<'a> Executor<'a> {
             }
         };
 
-        // Now safe to wipe the previous extraction. We only get here
-        // once we've already parsed the new archive successfully.
+        // Now safe to wipe the previous extraction.
         if self.fs.exists(&entry_root) {
             // For archive-file we wrote a single file; for archive we
             // wrote a directory tree. Handle both.
@@ -505,7 +503,6 @@ impl<'a> Executor<'a> {
             }
         };
 
-        // User-visible symlink.
         self.create_external_user_link(&symlink_target, user_path)?;
         self.write_sentinel(pack, handler, &sentinel)?;
 
@@ -550,19 +547,8 @@ impl<'a> Executor<'a> {
 
     /// Fetch one `type = "git-repo"` external.
     ///
-    /// Freshness model:
-    /// - **Unpinned** (`git_ref = None`, `commit = None`):
-    ///   `git ls-remote HEAD`; refresh when upstream moves.
-    /// - **`ref = "v1"`**: `git ls-remote v1`; refresh when that
-    ///   reference's SHA changes (rare for tags, possible for
-    ///   branch refs).
-    /// - **`commit = "<sha>"`**: no ls-remote at all; check the
-    ///   local clone against the pinned SHA and refresh only if
-    ///   they differ (which happens when the user edits the TOML).
-    ///
-    /// `subpath` triggers sparse-checkout on the initial clone; the
-    /// user-visible symlink then targets that subpath inside the
-    /// clone.
+    /// Freshness and `subpath` semantics follow the pin rules
+    /// documented on [`FetchSpec::GitRepo`].
     ///
     /// Network failures (ls-remote, fetch, even initial clone) are
     /// soft: the cached clone (if any) stays put and the result

--- a/crates/dodot-lib/src/execution/link.rs
+++ b/crates/dodot-lib/src/execution/link.rs
@@ -292,7 +292,6 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].success);
 
-        // Verify the double-link chain
         env.assert_double_link("vim", "symlink", "vimrc", &source, &user_path);
     }
 
@@ -340,10 +339,8 @@ mod tests {
             results[0].message
         );
 
-        // Data link should NOT have been created (pre-check prevents it)
         env.assert_no_handler_state("vim", "symlink");
 
-        // Original file should be untouched
         env.assert_file_contents(&user_path, "existing content");
     }
 
@@ -381,10 +378,8 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].success, "force should succeed");
 
-        // Verify the double-link chain was created
         env.assert_double_link("vim", "symlink", "vimrc", &source, &user_path);
 
-        // Content should now be from the pack
         let content = env.fs.read_to_string(&user_path).unwrap();
         assert_eq!(content, "set nocompatible");
     }
@@ -427,12 +422,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(results.len(), 2);
-        // First should fail (conflict)
         assert!(!results[0].success);
-        // Second should succeed (no conflict)
         assert!(results[1].success);
 
-        // gvimrc should be deployed despite vimrc conflict
         env.assert_double_link(
             "vim",
             "symlink",
@@ -482,7 +474,6 @@ mod tests {
             .file("keybindings.yaml", "keep me")
             .done()
             .build();
-        // Legacy setup: ~/.config/warp is a symlink into the pack itself.
         let pack_dir = env.dotfiles_root.join("warp");
         let config_warp = env.config_home.join("warp");
         env.fs.mkdir_all(&env.config_home).unwrap();
@@ -519,7 +510,6 @@ mod tests {
             results[0].message
         );
 
-        // No data link created, source file untouched.
         env.assert_no_handler_state("warp", "symlink");
         env.assert_file_contents(&source, "keep me");
     }
@@ -670,10 +660,8 @@ mod tests {
         let config_warp = env.config_home.join("warp");
         env.fs.mkdir_all(&env.config_home).unwrap();
 
-        // config_home is home/.config, dotfiles_root is home/dotfiles,
-        // so the relative hop is `../dotfiles/warp` — exactly the shape
-        // Copilot flagged: contains `..`, joins to a path that would
-        // NOT naively `starts_with(dotfiles_root)` without normalization.
+        // The relative hop contains `..`, so it only falls under
+        // dotfiles_root after lexical normalization.
         let rel_target = Path::new("../dotfiles/warp");
         env.fs.symlink(rel_target, &config_warp).unwrap();
 

--- a/crates/dodot-lib/src/execution/link.rs
+++ b/crates/dodot-lib/src/execution/link.rs
@@ -52,14 +52,14 @@ impl<'a> Executor<'a> {
             )]);
         }
 
-        // Pre-check: does a non-symlink file exist at user_path?
-        // We check BEFORE creating the data link to avoid leaving
-        // dangling state when the user link would fail.
+        // Pre-check for a conflicting occupant BEFORE creating the
+        // data link, to avoid leaving dangling state when the user
+        // link would fail.
         //
-        // #44: if the existing file's content is byte-identical to
-        // the source we'd deploy, treat it as safe to replace —
-        // the content reaching `user_path` doesn't change, only
-        // the storage representation does. No `--force` required.
+        // If the existing file's content is byte-identical to the
+        // source we'd deploy, treat it as safe to replace — the
+        // content reaching `user_path` doesn't change, only the
+        // storage representation does. No `--force` required.
         if !self.fs.is_symlink(user_path) && self.fs.exists(user_path) {
             let content_equivalent = crate::equivalence::is_equivalent(user_path, source, self.fs);
             if self.force || content_equivalent {
@@ -76,7 +76,6 @@ impl<'a> Executor<'a> {
                         "force-removing existing file"
                     );
                 }
-                // Remove the existing path before creating the symlink
                 if self.fs.is_dir(user_path) {
                     self.fs.remove_dir_all(user_path)?;
                 } else {
@@ -88,8 +87,6 @@ impl<'a> Executor<'a> {
                     path = %user_path.display(),
                     "conflict: file already exists"
                 );
-                // Return a failed result — non-fatal so other files
-                // in the pack can still be processed.
                 let op = Operation::CreateUserLink {
                     pack: pack.clone(),
                     handler: handler.clone(),
@@ -106,7 +103,6 @@ impl<'a> Executor<'a> {
             }
         }
 
-        // Step 1: Create data link (source → datastore)
         let datastore_path = self.datastore.create_data_link(pack, handler, source)?;
         debug!(
             pack,
@@ -114,7 +110,6 @@ impl<'a> Executor<'a> {
             "created data link"
         );
 
-        // Step 2: Create user link (datastore → user location)
         self.datastore
             .create_user_link(&datastore_path, user_path)?;
 
@@ -164,7 +159,6 @@ impl<'a> Executor<'a> {
             )];
         }
 
-        // Check for conflicts even in dry-run
         if !self.fs.is_symlink(user_path) && self.fs.exists(user_path) {
             if self.force {
                 return vec![OperationResult::ok(

--- a/crates/dodot-lib/src/execution/mod.rs
+++ b/crates/dodot-lib/src/execution/mod.rs
@@ -200,14 +200,12 @@ mod tests {
             ])
             .unwrap();
 
-        // All should succeed with dry-run messages
         assert_eq!(results.len(), 3); // Link=1, Stage=1, Run=1
         for r in &results {
             assert!(r.success);
             assert!(r.message.contains("[dry-run]"), "msg: {}", r.message);
         }
 
-        // Nothing should have been created
         env.assert_not_exists(&env.home.join(".vimrc"));
         env.assert_no_handler_state("vim", "symlink");
         env.assert_no_handler_state("vim", "shell");

--- a/crates/dodot-lib/src/execution/mod.rs
+++ b/crates/dodot-lib/src/execution/mod.rs
@@ -9,19 +9,6 @@
 //! [`mod@run`] for sentinel-gated command execution. This file owns the
 //! Executor struct, the per-call `execute()` entry point, and the
 //! match-based dispatchers (`execute_one`, `simulate`).
-//!
-//! ## Auto-executable permissions
-//!
-//! When `auto_chmod_exec` is enabled (the default), the executor
-//! ensures that files inside path-handler staged directories have
-//! execute permissions (`+x`). This matches the user's intent: files
-//! in `bin/` are there to be runnable, but execute bits can be lost
-//! in common workflows (git on macOS, manual file creation).
-//!
-//! Permission failures are reported as warnings in the operation
-//! results, not hard errors — the file is still staged and added to
-//! `$PATH`, it just won't be directly runnable until the user fixes
-//! permissions manually.
 
 mod fetch;
 mod link;

--- a/crates/dodot-lib/src/execution/run.rs
+++ b/crates/dodot-lib/src/execution/run.rs
@@ -1,6 +1,6 @@
 //! `Run` intent: execute a run-once handler command (install scripts,
 //! Brewfile bundle, `nix profile install`), gated by [`DataStore::did_run`]'s
-//! three-way classification (#169).
+//! three-way classification.
 //!
 //! Policy: run on `NeverRan`, skip silently on `RanCurrent`, skip with
 //! a "ran older version" notice on `RanDifferent`. `provision_rerun =
@@ -29,7 +29,6 @@ impl<'a> Executor<'a> {
             unreachable!("execute_run called with non-Run intent");
         };
 
-        // Three-way policy via did_run, unless --force.
         if !self.provision_rerun {
             match self
                 .datastore
@@ -79,9 +78,9 @@ impl<'a> Executor<'a> {
         let cmd_str = format!("{} {}", executable, arguments.join(" "));
         info!(pack, handler = handler.as_str(), command = %cmd_str.trim(), "running command");
 
-        // Run the command. `force=true` here tells run_and_record to
-        // skip its own internal has_sentinel pre-check — we've already
-        // made the policy decision above via did_run.
+        // `force=true` here tells run_and_record to skip its own
+        // internal has_sentinel pre-check — we've already made the
+        // policy decision above via did_run.
         self.datastore
             .run_and_record(pack, handler, executable, arguments, sentinel, true)?;
 

--- a/crates/dodot-lib/src/execution/run.rs
+++ b/crates/dodot-lib/src/execution/run.rs
@@ -231,7 +231,6 @@ mod tests {
         let env = TempEnvironment::builder().build();
         let (ds, runner) = make_datastore(&env);
 
-        // Pre-create sentinel for the SAME hash as the intent.
         let sentinel_dir = env.paths.handler_data_dir("vim", "install");
         env.fs.mkdir_all(&sentinel_dir).unwrap();
         env.fs
@@ -269,8 +268,6 @@ mod tests {
 
     #[test]
     fn execute_run_skips_with_notice_when_older_version_ran() {
-        // Pre-create a sentinel for a DIFFERENT hash → did_run returns
-        // RanDifferent → policy: skip with "ran older version" notice.
         let env = TempEnvironment::builder().build();
         let (ds, runner) = make_datastore(&env);
 

--- a/crates/dodot-lib/src/execution/run.rs
+++ b/crates/dodot-lib/src/execution/run.rs
@@ -4,7 +4,7 @@
 //!
 //! Policy: run on `NeverRan`, skip silently on `RanCurrent`, skip with
 //! a "ran older version" notice on `RanDifferent`. `provision_rerun =
-//! true` (the `--force` flag) bypasses both skip cases.
+//! true` (the `--provision-rerun` flag) bypasses both skip cases.
 
 use tracing::info;
 

--- a/crates/dodot-lib/src/execution/stage.rs
+++ b/crates/dodot-lib/src/execution/stage.rs
@@ -234,7 +234,6 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].success);
 
-        // Data link should exist
         let datastore_link = env
             .paths
             .handler_data_dir("vim", "shell")
@@ -251,7 +250,6 @@ mod tests {
             .build();
         let (ds, _) = make_datastore(&env);
 
-        // Verify the file starts without execute permission
         let tool_path = env.dotfiles_root.join("tools/bin/mytool");
         let meta_before = env.fs.stat(&tool_path).unwrap();
         assert_eq!(
@@ -277,7 +275,6 @@ mod tests {
             }])
             .unwrap();
 
-        // Should have the stage result + chmod result
         assert!(results.len() >= 2, "results: {results:?}");
         let chmod_result = results.iter().find(|r| r.message.contains("chmod +x"));
         assert!(
@@ -286,7 +283,6 @@ mod tests {
         );
         assert!(chmod_result.unwrap().success);
 
-        // Verify file is now executable
         let meta_after = env.fs.stat(&tool_path).unwrap();
         assert_ne!(
             meta_after.mode & 0o111,
@@ -304,7 +300,6 @@ mod tests {
             .build();
         let (ds, _) = make_datastore(&env);
 
-        // Pre-set execute permission
         let tool_path = env.dotfiles_root.join("tools/bin/mytool");
         env.fs.set_permissions(&tool_path, 0o755).unwrap();
 
@@ -325,7 +320,6 @@ mod tests {
             }])
             .unwrap();
 
-        // Should only have the stage result — no chmod needed
         let chmod_results: Vec<_> = results
             .iter()
             .filter(|r| r.message.contains("chmod"))
@@ -345,7 +339,6 @@ mod tests {
             .build();
         let (ds, _) = make_datastore(&env);
 
-        // auto_chmod_exec = false
         let executor = Executor::new(
             &ds,
             env.fs.as_ref(),
@@ -363,7 +356,6 @@ mod tests {
             }])
             .unwrap();
 
-        // Should only have the stage result — no chmod attempted
         let chmod_results: Vec<_> = results
             .iter()
             .filter(|r| r.message.contains("chmod"))
@@ -373,7 +365,6 @@ mod tests {
             "auto_chmod_exec=false should skip chmod: {chmod_results:?}"
         );
 
-        // File should remain non-executable
         let tool_path = env.dotfiles_root.join("tools/bin/mytool");
         let meta = env.fs.stat(&tool_path).unwrap();
         assert_eq!(meta.mode & 0o111, 0, "file should remain non-executable");
@@ -405,12 +396,10 @@ mod tests {
             }])
             .unwrap();
 
-        // The chmod should only apply to files, not the subdir directory
         let chmod_results: Vec<_> = results
             .iter()
             .filter(|r| r.message.contains("chmod"))
             .collect();
-        // subdir is a directory, not a file — should not be chmod'd
         for r in &chmod_results {
             assert!(
                 !r.message.contains("subdir"),
@@ -482,7 +471,6 @@ mod tests {
             }])
             .unwrap();
 
-        // Should report what would be chmod'd
         let chmod_results: Vec<_> = results
             .iter()
             .filter(|r| r.message.contains("chmod"))
@@ -493,7 +481,6 @@ mod tests {
         );
         assert!(chmod_results[0].message.contains("[dry-run]"));
 
-        // File should NOT have been modified
         let tool_path = env.dotfiles_root.join("tools/bin/mytool");
         let meta = env.fs.stat(&tool_path).unwrap();
         assert_eq!(
@@ -540,7 +527,6 @@ mod tests {
             "should chmod both files: {chmod_results:?}"
         );
 
-        // Both files should be executable
         for name in ["tool-a", "tool-b"] {
             let path = env.dotfiles_root.join(format!("tools/bin/{name}"));
             let meta = env.fs.stat(&path).unwrap();

--- a/crates/dodot-lib/src/execution/stage.rs
+++ b/crates/dodot-lib/src/execution/stage.rs
@@ -1,7 +1,8 @@
 //! `Stage` intent: copy a pack source into the datastore. The path
 //! handler also gets auto-chmod +x for files inside `bin/` so dropped
 //! execute bits (a common loss in git-on-macOS / manual-create flows)
-//! don't leave dead-end shims on `$PATH`.
+//! don't leave dead-end shims on `$PATH`. That chmod is gated on the
+//! executor's `auto_chmod_exec` flag, which is on by default.
 
 use tracing::{debug, info};
 
@@ -35,7 +36,6 @@ impl<'a> Executor<'a> {
 
         let mut results = vec![OperationResult::ok(op, format!("staged {}", filename))];
 
-        // Auto-chmod +x for path handler directories
         if handler == HANDLER_PATH && self.auto_chmod_exec {
             debug!(pack, source = %source.display(), "checking executable permissions");
             results.extend(self.ensure_executable(pack, source));
@@ -147,8 +147,6 @@ impl<'a> Executor<'a> {
                 }
                 Err(e) => {
                     info!(pack, file = %entry.name, error = %e, "chmod +x failed");
-                    // Warning, not failure — don't mark the pack as failed
-                    // just because chmod didn't work.
                     results.push(OperationResult::ok(
                         op,
                         format!("warning: could not chmod +x {}: {}", entry.name, e),

--- a/crates/dodot-lib/src/execution/test_support.rs
+++ b/crates/dodot-lib/src/execution/test_support.rs
@@ -1,11 +1,4 @@
-//! Shared test fixtures for the per-intent test suites.
-//!
-//! `MockCommandRunner` records every `(executable, arguments)` call so
-//! `Run`-intent tests can assert on the recorded shape; `make_datastore`
-//! wires it through a `FilesystemDataStore` that points at the test's
-//! `TempEnvironment`. Both are `pub(super)` so the per-intent modules
-//! (`link`, `stage`, `run`) and the dispatcher tests in `mod.rs` can
-//! reach them via `super::test_support::*` without duplicating fixtures.
+//! Shared fixtures for per-intent tests.
 
 use std::sync::{Arc, Mutex};
 

--- a/crates/dodot-lib/src/external/archive.rs
+++ b/crates/dodot-lib/src/external/archive.rs
@@ -252,12 +252,10 @@ mod tests {
     use flate2::Compression;
     use std::io::Write;
 
-    /// Build a tiny tar.gz with two entries for tests.
     fn fake_tar_gz() -> Vec<u8> {
         let mut tar_buf: Vec<u8> = Vec::new();
         {
             let mut builder = tar::Builder::new(&mut tar_buf);
-            // Plain file.
             let mut header = tar::Header::new_gnu();
             let body = b"hello tar\n";
             header.set_path("themes/alpha.zsh-theme").unwrap();
@@ -266,7 +264,6 @@ mod tests {
             header.set_cksum();
             builder.append(&header, &body[..]).unwrap();
 
-            // Nested file.
             let mut header = tar::Header::new_gnu();
             let body = b"#!/bin/sh\necho hi\n";
             header.set_path("themes/scripts/setup.sh").unwrap();
@@ -281,7 +278,6 @@ mod tests {
         gz.finish().unwrap()
     }
 
-    /// Build a tiny zip with one file for tests.
     fn fake_zip() -> Vec<u8> {
         let mut buf: Vec<u8> = Vec::new();
         {
@@ -362,8 +358,6 @@ mod tests {
 
     #[test]
     fn tar_symlink_entries_are_rejected() {
-        // Build a tar that contains a symlink entry — should be
-        // refused so we don't silently extract an empty file.
         let mut tar_buf: Vec<u8> = Vec::new();
         {
             let mut builder = tar::Builder::new(&mut tar_buf);

--- a/crates/dodot-lib/src/external/archive.rs
+++ b/crates/dodot-lib/src/external/archive.rs
@@ -136,8 +136,6 @@ fn read_tar_entry<R: std::io::Read>(
     let is_regular = header_entry_type.is_file();
     if !is_dir && !is_regular {
         // Symlinks, hardlinks, fifos, char/block devices, sparse, etc.
-        // Reject explicitly so the caller can surface a clear error
-        // rather than silently materialising an empty file.
         return Err(ArchiveError::UnsafePath(format!(
             "unsupported tar entry type {:?} at {}",
             header_entry_type,
@@ -234,8 +232,6 @@ fn validate_safe_archive_path(raw: &std::path::Path) -> Result<Option<PathBuf>, 
     for component in raw.components() {
         match component {
             Component::Normal(n) => cleaned.push(n),
-            // Skip pure `./` segments rather than fail (tar archives
-            // produced by `tar` itself frequently start with `./`).
             Component::CurDir => {}
             Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
                 return Err(ArchiveError::UnsafePath(raw.display().to_string()));

--- a/crates/dodot-lib/src/external/drift.rs
+++ b/crates/dodot-lib/src/external/drift.rs
@@ -10,7 +10,7 @@
 //! a thorough check involves hashing every deployed file, which can
 //! be expensive for big trees (think `oh-my-zsh`).
 //!
-//! Per-type strategy (PR 5):
+//! Per-type strategy:
 //! - **file** — compute sha256 of the datastore copy and compare
 //!   against the entry's configured sha256. Fast.
 //! - **git-repo** — `git -C <clone> status --porcelain`. Any output
@@ -132,10 +132,7 @@ fn check_file_drift(
     target: &str,
     fs: &dyn Fs,
 ) -> DriftReport {
-    // The file lives at `<entry-dir>/<basename-of-target>`. Resolve
-    // the exact path the executor would have written rather than
-    // scanning the dir (which can hold stale siblings and produce a
-    // nondeterministic answer).
+    // The file lives at `<entry-dir>/<basename-of-target>`.
     let basename = target_basename(target);
     let file_path: PathBuf = datastore_entry_dir.join(&basename);
     if !fs.exists(&file_path) {

--- a/crates/dodot-lib/src/external/drift.rs
+++ b/crates/dodot-lib/src/external/drift.rs
@@ -132,7 +132,9 @@ fn check_file_drift(
     target: &str,
     fs: &dyn Fs,
 ) -> DriftReport {
-    // The file lives at `<entry-dir>/<basename-of-target>`.
+    // Resolve the exact path the executor would have written rather
+    // than scanning the dir, which can hold stale siblings and produce
+    // a nondeterministic answer.
     let basename = target_basename(target);
     let file_path: PathBuf = datastore_entry_dir.join(&basename);
     if !fs.exists(&file_path) {

--- a/crates/dodot-lib/src/external/drift.rs
+++ b/crates/dodot-lib/src/external/drift.rs
@@ -290,7 +290,6 @@ sha256 = "{sha256}"
     fn file_drift_detected_when_user_edits_deployed_copy() {
         let env = TempEnvironment::builder().build();
         let configured_sha = hex_sha256(b"original content");
-        // User overwrote the deployed copy with something else.
         write_datastore_file(&env, "p", "x", "x", b"tampered content");
         let toml = file_externals_toml("x", &configured_sha);
         let reports = detect_drift_for_pack(
@@ -315,8 +314,6 @@ sha256 = "{sha256}"
         let env = TempEnvironment::builder().build();
         let body = b"current content";
         let sha = hex_sha256(body);
-        // Sibling that would lexically sort first and previously
-        // confused the check.
         write_datastore_file(&env, "p", "x", "0-old-name", b"stale");
         write_datastore_file(&env, "p", "x", "x", body);
         let toml = file_externals_toml("x", &sha);
@@ -374,7 +371,6 @@ sha256 = "abc"
         // tracks porcelain output.
         let env = TempEnvironment::builder().build();
         let mock = crate::external::MockGitRunner::new(&"a".repeat(40), b"");
-        // Fake the clone directory existing.
         let clone_dir = env
             .paths
             .handler_data_dir("p", crate::handlers::HANDLER_EXTERNAL)

--- a/crates/dodot-lib/src/external/git.rs
+++ b/crates/dodot-lib/src/external/git.rs
@@ -305,12 +305,12 @@ pub struct MockGitRunner {
 
 #[cfg(any(test, feature = "test-utils"))]
 struct MockGitInner {
-    /// Upstream SHA returned by `ls_remote_head`. None = error.
+    /// Canned SHA returned by `ls_remote`; `None` makes the mock return an error.
     pub ls_remote_sha: Option<String>,
     /// SHA recorded by the last clone / fetch+reset / used by
     /// `local_head` to answer subsequent queries.
     pub local_sha: Option<String>,
-    /// Whether ls_remote_head should fail with a transient error
+    /// Whether `ls_remote` should fail with a transient error
     /// to exercise the offline-tolerant path.
     pub ls_remote_offline: bool,
     /// Whether fetch_and_reset should fail.
@@ -356,7 +356,7 @@ impl MockGitRunner {
         g.ls_remote_sha = Some(sha.into());
     }
 
-    /// Force `ls_remote_head` to fail transiently (network down).
+    /// Force `ls_remote` to fail transiently (network down).
     pub fn set_ls_remote_offline(&self, offline: bool) {
         let mut g = self.inner.lock().unwrap();
         g.ls_remote_offline = offline;

--- a/crates/dodot-lib/src/external/git.rs
+++ b/crates/dodot-lib/src/external/git.rs
@@ -2,10 +2,10 @@
 //!
 //! Shell-out to the user's `git` binary is the simplest design that
 //! supports shallow clones (`--depth=1 --filter=blob:none`) and
-//! sparse-tree fetch — both features the issue explicitly requires
-//! and that the pure-Rust gitoxide crates don't yet expose at a
-//! porcelain level. The dependency on a system `git` is a reasonable
-//! prerequisite for dodot users (they're managing dotfiles, after all).
+//! sparse-tree fetch — both required here, and neither exposed at a
+//! porcelain level by the pure-Rust gitoxide crates. The dependency on
+//! a system `git` is a reasonable prerequisite for dodot users (they're
+//! managing dotfiles, after all).
 //!
 //! The trait abstraction exists so tests don't have to network out to
 //! real repos. Tests use [`MockGitRunner`] which records calls and

--- a/crates/dodot-lib/src/external/mod.rs
+++ b/crates/dodot-lib/src/external/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! A pack opts into externally-sourced content by placing an
 //! `externals.toml` at its root. Each `[entry]` block declares a single
-//! resource (a remote file today, a git repo in a later PR) and the
-//! target path under `$HOME` where it should appear.
+//! resource (a remote file, a git repo, or an archive) and the target
+//! path under `$HOME` where it should appear.
 //!
 //! ```toml
 //! [shared-aliases]

--- a/crates/dodot-lib/src/external/spec.rs
+++ b/crates/dodot-lib/src/external/spec.rs
@@ -15,12 +15,12 @@
 //! sha256 = "..."
 //! ```
 //!
-//! `file` and `git-repo` are implemented; any other `type` value
-//! parses to [`FetchSpec::Unsupported`]. The original type string is
-//! not retained — `#[serde(other)]` does not carry it over — so the
+//! Any unrecognized `type` value parses to
+//! [`FetchSpec::Unsupported`]. The original type string is not
+//! retained — `#[serde(other)]` does not carry it over — so the
 //! handler's diagnostic surfaces the entry name and a generic
 //! "unsupported type" message rather than echoing back what the user
-//! wrote. Subsequent PRs add `archive` / `archive-file`.
+//! wrote.
 
 use std::collections::BTreeMap;
 
@@ -54,9 +54,6 @@ pub struct ExternalEntry {
 /// The fetch recipe for one external entry.
 ///
 /// Tagged externally by the `type` field per TOML convention.
-/// `archive` and `archive-file` arrive in a later PR — until then,
-/// those parse into [`FetchSpec::Unsupported`] so the handler can
-/// surface "not yet implemented" without choking the whole pack.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum FetchSpec {

--- a/crates/dodot-lib/src/external/spec.rs
+++ b/crates/dodot-lib/src/external/spec.rs
@@ -577,7 +577,6 @@ mod tests {
 
     #[test]
     fn missing_sha256_on_file_is_an_error() {
-        // sha256 is mandatory; serde should reject the missing field.
         let toml = r#"
             [unpinned]
             type = "file"

--- a/crates/dodot-lib/src/fs/mod.rs
+++ b/crates/dodot-lib/src/fs/mod.rs
@@ -68,14 +68,11 @@ pub trait Fs: Send + Sync {
     /// even briefly — closing the race window between
     /// `write_file` (lands at e.g. 0644 on a typical 022 umask)
     /// and `set_permissions` (tightens to 0600). See
-    /// `secrets.lex` §4.3 + the Phase S3 chmod-race review on
-    /// PR #130.
+    /// `secrets.lex` §4.3.
     ///
-    /// Default impl falls back to `write_file` then
-    /// `set_permissions` so existing `Fs` implementations stay
-    /// correct (semantics-preserving) without forcing an upgrade;
-    /// the production `OsFs` overrides to use `OpenOptions::mode`
-    /// for the atomic version.
+    /// The default impl is the racy `write_file` +
+    /// `set_permissions` pair; `OsFs` overrides it to apply the
+    /// mode via `OpenOptions::mode` instead.
     fn write_file_with_mode(&self, path: &Path, contents: &[u8], mode: u32) -> Result<()> {
         self.write_file(path, contents)?;
         self.set_permissions(path, mode)
@@ -122,9 +119,7 @@ pub trait Fs: Send + Sync {
     /// source-side mtimes when deciding whether to touch the source.
     ///
     /// **Default implementation panics.** Override in `Fs` impls that
-    /// need mtime support (currently `OsFs`). Provided as a default
-    /// so adding mtime operations doesn't break any existing in-tree
-    /// or downstream `Fs` impl.
+    /// need mtime support (currently `OsFs`).
     fn modified(&self, _path: &Path) -> Result<std::time::SystemTime> {
         unimplemented!("Fs::modified is only implemented by OsFs")
     }

--- a/crates/dodot-lib/src/fs/os.rs
+++ b/crates/dodot-lib/src/fs/os.rs
@@ -230,7 +230,6 @@ mod tests {
         assert!(fs.is_symlink(&link));
         assert_eq!(fs.readlink(&link).unwrap(), original);
 
-        // Reading through the symlink works
         let content = fs.read_to_string(&link).unwrap();
         assert_eq!(content, "content");
     }
@@ -362,7 +361,6 @@ mod tests {
         assert_eq!(meta.permissions().mode() & 0o777, 0o755);
     }
 
-    // Compile-time check: Fs must be object-safe
     #[allow(dead_code)]
     fn assert_object_safe(_: &dyn Fs) {}
 }

--- a/crates/dodot-lib/src/fs/os.rs
+++ b/crates/dodot-lib/src/fs/os.rs
@@ -74,9 +74,6 @@ impl Fs for OsFs {
             .mode(mode)
             .open(path)
             .map_err(|e| fs_err(path, e))?;
-        // Tighten the mode regardless of whether the file already
-        // existed, so the plaintext never sits at a permissive
-        // mode while the bytes are written.
         let perms = fs::Permissions::from_mode(mode);
         fs::set_permissions(path, perms).map_err(|e| fs_err(path, e))?;
         file.write_all(contents).map_err(|e| fs_err(path, e))?;

--- a/crates/dodot-lib/src/gates/mod.rs
+++ b/crates/dodot-lib/src/gates/mod.rs
@@ -143,8 +143,6 @@ impl HostFacts {
 }
 
 fn detect_os() -> String {
-    // Match the values templates already expose so users don't have
-    // to learn two name systems.
     if cfg!(target_os = "macos") {
         "darwin".into()
     } else if cfg!(target_os = "linux") {
@@ -432,10 +430,9 @@ pub fn compile_mapping_gates<'a>(
 /// when the host's `os` matches at least one entry. Aliases recognised
 /// in the OS labels apply: `macos` → `darwin`.
 ///
-/// This is the entire mechanism behind the C3 surface — pack-level OS
-/// gating sits beside the filename grammar without sharing machinery
-/// because the granularity (whole pack) and the data flow (config field
-/// vs filename) are different.
+/// Pack-level OS gating sits beside the filename grammar without
+/// sharing machinery: the granularity (whole pack) and the data flow
+/// (config field vs filename) are different.
 pub fn pack_os_active(allowed: &[String], host: &HostFacts) -> bool {
     if allowed.is_empty() {
         return true;
@@ -512,13 +509,9 @@ pub enum BasenameGate<'a> {
 /// Hidden-file-style basenames (start with `.`) are skipped because the
 /// scanner already drops them at walk time. We don't special-case them.
 pub fn parse_basename_gate(basename: &str) -> BasenameGate<'_> {
-    // Scan `._` boundaries from right to left. For each, the label runs
-    // from after `_` up to the next `.` (or end of basename for the
-    // extensionless form). The first valid label found is the gate.
-    //
-    // Right-to-left ensures that in `foo._bar._baz.sh` only `._baz` is
-    // taken as the gate, leaving `foo._bar` literal — `_bar` would only
-    // be a gate if the user wrote `foo._bar.sh`.
+    // Right-to-left scan: in `foo._bar._baz.sh` only `._baz` is taken
+    // as the gate, leaving `foo._bar` literal — `_bar` would only be a
+    // gate if the user wrote `foo._bar.sh`.
     let bytes = basename.as_bytes();
     let mut i = bytes.len();
     while i >= 2 {

--- a/crates/dodot-lib/src/gates/mod.rs
+++ b/crates/dodot-lib/src/gates/mod.rs
@@ -615,7 +615,6 @@ mod tests {
 
     #[test]
     fn missing_dimension_does_not_match() {
-        // Predicate requires hostname=foo, but host has no hostname.
         let p = GatePredicate {
             matchers: vec![(Dimension::Hostname, "foo".into())],
         };
@@ -743,7 +742,6 @@ mod tests {
         darwin.insert("hostname".into(), "specific-mac".into());
         user.insert("darwin".into(), darwin);
         t.merge_user(&user).unwrap();
-        // Now darwin requires the hostname too.
         let p = t.lookup("darwin").unwrap();
         assert_eq!(p.matchers.len(), 2);
     }
@@ -905,11 +903,8 @@ mod tests {
 
     #[test]
     fn dir_gate_invalid_chars_not_a_gate() {
-        // empty label
         assert_eq!(parse_dir_gate_label("_"), None);
-        // dot in label (would be a basename gate, not a dir gate)
         assert_eq!(parse_dir_gate_label("_da.rwin"), None);
-        // space
         assert_eq!(parse_dir_gate_label("_dar win"), None);
     }
 
@@ -917,7 +912,6 @@ mod tests {
 
     #[test]
     fn hostfacts_detect_runs() {
-        // Smoke test: detect() shouldn't panic and must populate os/arch.
         let h = HostFacts::detect();
         assert!(!h.os.is_empty());
         assert!(!h.arch.is_empty());

--- a/crates/dodot-lib/src/handlers/externals.rs
+++ b/crates/dodot-lib/src/handlers/externals.rs
@@ -1,14 +1,12 @@
 //! Externals handler — declarative remote-resource deployment.
 //!
 //! The trigger file is `externals.toml` at the pack root. Each section
-//! declares one external resource (currently `type = "file"`; the
-//! git-repo and archive variants land in later PRs). The handler parses
-//! the file and emits one [`HandlerIntent::Fetch`] per entry.
+//! declares one external resource (currently `type = "file"`). The
+//! handler parses the file and emits one [`HandlerIntent::Fetch`] per
+//! entry.
 //!
-//! The handler itself is read-only — fetching, hashing, and symlink
-//! creation all happen in `crate::execution::fetch`. This mirrors the
-//! existing handler/executor split: planning is idempotent and safe to
-//! re-run; I/O lives in the executor.
+//! Fetching, hashing, and symlink creation all happen in
+//! `crate::execution::fetch`.
 
 use std::path::{Path, PathBuf};
 
@@ -93,10 +91,8 @@ impl Handler for ExternalsHandler {
         pack: &str,
         datastore: &dyn DataStore,
     ) -> Result<HandlerStatus> {
-        // Coarse-grained for v1: report deployed if *any* sentinel
-        // exists for the pack/external pair. Per-entry status arrives
-        // when we add the `dodot status` external-aware rendering in a
-        // later PR.
+        // Coarse-grained: deployed if *any* sentinel exists for the
+        // pack/external pair, not per declared entry.
         let deployed = datastore.has_handler_state(pack, HANDLER_EXTERNAL)?;
         Ok(HandlerStatus {
             file: file.to_string_lossy().into_owned(),

--- a/crates/dodot-lib/src/handlers/externals.rs
+++ b/crates/dodot-lib/src/handlers/externals.rs
@@ -1,9 +1,9 @@
 //! Externals handler — declarative remote-resource deployment.
 //!
 //! The trigger file is `externals.toml` at the pack root. Each section
-//! declares one external resource (currently `type = "file"`). The
-//! handler parses the file and emits one [`HandlerIntent::Fetch`] per
-//! entry.
+//! declares one external resource (`file`, `git-repo`, `archive`, or
+//! `archive-file`). The handler parses the file and emits one
+//! [`HandlerIntent::Fetch`] per entry.
 //!
 //! Fetching, hashing, and symlink creation all happen in
 //! `crate::execution::fetch`.

--- a/crates/dodot-lib/src/handlers/filter.rs
+++ b/crates/dodot-lib/src/handlers/filter.rs
@@ -192,7 +192,6 @@ mod tests {
             env.paths.clone(),
             Arc::new(NoopCommandRunner),
         );
-        // Seed unrelated state to prove check_status ignores it.
         let source = env.dotfiles_root.join("vim/vimrc");
         ds.create_data_link("vim", HANDLER_SYMLINK, &source)
             .unwrap();

--- a/crates/dodot-lib/src/handlers/gate.rs
+++ b/crates/dodot-lib/src/handlers/gate.rs
@@ -135,9 +135,6 @@ mod tests {
             env.paths.clone(),
             Arc::new(NoopCommandRunner),
         );
-        // Seed state under a *different* handler — the property is that
-        // GateHandler::check_status never consults the datastore, so any
-        // existing state (related or not) must not flip `deployed`.
         let source = env.dotfiles_root.join("vim/vimrc");
         ds.create_data_link("vim", HANDLER_SYMLINK, &source)
             .unwrap();

--- a/crates/dodot-lib/src/handlers/homebrew.rs
+++ b/crates/dodot-lib/src/handlers/homebrew.rs
@@ -3,8 +3,7 @@
 //!
 //! The bulk of the behavior lives in
 //! [`crate::handlers::run_once::RunOnceHandler`]. This module supplies
-//! the [`BrewfileCommand`] specialization: program name (`brew`) and
-//! argument shape (`bundle --file <path>`).
+//! the [`BrewfileCommand`] specialization.
 
 use std::path::Path;
 
@@ -15,10 +14,9 @@ use crate::handlers::{ExecutionPhase, HANDLER_HOMEBREW};
 ///
 /// Invokes `brew bundle --file <abs path>`. No pre-flight validation —
 /// `brew` itself surfaces parse errors clearly when the Brewfile is
-/// malformed. This matches the
+/// malformed. See the
 /// [`RunOnceCommand`](crate::handlers::run_once::RunOnceCommand)
-/// lifecycle invariant: content errors surface at apply time, not at
-/// planning time.
+/// lifecycle invariant.
 pub struct BrewfileCommand;
 
 impl RunOnceCommand for BrewfileCommand {

--- a/crates/dodot-lib/src/handlers/install.rs
+++ b/crates/dodot-lib/src/handlers/install.rs
@@ -97,10 +97,8 @@ mod tests {
         assert_eq!(interpreter_for(Path::new("install.sh")), "bash");
         assert_eq!(interpreter_for(Path::new("install.bash")), "bash");
         assert_eq!(interpreter_for(Path::new("install.zsh")), "zsh");
-        // Unknown / missing extension falls back to bash.
         assert_eq!(interpreter_for(Path::new("install")), "bash");
         assert_eq!(interpreter_for(Path::new("install.ksh")), "bash");
-        // Path components don't interfere with extension lookup.
         assert_eq!(interpreter_for(Path::new("/a/b/install.zsh")), "zsh");
     }
 

--- a/crates/dodot-lib/src/handlers/install.rs
+++ b/crates/dodot-lib/src/handlers/install.rs
@@ -36,8 +36,7 @@ use crate::handlers::{ExecutionPhase, HANDLER_INSTALL};
 /// as `<interpreter> -- <abs path>` (the `--` end-of-flags separator
 /// guards against scripts whose names start with a dash). No
 /// pre-flight content validation — a script's syntax errors surface
-/// at apply time via the interpreter, the same way `brew bundle`
-/// surfaces Brewfile errors. See the
+/// at apply time via the interpreter. See the
 /// [`RunOnceCommand`](crate::handlers::run_once::RunOnceCommand)
 /// lifecycle invariant.
 pub struct InstallCommand;

--- a/crates/dodot-lib/src/handlers/mod.rs
+++ b/crates/dodot-lib/src/handlers/mod.rs
@@ -214,11 +214,11 @@ pub trait Handler: Send + Sync {
     /// human-readable strings the orchestration surfaces in
     /// `PackStatusResult.warnings`.
     ///
-    /// Default empty. The symlink handler overrides this to flag
-    /// `_lib/` entries on non-macOS platforms (per
-    /// `docs/proposals/macos-paths.lex` §4.2): the pack is otherwise
-    /// fine, other entries deploy normally, but the user gets a visible
-    /// "skipped on this platform" notice.
+    /// Default empty. Override when a handler deliberately drops an
+    /// entry and the user should know: the pack stays valid and its
+    /// other entries deploy normally, but a visible notice explains
+    /// the gap. The symlink handler uses this for macOS-only paths on
+    /// other platforms.
     fn warnings_for_matches(
         &self,
         _matches: &[RuleMatch],
@@ -246,17 +246,12 @@ pub struct HandlerConfig {
     /// Paths that must be forced to `$HOME` (e.g. `["ssh", "bashrc"]`).
     pub force_home: Vec<String>,
     /// Paths that must be forced to the app-support root (e.g.
-    /// `["Code", "Cursor"]`). Curated GUI-app folder names whose first
-    /// path segment routes to `<app_support_dir>/<seg>/<rest>` without
-    /// requiring a `_app/` prefix in the pack tree. See
-    /// `docs/proposals/macos-paths.lex` §3.4.
+    /// `["Code", "Cursor"]`). See
+    /// [`SymlinkSection::force_app`](crate::config::SymlinkSection::force_app).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub force_app: Vec<String>,
-    /// Pack-name → app-support folder name rewrites. When the pack
-    /// name appears as a key here, the resolver's default rule routes
-    /// through `<app_support_dir>/<alias>/<rel_path>` instead of
-    /// `$XDG_CONFIG_HOME/<pack>/<rel_path>`. See `app_aliases` in
-    /// `docs/proposals/macos-paths.lex` §3.3.
+    /// Pack-name → app-support folder name rewrites. See
+    /// [`SymlinkSection::app_aliases`](crate::config::SymlinkSection::app_aliases).
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub app_aliases: std::collections::HashMap<String, String>,
     /// Paths that must not be symlinked (e.g. `[".ssh/id_rsa"]`).
@@ -333,9 +328,7 @@ pub fn configuration_handler_names(fs: &dyn Fs) -> Vec<String> {
 /// reference is needed by the run-once handlers (install, homebrew,
 /// nix) for checksum computation; `runner` is threaded in for any
 /// environmental pre-flight a `RunOnceCommand` may want to do at
-/// intent-production time (see the lifecycle-invariant note on
-/// `RunOnceCommand` — per-content validation is out of scope for
-/// run-once handlers).
+/// intent-production time.
 pub fn create_registry<'a>(
     fs: &'a dyn Fs,
     runner: &'a dyn crate::datastore::CommandRunner,

--- a/crates/dodot-lib/src/handlers/mod.rs
+++ b/crates/dodot-lib/src/handlers/mod.rs
@@ -395,7 +395,6 @@ fn validate_registry(registry: &HashMap<String, Box<dyn Handler + '_>>) {
 mod tests {
     use super::*;
 
-    // Compile-time check: Handler must be object-safe
     #[allow(dead_code)]
     fn assert_object_safe(_: &dyn Handler) {}
 

--- a/crates/dodot-lib/src/handlers/nix.rs
+++ b/crates/dodot-lib/src/handlers/nix.rs
@@ -124,11 +124,8 @@ impl RunOnceCommand for NixCommand {
         )
     }
 
-    // No `validate` override — see lifecycle-invariant note on
-    // RunOnceCommand. Content-shape checks at planning time would
-    // diverge nix from install / homebrew. Malformed manifests
-    // surface at apply time via the `nix profile install` subprocess
-    // exit code and stderr, the same way a broken Brewfile does.
+    // No `validate` override — see the lifecycle-invariant note on
+    // `RunOnceCommand`.
 
     fn status_deployed(&self) -> &str {
         "nix packages installed"

--- a/crates/dodot-lib/src/handlers/nix.rs
+++ b/crates/dodot-lib/src/handlers/nix.rs
@@ -210,8 +210,6 @@ mod tests {
         let (e2, a2) = NixCommand.command_for(Path::new("/b/packages.nix"));
         assert_eq!(e1, e2);
         assert_eq!(a1.len(), a2.len());
-        // The argv structure is identical — only the path inside
-        // the wrapper expression differs.
         assert_eq!(a1[0], a2[0]); // "profile"
         assert_eq!(a1[1], a2[1]); // "install"
         assert_eq!(a1[2], a2[2]); // "--expr"
@@ -222,12 +220,10 @@ mod tests {
     #[test]
     fn nix_path_literal_quotes_and_escapes() {
         assert_eq!(nix_path_literal(Path::new("/a/b.nix")), "\"/a/b.nix\"");
-        // Embedded double-quote — escaped.
         assert_eq!(
             nix_path_literal(Path::new("/weird\"name.nix")),
             "\"/weird\\\"name.nix\""
         );
-        // Embedded backslash — escaped.
         assert_eq!(
             nix_path_literal(Path::new("/with\\backslash.nix")),
             "\"/with\\\\backslash.nix\""

--- a/crates/dodot-lib/src/handlers/path.rs
+++ b/crates/dodot-lib/src/handlers/path.rs
@@ -214,8 +214,6 @@ mod tests {
             Arc::new(NoopCommandRunner),
         );
 
-        // Seed handler state by linking the bin dir as the path handler
-        // would once executed.
         let bin_dir = env.dotfiles_root.join("dev/bin");
         ds.create_data_link("dev", HANDLER_PATH, &bin_dir).unwrap();
 

--- a/crates/dodot-lib/src/handlers/run_once.rs
+++ b/crates/dodot-lib/src/handlers/run_once.rs
@@ -1,6 +1,5 @@
 //! `RunOnceCommand` + `RunOnceHandler<C>` — the shared shape behind
-//! the run-once provisioning handlers (`install`, `homebrew`, and the
-//! forthcoming `nix`).
+//! the run-once provisioning handlers (`install`, `homebrew`, `nix`).
 //!
 //! All three of these handlers do the same job: run a program on a
 //! user-provided file, hash the file, write a sentinel so we know not
@@ -10,7 +9,7 @@
 //! [`RunOnceCommand`] trait, with [`RunOnceHandler`] handling the
 //! rest.
 //!
-//! # Three-state run-once semantics (#169 PR C / PR D)
+//! # Three-state run-once semantics
 //!
 //! Run-once handlers consult [`DataStore::did_run`](crate::datastore::DataStore::did_run)
 //! to classify a matched file into one of three states:
@@ -23,9 +22,9 @@
 //! 3. [`RanDifferent`](crate::datastore::DidRunStatus::RanDifferent) — a
 //!    sentinel exists but for a *different* content hash; skip with
 //!    notice. The user opts in to re-running via
-//!    `dodot up --provision-rerun` (the existing `provision_rerun`
-//!    flag — distinct from `--force`, which only overwrites
-//!    pre-existing files at symlink target paths).
+//!    `dodot up --provision-rerun` (the `provision_rerun` flag —
+//!    distinct from `--force`, which only overwrites pre-existing
+//!    files at symlink target paths).
 //!
 //! `dodot status` renders this three-way result as `pending` /
 //! `deployed` / `older version (N lines added, M removed)` rows; the
@@ -38,9 +37,9 @@
 //! writes a `<sentinel>.snapshot` sibling capturing the script's bytes
 //! at the moment of a successful run. Snapshots are the data behind
 //! the `(N+ M-)` summary in status and the body of
-//! `dodot status --diff`. Sentinels predating the convention
-//! (pre-#169 PR C) have no snapshot — those rows surface as `older
-//! version (no diff data)` and are excluded from `--diff` output.
+//! `dodot status --diff`. Sentinels written before snapshots existed
+//! have no snapshot sibling — those rows surface as `older version
+//! (no diff data)` and are excluded from `--diff` output.
 //!
 //! Snapshots live at
 //! `<datastore>/packs/<pack>/<handler>/<filename>-<hash>.snapshot`;
@@ -110,19 +109,14 @@ pub trait RunOnceCommand: Send + Sync {
 
     /// Optional pre-flight check. Default: no-op.
     ///
-    /// **Scope: environmental, not content.** See the
-    /// "Lifecycle invariant" section in the trait docs — a
-    /// validator that fails per-content (e.g. file-syntax check,
-    /// manifest-shape rejection) breaks the shared `did_run`
-    /// lifecycle by failing planning for a file the run-once
-    /// policy says should surface as `older version`. Use
+    /// **Scope: environmental, not content** — see the
+    /// "Lifecycle invariant" section in the trait docs. Use
     /// `validate` only for environment-level prerequisites that
     /// fail consistently regardless of the file's current
     /// contents.
     ///
     /// Returning `Err` aborts intent generation for the matched
-    /// file and propagates the error. The default implementation
-    /// passes any file through unchanged.
+    /// file and propagates the error.
     ///
     /// Implementations receive both `fs` (for reading the matched
     /// file's bytes without re-entering the executor) and `runner`
@@ -151,8 +145,8 @@ pub trait RunOnceCommand: Send + Sync {
     /// Human-readable status message when a sentinel exists but for
     /// a *different* content hash — the file has been edited since
     /// the last successful run, but the conservative
-    /// notify-don't-rerun policy (#169 PR C) leaves the prior state
-    /// in place until the user opts in via `--provision-rerun`.
+    /// notify-don't-rerun policy leaves the prior state in place
+    /// until the user opts in via `--provision-rerun`.
     ///
     /// Default: `"older version"`. Overridden per-handler for
     /// readability — e.g. `"brew packages older version"` for
@@ -352,10 +346,8 @@ pub fn status_messages_for<C: RunOnceCommand>(cmd: &C) -> RunOnceStatusMessages 
 }
 
 /// Look up the canonical run-state copy for a built-in run-once
-/// handler by name. `dodot status` consults this so it can render
-/// the three-state row label per handler without instantiating a
-/// `RunOnceHandler<C>` against the right `Fs`. Unknown handler names
-/// fall back to the trait defaults.
+/// handler by name. Unknown handler names fall back to the trait
+/// defaults.
 pub fn run_once_status_messages(handler: &str) -> RunOnceStatusMessages {
     use crate::handlers::{HANDLER_HOMEBREW, HANDLER_INSTALL, HANDLER_NIX};
     if handler == HANDLER_INSTALL {
@@ -379,10 +371,6 @@ pub fn run_once_status_messages(handler: &str) -> RunOnceStatusMessages {
 /// Returns the first 8 bytes of the SHA-256 hash as 16 hex chars —
 /// unique enough for sentinel-name disambiguation, short enough to
 /// keep on-disk paths readable.
-///
-/// Internal helper used by [`RunOnceHandler`] and (in PR B) by the
-/// retrofitted `install` / `homebrew` handlers. Crate-scoped to keep
-/// it out of dodot-lib's public API surface.
 pub(crate) fn file_checksum(fs: &dyn Fs, path: &Path) -> Result<String> {
     let mut reader = fs.open_read(path)?;
     let mut hasher = Sha256::new();

--- a/crates/dodot-lib/src/handlers/run_once.rs
+++ b/crates/dodot-lib/src/handlers/run_once.rs
@@ -412,7 +412,6 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    // Compile-time check: RunOnceCommand is object-safe.
     #[allow(dead_code)]
     fn assert_object_safe(_: &dyn RunOnceCommand) {}
 
@@ -431,7 +430,6 @@ mod tests {
         FilesystemDataStore::new(env.fs.clone(), env.paths.clone(), Arc::new(NoopRunner))
     }
 
-    /// Test double — a minimal `RunOnceCommand` implementation.
     struct FakeCommand {
         name: &'static str,
         phase: ExecutionPhase,
@@ -567,10 +565,8 @@ mod tests {
                 assert_eq!(pack, "vim");
                 assert_eq!(h, "fake");
                 assert_eq!(executable, "bash");
-                // Args template + appended path.
                 assert_eq!(arguments[0], "--");
                 assert!(arguments[1].ends_with("vim/setup.sh"));
-                // Sentinel shape: "<filename>-<16 hex chars>".
                 assert!(sentinel.starts_with("setup.sh-"));
                 assert_eq!(sentinel.len(), "setup.sh-".len() + 16);
                 assert_eq!(filename, "setup.sh");
@@ -644,10 +640,7 @@ mod tests {
 
     #[test]
     fn validate_does_not_fire_on_placeholder_match() {
-        // A validator that always errors must NOT be called for a
-        // first-time-pack passive placeholder (no rendered bytes, no
-        // on-disk file). Regression test for Copilot review on #170 —
-        // the earlier draft validated before checking for content.
+        // A passive placeholder has no content to validate.
         let env = TempEnvironment::builder().build();
         let cmd = FakeCommand {
             validate_fails: true,
@@ -670,8 +663,6 @@ mod tests {
 
     #[test]
     fn to_intents_skips_first_time_pack_passive_placeholder() {
-        // No rendered_bytes, file doesn't exist on disk → skip (no
-        // intent), don't error.
         let env = TempEnvironment::builder().build();
         let handler = RunOnceHandler::new(env.fs.as_ref(), &NoopRunner, FakeCommand::new("fake"));
 
@@ -782,7 +773,6 @@ mod tests {
         let checksum = file_checksum(env.fs.as_ref(), &abs).unwrap();
         let sentinel = format!("setup.sh-{checksum}");
 
-        // Pre-create the sentinel on disk so check_status finds it.
         let sentinel_dir = env.paths.handler_data_dir("vim", "fake");
         env.fs.mkdir_all(&sentinel_dir).unwrap();
         env.fs
@@ -811,8 +801,6 @@ mod tests {
             .build();
         let abs = env.dotfiles_root.join("vim/setup.sh");
 
-        // Pre-create a sentinel for a different hash → did_run
-        // returns RanDifferent → check_status reports "older version".
         let sentinel_dir = env.paths.handler_data_dir("vim", "fake");
         env.fs.mkdir_all(&sentinel_dir).unwrap();
         env.fs

--- a/crates/dodot-lib/src/handlers/symlink/mod.rs
+++ b/crates/dodot-lib/src/handlers/symlink/mod.rs
@@ -1,4 +1,4 @@
-//! Symlink handler — the most complex handler.
+//! Symlink handler.
 //!
 //! Creates double-link chains from source files to user-visible locations.
 //! Target resolution priority (highest first):
@@ -85,7 +85,6 @@ impl Handler for SymlinkHandler {
         for m in matches {
             let rel_str = m.relative_path.to_string_lossy();
 
-            // Check protected paths
             if is_protected(&rel_str, &config.protected_paths) {
                 continue;
             }
@@ -144,7 +143,7 @@ impl Handler for SymlinkHandler {
                 ));
             }
         }
-        let _ = paths; // reserved for future per-warning path enrichment
+        let _ = paths; // unused here; supplied by the trait signature
         out
     }
 
@@ -158,11 +157,11 @@ impl Handler for SymlinkHandler {
 
         // The trait doesn't carry a `Pather`, so we can't compute the
         // resolved deploy path here. Producing a hand-rolled path string
-        // would re-implement (and inevitably drift from) `resolve_target`
-        // — the very bug-bomb #48's centralization is meant to prevent.
-        // Use a path-free message in the style of `path` and `shell`
-        // handlers; callers that need the deploy path call
-        // `resolve_target` directly via the `status::status()` flow.
+        // would re-implement (and inevitably drift from)
+        // `resolve_target`, which is deliberately the single place
+        // routing is decided. Use a path-free message in the style of
+        // `path` and `shell` handlers; callers that need the deploy path
+        // call `resolve_target` directly via the `status::status()` flow.
         Ok(HandlerStatus {
             file: file.to_string_lossy().into_owned(),
             handler: HANDLER_SYMLINK.into(),
@@ -220,7 +219,6 @@ fn dir_intents(
         }]);
     }
 
-    // Per-file mode: recurse the directory and emit one intent per file.
     let mut intents = Vec::new();
     collect_per_file_intents(m, &m.absolute_path, config, paths, fs, &mut intents)?;
     Ok(intents)
@@ -258,9 +256,8 @@ fn collect_per_file_intents(
             continue;
         }
         check_routing_conflict(&m.pack, &rel_str, config)?;
-        // Use the full Resolution channel so `_lib/` on non-macOS is
-        // skipped (no Link intent produced); `warnings_for_matches`
-        // surfaces the user-visible warning out-of-band.
+        // Go through the full `Resolution` channel so a `Skip` drops the
+        // entry instead of producing a Link intent.
         match resolve_target_full(&m.pack, &rel_str, config, paths) {
             Resolution::Path(user_path) => out.push(HandlerIntent::Link {
                 pack: m.pack.clone(),
@@ -443,17 +440,13 @@ pub(crate) fn resolve_target_full(
     // Priority 0: Custom target override from [symlink.targets]
     if let Some(target) = config.targets.get(rel_path) {
         if target.starts_with('/') {
-            // Absolute path — use as-is
             return Resolution::Path(PathBuf::from(target));
         }
-        // Relative path — resolve from XDG_CONFIG_HOME
+        // A relative override resolves from XDG_CONFIG_HOME.
         return Resolution::Path(xdg_config.join(target));
     }
 
-    // Priority 1: file-level prefixes (per-file opt-in, top-level only).
-    // Each strips the prefix and routes the remainder under a fixed
-    // root, skipping pack namespacing — parallel to the directory
-    // prefixes at Priority 2.
+    // Priority 1: file-level prefixes (top-level files only).
     if let Some((kind, rest)) = strip_file_prefix(rel_path) {
         return match kind {
             FilePrefix::Home => Resolution::Path(home.join(format!(".{rest}"))),
@@ -471,11 +464,8 @@ pub(crate) fn resolve_target_full(
         };
     }
 
-    // Priority 2: Explicit directory-prefix escape hatches.
-    // _home/<rest> → $HOME/.<rest> (raw, no pack namespace)
-    // _xdg/<rest>  → $XDG_CONFIG_HOME/<rest> (raw, no pack namespace)
-    // _app/<rest>  → <app_support_dir>/<rest> (raw, no pack namespace)
-    // _lib/<rest>  → $HOME/Library/<rest> (macOS only; warn elsewhere)
+    // Priority 2: directory-prefix escape hatches. Each strips its
+    // prefix and routes the remainder raw, with no pack namespace.
     if let Some(stripped) = rel_path.strip_prefix("_home/") {
         let parts: Vec<&str> = stripped.split('/').collect();
         if let Some(first) = parts.first() {
@@ -538,8 +528,7 @@ pub(crate) fn resolve_target_full(
 
     // Priority 4: force_app — curated GUI-app folders that route to
     // `<app_support_dir>/<first-segment>/<rest>` without a `_app/`
-    // prefix. Mirrors `force_home` semantics: first segment compared
-    // case-sensitively (Library folder names *are* case-sensitive).
+    // prefix.
     if is_force_app(rel_path, &config.force_app) {
         return Resolution::Path(app_support.join(rel_path));
     }
@@ -556,15 +545,9 @@ pub(crate) fn resolve_target_full(
     }
 
     // Priority 6: Default — $XDG_CONFIG_HOME/<pack>/<rel_path>
-    //
-    // The pack name namespaces every entry by default so common modern
-    // tools (nvim, helix, ghostty, …) work out of the box without
-    // requiring `pack/program/` doubled paths. The escape hatches above
-    // cover legacy `$HOME` tools and any user-specified overrides.
     Resolution::Path(xdg_config.join(pack).join(rel_path))
 }
 
-/// Check if a path matches any force_home entry.
 fn is_force_home(rel_path: &str, force_home: &[String]) -> bool {
     let first_segment = rel_path.split('/').next().unwrap_or(rel_path);
     let without_dot = first_segment.strip_prefix('.').unwrap_or(first_segment);
@@ -586,7 +569,6 @@ fn is_force_app(rel_path: &str, force_app: &[String]) -> bool {
     force_app.iter().any(|entry| entry == first_segment)
 }
 
-/// Check if a path is in the protected paths list.
 fn is_protected(rel_path: &str, protected_paths: &[String]) -> bool {
     let normalized = rel_path.strip_prefix("./").unwrap_or(rel_path);
     let with_dot = if !normalized.starts_with('.') {
@@ -596,11 +578,10 @@ fn is_protected(rel_path: &str, protected_paths: &[String]) -> bool {
     };
 
     for protected in protected_paths {
-        // Exact match
         if protected == normalized || protected == &with_dot {
             return true;
         }
-        // Parent directory match
+        // A protected directory protects everything under it.
         if normalized.starts_with(&format!("{protected}/"))
             || with_dot.starts_with(&format!("{protected}/"))
         {

--- a/crates/dodot-lib/src/handlers/symlink/tests/cascade.rs
+++ b/crates/dodot-lib/src/handlers/symlink/tests/cascade.rs
@@ -270,8 +270,7 @@ fn force_app_outranks_app_alias() {
 
 #[test]
 fn home_prefix_routes_top_level_file_to_home() {
-    // home.X is the per-file opt-in for $HOME/.X placement, replacing
-    // the older `dot.X` prefix in #48.
+    // home.X is the per-file opt-in for $HOME/.X placement.
     let config = HandlerConfig::default();
     let target = resolve_target("git", "home.gitconfig", &config, &test_pather());
     assert_eq!(target, PathBuf::from("/home/alice/.gitconfig"));
@@ -332,9 +331,8 @@ fn strip_file_prefix_unit() {
     assert_eq!(strip_file_prefix("lib."), None);
 }
 
-/// A file literally named `home.` falls through the priority list to
-/// the pack-namespaced XDG default — never to `$HOME/.`. Regression
-/// for review item #3 on PR #49.
+/// A file literally named `home.` falls through to the pack-namespaced
+/// XDG default, never `$HOME/.`.
 #[test]
 fn literal_home_dot_filename_does_not_target_home_root() {
     let config = HandlerConfig::default();
@@ -342,8 +340,7 @@ fn literal_home_dot_filename_does_not_target_home_root() {
     assert_eq!(target, PathBuf::from("/home/alice/.config/misc/home."));
 }
 
-/// Same regression for the new file prefixes — bare `app.`, `xdg.`,
-/// `lib.` filenames must not target the routing root.
+/// Bare `app.`, `xdg.`, and `lib.` filenames must not target a routing root.
 #[test]
 fn literal_bare_file_prefix_filenames_do_not_target_root() {
     let config = HandlerConfig::default();

--- a/crates/dodot-lib/src/handlers/symlink/tests/integration.rs
+++ b/crates/dodot-lib/src/handlers/symlink/tests/integration.rs
@@ -114,21 +114,17 @@ fn targets_without_prefix_is_not_a_conflict() {
 
 #[test]
 fn has_routing_prefix_unit() {
-    // File-level prefixes
     assert!(has_routing_prefix("home.bashrc"));
     assert!(has_routing_prefix("app.settings.json"));
     assert!(has_routing_prefix("xdg.mimeapps.list"));
     assert!(has_routing_prefix("lib.com.example.plist"));
-    // Subtree prefixes
     assert!(has_routing_prefix("_home/vimrc"));
     assert!(has_routing_prefix("_xdg/ghostty/config"));
     assert!(has_routing_prefix("_app/Code/User/settings.json"));
     assert!(has_routing_prefix("_lib/LaunchAgents/foo.plist"));
-    // Bare prefix dir names too — the catchall scanner can match
-    // those at the top level when nothing else inside them does.
+    // The catchall can surface bare prefix directories when their children do not match.
     assert!(has_routing_prefix("_home"));
     assert!(has_routing_prefix("_app"));
-    // Plain names — no prefix.
     assert!(!has_routing_prefix("vimrc"));
     assert!(!has_routing_prefix("subdir/home.conf"));
     // Empty-rest forms fall through, so they don't carry routing
@@ -223,7 +219,6 @@ fn plain_top_level_dir_produces_single_wholesale_intent() {
     } = &intents[0]
     {
         assert!(source.ends_with("warp/themes"));
-        // Under #48, top-level dirs deploy under the pack's XDG dir.
         assert!(
             user_path.ends_with(".config/warp/themes"),
             "user_path={}",
@@ -348,7 +343,6 @@ fn lib_prefix_emits_warning_on_non_macos() {
             warnings.is_empty(),
             "_lib/ should not warn on macOS; got {warnings:?}"
         );
-        // And the intent is generated as a real Link.
         let intents = handler
             .to_intents(&[m], &config, env.paths.as_ref(), env.fs.as_ref())
             .unwrap();
@@ -359,7 +353,6 @@ fn lib_prefix_emits_warning_on_non_macos() {
             warnings[0].contains("macOS-only path"),
             "warning text should mention macOS-only: {warnings:?}"
         );
-        // And the intent is *omitted* — `to_intents` skips it.
         let intents = handler
             .to_intents(&[m], &config, env.paths.as_ref(), env.fs.as_ref())
             .unwrap();
@@ -372,11 +365,10 @@ fn lib_prefix_emits_warning_on_non_macos() {
 
 #[test]
 fn top_level_app_and_lib_dirs_force_per_file_mode() {
-    // Regression: a top-level `_app` or `_lib` directory MUST NOT
+    // A top-level `_app` or `_lib` directory must not
     // be wholesale-linked — that would bake the prefix into the
     // deploy path (`~/.config/<pack>/_app/...`). Same per-file
-    // forcing as `_home` and `_xdg`. Discovered by the bats e2e
-    // suite for `_app/`.
+    // forcing as `_home` and `_xdg`.
     for prefix in ["_app", "_lib"] {
         let env = crate::testing::TempEnvironment::builder()
             .pack("macapps")
@@ -405,9 +397,7 @@ fn top_level_app_and_lib_dirs_force_per_file_mode() {
             expected,
             "prefix={prefix}: expected {expected} intents, got {intents:?}"
         );
-        // The user_path should NOT contain the literal prefix —
-        // the resolver stripped it. (Skip this check when no
-        // intents were produced.)
+        // No intent is the expected non-macOS `_lib/` case.
         if let Some(HandlerIntent::Link { user_path, .. }) = intents.first() {
             assert!(
                 !user_path.to_string_lossy().contains(&format!("/{prefix}/")),

--- a/crates/dodot-lib/src/handlers/symlink/tests/mod.rs
+++ b/crates/dodot-lib/src/handlers/symlink/tests/mod.rs
@@ -1,12 +1,4 @@
-//! Tests for the symlink handler.
-//!
-//! Shared fixtures (`test_pather`, `default_config`) live here so the
-//! per-tier sub-modules can `use super::{...}` without re-defining each
-//! one. Small sections — default rule, pack-prefix interaction,
-//! protected paths, force_home matching — stay inline. The big topical
-//! suites live in sibling files: cascade priority resolution and the
-//! integration tests covering routing conflicts, custom targets,
-//! wholesale-vs-per-file behaviour, and `_lib/` warnings.
+//! Tests and shared fixtures for the symlink handler.
 
 #![allow(unused_imports)]
 
@@ -58,8 +50,7 @@ pub(super) fn default_config() -> HandlerConfig {
 
 #[test]
 fn top_level_file_goes_to_pack_xdg_dir() {
-    // Under #48: top-level files in a pack default to
-    // $XDG_CONFIG_HOME/<pack>/<file>, not $HOME/.<file>.
+    // Top-level files default to $XDG_CONFIG_HOME/<pack>/<file>.
     let config = HandlerConfig::default();
     let target = resolve_target("vim", "vimrc", &config, &test_pather());
     assert_eq!(target, PathBuf::from("/home/alice/.config/vim/vimrc"));
@@ -114,9 +105,8 @@ fn prefixed_pack_with_force_home_still_strips_prefix() {
     assert_eq!(target, PathBuf::from("/home/alice/.ssh/config"));
 }
 
-/// Regression for the 0.16.0 pilot: pack `ghostty` with top-level
-/// file `config` used to resolve to `$HOME/.config` (collision with
-/// XDG_CONFIG_HOME directory). Under #48 it goes under the pack.
+/// A top-level `config` file stays under the pack namespace instead of
+/// colliding with the XDG_CONFIG_HOME directory.
 #[test]
 fn top_level_file_named_config_goes_under_pack_no_xdg_collision() {
     let config = HandlerConfig::default();

--- a/crates/dodot-lib/src/lib.rs
+++ b/crates/dodot-lib/src/lib.rs
@@ -21,9 +21,7 @@ pub mod rules;
 pub mod secret;
 pub mod shell;
 
-// The testing module is available:
-// - Always during `cargo test` (dev-dependencies provide tempfile)
-// - When the `test-utils` feature is enabled (for external consumers)
+// `test-utils` exposes the testing module to external consumers.
 #[cfg(any(test, feature = "test-utils"))]
 pub mod testing;
 

--- a/crates/dodot-lib/src/operations/mod.rs
+++ b/crates/dodot-lib/src/operations/mod.rs
@@ -125,7 +125,7 @@ pub enum HandlerIntent {
     /// [`DataStore::did_run`](crate::datastore::DataStore::did_run)
     /// to drive the three-way policy: run on first encounter, skip
     /// silently when the recorded hash matches, surface a
-    /// "ran older version" notice when it doesn't (#169).
+    /// "ran older version" notice when it doesn't.
     ///
     /// `filename` is the basename of the run-once file (e.g.
     /// `install.sh`, `Brewfile`, `packages.nix`) — used by `did_run`

--- a/crates/dodot-lib/src/packs/context.rs
+++ b/crates/dodot-lib/src/packs/context.rs
@@ -5,10 +5,6 @@
 //! flags that scope a single invocation (`dry_run`, `force`, view/group
 //! mode, …). Production wires up [`ExecutionContext::production`];
 //! tests assemble fields directly.
-//!
-//! Lives in its own file so the orchestration pipeline can stay focused
-//! on `execute()` / `plan_pack()` without the constructor weighing
-//! every read.
 
 use std::sync::Arc;
 

--- a/crates/dodot-lib/src/packs/mod.rs
+++ b/crates/dodot-lib/src/packs/mod.rs
@@ -333,7 +333,6 @@ mod tests {
             .done()
             .build();
 
-        // Manually create a hidden dir
         env.fs
             .mkdir_all(&env.dotfiles_root.join(".hidden-pack"))
             .unwrap();
@@ -432,7 +431,6 @@ mod tests {
             .done()
             .build();
 
-        // Create a file at dotfiles root (not a pack)
         env.fs
             .write_file(&env.dotfiles_root.join("README.md"), b"# my dotfiles")
             .unwrap();
@@ -472,11 +470,8 @@ mod tests {
     fn parse_prefix_passes_through_unprefixed_names() {
         assert_eq!(parse_prefix("vim"), Ok(None));
         assert_eq!(parse_prefix("my-pack"), Ok(None));
-        // Digits without a separator → not a prefix.
         assert_eq!(parse_prefix("vim2"), Ok(None));
-        // Non-digit prefix → not a prefix.
         assert_eq!(parse_prefix("a01-foo"), Ok(None));
-        // Separator at position 0 (no digits) → not a prefix.
         assert_eq!(parse_prefix("-foo"), Ok(None));
         assert_eq!(parse_prefix("_foo"), Ok(None));
     }
@@ -543,7 +538,6 @@ mod tests {
 
     #[test]
     fn scan_interleaves_prefixed_and_unprefixed_via_lex() {
-        // `010-brew` < `020-zsh` < `nvim` < `starship`.
         let env = TempEnvironment::builder()
             .pack("nvim")
             .file("init.lua", "x")

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -35,14 +35,8 @@ pub use resolve::{resolve_pack_dir_name, validate_pack_names};
 
 // ── Pipeline ────────────────────────────────────────────────────
 
-/// Execute a command across all (or filtered) packs.
-///
-/// This is the single entry point for the orchestration pipeline:
-///
-/// 1. Load root config
-/// 2. Discover packs (filtering by name if specified)
-/// 3. For each pack: load merged config → execute command → collect result
-/// 4. Aggregate results
+/// Execute a command across all (or filtered) packs — the single entry
+/// point for the orchestration pipeline.
 pub fn execute(
     command: &dyn Command,
     pack_filter: Option<&[String]>,
@@ -50,14 +44,12 @@ pub fn execute(
 ) -> Result<ExecuteResult> {
     info!(command = command.name(), "starting command");
 
-    // Load root config for pack-level ignore patterns
     let root_config = ctx.config_manager.root_config()?;
     debug!(
         ignore_patterns = ?root_config.pack.ignore,
         "loaded root config"
     );
 
-    // Discover packs
     let mut all_packs = packs::discover_packs(
         ctx.fs.as_ref(),
         ctx.paths.dotfiles_root(),
@@ -69,7 +61,6 @@ pub fn execute(
         "discovered packs"
     );
 
-    // Validate and apply name filter
     if let Some(names) = pack_filter {
         let _warnings = validate_pack_names(names, ctx)?;
         // Warnings are handled by the calling command (status/up/down)
@@ -87,7 +78,6 @@ pub fn execute(
     for mut pack in all_packs {
         info!(pack = %pack.name, "processing pack");
 
-        // Load pack-specific merged config
         let pack_config = match ctx.config_manager.config_for_pack(&pack.path) {
             Ok(pack_config) => {
                 debug!(pack = %pack.name, "loaded pack config");
@@ -107,8 +97,8 @@ pub fn execute(
             }
         };
 
-        // C3: skip packs gated out by `[pack] os` on this host. Counted
-        // as successful (it's the configured behaviour, not a failure)
+        // Packs gated out by `[pack] os` on this host count as
+        // successful (it's the configured behaviour, not a failure)
         // with no operations — same shape `.dodotignore` would have if
         // it reached this loop.
         if !crate::gates::pack_os_active(&pack_config.pack.os, host) {
@@ -191,7 +181,6 @@ pub fn prepare_packs(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> 
         info!(count = all_packs.len(), "packs after filter");
     }
 
-    // Load per-pack config
     let mut configured = Vec::with_capacity(all_packs.len());
     for mut pack in all_packs {
         let pack_config = ctx.config_manager.config_for_pack(&pack.path)?;

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -375,7 +375,6 @@ mod tests {
         assert_eq!(result.failed_packs, 0);
         assert!(result.is_success());
 
-        // Both packs should have operations
         for pr in &result.pack_results {
             assert!(pr.success, "pack {} failed", pr.pack_name);
             assert!(
@@ -495,7 +494,6 @@ mod tests {
         let results = run_handler_pipeline(&pack, &ctx).unwrap();
         assert!(results.iter().all(|r| r.success));
 
-        // Verify symlinks were created
         let vim_symlink_dir = ctx.paths.handler_data_dir("vim", "symlink");
         assert!(ctx.fs.exists(&vim_symlink_dir));
     }
@@ -539,7 +537,6 @@ mod tests {
         assert!(result.is_success());
         assert!(!result.pack_results[0].operations.is_empty());
 
-        // No filesystem changes should have been made
         let vim_symlink_dir = ctx.paths.handler_data_dir("vim", "symlink");
         assert!(!ctx.fs.exists(&vim_symlink_dir));
     }
@@ -566,7 +563,6 @@ mod tests {
 
         let results = run_handler_pipeline(&pack, &ctx).unwrap();
 
-        // Should have symlink operations but no RunCommand
         for r in &results {
             assert!(
                 !matches!(r.operation, crate::operations::Operation::RunCommand { .. }),

--- a/crates/dodot-lib/src/packs/orchestration/planning.rs
+++ b/crates/dodot-lib/src/packs/orchestration/planning.rs
@@ -632,7 +632,6 @@ mod tests {
         let intents =
             collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap();
 
-        // Should produce a Link intent for "config.toml" (not "config.toml.identity")
         assert_eq!(intents.len(), 1, "intents: {intents:?}");
 
         match &intents[0] {
@@ -644,13 +643,11 @@ mod tests {
             } => {
                 assert_eq!(p, "app");
                 assert_eq!(handler, "symlink");
-                // The source should be in the datastore (preprocessed handler dir)
                 assert!(
                     source.to_string_lossy().contains("preprocessed"),
                     "source should be in preprocessed dir: {}",
                     source.display()
                 );
-                // The user_path should NOT contain .identity extension
                 let user_str = user_path.to_string_lossy();
                 assert!(
                     !user_str.contains("identity"),
@@ -688,7 +685,6 @@ mod tests {
         let intents =
             collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap();
 
-        // Should have 2 Link intents: one for config.toml (preprocessed), one for readme.txt (regular)
         assert_eq!(intents.len(), 2, "intents: {intents:?}");
 
         let intent_sources: Vec<String> = intents
@@ -701,7 +697,6 @@ mod tests {
             })
             .collect();
 
-        // One should be in the preprocessed dir, the other in the pack dir
         let has_preprocessed = intent_sources.iter().any(|s| s.contains("preprocessed"));
         let has_regular = intent_sources
             .iter()
@@ -756,7 +751,6 @@ mod tests {
             .done()
             .build();
 
-        // Write config disabling preprocessing
         env.fs
             .write_file(
                 &env.dotfiles_root.join(".dodot.toml"),
@@ -782,8 +776,6 @@ mod tests {
         let intents =
             collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap();
 
-        // With preprocessing disabled, the .identity file is treated as regular
-        // and deployed as-is with the .identity extension preserved
         assert_eq!(intents.len(), 1);
         match &intents[0] {
             crate::operations::HandlerIntent::Link { user_path, .. } => {
@@ -815,7 +807,6 @@ mod tests {
                 .to_handler_config(),
         );
 
-        // No preprocessor registry at all
         let intents = collect_pack_intents_with_preprocessors(&pack, &ctx, None).unwrap();
 
         assert_eq!(intents.len(), 1);
@@ -833,7 +824,6 @@ mod tests {
 
     #[test]
     fn preprocessing_end_to_end_deploy_and_verify_content() {
-        // Full pipeline: preprocess → collect intents → execute → verify user file
         let env = TempEnvironment::builder()
             .pack("app")
             .file("config.toml.identity", "host = localhost\nport = 5432")
@@ -858,7 +848,6 @@ mod tests {
         let intents =
             collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap();
 
-        // Extract the user_path from the intent so we know where to check
         let user_path = match &intents[0] {
             crate::operations::HandlerIntent::Link { user_path, .. } => user_path.clone(),
             other => panic!("expected Link intent, got: {other:?}"),
@@ -871,7 +860,6 @@ mod tests {
             "all operations should succeed: {results:?}"
         );
 
-        // The user file should exist and have the preprocessed content
         assert!(
             ctx.fs.exists(&user_path),
             "user file should exist at: {}",
@@ -882,7 +870,6 @@ mod tests {
             "user file should be a symlink"
         );
 
-        // Content should be the preprocessed (identity = same) content
         let content = ctx.fs.read_to_string(&user_path).unwrap();
         assert_eq!(content, "host = localhost\nport = 5432");
     }
@@ -944,7 +931,6 @@ mod tests {
                 .to_handler_config(),
         );
 
-        // Register both identity and unarchive preprocessors
         let mut registry = crate::preprocessing::PreprocessorRegistry::new();
         registry.register(Box::new(
             crate::preprocessing::identity::IdentityPreprocessor::new(),
@@ -956,7 +942,6 @@ mod tests {
         let intents =
             collect_pack_intents_with_preprocessors(&pack, &ctx, Some(&registry)).unwrap();
 
-        // The .identity file should still be handled by the identity preprocessor
         assert_eq!(intents.len(), 1);
         match &intents[0] {
             crate::operations::HandlerIntent::Link { source, .. } => {
@@ -982,8 +967,6 @@ mod tests {
             .done()
             .build();
 
-        // Create a simple tar.gz at the pack's bin/ dir so it maps to
-        // the path handler after expansion.
         let archive_path = env.dotfiles_root.join("tools/payload.tar.gz");
         let file = std::fs::File::create(&archive_path).unwrap();
         let enc = GzEncoder::new(file, Compression::default());
@@ -1008,11 +991,8 @@ mod tests {
                 .to_handler_config(),
         );
 
-        // Call the real production entrypoint — no explicit registry.
         let intents = collect_pack_intents(&pack, &ctx).unwrap();
 
-        // Should include a Link intent for the expanded `mytool` file,
-        // with its source in the preprocessed datastore directory.
         let has_expanded_source = intents.iter().any(|i| match i {
             crate::operations::HandlerIntent::Link { source, .. } => {
                 source.to_string_lossy().contains("preprocessed")
@@ -1069,7 +1049,6 @@ mod tests {
 
     #[test]
     fn template_with_shell_handler_sources_rendered_content() {
-        // aliases.sh.tmpl should match the shell handler after stripping.
         let env = TempEnvironment::builder()
             .pack("tools")
             .file("aliases.sh.tmpl", "alias hello='echo {{ greeting }}'")
@@ -1104,7 +1083,6 @@ mod tests {
 
     #[test]
     fn template_respects_per_pack_var_overrides() {
-        // Root config defines name=Alice; pack overrides to name=Bob.
         let env = TempEnvironment::builder()
             .pack("app")
             .file("greeting.tmpl", "hello {{ name }}")
@@ -1112,7 +1090,6 @@ mod tests {
             .done()
             .build();
 
-        // Root config: name = Alice
         env.fs
             .write_file(
                 &env.dotfiles_root.join(".dodot.toml"),
@@ -1166,8 +1143,6 @@ mod tests {
         );
 
         let intents = collect_pack_intents(&pack, &ctx).unwrap();
-        // With preprocessing disabled, the .tmpl file is treated as a
-        // regular file and deployed verbatim (retaining the .tmpl extension).
         assert_eq!(intents.len(), 1);
         match &intents[0] {
             crate::operations::HandlerIntent::Link {
@@ -1297,7 +1272,6 @@ mod tests {
         // SHA-256 of the *rendered* script in the datastore.
         assert!(sentinel.starts_with("install.sh-"));
 
-        // Verify the rendered file contains the OS substitution
         let content = ctx.fs.read_to_string(&rendered_path).unwrap();
         assert!(
             content.contains(std::env::consts::OS),
@@ -1395,7 +1369,6 @@ mod tests {
                 .to_handler_config(),
         );
 
-        // Prime baseline.
         let _ = plan_pack(&pack, &ctx, crate::preprocessing::PreprocessMode::Active).unwrap();
         let deployed = env
             .paths

--- a/crates/dodot-lib/src/packs/orchestration/planning.rs
+++ b/crates/dodot-lib/src/packs/orchestration/planning.rs
@@ -282,6 +282,11 @@ fn collect_pack_intents_inner(
 /// Same scan/preprocess/match/group/intents pipeline as
 /// [`collect_pack_intents_inner`], but additionally collects
 /// per-handler `warnings_for_matches` output.
+///
+/// Takes the pack config pre-loaded: both entrypoints load it once and
+/// pass it through, so config is not re-merged per pack. `ConfigManager`
+/// caches by path anyway, but threading it explicitly makes the data
+/// flow obvious.
 fn plan_pack_inner(
     pack: &Pack,
     ctx: &ExecutionContext,

--- a/crates/dodot-lib/src/packs/orchestration/planning.rs
+++ b/crates/dodot-lib/src/packs/orchestration/planning.rs
@@ -2,7 +2,7 @@
 //!
 //! Owns [`plan_pack`] (the main planner), [`plan_pack_inner`] (the
 //! actual scan → preprocess → match-rules → group-by-handler →
-//! to_intents pipeline, ~210 LOC), the [`PackPlan`] result type,
+//! to_intents pipeline), the [`PackPlan`] result type,
 //! [`build_gate_table`] (`HostFacts`/`[gates]` merging), and the
 //! per-pack `collect_pack_intents` API plus its diagnostic helpers
 //! (`missing_target_hints`, `display_path_relative_to_home`).
@@ -105,10 +105,6 @@ pub fn plan_pack(
     plan_pack_inner(pack, ctx, &pack_config, Some(&registry), mode)
 }
 
-/// Shared implementation that takes a pre-loaded pack config. Both
-/// entrypoints load the config once and pass it through so we don't
-/// re-merge config for every pack (the ConfigManager caches by path,
-/// but passing the config explicitly makes the data flow obvious).
 /// Resolve the gate table for a pack: built-in seed plus any
 /// user-defined `[gates]` entries from config.
 fn build_gate_table(pack_config: &crate::config::DodotConfig) -> Result<GateTable> {
@@ -155,10 +151,8 @@ pub(crate) fn filter_pre_preprocess_gates(
     use crate::gates::{parse_basename_gate, BasenameGate};
     use crate::rules::GateFailure;
 
-    // Pre-compile + sort + validate `[mappings.gates]` globs via the
-    // shared helper so this path and `match_entries` can never disagree
-    // about iteration order, validation, or first-match semantics. See
-    // `gates::compile_mapping_gates`.
+    // Shared with `match_entries` — see `gates::compile_mapping_gates`
+    // for the ordering and validation contract.
     let compiled_mapping_gates = crate::gates::compile_mapping_gates(mappings_gates, pack_name)?;
 
     // Helper: build a GateFailure from a label + predicate, summarising
@@ -184,8 +178,6 @@ pub(crate) fn filter_pre_preprocess_gates(
 
     let mut out = Vec::with_capacity(entries.len());
     for entry in entries {
-        // Already-failed entries (from the directory-segment walk)
-        // pass through untouched.
         if entry.gate_failure.is_some() {
             out.push(entry);
             continue;
@@ -205,8 +197,6 @@ pub(crate) fn filter_pre_preprocess_gates(
             .find(|(pat, _)| pat.matches(&rel_str))
             .map(|(_, label)| *label);
 
-        // Conflict guard: filename gate AND `[mappings.gates]` on the
-        // same file is ambiguous — pick one.
         if let (BasenameGate::Found { .. }, Some(map_label)) = (&basename_gate, mapping_match) {
             return Err(crate::DodotError::Config(format!(
                 "gate-routing conflict in pack `{pack_name}` for `{}`: \
@@ -328,13 +318,10 @@ fn plan_pack_inner(
     let entries = scanner.walk_pack(&pack.path, &pack_config.pack.ignore, &gates, host)?;
     debug!(pack = %pack.name, entries = entries.len(), "walked pack directory");
 
-    // Phase 1.5: Apply all gate sources (basename `._<label>` AND
-    // `[mappings.gates]` glob hits) BEFORE preprocessing. Otherwise a
-    // gate-failed `aliases._linux.sh.tmpl` (or a mapping-gated
-    // `Brewfile`) on a non-matching host still triggers template
-    // render / secret-provider / baseline-cache work for an entry the
-    // user explicitly opted out of. match_entries re-evaluates these
-    // gates so the failure also surfaces as a `gate`-handler match.
+    // Phase 1.5: Apply the remaining gate sources before preprocessing
+    // — see `filter_pre_preprocess_gates` for why they belong here.
+    // match_entries re-evaluates these gates so a failure also surfaces
+    // as a `gate`-handler match.
     let entries = filter_pre_preprocess_gates(
         entries,
         &gates,
@@ -440,7 +427,6 @@ fn plan_pack_inner(
             }
         };
 
-        // Skip code execution handlers if --no-provision
         if ctx.no_provision && handler.category() == handlers::HandlerCategory::CodeExecution {
             debug!(pack = %pack.name, handler = %handler_name, "skipping code-execution handler (--no-provision)");
             continue;
@@ -470,7 +456,7 @@ fn plan_pack_inner(
         }
     }
 
-    // Missing-target hints (M6 §8.2) — macOS only.
+    // Missing-target hints — macOS only.
     //
     // For each Link intent that lands under `app_support_dir`, check
     // whether the immediate child folder exists on disk. If not, the

--- a/crates/dodot-lib/src/packs/orchestration/test_support.rs
+++ b/crates/dodot-lib/src/packs/orchestration/test_support.rs
@@ -1,13 +1,4 @@
-//! Shared test fixtures for the orchestration test suites.
-//!
-//! `MockCommandRunner` records every `(executable, arguments)` call so
-//! provisioning-flow tests can assert on the recorded shape;
-//! `make_context` wires it through a `FilesystemDataStore`, and
-//! `TestUpCommand` is a tiny `Command` impl that runs the handler
-//! pipeline and reports per-pack results — the same shape `up`/`down`
-//! use in production. All three are `pub(super)` so the dispatcher,
-//! planning, and resolve test suites can reach them via
-//! `super::test_support::*` without duplicating fixtures.
+//! Shared orchestration-test fixtures.
 
 use std::sync::{Arc, Mutex};
 
@@ -65,7 +56,7 @@ pub(super) fn make_context(env: &TempEnvironment) -> ExecutionContext {
         syntax_checker: Arc::new(crate::shell::NoopSyntaxChecker),
         command_runner: runner,
         dry_run: false,
-        no_provision: true, // skip install/homebrew in tests
+        no_provision: true,
         provision_rerun: false,
         force: false,
         check_drift: false,
@@ -77,7 +68,6 @@ pub(super) fn make_context(env: &TempEnvironment) -> ExecutionContext {
     }
 }
 
-/// Simple command that runs the handler pipeline.
 pub(super) struct TestUpCommand;
 
 impl Command for TestUpCommand {
@@ -88,9 +78,7 @@ impl Command for TestUpCommand {
     fn execute_for_pack(&self, pack: &Pack, ctx: &ExecutionContext) -> Result<PackResult> {
         let operations: Vec<OperationResult> = run_handler_pipeline(pack, ctx)?;
         let success = operations.iter().all(|r| r.success);
-        // Mirror what the real up/down commands do: the user-facing
-        // pack identifier carried in `PackResult.pack_name` is the
-        // pack's display name, not its raw on-disk directory.
+        // Results use the display name rather than the raw on-disk directory.
         Ok(PackResult {
             pack_name: pack.display_name.clone(),
             success,

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -665,7 +665,6 @@ mod tests {
         }
     }
 
-    // Compile-time check: Pather must be object-safe
     #[allow(dead_code)]
     fn assert_object_safe(_: &dyn Pather) {}
 }

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -13,9 +13,9 @@
 //!    exactly this.
 //!
 //! 2. **Centralisation of OS-shaped policy.** The XDG fallback chain,
-//!    the `DOTFILES_ROOT` env-var lookup, and (planned, per
-//!    `docs/proposals/macos-paths.lex`) the macOS `app_support_dir`
-//!    selection all live in one place. The resolver, the symlink
+//!    the `DOTFILES_ROOT` env-var lookup, and the macOS
+//!    `app_support_dir` selection (`docs/proposals/macos-paths.lex`)
+//!    all live in one place. The resolver, the symlink
 //!    handler, and `adopt`'s source-path inference all consult the
 //!    same accessors — drift between them is impossible by construction.
 //!
@@ -47,9 +47,7 @@ use crate::Result;
 /// Provides all path calculations for dodot.
 ///
 /// Every path that dodot uses — XDG directories, pack locations,
-/// handler data directories — is computed through this trait. This
-/// keeps path logic centralised and makes testing straightforward:
-/// construct a `Pather` whose directories all live under a temp dir.
+/// handler data directories — is computed through this trait.
 ///
 /// Use `&dyn Pather` (trait objects) throughout the codebase.
 pub trait Pather: Send + Sync {
@@ -392,7 +390,8 @@ impl Pather for XdgPather {
     }
 }
 
-/// Resolve `HOME` from environment, falling back to the `dirs` approach.
+/// Resolve `HOME` from the environment, falling back to a placeholder
+/// path when it is unset.
 fn resolve_home() -> PathBuf {
     std::env::var("HOME")
         .map(PathBuf::from)
@@ -409,12 +408,10 @@ fn resolve_home() -> PathBuf {
 /// 2. Git repository root (`git rev-parse --show-toplevel`)
 /// 3. `$HOME/dotfiles` fallback
 fn resolve_dotfiles_root(home: &Path) -> PathBuf {
-    // 1. Explicit env var
     if let Ok(root) = std::env::var("DOTFILES_ROOT") {
         return expand_tilde(&root, home);
     }
 
-    // 2. Git toplevel
     if let Ok(output) = std::process::Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .output()
@@ -427,7 +424,6 @@ fn resolve_dotfiles_root(home: &Path) -> PathBuf {
         }
     }
 
-    // 3. Fallback
     home.join("dotfiles")
 }
 

--- a/crates/dodot-lib/src/plists/mod.rs
+++ b/crates/dodot-lib/src/plists/mod.rs
@@ -113,7 +113,6 @@ fn filter_err(direction: &str, e: plist::Error) -> DodotError {
 mod tests {
     use super::*;
 
-    /// Minimal XML plist with two keys in non-alphabetical order.
     const UNSORTED_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -199,7 +198,6 @@ mod tests {
     /// must produce identical XML across runs.
     #[test]
     fn determinism_property_test() {
-        // Start from a plist with deliberately unstable encoder ordering.
         let canonical = clean(UNSORTED_XML.as_bytes()).expect("clean 1");
 
         // Round-trip several times. If anything is non-deterministic
@@ -218,7 +216,6 @@ mod tests {
 
     #[test]
     fn clean_accepts_binary_input() {
-        // Build canonical XML, convert to binary, ensure clean accepts it.
         let canonical = clean(UNSORTED_XML.as_bytes()).expect("clean");
         let binary = smudge(&canonical).expect("smudge");
         let from_binary = clean(&binary).expect("clean from binary");
@@ -254,7 +251,6 @@ mod tests {
         let xml = clean(mixed.as_bytes()).expect("clean");
         let xml_str = std::str::from_utf8(&xml).expect("utf8");
 
-        // Top-level keys sorted: arr_key, bool_key, int_key, real_key, string_key.
         let positions = ["arr_key", "bool_key", "int_key", "real_key", "string_key"]
             .iter()
             .map(|k| xml_str.find(k).unwrap_or_else(|| panic!("missing {k}")))
@@ -264,7 +260,6 @@ mod tests {
             "top-level keys not sorted, got:\n{xml_str}"
         );
 
-        // Nested dict in array: a before z.
         let a_inner = xml_str.rfind(">a<").expect("inner a");
         let z_inner = xml_str.rfind(">z<").expect("inner z");
         assert!(
@@ -289,7 +284,6 @@ mod tests {
             !xml.contains(&b'\r'),
             "clean output must contain no CR bytes"
         );
-        // And the canonical output is identical to the LF-input case.
         let lf_xml = clean(UNSORTED_XML.as_bytes()).expect("clean lf");
         assert_eq!(xml, lf_xml, "CRLF and LF inputs must produce same output");
     }

--- a/crates/dodot-lib/src/preprocessing/age.rs
+++ b/crates/dodot-lib/src/preprocessing/age.rs
@@ -377,12 +377,8 @@ mod tests {
 
     #[test]
     fn expand_preserves_binary_plaintext_verbatim_via_run_bytes() {
-        // Non-UTF-8 plaintext (a raw binary key blob) flows
-        // through intact via `run_bytes`. The earlier `run` path
-        // would have decoded stdout via `String::from_utf8_lossy`
-        // and replaced 0xff / 0xfe with U+FFFD, corrupting
-        // round-tripped bytes. Pin that the preprocessor goes
-        // through `run_bytes` and the bytes survive verbatim.
+        // Non-UTF-8 plaintext must flow through `run_bytes`; lossy
+        // string decoding would replace 0xff / 0xfe and corrupt it.
         let raw = vec![0u8, 1, 2, 0xff, 0xfe, b'\n', 0x80, 0xc0];
         let runner = Arc::new(ScriptedBytesRunner::new().expect(
             "age",

--- a/crates/dodot-lib/src/preprocessing/age.rs
+++ b/crates/dodot-lib/src/preprocessing/age.rs
@@ -43,8 +43,7 @@ use crate::{DodotError, Result};
 /// Holds the identity path resolved at construction so every
 /// `expand()` call uses the same identity file (no re-reading of
 /// env vars per file). The path is **not** validated to exist at
-/// construction; `age` validates at decrypt time and emits a
-/// diagnostic we surface verbatim if the file is missing.
+/// construction; `age` reports a missing identity at decrypt time.
 pub struct AgePreprocessor {
     runner: Arc<dyn CommandRunner>,
     identity: PathBuf,

--- a/crates/dodot-lib/src/preprocessing/baseline.rs
+++ b/crates/dodot-lib/src/preprocessing/baseline.rs
@@ -455,7 +455,6 @@ mod tests {
 
     #[test]
     fn build_records_hashes_and_optional_fields() {
-        // Empty optionals → empty strings (serde default), not Null.
         let p = Path::new("/dummy/source");
         let b = Baseline::build(p, b"hello", b"hello", None, None);
         assert_eq!(b.version, SCHEMA_VERSION);
@@ -465,7 +464,6 @@ mod tests {
         assert!(b.context_hash.is_empty());
         assert!(b.tracked_render.is_empty());
 
-        // Provided optionals → encoded.
         let b2 = Baseline::build(p, b"x", b"y", Some("tracked"), Some(&[0xff; 32]));
         assert_eq!(b2.context_hash.len(), 64);
         assert!(b2.context_hash.chars().all(|c| c == 'f'));
@@ -484,7 +482,6 @@ mod tests {
             None,
             None,
         );
-        // Replacement character for the invalid 0xff.
         assert_eq!(b.rendered_content, "fo\u{fffd}o");
     }
 
@@ -509,7 +506,6 @@ mod tests {
 
     #[test]
     fn write_overwrites_existing_baseline() {
-        // A second write at the same logical path replaces the first.
         let env = TempEnvironment::builder().build();
         let first = Baseline::build(Path::new("/dummy"), b"first", b"src", None, None);
         first
@@ -559,7 +555,6 @@ mod tests {
         assert_eq!(hex_encode_32(&[0; 32]).len(), 64);
         assert!(hex_encode_32(&[0; 32]).chars().all(|c| c == '0'));
         assert_eq!(hex_encode_32(&[0xab; 32]).len(), 64);
-        // Lowercase by convention.
         assert!(hex_encode_32(&[0xab; 32])
             .chars()
             .all(|c| c == 'a' || c == 'b'));

--- a/crates/dodot-lib/src/preprocessing/conflict.rs
+++ b/crates/dodot-lib/src/preprocessing/conflict.rs
@@ -136,7 +136,6 @@ mod tests {
 
     #[test]
     fn detects_a_full_three_line_block() {
-        // The canonical case — start, mid, end on three separate lines.
         let content = format!(
             "name = Alice\n{}\nhost = \"{{{{ env.DB_HOST }}}}\"\n{}\nhost = \"prod.db\"\n{}\nport = 5432\n",
             MARKER_START, MARKER_MID, MARKER_END
@@ -144,7 +143,6 @@ mod tests {
         assert!(contains_unresolved_markers(&content));
         let lines = find_unresolved_marker_lines(&content);
         assert_eq!(lines.len(), 3, "got: {lines:?}");
-        // Line numbers are 1-based.
         assert_eq!(lines[0].0, 2);
         assert_eq!(lines[1].0, 4);
         assert_eq!(lines[2].0, 6);
@@ -184,7 +182,6 @@ mod tests {
         assert!(contains_unresolved_markers(&content));
         let lines = find_unresolved_marker_lines(&content);
         assert_eq!(lines.len(), 1);
-        // Trailing \r must not survive into the reported line text.
         assert!(!lines[0].1.contains('\r'));
     }
 
@@ -283,14 +280,13 @@ mod tests {
 
     #[test]
     fn marker_constants_use_distinct_directional_chars() {
-        // Sanity test: the three markers must start with different
-        // characters so a one-line scan can tell them apart, and so
+        // The three markers start with different characters so a
+        // one-line scan can tell them apart, and so
         // they don't collide with git's own `<<<<<<<` / `>>>>>>>` /
         // `=======` markers (we use 6 chars, git uses 7).
         assert!(MARKER_START.starts_with('>'));
         assert!(MARKER_MID.starts_with('='));
         assert!(MARKER_END.starts_with('<'));
-        // 6-char prefixes, not 7.
         assert!(MARKER_START.starts_with(">>>>>> "));
         assert!(MARKER_MID.starts_with("====== "));
         assert!(MARKER_END.starts_with("<<<<<< "));

--- a/crates/dodot-lib/src/preprocessing/divergence.rs
+++ b/crates/dodot-lib/src/preprocessing/divergence.rs
@@ -308,7 +308,6 @@ mod tests {
                 "config.toml",
             )
             .unwrap();
-        // Drop a sidecar next to it.
         let sidecar = crate::preprocessing::baseline::SecretsSidecar::new(vec![
             crate::preprocessing::SecretLineRange {
                 start: 0,
@@ -327,14 +326,12 @@ mod tests {
             .unwrap();
 
         let baselines = collect_baselines(env.fs.as_ref(), env.paths.as_ref()).unwrap();
-        // Exactly one entry — the baseline. The sidecar is skipped.
         assert_eq!(baselines.len(), 1);
         assert_eq!(baselines[0].2, "config.toml");
     }
 
     #[test]
     fn synced_state_when_nothing_changed() {
-        // Baseline + source bytes + deployed bytes all match.
         let env = TempEnvironment::builder().build();
         write_pack_template(&env, "app", "config.toml.tmpl", "src");
         write_deployed(&env, "app", "preprocessed", "config.toml", "rendered");
@@ -464,7 +461,6 @@ mod tests {
                 "config.toml",
             )
             .unwrap();
-        // Deliberately do NOT write the deployed file.
 
         let reports = collect_divergences(env.fs.as_ref(), env.paths.as_ref()).unwrap();
         assert_eq!(reports[0].state, DivergenceState::MissingDeployed);

--- a/crates/dodot-lib/src/preprocessing/identity.rs
+++ b/crates/dodot-lib/src/preprocessing/identity.rs
@@ -159,7 +159,6 @@ mod tests {
             .done()
             .build();
 
-        // Write binary content directly
         let source = env.dotfiles_root.join("app/data.bin.identity");
         let binary = vec![0u8, 1, 2, 255, 128, 64];
         env.fs.write_file(&source, &binary).unwrap();
@@ -185,7 +184,6 @@ mod tests {
     #[test]
     fn double_extension_only_strips_last() {
         let pp = IdentityPreprocessor::new();
-        // Only the outermost .identity is stripped
         assert_eq!(pp.stripped_name("file.identity.identity"), "file.identity");
         assert!(pp.matches_extension("file.identity.identity"));
     }

--- a/crates/dodot-lib/src/preprocessing/identity.rs
+++ b/crates/dodot-lib/src/preprocessing/identity.rs
@@ -11,9 +11,6 @@ use crate::preprocessing::{ExpandedFile, Preprocessor, TransformType};
 use crate::Result;
 
 /// A preprocessor that passes content through unchanged.
-///
-/// Useful for testing the preprocessing pipeline without depending
-/// on any transformation engine.
 pub struct IdentityPreprocessor {
     extension: String,
 }

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -47,16 +47,15 @@ pub enum TransformType {
 /// Lines are 0-indexed and `start..end` is half-open. A single-line
 /// secret occupies line `start` and is encoded as `end == start + 1`
 /// (`start == end` would be an empty range and is never produced).
-/// For Phase S1 every entry is single-line: multi-line secrets are
-/// refused at resolution time per `secrets.lex` §3.4. The `end` field
-/// is preserved in the schema for forward-compatibility but the
-/// renderer never produces `end > start + 1`.
+/// Every entry is single-line: multi-line secrets are refused at
+/// resolution time per `secrets.lex` §3.4. The `end` field exists in
+/// the schema for forward-compatibility, but the renderer never
+/// produces `end > start + 1`.
 ///
 /// Persisted to disk under `<baseline>.secret.json` (see
 /// `secrets.lex` §3.3); consumed by the dry-run preview rendering
 /// (§7.4) to mask resolved values, and by the burgertocow mask
-/// integration (issue arthur-debert/burgertocow#13) to skip those
-/// lines from the reverse diff.
+/// integration to skip those lines from the reverse diff.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SecretLineRange {
     /// First line, 0-indexed, inclusive.
@@ -71,10 +70,6 @@ pub struct SecretLineRange {
 }
 
 /// A single file produced by a preprocessor's expansion.
-///
-/// Construct ad-hoc via the struct literal; tests commonly use
-/// `ExpandedFile { relative_path, content, ..Default::default() }` to
-/// fill in the optional cache-related fields.
 #[derive(Debug, Clone, Default)]
 pub struct ExpandedFile {
     /// Path relative to the expansion output (usually just the filename).
@@ -111,8 +106,8 @@ pub struct ExpandedFile {
     pub secret_line_ranges: Vec<SecretLineRange>,
     /// Unix mode the rendered datastore file should be chmod'd to
     /// after the pipeline writes it. `None` (the default) leaves
-    /// the file at whatever umask-derived mode `write_file` produced
-    /// — the pre-S3 behavior for templates / unarchive output.
+    /// the file at whatever umask-derived mode `write_file` produced,
+    /// as template and unarchive output does.
     /// Whole-file secret preprocessors (`age`, `gpg`) set this to
     /// `Some(0o600)` to enforce `secrets.lex` §4.3: rendered
     /// secrets land 0600 regardless of the source file's mode.

--- a/crates/dodot-lib/src/preprocessing/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/mod.rs
@@ -414,7 +414,6 @@ pub fn build_secret_registry(
 mod tests {
     use super::*;
 
-    // Compile-time check: Preprocessor must be object-safe
     #[allow(dead_code)]
     fn assert_object_safe(_: &dyn Preprocessor) {}
 
@@ -458,7 +457,6 @@ mod tests {
         registry.register(Box::new(
             crate::preprocessing::identity::IdentityPreprocessor::new(),
         ));
-        // Registering a second one that matches the same extension
         registry.register(Box::new(
             crate::preprocessing::identity::IdentityPreprocessor::with_extension("identity"),
         ));
@@ -479,18 +477,15 @@ mod tests {
 
         assert_eq!(registry.len(), 2);
 
-        // Each matches its own extension
         assert!(registry.is_preprocessor_file("config.toml.identity"));
         assert!(registry.is_preprocessor_file("bin.tar.gz"));
 
-        // Neither matches the other
         let identity = registry.find_for_file("config.toml.identity").unwrap();
         assert_eq!(identity.name(), "identity");
 
         let unarchive = registry.find_for_file("bin.tar.gz").unwrap();
         assert_eq!(unarchive.name(), "unarchive");
 
-        // Non-preprocessor files still return None
         assert!(registry.find_for_file("regular.txt").is_none());
     }
 
@@ -559,8 +554,6 @@ mod tests {
         assert!(reg.find_for_file("id_ed25519.age").is_none());
         assert!(reg.find_for_file("Brewfile.gpg").is_none());
         assert!(reg.find_for_file("notes.asc").is_none());
-        // Sanity: template + unarchive are still registered (the
-        // pre-S3 default set).
         assert!(reg.find_for_file("config.toml.tmpl").is_some());
         assert!(reg.find_for_file("bin.tar.gz").is_some());
     }
@@ -593,9 +586,7 @@ mod tests {
             crate::preprocessing::identity::IdentityPreprocessor::new(),
         ));
 
-        // "identity" alone is not ".identity"
         assert!(!registry.is_preprocessor_file("identity"));
-        // File without the dot prefix shouldn't match
         assert!(!registry.is_preprocessor_file("fileidentity"));
     }
 }

--- a/crates/dodot-lib/src/preprocessing/pipeline/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline/mod.rs
@@ -34,13 +34,12 @@ use crate::{DodotError, Result};
 ///   baseline cache. No provider calls. No datastore writes. No
 ///   baseline writes.
 ///
-/// This enum is the single boolean the pipeline gates on. Active is
-/// the existing behavior; Passive is the §7.4-compliant read-only
-/// path. See issue #121.
+/// This enum is the single boolean the pipeline gates on. See issue
+/// #121.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PreprocessMode {
     /// Run preprocessors, write rendered outputs to the datastore,
-    /// write baselines to the cache. The original `dodot up` path.
+    /// write baselines to the cache. The `dodot up` path.
     Active,
     /// Read everything from the baseline cache. Skip preprocessor
     /// expansion (no provider calls), skip datastore writes, skip
@@ -124,7 +123,7 @@ pub struct PreprocessResult {
     /// this map first and fall back to disk read for non-template
     /// files. Without this, Passive callers — where the rendered
     /// file isn't on disk — couldn't produce correct sentinels for
-    /// templated install scripts or Brewfiles. See issue #121.
+    /// templated install scripts or Brewfiles.
     pub rendered_bytes: HashMap<PathBuf, Arc<[u8]>>,
     /// Files whose deployed bytes diverged from the cached baseline and
     /// were therefore preserved instead of being overwritten. Empty
@@ -399,20 +398,13 @@ pub fn preprocess_pack(
             "expanding"
         );
 
-        // Safety gate: refuse to expand a source carrying unresolved
-        // dodot-conflict markers. Otherwise the markers would render
-        // verbatim through the template engine and deploy as broken
-        // config. Gated on `supports_reverse_merge` so non-tracking
+        // Safety gate (see `conflict::ensure_no_unresolved_markers`
+        // for the lossy-decode contract): refuse to expand a source
+        // carrying unresolved dodot-conflict markers, which would
+        // otherwise render verbatim and deploy as broken config.
+        // Gated on `supports_reverse_merge` so non-tracking
         // preprocessors (unarchive, identity) don't pay the read cost
         // — their sources can't naturally carry the marker token.
-        //
-        // Lossy UTF-8 conversion: we read raw bytes and decode lossily
-        // so a non-UTF-8 source for a reverse-merge-capable
-        // preprocessor still gets a clean scan rather than failing
-        // with a generic UTF-8 decode error. The marker token is
-        // ASCII, so the lossy decode preserves it. Templates today
-        // are always UTF-8 in practice; this is defence-in-depth for
-        // future preprocessors.
         // See preprocessing-pipeline.lex §6.3.
         if preprocessor.supports_reverse_merge() {
             let source_bytes = fs.read_file(&entry.absolute_path)?;
@@ -423,21 +415,17 @@ pub fn preprocess_pack(
             )?;
         }
 
-        // Expand the source file
         let expanded_files = preprocessor.expand(&entry.absolute_path, fs)?;
 
         for expanded in expanded_files {
-            // Reject unsafe paths from the preprocessor (tar-slip,
-            // absolute paths, parent-dir escapes) before any disk write.
             validate_safe_relative_path(
                 &expanded.relative_path,
                 preprocessor.name(),
                 &entry.absolute_path,
             )?;
 
-            // Compute the virtual relative path.
-            // If the source was in a subdirectory (e.g., "subdir/config.toml.identity"),
-            // the virtual entry should preserve the parent (e.g., "subdir/config.toml").
+            // A source in a subdirectory (e.g. "subdir/config.toml.identity")
+            // keeps its parent in the virtual entry ("subdir/config.toml").
             let virtual_relative = if let Some(parent) = entry.relative_path.parent() {
                 if parent == Path::new("") {
                     expanded.relative_path.clone()
@@ -471,38 +459,18 @@ pub fn preprocess_pack(
                 });
             }
 
-            // Write expanded content to datastore, preserving directory
-            // structure. Directories get mkdir'd; files get their content
-            // written. `write_rendered_file` creates any needed parent
-            // directories.
-            //
-            // Divergence guard (§6.4): for tracked-render preprocessors,
-            // check whether the deployed file has diverged from the
-            // cached baseline before overwriting. If it has, skip the
-            // *write* and record a SkippedRender so the caller can warn
-            // the user. `force = true` bypasses the guard. See
-            // `check_divergence` for the byte-level rule.
-            //
-            // The render itself (`preprocessor.expand` above) has
-            // already run by this point — moving the divergence check
-            // ahead of expansion would require knowing every output
-            // path before producing any of them, which the preprocessor
-            // contract doesn't expose. The cost of the spurious render
-            // is the cycles burned plus any one-shot side effects in
-            // expand (e.g. secret-provider prompts for templates that
-            // resolve `{{ secrets.X }}`). For divergent files this
-            // means the prompt fires even though the rendered bytes
-            // are immediately discarded; users who want to avoid that
-            // should resolve the divergence (`dodot transform check`)
-            // before the next `dodot up`. Tracked here for §6.4
-            // follow-up; not blocking the divergence-preservation
-            // contract this guard exists to keep.
-            //
-            // The guard fires regardless of `write_baselines` — it's a
-            // read-only check against the existing cache, and read-only
-            // callers (`dodot status`) need it just as much as `dodot
-            // up` does. Without this, status would re-render and
-            // overwrite the user's edited deployed file silently.
+            // The divergence guard (§6.4) runs *after*
+            // `preprocessor.expand` above: moving it ahead of expansion
+            // would require knowing every output path before producing
+            // any of them, which the preprocessor contract doesn't
+            // expose. The cost of the spurious render is the cycles
+            // burned plus any one-shot side effects in expand (e.g.
+            // secret-provider prompts for templates that resolve
+            // `{{ secrets.X }}`). For divergent files the prompt fires
+            // even though the rendered bytes are immediately discarded;
+            // users who want to avoid that should resolve the
+            // divergence (`dodot transform check`) before the next
+            // `dodot up`.
             let mut skip_path: Option<PathBuf> = None;
             // Divergence-guard gate: fires for any preprocessor
             // that produces a single file we can hash against the
@@ -591,31 +559,24 @@ pub fn preprocess_pack(
 
             // Persist a baseline record so future `dodot transform
             // check` / clean-filter calls can detect drift without
-            // re-rendering. Only write when:
+            // re-rendering. The gate mirrors the divergence guard, so
+            // the guard has data to compare against next run. Only
+            // write when:
             //   - the entry is a file (directory entries from archive
             //     preprocessors carry no rendered content),
-            //   - the preprocessor produced a tracked render (i.e. it's
-            //     a generative-with-tracking preprocessor, currently
-            //     just templates). Plain Generative preprocessors that
-            //     don't support reverse-merge (unarchive) skip the
-            //     baseline because the cache is only meaningful when
-            //     paired with burgertocow tracking, AND
+            //   - the preprocessor participates: templates supply
+            //     `tracked_render` (which both unlocks reverse-merge
+            //     and seeds the baseline), whole-file secrets supply
+            //     `deploy_mode` (no marker stream, but rendered_hash
+            //     is still meaningful for divergence detection per
+            //     `secrets.lex` §4.4). Preprocessors with neither
+            //     (unarchive) skip the baseline, AND
             //   - the divergence guard didn't skip the write (otherwise
             //     we'd update the baseline to match a render that never
             //     hit disk, breaking future divergence detection).
             //
-            // Mode-gating happens at the function boundary: this whole
-            // branch only runs in `PreprocessMode::Active`. Passive
-            // commands take the early-return at the top of the
-            // function and never reach this code.
-            // Baseline-write gate: write whenever the divergence
-            // guard would fire next time, so the guard has data to
-            // compare against. Templates supply `tracked_render`
-            // (which both unlocks reverse-merge and seeds the
-            // baseline); whole-file secrets supply `deploy_mode`
-            // (no marker stream — `tracked_render = None` — but
-            // rendered_hash is still meaningful for divergence
-            // detection per `secrets.lex` §4.4).
+            // Reached only in `PreprocessMode::Active` — Passive takes
+            // the early return at the top of the function.
             let should_write_baseline = !expanded.is_dir
                 && !was_skipped
                 && (expanded.tracked_render.is_some() || expanded.deploy_mode.is_some());
@@ -650,11 +611,9 @@ pub fn preprocess_pack(
                     );
                 }
 
-                // Secrets sidecar (secrets.lex §3.3). Always called;
-                // the writer no-ops when the render had no
-                // `secret(...)` calls AND removes a stale sidecar
-                // from a prior render that DID, so the on-disk
-                // state always matches the latest render.
+                // Secrets sidecar (secrets.lex §3.3). Always called so
+                // the on-disk state matches the latest render; see
+                // `SecretsSidecar::write` for the no-secrets case.
                 let sidecar = crate::preprocessing::baseline::SecretsSidecar::new(
                     expanded.secret_line_ranges.clone(),
                 );
@@ -753,7 +712,7 @@ pub fn preprocess_pack(
 /// This contract is what `secrets.lex` §7.4 demands: `dodot status`
 /// and `dodot up --dry-run` MUST NOT trigger template evaluation,
 /// MUST NOT surface provider auth prompts, and MUST NOT mutate disk
-/// state. See issue #121.
+/// state.
 ///
 /// Limitation: this assumes a 1:1 source→virtual relationship via
 /// `stripped_name`. That holds for templates (the only shipped
@@ -802,17 +761,11 @@ fn preprocess_pack_passive(
             .handler_data_dir(&pack.name, PREPROCESSED_HANDLER)
             .join(&virtual_relative);
 
-        // Try to load the cached baseline. If absent, this is a
-        // first-time template that has never been deployed: surface
-        // a placeholder virtual entry (no rendered_bytes) so callers
-        // like `dodot status` can render it as "pending" under the
-        // stripped name. Critically, we do NOT fall through to
-        // template evaluation — that's the §7.4 violation we're
-        // here to fix. Handlers that need rendered bytes for
-        // sentinel hashing (`install`, `homebrew`) will fall back
-        // to disk-read on the missing datastore path and report
-        // pending; symlink-targeted templates render cleanly as
-        // pending without needing the bytes at all.
+        // A missing baseline means a first-time template that has
+        // never been deployed. It surfaces as a placeholder virtual
+        // entry with no rendered bytes; falling through to template
+        // evaluation here would be the §7.4 violation this path
+        // exists to avoid.
         let cache_filename = cache_filename_for(&virtual_relative);
         let baseline =
             match Baseline::load(fs, paths, &pack.name, PREPROCESSED_HANDLER, &cache_filename)? {
@@ -833,8 +786,7 @@ fn preprocess_pack_passive(
         // can surface the same `Health::Preserved` row that the
         // active path does. The byte comparison is local and free
         // of side effects — no provider calls, no template eval —
-        // so it stays inside the §7.4 envelope. Skipped only when a
-        // baseline exists (no baseline → no comparison reference).
+        // so it stays inside the §7.4 envelope.
         if baseline.is_some() {
             if let Ok(DivergenceCheck::Skip {
                 state,
@@ -856,12 +808,10 @@ fn preprocess_pack_passive(
         }
 
         // Carry the baseline's rendered content forward as the
-        // in-memory bytes for downstream sentinel hashing when a
-        // baseline exists. Without a baseline (first-time pack), no
-        // bytes are available — handlers that need them will see
-        // `m.rendered_bytes == None` and fall back to disk read,
-        // which correctly fails for the missing datastore file and
-        // shows up as "pending" in status.
+        // in-memory bytes for downstream sentinel hashing. Without a
+        // baseline, handlers fall back to a disk read that correctly
+        // fails for the missing datastore file and shows up as
+        // "pending" in status.
         if let Some(b) = baseline {
             let bytes: Arc<[u8]> = Arc::from(b.rendered_content.into_bytes());
             rendered_bytes.insert(datastore_path.clone(), bytes);

--- a/crates/dodot-lib/src/preprocessing/pipeline/tests/baseline.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline/tests/baseline.rs
@@ -83,9 +83,7 @@ fn baseline_is_written_when_paths_provided_and_tracked_render_present() {
 
     assert_eq!(baseline.rendered_content, "name = rendered");
     assert_eq!(baseline.tracked_render, "name = \u{1e}rendered\u{1f}");
-    // Source hash is the SHA of the source file's bytes.
     assert_eq!(baseline.source_hash.len(), 64);
-    // Context hash matches the one the preprocessor emitted.
     assert!(
         baseline.context_hash.chars().all(|c| c == 'a' || c == 'b'),
         "context hash should be 0xab repeated, got: {}",
@@ -100,7 +98,7 @@ fn baseline_is_skipped_in_passive_mode() {
     // NOT touch the baseline cache. No baseline should be written
     // in that case — overwriting it would erase the
     // divergence-detection ground truth captured at the last
-    // `dodot up`. Per `secrets.lex` §7.4 / issue #121.
+    // `dodot up`. See `secrets.lex` §7.4.
     let env = TempEnvironment::builder()
         .pack("app")
         .file("config.toml.tracked", "src")
@@ -238,7 +236,6 @@ fn baseline_overwrites_on_repeated_up() {
         }]
     };
 
-    // First run.
     let mut registry1 = PreprocessorRegistry::new();
     registry1.register(Box::new(ScriptedPreprocessor {
         name: "ts",
@@ -258,7 +255,6 @@ fn baseline_overwrites_on_repeated_up() {
     )
     .unwrap();
 
-    // Second run with changed outputs.
     let mut registry2 = PreprocessorRegistry::new();
     registry2.register(Box::new(ScriptedPreprocessor {
         name: "ts",
@@ -353,9 +349,6 @@ fn end_to_end_baseline_for_real_template_preprocessor() {
         "tracked render must contain marker bytes, got: {:?}",
         baseline.tracked_render
     );
-    // Context hash is the template preprocessor's deterministic
-    // hex; non-empty.
     assert_eq!(baseline.context_hash.len(), 64);
-    // Rendered hash is SHA-256 hex.
     assert_eq!(baseline.rendered_hash.len(), 64);
 }

--- a/crates/dodot-lib/src/preprocessing/pipeline/tests/conflict_marker.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline/tests/conflict_marker.rs
@@ -22,8 +22,8 @@ use super::{make_datastore, make_pack, make_registry, ScriptedPreprocessor};
 
 #[test]
 fn conflict_marker_in_template_source_blocks_expansion() {
-    // The most important test for R2: a template source containing
-    // a dodot-conflict marker must be refused at the pipeline level
+    // A template source containing a dodot-conflict marker must be
+    // refused at the pipeline level
     // — otherwise the markers would render verbatim through
     // MiniJinja and deploy into the user's config as garbage.
     use std::collections::HashMap;
@@ -271,8 +271,7 @@ fn gate_handles_non_utf8_source_via_lossy_decode() {
         gate_failure: None,
     }];
 
-    // Should NOT error: the gate's lossy decode handles non-UTF-8
-    // gracefully, and there are no marker lines in the bytes.
+    // Lossy decoding accepts non-UTF-8 bytes when no marker lines are present.
     let result = preprocess_pack(
         entries,
         &registry,
@@ -388,7 +387,6 @@ fn template_renders_normally_after_markers_are_resolved() {
         gate_failure: None,
     }];
 
-    // Round 1: clean source → success.
     let result = preprocess_pack(
         entries.clone(),
         &registry,
@@ -402,7 +400,6 @@ fn template_renders_normally_after_markers_are_resolved() {
     .expect("clean source should expand successfully");
     assert_eq!(result.virtual_entries.len(), 1);
 
-    // Round 2: user adds a marker → blocked.
     let dirty = format!(
         "hello\n{}\n{{{{ name }}}}\n{}\n",
         crate::preprocessing::conflict::MARKER_START,
@@ -424,7 +421,6 @@ fn template_renders_normally_after_markers_are_resolved() {
     .unwrap_err();
     assert!(matches!(err, DodotError::UnresolvedConflictMarker { .. }));
 
-    // Round 3: user resolves → success again.
     env.fs
         .write_file(
             &env.dotfiles_root.join("app/greet.tmpl"),

--- a/crates/dodot-lib/src/preprocessing/pipeline/tests/divergence.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline/tests/divergence.rs
@@ -1,4 +1,4 @@
-//! Divergence guard (issue #110, §6.4): the "deployed file was edited
+//! Divergence guard (§6.4): the "deployed file was edited
 //! out-of-band" detector that blocks an automatic re-render.
 
 #![allow(unused_imports)]
@@ -81,17 +81,14 @@ fn divergence_guard_skips_when_deployed_was_edited() {
         .done()
         .build();
 
-    // First run: clean deploy, baseline written.
     let first = run_template_preprocess(&env, "app", false);
     assert!(first.skipped.is_empty(), "first deploy must not skip");
     let deployed_path = &first.virtual_entries[0].absolute_path.clone();
 
-    // User edits the deployed file directly.
     env.fs
         .write_file(deployed_path, b"name = USER EDITED")
         .unwrap();
 
-    // Second run with the same source → guard fires.
     let second = run_template_preprocess(&env, "app", false);
     assert_eq!(second.skipped.len(), 1, "deployed-edit must skip");
     let skip = &second.skipped[0];
@@ -124,7 +121,6 @@ fn divergence_guard_skips_when_both_changed() {
     let first = run_template_preprocess(&env, "app", false);
     let deployed_path = first.virtual_entries[0].absolute_path.clone();
 
-    // Edit both the source template and the deployed file.
     env.fs
         .write_file(
             &env.dotfiles_root.join("app/config.toml.tmpl"),
@@ -158,7 +154,6 @@ fn divergence_guard_proceeds_when_source_changed_only() {
     let first = run_template_preprocess(&env, "app", false);
     let deployed_path = first.virtual_entries[0].absolute_path.clone();
 
-    // Source edited; deployed left untouched.
     env.fs
         .write_file(
             &env.dotfiles_root.join("app/config.toml.tmpl"),
@@ -287,7 +282,6 @@ fn divergence_guard_reproceeds_when_user_undoes_their_edit() {
     let first = run_template_preprocess(&env, "app", false);
     let deployed_path = first.virtual_entries[0].absolute_path.clone();
 
-    // Edit, then revert.
     env.fs
         .write_file(&deployed_path, b"name = USER EDITED")
         .unwrap();
@@ -319,7 +313,6 @@ fn divergence_guard_active_for_read_only_callers() {
         .done()
         .build();
 
-    // Prime the baseline with a normal `up`.
     let _ = run_template_preprocess(&env, "app", false);
     let baseline_before = crate::preprocessing::baseline::Baseline::load(
         env.fs.as_ref(),
@@ -331,7 +324,6 @@ fn divergence_guard_active_for_read_only_callers() {
     .unwrap()
     .unwrap();
 
-    // User edits the deployed file directly.
     let deployed_path = env
         .paths
         .handler_data_dir("app", "preprocessed")
@@ -340,7 +332,6 @@ fn divergence_guard_active_for_read_only_callers() {
         .write_file(&deployed_path, b"name = USER EDITED")
         .unwrap();
 
-    // Simulate `status`: write_baselines=false, force=false.
     use std::collections::HashMap;
     let template_pp = crate::preprocessing::template::TemplatePreprocessor::new(
         vec!["tmpl".into()],

--- a/crates/dodot-lib/src/preprocessing/pipeline/tests/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline/tests/mod.rs
@@ -1,14 +1,4 @@
-//! Tests for the preprocessing pipeline.
-//!
-//! Shared helpers (`make_pack`, `make_registry`, `make_datastore`) and
-//! the `ScriptedPreprocessor` test double live here so the per-section
-//! sub-modules can `use super::{...}` without re-defining each fixture.
-//!
-//! General pipeline tests (passthrough, identity expansion, merging,
-//! collision detection, partitioning) stay inline. The four big topical
-//! suites — path-traversal defenses, baseline-cache integration, the
-//! conflict-marker safety gate, and the divergence guard — live in
-//! sibling files.
+//! Tests and shared fixtures for the preprocessing pipeline.
 
 #![allow(unused_imports)]
 
@@ -183,11 +173,9 @@ fn identity_preprocessor_creates_virtual_entry() {
     assert_eq!(virtual_entry.relative_path, PathBuf::from("config.toml"));
     assert!(!virtual_entry.is_dir);
 
-    // Verify the file was written to the datastore
     let content = env.fs.read_to_string(&virtual_entry.absolute_path).unwrap();
     assert_eq!(content, "host = localhost");
 
-    // Verify source map
     assert_eq!(
         result.source_map[&virtual_entry.absolute_path],
         env.dotfiles_root.join("app/config.toml.identity")
@@ -478,7 +466,6 @@ fn multiple_preprocessor_files_in_one_pack() {
     assert!(names.contains(&"config.toml".to_string()));
     assert!(names.contains(&"settings.json".to_string()));
 
-    // Each should have a source_map entry
     assert_eq!(result.source_map.len(), 2);
 }
 
@@ -565,7 +552,6 @@ fn source_map_is_complete() {
     )
     .unwrap();
 
-    // Every virtual entry must have a source_map entry
     for ve in &result.virtual_entries {
         assert!(
             result.source_map.contains_key(&ve.absolute_path),
@@ -573,7 +559,6 @@ fn source_map_is_complete() {
             ve.absolute_path.display()
         );
     }
-    // No regular entries in the source_map
     for re in &result.regular_entries {
         assert!(
             !result.source_map.contains_key(&re.absolute_path),
@@ -633,7 +618,6 @@ fn preprocessing_is_idempotent() {
         result2.virtual_entries[0].relative_path
     );
 
-    // Datastore file should be the same content
     let content1 = env
         .fs
         .read_to_string(&result1.virtual_entries[0].absolute_path)
@@ -657,7 +641,6 @@ fn expansion_error_propagates() {
     let datastore = make_datastore(&env);
     let pack = make_pack("app", env.dotfiles_root.join("app"));
 
-    // Point to a file that doesn't exist — expansion should fail
     let entries = vec![PackEntry {
         relative_path: "missing.conf.identity".into(),
         absolute_path: env.dotfiles_root.join("app/missing.conf.identity"),
@@ -685,7 +668,7 @@ fn expansion_error_propagates() {
 #[test]
 fn inter_preprocessor_collision_detected() {
     // Two preprocessors produce the same logical name.
-    // Set up: `config.toml.identity` and `config.toml.other` (custom
+    // `config.toml.identity` and `config.toml.other` (custom
     // extension) both strip to `config.toml`. The pipeline must
     // detect this and refuse rather than silently overwriting.
     let env = TempEnvironment::builder()
@@ -770,7 +753,6 @@ fn datastore_preserves_directory_structure() {
     assert_eq!(result.virtual_entries.len(), 1);
     let datastore_path = &result.virtual_entries[0].absolute_path;
 
-    // The datastore path should contain the subdirectory structure, not flattened
     let ds_str = datastore_path.to_string_lossy();
     assert!(
         ds_str.contains("sub/config.toml"),
@@ -781,7 +763,6 @@ fn datastore_preserves_directory_structure() {
         "datastore path should not contain flattening separator, got: {ds_str}"
     );
 
-    // File should actually exist at that path
     assert!(env.fs.exists(datastore_path));
     let content = env.fs.read_to_string(datastore_path).unwrap();
     assert_eq!(content, "nested");
@@ -789,8 +770,7 @@ fn datastore_preserves_directory_structure() {
 
 #[test]
 fn datastore_distinguishes_sibling_from_flattened_name() {
-    // Regression test for the flatten-with-`__` edge case: a user could
-    // have `a/b.txt` and `a__b.txt` both as preprocessor outputs, which
+    // `a/b.txt` and `a__b.txt` could both be preprocessor outputs and
     // would have collided under the old flattening scheme. With
     // directory-preserving storage they live in distinct datastore paths.
     let env = TempEnvironment::builder()
@@ -833,7 +813,6 @@ fn datastore_distinguishes_sibling_from_flattened_name() {
 
     assert_eq!(result.virtual_entries.len(), 2);
 
-    // Both files must exist with distinct content
     let nested = result
         .virtual_entries
         .iter()

--- a/crates/dodot-lib/src/preprocessing/pipeline/tests/path_traversal.rs
+++ b/crates/dodot-lib/src/preprocessing/pipeline/tests/path_traversal.rs
@@ -71,7 +71,6 @@ fn rejects_absolute_path_from_preprocessor() {
         matches!(err, DodotError::PreprocessorError { ref message, .. } if message.contains("unsafe path")),
         "expected unsafe-path error, got: {err}"
     );
-    // Verify the malicious target was not written
     assert!(!std::path::Path::new("/etc/passwd.dodot-would-have-written-here").exists());
 }
 

--- a/crates/dodot-lib/src/preprocessing/reverse_merge.rs
+++ b/crates/dodot-lib/src/preprocessing/reverse_merge.rs
@@ -200,9 +200,6 @@ mod tests {
         // pure-data edit and recommends no template change.
         let template = "name = {{ name }}\nport = 5432\n";
         let (rendered, tracked) = render(template, serde_json::json!({"name": "Alice"}));
-        // Re-render with a different value to simulate the deployed
-        // file as it would be after the next `dodot up` (or after
-        // the user manually edited the value).
         let _ = rendered;
         let deployed = "name = Bob\nport = 5432\n";
         let outcome = reverse_merge(template, &tracked, deployed, &[]).unwrap();
@@ -245,7 +242,6 @@ mod tests {
         // Conflict and leaves the source untouched.
         let template = "{% for i in items %}- {{ i }}\n{% endfor %}";
         let (_, tracked) = render(template, serde_json::json!({"items": ["a", "b", "c"]}));
-        // Inconsistent prefix edits per iteration:
         let deployed = "* a\n+ b\n- c\n";
         let outcome = reverse_merge(template, &tracked, deployed, &[]).unwrap();
         assert!(
@@ -272,7 +268,6 @@ mod tests {
         let outcome = reverse_merge(template, &tracked, deployed, &[]).unwrap();
         match outcome {
             ReverseMergeOutcome::Patched(patched) => {
-                // Template's loop body now uses `*` instead of `-`.
                 assert!(patched.contains("* {{ i }}"), "patched: {patched:?}");
             }
             other => panic!("expected Patched for consistent loop edit, got: {other:?}"),
@@ -309,8 +304,6 @@ mod tests {
         assert!(ReverseMergeOutcome::Conflict(String::new()).is_actionable());
     }
 
-    /// Helper for the masking tests below — build a single-line
-    /// `SecretLineRange` covering the given 0-indexed line.
     fn mask_line(line: usize, reference: &str) -> SecretLineRange {
         SecretLineRange {
             start: line,
@@ -341,14 +334,9 @@ mod tests {
         assert_eq!(rendered, "user = Ada\npassword = OLD\n");
         let deployed = "user = Ada\npassword = NEW_ROTATED\n";
 
-        // Without mask: a unified diff propagates the rotated value
-        // back to the template (or surfaces a conflict — either way,
-        // *not* Unchanged).
         let unmasked = reverse_merge(template, &tracked, deployed, &[]).unwrap();
         assert_ne!(unmasked, ReverseMergeOutcome::Unchanged);
 
-        // With the line-1 mask: byte change on the masked line is
-        // invisible → Unchanged.
         let masked =
             reverse_merge(template, &tracked, deployed, &[mask_line(1, "pass:db")]).unwrap();
         assert_eq!(masked, ReverseMergeOutcome::Unchanged);
@@ -373,7 +361,6 @@ mod tests {
         match outcome {
             ReverseMergeOutcome::Patched(patched) => {
                 assert!(patched.contains("port = 9999"), "patched: {patched:?}");
-                // The masked line stays at "OLD" in the source.
                 assert!(
                     patched.contains("secret_line = OLD"),
                     "masked line must not propagate: {patched:?}"

--- a/crates/dodot-lib/src/preprocessing/reverse_merge.rs
+++ b/crates/dodot-lib/src/preprocessing/reverse_merge.rs
@@ -25,9 +25,8 @@
 //! secret-provider auth prompts in the variable context — auth fatigue
 //! that the magic.lex design specifically rules out. We rehydrate the
 //! cached tracked string via
-//! [`burgertocow::TrackedRender::from_tracked_string`] (added in
-//! burgertocow 0.3) and feed it into `generate_diff_with_markers`
-//! directly.
+//! [`burgertocow::TrackedRender::from_tracked_string`] and feed it
+//! into `generate_diff_with_markers` directly.
 
 use std::ops::Range;
 
@@ -80,11 +79,9 @@ impl ReverseMergeOutcome {
 /// bytes — so a rotated `{{ secret(...) }}` value (or a hand-edit
 /// to a secret line) does not propagate into a template-space diff
 /// that would replace the `secret(...)` expression with the literal
-/// rotated value. See `secrets.lex` §3.3 / burgertocow#13.
+/// rotated value. See `secrets.lex` §3.3.
 ///
-/// The legacy three-arg shape is preserved as
-/// [`reverse_merge_no_mask`] for callers that don't have a sidecar
-/// loaded yet (every existing call site keeps the same behavior).
+/// Callers without a sidecar loaded use [`reverse_merge_no_mask`].
 pub fn reverse_merge(
     template_src: &str,
     cached_tracked: &str,
@@ -109,9 +106,7 @@ pub fn reverse_merge(
     let mid = format!("\n{MARKER_MID}\n");
     let end = format!("\n{MARKER_END}\n");
     let markers = ConflictMarkers::new(&start, &mid, &end);
-    // Convert `SecretLineRange { start, end, .. }` to the
-    // `Range<usize>` shape `DiffOptions` consumes. Bound to a local
-    // `Vec` because `with_mask` takes a borrowed slice.
+    // Bound to a local `Vec` because `with_mask` takes a borrowed slice.
     let mask: Vec<Range<usize>> = secret_ranges.iter().map(|r| r.start..r.end).collect();
     let opts = DiffOptions::new(&markers).with_mask(&mask);
     let diff = generate_diff_with_markers_opts(template_src, &tracked, deployed, &opts);
@@ -161,8 +156,7 @@ pub fn reverse_merge(
 /// Convenience for callers that haven't loaded a secrets sidecar
 /// for this file (or are computing reverse-merge for a file that
 /// has no `secret(...)` calls). Equivalent to
-/// [`reverse_merge`] with an empty mask — burgertocow then behaves
-/// byte-identically to the pre-0.4 single-mask-less entry point.
+/// [`reverse_merge`] with an empty mask.
 pub fn reverse_merge_no_mask(
     template_src: &str,
     cached_tracked: &str,

--- a/crates/dodot-lib/src/preprocessing/template/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/template/mod.rs
@@ -669,7 +669,6 @@ mod tests {
             .unwrap();
 
         let source = env.dotfiles_root.join("app/bad.tmpl");
-        // Ensure the env var is genuinely unset
         std::env::remove_var("DEFINITELY_UNSET_VAR_ZZZ_12345");
         let err = pp.expand(&source, env.fs.as_ref()).unwrap_err();
         assert!(
@@ -822,7 +821,6 @@ mod tests {
         .unwrap();
         assert_eq!(pp.stripped_name("config.j2.tmpl"), "config");
 
-        // Opposite config order yields the same result.
         let pp_reversed = TemplatePreprocessor::new(
             vec!["j2.tmpl".into(), "tmpl".into()],
             HashMap::new(),
@@ -906,11 +904,8 @@ mod tests {
 
     #[test]
     fn renders_for_loop_over_user_var() {
-        // Regression guard: MiniJinja supports loops, but we want to
-        // confirm that user-defined vars (which are plain strings) still
-        // work inside a minimal control-flow structure. Strings are
-        // iterable as sequences of characters — confirm our value-layer
-        // doesn't silently block that.
+        // MiniJinja loops must accept user-defined vars, which are plain
+        // strings, without the value layer blocking iteration.
         let env = crate::testing::TempEnvironment::builder()
             .pack("app")
             .file(
@@ -1007,13 +1002,11 @@ mod tests {
         // present; if they return None, the key is absent.
         let ctx = build_dodot_context(&make_pather());
 
-        // These are always present:
         assert!(ctx.contains_key("os"));
         assert!(ctx.contains_key("arch"));
         assert!(ctx.contains_key("home"));
         assert!(ctx.contains_key("dotfiles_root"));
 
-        // Optional keys: present iff the detection helper returned Some.
         assert_eq!(
             ctx.contains_key("username"),
             crate::gates::detect_username().is_some()
@@ -1249,7 +1242,6 @@ mod tests {
         let result = pp.expand(&source, env.fs.as_ref()).unwrap();
         let rendered = String::from_utf8_lossy(&result[0].content);
         assert_eq!(rendered, "a = v\nb = v\nc = v\n");
-        // Cache hit on calls 2 and 3.
         assert_eq!(
             mock.resolve_call_count(),
             1,
@@ -1312,7 +1304,6 @@ mod tests {
             .build();
         let source = env.dotfiles_root.join("app/c.tmpl");
         let result = pp.expand(&source, env.fs.as_ref()).unwrap();
-        // k1's value lands on line 1 (0-indexed), k2's on line 3.
         let ranges = &result[0].secret_line_ranges;
         assert_eq!(ranges.len(), 2);
         assert_eq!(ranges[0].reference, "pass:k1");
@@ -1336,7 +1327,6 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("multi-line value"));
         assert!(msg.contains("single-line only"));
-        // Points the user at the whole-file path, not just rejecting.
         assert!(msg.contains("whole-file deploy"));
     }
 
@@ -1351,14 +1341,12 @@ mod tests {
         let source = env.dotfiles_root.join("app/c.tmpl");
         let err = pp.expand(&source, env.fs.as_ref()).unwrap_err();
         let msg = err.to_string();
-        // The mock's "no canned value" message comes through.
         assert!(msg.contains("MockSecretProvider"));
         assert!(msg.contains("missing"));
     }
 
     #[test]
     fn secret_function_unknown_scheme_lists_configured_schemes() {
-        // Registry has `pass` only; template references `op://...`.
         let pp = pp_with_secrets("pass", &[("k", "v")]);
         let env = crate::testing::TempEnvironment::builder()
             .pack("app")

--- a/crates/dodot-lib/src/preprocessing/template/mod.rs
+++ b/crates/dodot-lib/src/preprocessing/template/mod.rs
@@ -197,18 +197,12 @@ impl TemplatePreprocessor {
             env.add_global(name.clone(), Value::from(val.clone()));
         }
 
-        // Install the `secret(...)` function. Two cases:
-        //
-        // - Registry configured: function dispatches through the
-        //   registry. Refuses multi-line values per §3.4. Records
-        //   the (reference, value) pair into `sidecar` so the
-        //   caller can compute line ranges after rendering.
-        // - No registry: function still exists, but every call
-        //   surfaces a clean render error pointing the user at
-        //   `[secret] enabled = true`. The presence-without-function
-        //   alternative would surface as MiniJinja's generic
-        //   "undefined" error which doesn't tell the user how to
-        //   fix the config.
+        // The `secret(...)` function is installed whether or not a
+        // registry is configured: without one, every call surfaces a
+        // clean render error pointing the user at
+        // `[secret] enabled = true`. Leaving the function undefined
+        // instead would surface MiniJinja's generic "undefined"
+        // error, which doesn't tell the user how to fix the config.
         match &self.secret_registry {
             Some(registry) => {
                 let registry = registry.clone();
@@ -216,16 +210,15 @@ impl TemplatePreprocessor {
                 env.add_function(
                     "secret",
                     move |reference: &str| -> std::result::Result<String, MjError> {
-                        // Within-run cache: first call for a given
-                        // reference goes to the provider; subsequent
-                        // calls (in this template or any other
-                        // rendered through the same registry
-                        // instance) hit the cache and never shell
-                        // out. Multi-line / non-UTF-8 are detected
-                        // up here so the rich error messages stay
-                        // co-located with the callback that surfaces
-                        // them; only validated values reach the
-                        // cache. See `secrets.lex` §7.4 / §3.4.
+                        // Within-run cache: a repeat reference (in
+                        // this template or any other rendered through
+                        // the same registry instance) never shells
+                        // out again. Multi-line / non-UTF-8 values
+                        // are rejected up here so the rich error
+                        // messages stay co-located with the callback
+                        // that surfaces them; only validated values
+                        // reach the cache. See `secrets.lex` §7.4 /
+                        // §3.4.
                         //
                         // The cache holds `Arc<SecretString>` so the
                         // resolved bytes get zeroized when the
@@ -254,10 +247,6 @@ impl TemplatePreprocessor {
                                     ),
                                 ));
                             }
-                            // Validate UTF-8 before caching — a
-                            // non-UTF-8 value never reaches the
-                            // cache (the call propagates the rich
-                            // error instead).
                             value.expose().map_err(|_| {
                                 MjError::new(
                                     MjErrorKind::InvalidOperation,
@@ -282,10 +271,8 @@ impl TemplatePreprocessor {
                             reference: reference.to_string(),
                             value: owned,
                         });
-                        // The sentinel is what flows through MiniJinja
-                        // and into the rendered output; `expand()`
-                        // computes line ranges by locating sentinels
-                        // and then substitutes them back to the value.
+                        // The sentinel, not the value, is what flows
+                        // through MiniJinja into the rendered output.
                         Ok(sentinel)
                     },
                 );
@@ -331,7 +318,7 @@ impl Preprocessor for TemplatePreprocessor {
     fn matches_extension(&self, filename: &str) -> bool {
         // Extensions are normalized (no leading dot) at construction.
         // We require a literal "." before the extension to avoid e.g.
-        // "mpl" matching "foo.tmpl". No per-call allocation.
+        // "mpl" matching "foo.tmpl".
         self.extensions.iter().any(|ext| {
             filename
                 .strip_suffix(ext.as_str())
@@ -365,11 +352,9 @@ impl Preprocessor for TemplatePreprocessor {
         // surfaces sensibly in any error MiniJinja produces.
         let template_name = source.to_string_lossy().into_owned();
 
-        // Per-render sidecar accumulator. Each `secret(...)` call
-        // pushes a `SecretCallEntry { sentinel, reference, value }`;
-        // the rendered output carries the sentinel (not the value),
-        // and `finalize_secrets` below turns sentinels into line
-        // ranges and then substitutes them back to the real value.
+        // Per-render sidecar accumulator: `finalize_secrets` below
+        // turns the recorded sentinels into line ranges and then
+        // substitutes them back to the real values.
         let sidecar: Arc<Mutex<Vec<SecretCallEntry>>> = Arc::new(Mutex::new(Vec::new()));
         let render_id = next_render_id();
 

--- a/crates/dodot-lib/src/preprocessing/template/secrets.rs
+++ b/crates/dodot-lib/src/preprocessing/template/secrets.rs
@@ -39,8 +39,7 @@ pub(super) fn next_render_id() -> u64 {
 /// (U+E000–U+F8FF), which by definition has no assigned meaning and
 /// does not appear in normal dotfile content. Combined with the
 /// per-render id, the resulting string is unique within and across
-/// renders, eliminating the substring-collision failure mode of the
-/// previous "search for the resolved value" approach.
+/// renders.
 pub(super) fn make_secret_sentinel(render_id: u64, call_idx: usize) -> String {
     let mut s = String::with_capacity(20);
     s.push('\u{E000}');
@@ -53,7 +52,7 @@ pub(super) fn make_secret_sentinel(render_id: u64, call_idx: usize) -> String {
 }
 
 /// Walk `rendered` to convert each sentinel into a [`SecretLineRange`]
-/// (single-line per Phase S1 / §3.4), then substitute every sentinel
+/// (single-line per §3.4), then substitute every sentinel
 /// back to its real value in both `rendered` and `tracked` and return
 /// all three.
 ///

--- a/crates/dodot-lib/src/preprocessing/unarchive.rs
+++ b/crates/dodot-lib/src/preprocessing/unarchive.rs
@@ -94,7 +94,6 @@ impl Preprocessor for UnarchivePreprocessor {
                 })?
                 .into_owned();
 
-            // Tar-slip guard: reject absolute paths and `..` components.
             if !entry_path_is_safe(&entry_path) {
                 return Err(DodotError::PreprocessorError {
                     preprocessor: "unarchive".into(),

--- a/crates/dodot-lib/src/preprocessing/unarchive.rs
+++ b/crates/dodot-lib/src/preprocessing/unarchive.rs
@@ -168,7 +168,7 @@ mod tests {
         assert!(!pp.matches_extension("file.tar"));
         assert!(!pp.matches_extension("file.gz"));
         assert!(!pp.matches_extension("file.zip"));
-        assert!(!pp.matches_extension("tar.gz")); // no base name before extension? still matches
+        assert!(!pp.matches_extension("tar.gz"));
     }
 
     #[test]
@@ -197,13 +197,11 @@ mod tests {
             .done()
             .build();
 
-        // Create a tar.gz archive programmatically
         let archive_path = env.dotfiles_root.join("tools/bin.tar.gz");
         let file = std::fs::File::create(&archive_path).unwrap();
         let enc = GzEncoder::new(file, Compression::default());
         let mut builder = tar::Builder::new(enc);
 
-        // Add a file to the archive
         let content = b"#!/bin/sh\necho hello";
         let mut header = tar::Header::new_gnu();
         header.set_path("mytool").unwrap();
@@ -212,7 +210,6 @@ mod tests {
         header.set_cksum();
         builder.append(&header, &content[..]).unwrap();
 
-        // Add another file
         let content2 = b"#!/bin/sh\necho world";
         let mut header2 = tar::Header::new_gnu();
         header2.set_path("other-tool").unwrap();
@@ -224,7 +221,6 @@ mod tests {
         let enc = builder.into_inner().unwrap();
         enc.finish().unwrap();
 
-        // Now expand it
         let pp = UnarchivePreprocessor::new();
         let result = pp.expand(&archive_path, env.fs.as_ref()).unwrap();
 
@@ -264,7 +260,6 @@ mod tests {
         let enc = GzEncoder::new(file, Compression::default());
         let mut builder = tar::Builder::new(enc);
 
-        // Add a directory entry
         let mut dir_header = tar::Header::new_gnu();
         dir_header.set_path("subdir/").unwrap();
         dir_header.set_size(0);
@@ -273,7 +268,6 @@ mod tests {
         dir_header.set_cksum();
         builder.append(&dir_header, &[][..]).unwrap();
 
-        // Add a file inside the directory
         let content = b"nested file";
         let mut file_header = tar::Header::new_gnu();
         file_header.set_path("subdir/nested.txt").unwrap();

--- a/crates/dodot-lib/src/probe/brew.rs
+++ b/crates/dodot-lib/src/probe/brew.rs
@@ -538,7 +538,6 @@ mod tests {
 
         let now = 1_000_000;
         let _ = info_cask("cursor", &cache, now, env.fs.as_ref(), &runner).unwrap();
-        // Simulate clock advance past TTL.
         let _ = info_cask(
             "cursor",
             &cache,
@@ -642,13 +641,10 @@ mod tests {
             env.fs.as_ref(),
             /*cache_only=*/ true,
         );
-        // Installed list still populated (brew list was called).
         assert!(result
             .installed_tokens
             .contains(&"visual-studio-code".into()));
-        // No info → no folder match.
         assert!(result.folder_to_token.is_empty());
-        // And brew info was never invoked.
         assert_eq!(
             runner.call_count(&["brew", "info", "--json=v2", "--cask", "visual-studio-code"]),
             0,

--- a/crates/dodot-lib/src/probe/brew.rs
+++ b/crates/dodot-lib/src/probe/brew.rs
@@ -1,11 +1,10 @@
 //! Homebrew-cask probe — advisory lookup of cask metadata.
 //!
-//! Implements Phase M6 of `docs/proposals/macos-paths.lex` §8.2. The
-//! cardinal rule from §8 holds: probes are *advisory*, never
-//! authoritative. The symlink resolver in §5 never consults this
-//! module, and a probe failure (no `brew` on PATH, malformed JSON,
-//! cache miss) never alters routing — it just means the user sees a
-//! less-rich suggestion or warning.
+//! See `docs/proposals/macos-paths.lex` §8.2. The cardinal rule from
+//! §8 holds: probes are *advisory*, never authoritative. The symlink
+//! resolver in §5 never consults this module, and a probe failure (no
+//! `brew` on PATH, malformed JSON, cache miss) never alters routing —
+//! it just means the user sees a less-rich suggestion or warning.
 //!
 //! ## What the probe surfaces
 //!
@@ -341,8 +340,7 @@ pub fn match_folders_to_installed_casks(
     out.installed_tokens = list_installed_casks(runner);
     for token in &out.installed_tokens {
         let info = if cache_only {
-            // Cache-only mode: read the on-disk entry if fresh, never
-            // spawn `brew info`. A miss leaves this token unmatched.
+            // A cache miss leaves this token unmatched.
             read_cache(&cache_path_for(cache_dir, token), fs)
                 .filter(|e| now_secs.saturating_sub(e.fetched_at) < CACHE_TTL_SECS)
                 .map(|e| e.info)

--- a/crates/dodot-lib/src/probe/data_dir_tree.rs
+++ b/crates/dodot-lib/src/probe/data_dir_tree.rs
@@ -175,7 +175,6 @@ mod tests {
     #[test]
     fn missing_data_dir_returns_empty_root() {
         let env = TempEnvironment::builder().build();
-        // Remove the data dir to simulate a fresh install.
         env.fs.remove_dir_all(&env.data_dir).unwrap();
 
         let root = collect_data_dir_tree(env.fs.as_ref(), env.paths.as_ref(), 4).unwrap();
@@ -186,7 +185,6 @@ mod tests {
     #[test]
     fn depth_zero_returns_root_only_with_truncated_count() {
         let env = TempEnvironment::builder().build();
-        // Create a couple of files under data_dir so there's something to truncate.
         env.fs
             .write_file(&env.data_dir.join("a.txt"), b"hi")
             .unwrap();
@@ -283,9 +281,6 @@ mod tests {
     #[test]
     fn count_and_total_size_helpers_agree() {
         let env = TempEnvironment::builder().build();
-        // Start from a clean data_dir so we control the exact shape.
-        // (TempEnvironment pre-creates `shell/` and `packs/` — fine for
-        // realism, but confuses exact-count assertions.)
         env.fs.remove_dir_all(&env.data_dir).unwrap();
         env.fs.mkdir_all(&env.data_dir).unwrap();
 

--- a/crates/dodot-lib/src/probe/data_dir_tree.rs
+++ b/crates/dodot-lib/src/probe/data_dir_tree.rs
@@ -107,7 +107,6 @@ fn walk(fs: &dyn Fs, path: &Path, display_name: &str, remaining_depth: usize) ->
         });
     }
 
-    // Directory.
     if remaining_depth == 0 {
         // Report how many entries are hidden so the user knows the
         // subtree wasn't empty.

--- a/crates/dodot-lib/src/probe/deployment_map.rs
+++ b/crates/dodot-lib/src/probe/deployment_map.rs
@@ -338,8 +338,6 @@ mod tests {
     fn sentinel_file_classified_as_file_with_no_source() {
         let env = TempEnvironment::builder().build();
 
-        // Simulate an install handler sentinel: a plain file in the
-        // handler dir, not a symlink.
         let handler_dir = env.paths.handler_data_dir("nvim", "install");
         env.fs.mkdir_all(&handler_dir).unwrap();
         env.fs
@@ -432,8 +430,6 @@ git\tsymlink\tsymlink\t/src/b\t/ds/b
 
     #[test]
     fn parser_skips_malformed_rows() {
-        // Too few columns and an unknown kind should both be dropped,
-        // not crash.
         let content = "\
 only-two-cols\tvalue
 vim\tshell\tweird-kind\t/a\t/b
@@ -482,15 +478,12 @@ vim\tshell\tsymlink\t/a\t/b
 
     #[test]
     fn paths_with_tabs_would_break_tsv_but_are_not_produced_by_dodot() {
-        // Documenting an invariant rather than testing a path: dodot
-        // never creates paths containing literal tab characters, so we
+        // Dodot never creates paths containing literal tab characters, so we
         // don't escape them in the TSV. A pack dir named "foo\tbar"
         // would produce a malformed row — but dodot's pack discovery
         // rejects such names upstream (ignore list + XDG conventions).
         //
-        // This test just locks in the current format so a future change
-        // that wants tab-containing paths has to explicitly revisit
-        // escaping.
+        // Supporting tab-containing paths would require revisiting escaping.
         let entry = DeploymentMapEntry {
             pack: "p".into(),
             handler: "h".into(),

--- a/crates/dodot-lib/src/probe/macos_native.rs
+++ b/crates/dodot-lib/src/probe/macos_native.rs
@@ -1,9 +1,8 @@
 //! macOS-native metadata probes: `mdls` and `mdfind`.
 //!
-//! Implements Phase M6 of `docs/proposals/macos-paths.lex` §8.3. Same
-//! advisory-only contract as `probe::brew`: failures return `None`
-//! and never propagate; the resolver in §5 doesn't consult these
-//! either.
+//! See `docs/proposals/macos-paths.lex` §8.3. Same advisory-only
+//! contract as `probe::brew`: failures return `None` and never
+//! propagate; the resolver in §5 doesn't consult these either.
 //!
 //! ## Why these and not the others
 //!
@@ -92,7 +91,6 @@ fn parse_mdls_value(stdout: &str) -> Option<String> {
             if trimmed == "(null)" || trimmed.is_empty() {
                 return None;
             }
-            // Strip surrounding double quotes if present.
             let unquoted = trimmed
                 .strip_prefix('"')
                 .and_then(|s| s.strip_suffix('"'))

--- a/crates/dodot-lib/src/probe/mod.rs
+++ b/crates/dodot-lib/src/probe/mod.rs
@@ -1,7 +1,7 @@
 //! Probe — introspection for the deployed state.
 //!
 //! Read-only views over `<data_dir>`, plus the markers `dodot up`
-//! writes there:
+//! writes there ([`cfprefsd_marker`], [`last_up`]):
 //!
 //! - [`deployment_map`] — the `pack / handler / source / deployed` map
 //!   that `dodot refresh` (see `docs/proposals/magic.lex`) also

--- a/crates/dodot-lib/src/probe/mod.rs
+++ b/crates/dodot-lib/src/probe/mod.rs
@@ -1,6 +1,7 @@
 //! Probe — introspection for the deployed state.
 //!
-//! Today this module provides two read-only views over `<data_dir>`:
+//! Read-only views over `<data_dir>`, plus the markers `dodot up`
+//! writes there:
 //!
 //! - [`deployment_map`] — the `pack / handler / source / deployed` map
 //!   that `dodot refresh` (see `docs/proposals/magic.lex`) also
@@ -8,11 +9,10 @@
 //!   and `down`.
 //! - [`data_dir_tree`] — a bounded-depth tree walk for `dodot probe
 //!   show-data-dir`.
+//! - [`shell_init`] — shell-startup timing profiles under
+//!   `<data_dir>/probes/shell-init/`.
 //!
-//! See `docs/proposals/profiling.lex` for the full feature spec. A
-//! later phase will add shell-init timing reports under
-//! `<data_dir>/probes/shell-init/`; that state lives in a sibling
-//! submodule when it lands.
+//! See `docs/proposals/profiling.lex` for the full feature spec.
 
 pub mod brew;
 pub mod cfprefsd_marker;

--- a/crates/dodot-lib/src/probe/shell_init.rs
+++ b/crates/dodot-lib/src/probe/shell_init.rs
@@ -103,7 +103,6 @@ pub fn read_latest_profile(fs: &dyn Fs, paths: &dyn Pather) -> Result<Option<Pro
 
 /// Read up to `limit` most recent profiles, newest first.
 ///
-/// Profiles are returned in reverse chronological order (newest first).
 /// The cap exists because callers know how much they need — `--runs 5`
 /// asks for five — and the directory may have hundreds of files.
 ///
@@ -205,7 +204,6 @@ pub fn parse_errors_log(content: &str) -> Vec<ProfileErrorRecord> {
     for raw_line in content.lines() {
         let line = raw_line.trim_end_matches('\r');
         if let Some(rest) = line.strip_prefix("@@\t") {
-            // New record header. Flush any in-progress record first.
             flush(&mut current, &mut out);
             let mut parts = rest.splitn(2, '\t');
             let Some(target) = parts.next() else { continue };
@@ -255,7 +253,7 @@ pub fn parse_profile(filename: &str, content: &str) -> Profile {
                     "shell" => shell = val.to_string(),
                     "start_t" => start_t = val.parse::<f64>().ok(),
                     "end_t" => end_t = val.parse::<f64>().ok(),
-                    _ => {} // unknown header — ignore
+                    _ => {}
                 }
             }
             continue;
@@ -445,7 +443,6 @@ pub struct AggregatedView {
 pub fn aggregate_profiles(profiles: &[Profile]) -> AggregatedView {
     use std::collections::BTreeMap;
 
-    // Bucket durations by (pack, handler, target).
     let mut buckets: BTreeMap<(String, String, String), Vec<u64>> = BTreeMap::new();
     for p in profiles {
         for e in &p.entries {

--- a/crates/dodot-lib/src/probe/shell_init.rs
+++ b/crates/dodot-lib/src/probe/shell_init.rs
@@ -635,7 +635,6 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             .into_iter()
             .map(|e| e.name)
             .collect();
-        // The three highest-numbered (newest) files survive.
         assert_eq!(
             remaining,
             vec![
@@ -677,8 +676,6 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
         let env = TempEnvironment::builder().build();
         let dir = env.paths.probes_shell_init_dir();
         env.fs.mkdir_all(&dir).unwrap();
-        // Five profile files (more than `keep`), plus two non-profile
-        // files that the rotator must leave alone.
         for i in 1..=5 {
             env.fs
                 .write_file(&dir.join(format!("profile-{i}-1-1.tsv")), b"")
@@ -691,19 +688,15 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             .write_file(&dir.join("notes.txt"), b"keep me")
             .unwrap();
 
-        // keep=2 forces the pruning path (5 profiles → 2 should remain).
         let removed = rotate_profiles(env.fs.as_ref(), env.paths.as_ref(), 2).unwrap();
         assert_eq!(removed, 3);
 
-        // The two newest profiles survive.
         assert!(env.fs.exists(&dir.join("profile-4-1-1.tsv")));
         assert!(env.fs.exists(&dir.join("profile-5-1-1.tsv")));
-        // The three oldest are gone.
         assert!(!env.fs.exists(&dir.join("profile-1-1-1.tsv")));
         assert!(!env.fs.exists(&dir.join("profile-2-1-1.tsv")));
         assert!(!env.fs.exists(&dir.join("profile-3-1-1.tsv")));
 
-        // Non-profile files are untouched.
         assert!(env.fs.exists(&dir.join("README")));
         assert!(env.fs.exists(&dir.join("notes.txt")));
     }
@@ -758,8 +751,6 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
 
     #[test]
     fn group_profile_sorts_across_packs() {
-        // Entries arrive in deliberately scrambled order; the result
-        // must still be (pack, handler)-sorted.
         let p = Profile {
             filename: "x".into(),
             shell: "bash".into(),
@@ -873,10 +864,8 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
         let v: Vec<u64> = (1..=10).collect();
         assert_eq!(percentile(&v, 50), 5);
         assert_eq!(percentile(&v, 95), 10);
-        // Single sample → all percentiles return it.
         assert_eq!(percentile(&[42], 50), 42);
         assert_eq!(percentile(&[42], 95), 42);
-        // Empty slice safely returns 0.
         assert_eq!(percentile(&[], 50), 0);
     }
 
@@ -908,7 +897,6 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
             total_duration_us: 0,
             errors: Vec::new(),
             entries: vec![entry("vim", "shell", "/a", 120)],
-            // /b absent in this run (sparse target presence).
         };
         let agg = aggregate_profiles(&[p1, p2, p3]);
         assert_eq!(agg.runs, 3);
@@ -933,7 +921,6 @@ source\tvim\tshell\t/x\t1714000000.001000\t1714000000.002000\t0\n";
 
     #[test]
     fn aggregate_targets_sort_by_pack_handler_target() {
-        // Inputs scrambled; output must be (pack, handler, target)-sorted.
         let p = Profile {
             filename: "p".into(),
             shell: "".into(),
@@ -1043,7 +1030,6 @@ warning: deprecated\n\
 
     #[test]
     fn parse_errors_log_skips_malformed_headers() {
-        // A header missing the exit status, and one with non-integer exit.
         let content = "@@\t/p/a.sh\n\
 some line\n\
 @@\t/p/b.sh\tnotanint\n\
@@ -1066,7 +1052,6 @@ real error\n\
     #[test]
     fn read_recent_loads_sibling_errors_log_when_present() {
         let env = TempEnvironment::builder().build();
-        // A profile with one source entry...
         write_profile(
             &env,
             "profile-1000-1-1.tsv",
@@ -1075,7 +1060,6 @@ real error\n\
 source\tvim\tshell\t/p/aliases.sh\t1.0\t1.001\t1\n\
 # end_t\t1.002\n",
         );
-        // ...and a sibling errors log containing one record.
         let dir = env.paths.probes_shell_init_dir();
         env.fs
             .write_file(

--- a/crates/dodot-lib/src/prompts/mod.rs
+++ b/crates/dodot-lib/src/prompts/mod.rs
@@ -221,7 +221,6 @@ mod tests {
         let r = registry(&env);
         let dismissed = r.dismissed();
         assert_eq!(dismissed.len(), 2);
-        // BTreeMap ordering — keys are sorted.
         assert_eq!(dismissed[0].0, "a");
         assert_eq!(dismissed[1].0, "b");
     }

--- a/crates/dodot-lib/src/rules/pattern.rs
+++ b/crates/dodot-lib/src/rules/pattern.rs
@@ -41,8 +41,6 @@ pub(super) fn compile_rules(rules: &[Rule]) -> Vec<CompiledRule> {
             let raw_pattern = rule.pattern.clone();
             let case_insensitive = rule.case_insensitive;
 
-            // For case-insensitive rules, lowercase the pattern at
-            // compile time; the matcher lowercases the filename to mirror.
             let normalized = if case_insensitive {
                 raw_pattern.to_lowercase()
             } else {
@@ -50,14 +48,12 @@ pub(super) fn compile_rules(rules: &[Rule]) -> Vec<CompiledRule> {
             };
 
             let pattern = if normalized.ends_with('/') {
-                // Directory pattern
                 let dir_name = normalized.trim_end_matches('/').to_string();
                 CompiledPattern::Directory(dir_name)
             } else if normalized.contains('*')
                 || normalized.contains('?')
                 || normalized.contains('[')
             {
-                // Glob pattern
                 match glob::Pattern::new(&normalized) {
                     Ok(p) => CompiledPattern::Glob(p),
                     Err(_) => CompiledPattern::Exact(normalized),

--- a/crates/dodot-lib/src/rules/scanner/mod.rs
+++ b/crates/dodot-lib/src/rules/scanner/mod.rs
@@ -37,7 +37,6 @@ fn is_ignored(name: &str, patterns: &[String]) -> bool {
                 return true;
             }
         }
-        // Exact match fallback
         if name == pattern {
             return true;
         }
@@ -57,13 +56,7 @@ impl<'a> Scanner<'a> {
 
     /// Scan a pack directory and return all rule matches.
     ///
-    /// Walks the pack directory (non-recursively for top-level, but
-    /// directories matched by the directory pattern are included as
-    /// single entries). Skips hidden files (except `.config`), special
-    /// files (`.dodot.toml`, `.dodotignore`), and files matching
-    /// pack-level ignore patterns.
-    ///
-    /// This is a convenience wrapper over [`walk_pack`] + [`match_entries`].
+    /// A convenience wrapper over [`walk_pack`] + [`match_entries`].
     /// `mappings_gates` is the `[mappings.gates]` glob → label map; pass
     /// an empty `HashMap` if not used.
     pub fn scan_pack(
@@ -79,12 +72,11 @@ impl<'a> Scanner<'a> {
         self.match_entries(&entries, rules, &pack.name, gates, host, mappings_gates)
     }
 
-    /// Walk a pack directory and return raw file entries.
-    ///
-    /// Skips hidden files (except `.config`), special files
-    /// (`.dodot.toml`, `.dodotignore`), and files matching
-    /// pack-level ignore patterns.
     /// Walk the pack's top-level children only.
+    ///
+    /// Hidden entries (except `.config`), dodot's own files
+    /// (`.dodot.toml`, `.dodotignore`), and pack-level `ignore` patterns
+    /// are filtered out.
     ///
     /// Returns depth-1 entries (files and directories directly under
     /// the pack root). Nested files/dirs are **not** returned — handlers
@@ -250,7 +242,6 @@ impl<'a> Scanner<'a> {
                 // unstripped filename.
             }
 
-            // Gate evaluation: parse, look up label, evaluate.
             let (effective_filename, effective_rel_path) = match basename_gate {
                 BasenameGate::None => (filename.clone(), entry.relative_path.clone()),
                 BasenameGate::Found { label, stripped } => {
@@ -405,17 +396,14 @@ impl<'a> Scanner<'a> {
         for entry in entries {
             let name = &entry.name;
 
-            // Skip hidden files/dirs (except .config)
             if name.starts_with('.') && name != ".config" {
                 continue;
             }
 
-            // Skip special files
             if SPECIAL_FILES.contains(&name.as_str()) {
                 continue;
             }
 
-            // Skip ignored patterns
             if is_ignored(name, ignore_patterns) {
                 continue;
             }
@@ -434,7 +422,6 @@ impl<'a> Scanner<'a> {
                     is_dir: true,
                     gate_failure: None,
                 });
-                // Recurse into subdirectories
                 self.walk_dir(base, &entry.path, ignore_patterns, results)?;
             } else {
                 results.push(PackEntry {

--- a/crates/dodot-lib/src/rules/scanner/tests/dir_gates.rs
+++ b/crates/dodot-lib/src/rules/scanner/tests/dir_gates.rs
@@ -37,7 +37,6 @@ fn dir_gate_passing_descends_and_flattens() {
         .collect();
     assert!(names.contains(&"macos.sh".to_string()), "{names:?}");
     assert!(names.contains(&"shared".to_string()), "{names:?}");
-    // The gate dir itself must NOT surface as an entry.
     assert!(!names.iter().any(|n| n.starts_with("_darwin")), "{names:?}");
 }
 
@@ -58,7 +57,6 @@ fn dir_gate_failing_emits_gate_match() {
         .scan_pack(&pack, &default_rules(), &[], &gates, &host, &HashMap::new())
         .unwrap();
 
-    // Exactly two matches: the gate dir (failed) and `shared`.
     assert_eq!(matches.len(), 2, "{matches:?}");
 
     let gate_match = matches
@@ -157,8 +155,6 @@ fn dir_gate_nested_failing_inner_gate_drops_subtree() {
     let matches = scanner
         .scan_pack(&pack, &default_rules(), &[], &gates, &host, &HashMap::new())
         .unwrap();
-    // One gate match for the inner _x86_64 dir; install.sh does
-    // NOT surface.
     let gate = matches
         .iter()
         .find(|m| m.handler == crate::handlers::HANDLER_GATE);

--- a/crates/dodot-lib/src/rules/scanner/tests/gates.rs
+++ b/crates/dodot-lib/src/rules/scanner/tests/gates.rs
@@ -33,8 +33,7 @@ fn gate_passing_strips_suffix_and_routes_to_handler() {
     let m = &matches[0];
     assert_eq!(m.handler, "install");
     assert_eq!(m.relative_path.to_string_lossy(), "install.sh");
-    // absolute_path is the original on-disk file — install handler
-    // executes the actual `install._darwin.sh` script.
+    // The stripped path is logical; the handler still receives the on-disk path.
     assert!(m
         .absolute_path
         .to_string_lossy()
@@ -61,7 +60,6 @@ fn gate_failing_emits_gate_handler_match() {
     // Gated entries keep their original path (with the suffix) so
     // status can render the source name truthfully.
     assert_eq!(m.relative_path.to_string_lossy(), "install._linux.sh");
-    // Metadata for the status renderer.
     assert_eq!(m.options.get("gate_label"), Some(&"linux".to_string()));
     assert_eq!(
         m.options.get("gate_predicate"),
@@ -100,14 +98,12 @@ fn gate_compound_user_label_evaluates_and() {
     let scanner = Scanner::new(env.fs.as_ref());
     let pack = make_pack("p", env.dotfiles_root.join("p"));
 
-    // Build a table with `arm-mac` defined.
     let mut user = HashMap::new();
     let mut arm_mac = HashMap::new();
     arm_mac.insert("os".into(), "darwin".into());
     arm_mac.insert("arch".into(), "aarch64".into());
     user.insert("arm-mac".into(), arm_mac);
 
-    // Case 1: darwin + aarch64 → pass.
     let mut gates = GateTable::with_builtins();
     gates.merge_user(&user).unwrap();
     let host = HostFacts::for_tests("darwin", "aarch64");
@@ -137,7 +133,6 @@ fn gate_compound_user_label_evaluates_and() {
     assert_eq!(matches[0].handler, "shell");
     assert_eq!(matches[0].relative_path.to_string_lossy(), "setup.sh");
 
-    // Case 2: darwin + x86_64 → fail (arch mismatch).
     let host_intel = HostFacts::for_tests("darwin", "x86_64");
     let matches = scanner
         .match_entries(
@@ -173,7 +168,6 @@ fn gate_composes_with_template_extension() {
         .unwrap();
     assert_eq!(matches.len(), 1);
     let m = &matches[0];
-    // .tmpl is preserved → preprocessor will pick it up.
     assert_eq!(m.relative_path.to_string_lossy(), "aliases.sh.tmpl");
     // Falls through to the catchall (symlink) since `aliases.sh.tmpl`
     // isn't in `mappings.shell`. In the real pipeline this match
@@ -230,23 +224,19 @@ fn gate_mixed_files_in_one_pack() {
             acc
         });
 
-    // install._darwin.sh stripped to install.sh → install handler.
     assert_eq!(
         by_handler.get("install"),
         Some(&vec!["install.sh".to_string()])
     );
-    // install._linux.sh kept as-is → gate handler.
     assert_eq!(
         by_handler.get(crate::handlers::HANDLER_GATE),
         Some(&vec!["install._linux.sh".to_string()])
     );
-    // vimrc → catchall symlink.
     assert_eq!(by_handler.get("symlink"), Some(&vec!["vimrc".to_string()]));
 }
 
 #[test]
 fn gate_brewfile_extensionless() {
-    // Brewfile._darwin → strips to Brewfile, matches homebrew handler.
     let env = TempEnvironment::builder()
         .pack("brew")
         .file("Brewfile._darwin", "brew \"ripgrep\"")

--- a/crates/dodot-lib/src/rules/scanner/tests/mod.rs
+++ b/crates/dodot-lib/src/rules/scanner/tests/mod.rs
@@ -1,9 +1,4 @@
-//! Scanner tests.
-//!
-//! Shared fixtures (`make_pack`, `test_gates`, `host_pair`,
-//! `default_rules`) and the scanner integration tests live here.
-//! Gate-specific suites are sibling files: filename gates, directory
-//! gates (C2), and `[mappings.gates]` glob gates (C4).
+//! Scanner tests and shared fixtures.
 
 #![allow(unused_imports)]
 
@@ -173,7 +168,6 @@ fn scan_pack_skips_special_files() {
         .done()
         .build();
 
-    // Also manually create .dodotignore (even though it shouldn't be scanned)
     let pack_dir = env.dotfiles_root.join("test");
     env.fs
         .write_file(&pack_dir.join(".dodotignore"), b"")
@@ -295,7 +289,6 @@ fn scan_pack_priority_ordering() {
     let scanner = Scanner::new(env.fs.as_ref());
     let pack = make_pack("test", env.dotfiles_root.join("test"));
 
-    // Both *.sh and aliases.sh match — higher priority should win
     let rules = vec![
         Rule {
             pattern: "*.sh".into(),
@@ -685,15 +678,12 @@ fn shell_glob_does_not_recurse_into_subdirectories() {
         .scan_pack(&pack, &rules, &[], &gates, &host, &HashMap::new())
         .unwrap();
 
-    // No nested entry should surface — the scanner is depth-1.
     assert!(
         !matches
             .iter()
             .any(|m| m.relative_path.to_string_lossy().contains('/')),
         "no nested matches expected: {matches:?}"
     );
-    // No shell-handler match should exist at all — the `scripts/`
-    // dir is matched as a dir and falls to the symlink catchall.
     assert!(
         !matches.iter().any(|m| m.handler == "shell"),
         "nested scripts must not route to shell: {matches:?}"

--- a/crates/dodot-lib/src/rules/types.rs
+++ b/crates/dodot-lib/src/rules/types.rs
@@ -43,9 +43,7 @@ fn is_false(b: &bool) -> bool {
 pub struct PackEntry {
     /// Path relative to the pack root (e.g. `"vimrc"`, `"nvim/init.lua"`).
     pub relative_path: PathBuf,
-    /// Absolute path to the file.
     pub absolute_path: PathBuf,
-    /// Whether this entry is a directory.
     pub is_dir: bool,
     /// When `Some`, this entry was gated out by a directory-segment
     /// gate (`_<label>/`) whose predicate evaluated false on this host.
@@ -71,16 +69,13 @@ pub struct RuleMatch {
     /// Path relative to the pack root (e.g. `"vimrc"`, `"nvim/init.lua"`).
     pub relative_path: PathBuf,
 
-    /// Absolute path to the file.
     pub absolute_path: PathBuf,
 
-    /// Name of the pack this file belongs to.
     pub pack: String,
 
     /// Name of the handler that should process this file.
     pub handler: String,
 
-    /// Whether this entry is a directory.
     pub is_dir: bool,
 
     /// Handler-specific options from the matched rule.

--- a/crates/dodot-lib/src/secret/bw.rs
+++ b/crates/dodot-lib/src/secret/bw.rs
@@ -8,11 +8,10 @@
 //! - `bw:gh-token#username` → resolves a different first-class field
 //!   (`username`, `password`, `notes`, `totp`, `uri`).
 //!
-//! Custom (user-defined) fields are out of scope for Phase S2; they
-//! require parsing the item JSON and walking the `fields` array, and
-//! the design intentionally keeps the Phase S2 surface narrow. A
-//! later phase can add `bw:<item>#field.<custom>` without breaking
-//! anything here.
+//! Custom (user-defined) fields are not supported: they'd require
+//! parsing the item JSON and walking the `fields` array. A
+//! `bw:<item>#field.<custom>` shape can be layered on later without
+//! breaking anything here.
 //!
 //! Resolution: `bw get <field> <item>` → emits the value on stdout,
 //! exit 0 on success, non-zero with diagnostic text on stderr for
@@ -37,9 +36,7 @@ use crate::{DodotError, Result};
 /// Listed in the same order as the `bw get --help` output.
 const FIRST_CLASS_FIELDS: &[&str] = &["password", "username", "notes", "totp", "uri"];
 
-/// Default field when the reference omits `#field`. Bitwarden items
-/// are predominantly used for credentials, so `password` is the
-/// principled default.
+/// Default field when the reference omits `#field`.
 const DEFAULT_FIELD: &str = "password";
 
 /// `SecretProvider` impl for the Bitwarden CLI (`bw`).
@@ -53,10 +50,9 @@ impl BwProvider {
     }
 
     /// Construct from the process environment. No env vars are read
-    /// at construction (auth comes from `BW_SESSION` which the bw
+    /// at construction (auth comes from `BW_SESSION`, which the bw
     /// binary reads itself); the function exists for symmetry with
-    /// `OpProvider::from_env` and to keep the call-site shape
-    /// uniform across providers.
+    /// `OpProvider::from_env`.
     pub fn from_env(runner: Arc<dyn CommandRunner>) -> Self {
         Self::new(runner)
     }
@@ -103,8 +99,8 @@ impl SecretProvider for BwProvider {
     }
 
     fn probe(&self) -> ProbeResult {
-        // Step 1: binary on PATH? `bw --version` doesn't hit the
-        // network and doesn't unlock anything.
+        // `bw --version` doesn't hit the network and doesn't unlock
+        // anything.
         match self.runner.run("bw", &["--version".into()]) {
             Ok(out) if out.exit_code == 0 => {}
             Ok(_) => {
@@ -124,11 +120,11 @@ impl SecretProvider for BwProvider {
             }
         }
 
-        // Step 2: vault state. `bw status` emits a JSON document
-        // with a `status` field of `unauthenticated` / `locked` /
-        // `unlocked`. We pattern-match on the substring rather than
-        // pulling in a JSON parser for this single field — the
-        // status enum is tiny and stable across bw versions.
+        // `bw status` emits a JSON document with a `status` field of
+        // `unauthenticated` / `locked` / `unlocked`. We pattern-match
+        // on the substring rather than pulling in a JSON parser for
+        // this single field — the status enum is tiny and stable
+        // across bw versions.
         match self.runner.run("bw", &["status".into()]) {
             Ok(out) if out.exit_code == 0 => {
                 let s = out.stdout.as_str();

--- a/crates/dodot-lib/src/secret/error_render.rs
+++ b/crates/dodot-lib/src/secret/error_render.rs
@@ -166,9 +166,7 @@ mod tests {
         )));
         let err = preflight(&reg).unwrap_err().to_string();
         assert!(err.contains("1 secret provider(s) need attention"));
-        // The Ok one isn't mentioned — silence is success.
         assert!(!err.contains("`pass`"));
-        // The failing one is.
         assert!(err.contains("`op` is not authenticated"));
         assert!(err.contains("OP_SERVICE_ACCOUNT_TOKEN"));
     }

--- a/crates/dodot-lib/src/secret/error_render.rs
+++ b/crates/dodot-lib/src/secret/error_render.rs
@@ -14,18 +14,8 @@ use crate::DodotError;
 /// facing message. `Ok` produces an empty string — callers gate on
 /// emptiness to decide whether to surface the line at all.
 ///
-/// The shapes match `secrets.lex` §5.4:
-///
-/// - **NotInstalled**: tells the user the CLI is missing and provides
-///   the provider-supplied install hint plus the disable-in-config
-///   escape hatch.
-/// - **NotAuthenticated**: tells the user auth is missing and provides
-///   the provider-supplied signin / env-var hint.
-/// - **Misconfigured**: surfaces the provider's specific
-///   configuration problem verbatim (e.g. "password store not
-///   initialised at /home/x/.password-store").
-/// - **ProbeFailed**: surfaces the diagnostic verbatim — these are
-///   the cases where probe() couldn't reach a clean conclusion.
+/// The message shapes match `secrets.lex` §5.4; provider-supplied
+/// hints are surfaced verbatim.
 pub fn render_probe_outcome(scheme: &str, outcome: &ProbeResult) -> String {
     let config_key = crate::secret::registry::scheme_to_config_key(scheme);
     match outcome {

--- a/crates/dodot-lib/src/secret/keychain.rs
+++ b/crates/dodot-lib/src/secret/keychain.rs
@@ -94,9 +94,9 @@ impl SecretProvider for KeychainProvider {
     }
 
     fn probe(&self) -> ProbeResult {
-        // Step 1: binary on PATH? On macOS `/usr/bin/security`
-        // is part of the base system, so a missing binary is
-        // almost always "this is a non-macOS host".
+        // On macOS `/usr/bin/security` is part of the base system,
+        // so a missing binary is almost always "this is a non-macOS
+        // host".
         match self.runner.run("security", &["-h".into()]) {
             Ok(_) => {}
             Err(_) => {
@@ -112,12 +112,11 @@ impl SecretProvider for KeychainProvider {
                 };
             }
         }
-        // Step 2: keychain accessibility. We don't have a known
-        // item to look up at probe time, so we use a lightweight
-        // sanity check: `security default-keychain` returns the
-        // user's default keychain path on success and a
-        // diagnostic on failure. Doesn't unlock anything, doesn't
-        // require any pre-existing items.
+        // Keychain accessibility. We don't have a known item to look
+        // up at probe time, so we use a lightweight sanity check:
+        // `security default-keychain` returns the user's default
+        // keychain path on success and a diagnostic on failure.
+        // Doesn't unlock anything, doesn't require pre-existing items.
         match self.runner.run("security", &["default-keychain".into()]) {
             Ok(out) if out.exit_code == 0 => ProbeResult::Ok,
             Ok(_) => ProbeResult::ProbeFailed {

--- a/crates/dodot-lib/src/secret/op.rs
+++ b/crates/dodot-lib/src/secret/op.rs
@@ -80,8 +80,8 @@ impl SecretProvider for OpProvider {
     }
 
     fn probe(&self) -> ProbeResult {
-        // Step 1: binary on PATH? `op --version` is fast and
-        // doesn't hit the network or unlock anything.
+        // `op --version` is fast and doesn't hit the network or
+        // unlock anything.
         match self.runner.run("op", &["--version".into()]) {
             Ok(out) if out.exit_code == 0 => {}
             Ok(_) => {
@@ -101,13 +101,12 @@ impl SecretProvider for OpProvider {
             }
         }
 
-        // Step 2: auth state. We require the non-interactive path
-        // (`OP_SERVICE_ACCOUNT_TOKEN`) because resolve()-time
-        // blocking on a desktop-app modal is exactly the
-        // auth-fatigue failure mode §7.4 was written to avoid.
-        // If the user prefers desktop-app integration on their
-        // workstation, they should still set the env var for dodot
-        // runs — the spec is unambiguous about that.
+        // We require the non-interactive path
+        // (`OP_SERVICE_ACCOUNT_TOKEN`) because resolve()-time blocking
+        // on a desktop-app modal is exactly the auth-fatigue failure
+        // mode §7.4 was written to avoid. Users who prefer desktop-app
+        // integration on their workstation still have to set the env
+        // var for dodot runs.
         if !self.has_service_token {
             return ProbeResult::NotAuthenticated {
                 hint: "set OP_SERVICE_ACCOUNT_TOKEN \
@@ -117,10 +116,9 @@ impl SecretProvider for OpProvider {
             };
         }
 
-        // Step 3: light service-account validity check. `op whoami`
-        // returns 0 when the token can authenticate, non-zero
-        // otherwise. Cheap, no vault reads, no items returned —
-        // safe to run on every probe.
+        // Service-account validity check. `op whoami` returns 0 when
+        // the token can authenticate, non-zero otherwise. Cheap, no
+        // vault reads, no items returned — safe to run on every probe.
         match self.runner.run("op", &["whoami".into()]) {
             Ok(out) if out.exit_code == 0 => ProbeResult::Ok,
             Ok(_) => ProbeResult::NotAuthenticated {
@@ -138,7 +136,6 @@ impl SecretProvider for OpProvider {
 
     fn resolve(&self, reference: &str) -> Result<SecretString> {
         Self::validate_reference(reference)?;
-        // Reconstruct the full URI form the CLI expects (op://...).
         let full = format!("op:{reference}");
         let out = self.runner.run("op", &["read".into(), full.clone()])?;
         if out.exit_code != 0 {
@@ -168,10 +165,8 @@ impl SecretProvider for OpProvider {
             return Err(DodotError::Other(err_msg));
         }
         // op read emits the value with a trailing newline. Strip
-        // exactly one trailing `\n` so values that legitimately end
-        // in `\n\n` keep one of them; in practice secret values
-        // shouldn't have either, but the principled move is to
-        // trim the CLI's added newline rather than `trim_end_matches`.
+        // exactly one trailing `\n` rather than `trim_end_matches`,
+        // so a value that legitimately ends in `\n\n` keeps one.
         let mut value = out.stdout;
         if value.ends_with('\n') {
             value.pop();

--- a/crates/dodot-lib/src/secret/pass.rs
+++ b/crates/dodot-lib/src/secret/pass.rs
@@ -96,8 +96,7 @@ impl SecretProvider for PassProvider {
 
     fn probe(&self) -> ProbeResult {
         // Cheap binary-on-PATH check: `pass version` returns 0 with
-        // a banner. `pass --help` would also work; `version` is the
-        // canonical "I'm here" probe across most tool conventions.
+        // a banner.
         match self.runner.run("pass", &["version".into()]) {
             Ok(out) if out.exit_code == 0 => {}
             Ok(_) => {
@@ -138,10 +137,10 @@ impl SecretProvider for PassProvider {
             .runner
             .run("pass", &["show".into(), reference.into()])?;
         if out.exit_code != 0 {
-            // Map the most common "entry not found" pattern to a
-            // sharper error. `pass show missing/path` exits 1 and
-            // prints `Error: missing/path is not in the password
-            // store.` to stderr. Detect by exit + a stable phrase.
+            // `pass show missing/path` exits 1 and prints `Error:
+            // missing/path is not in the password store.` to stderr.
+            // That phrase is stable, so match on it to produce a
+            // sharper error than the raw CLI text.
             let stderr = out.stderr.trim();
             let err_msg = if stderr.contains("not in the password store") {
                 format!(
@@ -162,10 +161,8 @@ impl SecretProvider for PassProvider {
             };
             return Err(DodotError::Other(err_msg));
         }
-        // pass show emits: <password>\n[optional metadata lines]\n
-        // The first line is the password. Strip trailing `\n` only;
-        // a multi-line value (subsequent lines) is metadata, not
-        // password content.
+        // `pass show` emits `<password>\n[optional metadata lines]`;
+        // only the first line is the password.
         let first_line = out.stdout.split('\n').next().unwrap_or("");
         Ok(SecretString::new(first_line.to_string()))
     }

--- a/crates/dodot-lib/src/secret/registry.rs
+++ b/crates/dodot-lib/src/secret/registry.rs
@@ -132,6 +132,9 @@ impl SecretRegistry {
     ///
     /// Cloning the returned `Arc` is a cheap pointer bump; the inner
     /// buffer is dropped (and zeroized) when the last holder is gone.
+    /// Callers go through [`crate::secret::SecretString::expose`] at the
+    /// substitution boundary — never an unsealed `String` copy in the
+    /// cache itself.
     ///
     /// Splitting cache access from resolution lets the caller
     /// validate values (multi-line refusal, UTF-8) with rich error

--- a/crates/dodot-lib/src/secret/registry.rs
+++ b/crates/dodot-lib/src/secret/registry.rs
@@ -130,12 +130,8 @@ impl SecretRegistry {
     /// [`Self::resolve`] and then [`Self::cache_put`] to populate
     /// the cache for future calls.
     ///
-    /// Returns `Arc<SecretString>` so the cached bytes stay zeroize-
-    /// on-drop — callers go through `SecretString::expose` at the
-    /// substitution boundary, never an unsealed `String` copy in
-    /// the cache itself. Cloning the Arc is a cheap pointer bump;
-    /// the inner buffer is dropped (and zeroized) when the last
-    /// holder is gone.
+    /// Cloning the returned `Arc` is a cheap pointer bump; the inner
+    /// buffer is dropped (and zeroized) when the last holder is gone.
     ///
     /// Splitting cache access from resolution lets the caller
     /// validate values (multi-line refusal, UTF-8) with rich error

--- a/crates/dodot-lib/src/secret/registry.rs
+++ b/crates/dodot-lib/src/secret/registry.rs
@@ -318,7 +318,6 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("missing a scheme prefix"));
         assert!(msg.contains("`<scheme>:<provider-specific-reference>`"));
-        // Examples in the message help the user reach for the right shape.
         assert!(msg.contains("op://"));
         assert!(msg.contains("pass:"));
     }
@@ -357,7 +356,6 @@ mod tests {
         let err = reg.resolve("sops:foo.yaml#x").unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("no secret provider registered for scheme `sops`"));
-        // Configured schemes appear sorted so the message is stable.
         assert!(msg.contains("op, pass"));
     }
 
@@ -365,7 +363,6 @@ mod tests {
     fn registry_register_replaces_same_scheme() {
         let mut reg = SecretRegistry::new();
         reg.register(Arc::new(MockSecretProvider::new("pass").with("k", "first")));
-        // Replace with a fresh provider for the same scheme.
         reg.register(Arc::new(
             MockSecretProvider::new("pass").with("k", "second"),
         ));

--- a/crates/dodot-lib/src/secret/secret_string.rs
+++ b/crates/dodot-lib/src/secret/secret_string.rs
@@ -185,4 +185,6 @@ mod tests {
         let s2 = SecretString::new("next-value".into());
         assert_eq!(s2.expose().unwrap(), "next-value");
     }
+
+    // The non-`Clone` contract is documented at the module boundary.
 }

--- a/crates/dodot-lib/src/secret/secret_string.rs
+++ b/crates/dodot-lib/src/secret/secret_string.rs
@@ -39,9 +39,10 @@ use zeroize::Zeroize;
 /// A resolved secret value, held briefly in process memory.
 ///
 /// Construct via [`SecretString::new`]; read via [`SecretString::expose`].
-/// Zeroes its buffer on drop. `Debug` prints `<redacted>`; `Display` and
-/// `Serialize` are not implemented at all. See the module docs for what
-/// this wrapper does and does not protect against.
+/// Zeroes its buffer on drop. `Debug` prints
+/// `SecretString(<redacted>, len=N)`; `Display` and `Serialize` are not
+/// implemented at all. See the module docs for what this wrapper does
+/// and does not protect against.
 pub struct SecretString {
     inner: Vec<u8>,
 }

--- a/crates/dodot-lib/src/secret/secret_string.rs
+++ b/crates/dodot-lib/src/secret/secret_string.rs
@@ -12,10 +12,10 @@
 //!   can't elide. Reduces the window where a stale-but-still-resident
 //!   buffer could be read by another process with sufficient
 //!   privilege.
-//! - **No `Debug` / `Display`.** The type is opaque to the standard
-//!   formatting machinery. A `tracing::error!("{e:?}", e=...)` that
-//!   accidentally captures a `SecretString` won't print the bytes; it
-//!   prints `SecretString(<redacted>)`.
+//! - **Redacted `Debug`, no `Display`.** A
+//!   `tracing::error!("{e:?}", e=...)` that accidentally captures a
+//!   `SecretString` won't print the bytes; it prints
+//!   `SecretString(<redacted>, len=N)`.
 //! - **No `Serialize`.** Same idea, for the JSON / TOML paths.
 //! - **No `Clone`.** Discourages duplicating the value into multiple
 //!   buffers; callers that genuinely need a copy can call

--- a/crates/dodot-lib/src/secret/secret_string.rs
+++ b/crates/dodot-lib/src/secret/secret_string.rs
@@ -39,9 +39,9 @@ use zeroize::Zeroize;
 /// A resolved secret value, held briefly in process memory.
 ///
 /// Construct via [`SecretString::new`]; read via [`SecretString::expose`].
-/// Zeroes its buffer on drop. Has no `Debug` / `Display` / `Serialize`
-/// implementations; printing one through any of those paths produces
-/// `<redacted>`.
+/// Zeroes its buffer on drop. `Debug` prints `<redacted>`; `Display` and
+/// `Serialize` are not implemented at all. See the module docs for what
+/// this wrapper does and does not protect against.
 pub struct SecretString {
     inner: Vec<u8>,
 }

--- a/crates/dodot-lib/src/secret/secret_string.rs
+++ b/crates/dodot-lib/src/secret/secret_string.rs
@@ -186,5 +186,6 @@ mod tests {
         assert_eq!(s2.expose().unwrap(), "next-value");
     }
 
-    // The non-`Clone` contract is documented at the module boundary.
+    // Absence of `Clone` is a compile-time API property; this runtime test
+    // module cannot assert it without a compile-fail harness.
 }

--- a/crates/dodot-lib/src/secret/secret_string.rs
+++ b/crates/dodot-lib/src/secret/secret_string.rs
@@ -185,13 +185,4 @@ mod tests {
         let s2 = SecretString::new("next-value".into());
         assert_eq!(s2.expose().unwrap(), "next-value");
     }
-
-    // Compile-time check: SecretString does NOT implement Clone.
-    // (If a future change accidentally derives Clone, the line below
-    // would compile and this test would silently pass. Instead, the
-    // negative assertion lives as a doc-comment; rust-analyzer / human
-    // review catches re-introduced Clone derivations.)
-    //
-    //   let s = SecretString::new("x".into());
-    //   let _ = s.clone();   // <-- must fail to compile
 }

--- a/crates/dodot-lib/src/secret/secret_tool.rs
+++ b/crates/dodot-lib/src/secret/secret_tool.rs
@@ -30,14 +30,12 @@
 //! `apt install libsecret-tools` / `dnf install libsecret`
 //! pointer.
 //!
-//! Why we don't expose generic attribute pairs in the reference
-//! syntax (e.g. `secret-tool:k1=v1,k2=v2`): the most common
-//! libsecret schema is the GNOME default with `service` and
-//! `account` attributes. Power users with custom schemas can
-//! still adopt secrets storage, but they lose the per-reference
-//! attribute flexibility — accept the simplification for now;
-//! a future extension can layer attribute pairs on top without
-//! breaking the existing shape.
+//! Why the reference syntax doesn't expose generic attribute pairs
+//! (e.g. `secret-tool:k1=v1,k2=v2`): the most common libsecret
+//! schema is the GNOME default with `service` and `account`
+//! attributes. Power users with custom schemas lose per-reference
+//! attribute flexibility; attribute pairs can be layered on later
+//! without breaking the existing shape.
 //!
 //! See `secrets.lex` §5.2 / §5.4 (provider table + error UX) and
 //! §S4 (OS-level providers).
@@ -103,8 +101,8 @@ impl SecretProvider for SecretToolProvider {
     }
 
     fn probe(&self) -> ProbeResult {
-        // Step 1: binary on PATH. `secret-tool --version` is
-        // cheap and doesn't touch the daemon.
+        // `secret-tool --version` is cheap and doesn't touch the
+        // daemon.
         match self.runner.run("secret-tool", &["--version".into()]) {
             Ok(out) if out.exit_code == 0 => {}
             Ok(_) => {

--- a/crates/dodot-lib/src/secret/sops.rs
+++ b/crates/dodot-lib/src/secret/sops.rs
@@ -10,8 +10,8 @@
 //!
 //! The dot-separated key path is translated to SOPS's bracketed
 //! `--extract` syntax (`["database"]["password"]`). Array indexing
-//! (`[0]`) is not supported in this phase; nested map keys cover
-//! the dotfile use case fully.
+//! (`[0]`) is not supported; nested map keys cover the dotfile use
+//! case fully.
 //!
 //! Auth: SOPS picks up its identity from the in-tree `.sops.yaml` +
 //! whichever key source it's configured to use (age, gpg, cloud
@@ -54,14 +54,12 @@ impl SopsProvider {
     /// would otherwise produce an empty bracket pair, which SOPS
     /// rejects with an opaque error).
     ///
-    /// Each segment is escaped before being wrapped in quotes:
-    /// `\` → `\\`, `"` → `\"`. SOPS's `--extract` uses a
-    /// JSON-string-like syntax for each bracket key, so segments
-    /// containing literal quotes or backslashes (legal YAML/JSON
-    /// keys) need the same escaping the language requires.
-    /// Without this, a key like `db."backup"` would land as
-    /// `["db.\"backup\""]` invalidly closed and SOPS would reject
-    /// the call with an opaque parse error.
+    /// SOPS's `--extract` uses a JSON-string-like syntax for each
+    /// bracket key, so each segment is escaped before being wrapped
+    /// in quotes: `\` → `\\`, `"` → `\"`. Without this, a key
+    /// containing a literal quote (legal in YAML/JSON) produces an
+    /// unbalanced bracket expression and SOPS rejects the call with
+    /// an opaque parse error.
     ///
     /// `dot_path` is the original user-facing path returned
     /// alongside `extract` so error messages can reference what
@@ -135,14 +133,10 @@ impl SecretProvider for SopsProvider {
                     .into(),
             },
         }
-        // Note: we deliberately don't try to probe the key state
-        // (age key, gpg-agent, KMS creds). SOPS auth depends on the
-        // in-tree `.sops.yaml` + whichever key backend it's configured
-        // for, and a meaningful auth probe would require an actual
-        // decrypt of a known file — which we don't have. Decryption
-        // failures surface at resolve time with the SOPS error text
-        // passed through verbatim, which is more diagnostic than any
-        // probe message we could synthesize.
+        // Key state (age key, gpg-agent, KMS creds) is deliberately
+        // not probed — a meaningful auth probe would require an
+        // actual decrypt of a known file, which we don't have. See
+        // the module docs.
     }
 
     fn resolve(&self, reference: &str) -> Result<SecretString> {

--- a/crates/dodot-lib/src/secret/sops.rs
+++ b/crates/dodot-lib/src/secret/sops.rs
@@ -533,7 +533,6 @@ mod tests {
         ));
         let p = SopsProvider::new(runner, root());
         let v = p.resolve("s.yaml#k").unwrap();
-        // Two newlines in stdout → one stays in resolved value.
         assert_eq!(v.expose().unwrap(), "multi-line-value\n");
     }
 }

--- a/crates/dodot-lib/src/secret/test_support.rs
+++ b/crates/dodot-lib/src/secret/test_support.rs
@@ -1,23 +1,11 @@
-//! Test doubles for the secrets layer — `MockSecretProvider` and
-//! `PanickingProvider`.
+//! Test doubles for the secrets layer.
 //!
-//! `MockSecretProvider` is the workhorse: tier-0 unit tests register
-//! it with a canned `reference -> value` map, then exercise everything
-//! above the trait (the registry, the `secret()` MiniJinja function,
-//! the AST pre-walk, the sidecar) without spawning a single
-//! subprocess.
+//! `MockSecretProvider` supplies canned values without spawning a subprocess.
 //!
-//! `PanickingProvider` is the §7.4 contract pin: a provider whose
-//! `resolve()` calls `panic!()`. Tests that exercise Passive-mode
-//! flows (`dodot status`, `dodot up --dry-run`) register it; if the
-//! flow accidentally invokes a provider, the panic surfaces and the
-//! test fails loudly. Same shape as the
-//! `up_dry_run_does_not_write_to_datastore` pattern from Wave 4.
+//! `PanickingProvider` proves that Passive-mode flows do not resolve secrets.
 //!
 //! See `secrets-testing.lex` §6.1 / §6.2 for the doc on each.
 //!
-//! Available under `#[cfg(test)]` only — these are not for production
-//! use and should not appear in the public API surface.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -27,29 +15,20 @@ use crate::secret::provider::{ProbeResult, SecretProvider};
 use crate::secret::secret_string::SecretString;
 use crate::{DodotError, Result};
 
-/// In-memory `SecretProvider` for tier-0 unit tests.
-///
-/// Constructed with a scheme name; populated via [`MockSecretProvider::with`]
-/// (chainable). Tracks `resolve()` invocation count so batching /
-/// caching tests can assert the provider was hit the right number of
-/// times.
+/// In-memory `SecretProvider` with canned values and call tracking.
 pub struct MockSecretProvider {
     scheme: String,
     /// Maps `reference -> value`. The `reference` here is what the
     /// registry passes through to `resolve()` (i.e. post-scheme
     /// suffix) — for `op://V/I/F` that's `//V/I/F`.
     values: HashMap<String, String>,
-    /// `probe()` return value. Defaults to `Ok`. Tests that exercise
-    /// the error UX path use [`MockSecretProvider::with_probe`].
+    /// `probe()` return value. Defaults to `Ok`.
     probe_result: Mutex<ProbeResult>,
-    /// Number of times `resolve()` has been called.
     resolve_calls: AtomicUsize,
 }
 
 impl MockSecretProvider {
-    /// New mock provider for the given scheme. By default, every
-    /// reference resolves to `Err("not found")` and `probe()` returns
-    /// `Ok`. Add canned values via [`Self::with`].
+    /// By default, references resolve to `Err("not found")` and probing succeeds.
     pub fn new(scheme: impl Into<String>) -> Self {
         Self {
             scheme: scheme.into(),
@@ -59,21 +38,16 @@ impl MockSecretProvider {
         }
     }
 
-    /// Add a canned `reference -> value` mapping. Chainable.
     pub fn with(mut self, reference: impl Into<String>, value: impl Into<String>) -> Self {
         self.values.insert(reference.into(), value.into());
         self
     }
 
-    /// Override the `probe()` return value. Used by tests that
-    /// exercise the error UX (NotInstalled, NotAuthenticated, etc.).
     pub fn with_probe(self, result: ProbeResult) -> Self {
         *self.probe_result.lock().unwrap() = result;
         self
     }
 
-    /// How many times `resolve()` has been called on this instance.
-    /// Used by batching / caching tests.
     pub fn resolve_call_count(&self) -> usize {
         self.resolve_calls.load(Ordering::SeqCst)
     }

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -1,9 +1,8 @@
 //! Shell integration — generates `dodot-init.sh`.
 //!
-//! Unlike the Go implementation which ships a ~400-line shell script
-//! that re-discovers the datastore layout at runtime, we generate a
-//! flat, declarative script from the actual datastore state. This
-//! means:
+//! The script is generated flat and declarative from the actual
+//! datastore state, rather than re-discovering the datastore layout at
+//! runtime in shell. This means:
 //!
 //! - Zero logic duplication between Rust and shell
 //! - The script is just `source` and `PATH=` lines — trivially fast
@@ -16,9 +15,6 @@
 //! [ -f ~/.local/share/dodot/shell/dodot-init.sh ] && . ~/.local/share/dodot/shell/dodot-init.sh
 //! ```
 //!
-//! In the future, this can also be exposed as `dodot init-sh` or
-//! a minimal standalone binary for even faster shell startup.
-//!
 //! # Profiling wrapper (Phase 2 of profiling.lex)
 //!
 //! When the caller passes `profiling_enabled = true`, the generator
@@ -29,7 +25,7 @@
 //! without the variable fall through to the unchanged source/PATH
 //! path with a single `[ "$_dodot_prof" = "1" ]` test of overhead.
 //! When `profiling_enabled = false`, the generated script is
-//! byte-identical to the pre-Phase-2 form.
+//! byte-identical to the unwrapped form.
 //!
 //! Sources are *not* wrapped in a shell function: in zsh, `source`
 //! inside a function changes scoping for plain variable assignments
@@ -81,7 +77,6 @@ pub fn generate_init_script(
     writeln!(script, "# Regenerated on every `dodot up` / `dodot down`.").unwrap();
     writeln!(script).unwrap();
 
-    // Discover all packs with state
     let packs_dir = paths.data_dir().join("packs");
     if !fs.exists(&packs_dir) {
         append_empty_notice(&mut script);
@@ -115,7 +110,6 @@ pub fn generate_init_script(
                     if !entry.is_symlink {
                         continue;
                     }
-                    // Follow the symlink to get the actual file path
                     let target = fs.readlink(&entry.path)?;
                     shell_sources.push((pack_display.clone(), target));
                 }
@@ -137,7 +131,6 @@ pub fn generate_init_script(
         }
     }
 
-    // If nothing is deployed, add an explanatory comment
     if path_additions.is_empty() && shell_sources.is_empty() {
         append_empty_notice(&mut script);
         return Ok(script);
@@ -153,7 +146,6 @@ pub fn generate_init_script(
         );
     }
 
-    // Emit PATH additions
     if !path_additions.is_empty() {
         writeln!(script, "# PATH additions").unwrap();
         for (pack, target) in &path_additions {
@@ -167,7 +159,6 @@ pub fn generate_init_script(
         writeln!(script).unwrap();
     }
 
-    // Emit shell sources
     if !shell_sources.is_empty() {
         writeln!(script, "# Shell scripts").unwrap();
         for (pack, target) in &shell_sources {
@@ -192,7 +183,6 @@ pub fn generate_init_script(
         writeln!(script).unwrap();
     }
 
-    // Profiling epilogue (close the report, scrub our state).
     if profiling_active {
         emit_profiling_epilogue(&mut script);
     }

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -466,7 +466,6 @@ mod tests {
         assert!(script.contains("No shell scripts or PATH additions"));
         assert!(script.contains("dodot up"));
         assert!(script.contains("dodot status"));
-        // No source or PATH lines
         assert!(!script.contains("export PATH"));
         assert!(!script.contains(". \""));
     }
@@ -534,24 +533,19 @@ mod tests {
 
         let ds = make_datastore(&env);
 
-        // Shell scripts
         ds.create_data_link("git", "shell", &env.dotfiles_root.join("git/aliases.sh"))
             .unwrap();
         ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
             .unwrap();
 
-        // Path
         ds.create_data_link("vim", "path", &env.dotfiles_root.join("vim/bin"))
             .unwrap();
 
         let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
 
-        // Should have both shell sources
         assert!(script.contains("# [git]"), "script:\n{script}");
         assert!(script.contains("# [vim]"), "script:\n{script}");
-        // Should have PATH addition
         assert!(script.contains("export PATH="), "script:\n{script}");
-        // Should have source lines
         let source_count = script.matches(". \"").count();
         assert_eq!(
             source_count, 2,
@@ -580,7 +574,6 @@ mod tests {
         assert!(content.starts_with("#!/bin/sh"));
         assert!(content.contains("aliases.sh"));
 
-        // Check executable permission
         let meta = std::fs::metadata(&script_path).unwrap();
         use std::os::unix::fs::PermissionsExt;
         assert_eq!(meta.permissions().mode() & 0o111, 0o111);
@@ -596,18 +589,15 @@ mod tests {
 
         let ds = make_datastore(&env);
 
-        // Initially empty
         let script1 = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
         assert!(!script1.contains("aliases.sh"));
 
-        // Deploy shell script
         ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
             .unwrap();
 
         let script2 = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
         assert!(script2.contains("aliases.sh"));
 
-        // Remove state
         ds.remove_state("vim", "shell").unwrap();
 
         let script3 = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), false).unwrap();
@@ -618,7 +608,6 @@ mod tests {
     fn ignores_non_symlink_files_in_handler_dirs() {
         let env = TempEnvironment::builder().build();
 
-        // Create a non-symlink file in the shell handler dir
         let shell_dir = env.paths.handler_data_dir("vim", "shell");
         env.fs.mkdir_all(&shell_dir).unwrap();
         env.fs
@@ -691,16 +680,12 @@ mod tests {
 
         let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
 
-        // Preamble feature-detects bash 5+ / zsh + EPOCHREALTIME
         assert!(script.contains("BASH_VERSION"));
         assert!(script.contains("ZSH_VERSION"));
         assert!(script.contains("EPOCHREALTIME"));
-        // The profile dir comes from Pather, so the script should embed it.
         assert!(script.contains(env.paths.probes_shell_init_dir().to_str().unwrap()));
-        // File naming includes pid + RANDOM for collision-resistance.
         assert!(script.contains("$$"));
         assert!(script.contains("RANDOM"));
-        // Header lines we always emit.
         assert!(script.contains("# dodot shell-init profile v1"));
         assert!(script.contains("columns\\tphase\\tpack\\thandler\\ttarget"));
     }
@@ -753,7 +738,6 @@ mod tests {
 
         let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
 
-        // Errors-log sibling is derived from the profile-file path.
         assert!(
             script.contains("_dodot_err_file=\"${_dodot_prof_file%.tsv}.errors.log\""),
             "errors-log path must be a sibling of the profile TSV:\n{script}"
@@ -765,7 +749,6 @@ mod tests {
             script.contains("[ -f \"$_dodot_err_file\" ] || printf '# dodot shell-init errors v1"),
             "errors-log header must be seeded lazily on first stderr:\n{script}"
         );
-        // Stderr is redirected to the per-shell scratch file during the source.
         assert!(
             script.contains("2>\"$_dodot_err_tmp\""),
             "source must redirect stderr to scratch file:\n{script}"
@@ -776,7 +759,6 @@ mod tests {
             script.contains(": > \"$_dodot_err_tmp\""),
             "scratch file must be truncated before each source:\n{script}"
         );
-        // The record header uses the @@ sentinel + tab-separated target/exit.
         assert!(
             script.contains("printf '@@\\t%s\\t%s\\n'"),
             "errors-log records must use @@ header format:\n{script}"
@@ -796,16 +778,13 @@ mod tests {
             .unwrap();
 
         let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
-        // End-of-run timestamp.
         assert!(script.contains("# end_t"));
-        // We scrub our state to avoid leaking into the user's shell.
         assert!(script.contains("unset _dodot_prof"));
         assert!(script.contains("_dodot_prof_file"));
     }
 
     #[test]
     fn profiling_enabled_with_empty_datastore_skips_preamble() {
-        // No deployed entries → empty notice only, no profiling boilerplate.
         let env = TempEnvironment::builder().build();
         let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
         assert!(script.contains("No shell scripts or PATH additions"));
@@ -814,15 +793,8 @@ mod tests {
 
     #[test]
     fn profiled_source_initialises_rc_so_missing_file_isnt_reported_as_failure() {
-        // Regression: previously the profiled branch was
-        //
-        //   _dodot_rc=$?  # after `[ -f X ] && . X`
-        //
-        // which captured the file-test exit (1) when the file was
-        // absent — falsely classifying "file missing" as "source
-        // exited 1". The fix initialises _dodot_rc to 0 before the
-        // attempt, and only updates it inside the `&& { . X; rc=$?; }`
-        // group when the source actually ran.
+        // A missing file is not a source failure: initialize rc to zero
+        // and only update it when the source command actually runs.
         let env = TempEnvironment::builder()
             .pack("vim")
             .file("aliases.sh", "alias vi=vim")
@@ -833,12 +805,10 @@ mod tests {
             .unwrap();
 
         let script = generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true).unwrap();
-        // Pre-attempt initialisation present.
         assert!(
             script.contains("_dodot_rc=0;"),
             "profiled branch must seed _dodot_rc=0 before the source attempt:\n{script}"
         );
-        // Source is wrapped so the rc only updates when `.` ran.
         assert!(
             script.contains("&& { . "),
             "profiled branch must guard the rc update inside `&& {{ … }}`:\n{script}"

--- a/crates/dodot-lib/src/shell/validate.rs
+++ b/crates/dodot-lib/src/shell/validate.rs
@@ -345,7 +345,6 @@ mod tests {
         ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
             .unwrap();
 
-        // First run: failure → sidecar written.
         let bad = CannedChecker::default();
         bad.set(
             "aliases.sh",
@@ -357,7 +356,6 @@ mod tests {
         let sidecar = error_sidecar_path(env.paths.as_ref(), "vim", "aliases.sh");
         assert!(env.fs.exists(&sidecar));
 
-        // Second run: success → sidecar removed.
         let good = CannedChecker::default();
         let report = validate_shell_sources(env.fs.as_ref(), env.paths.as_ref(), &good).unwrap();
         assert_eq!(report.checked, 1);
@@ -379,7 +377,6 @@ mod tests {
         ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.zsh"))
             .unwrap();
 
-        // Prime a stale sidecar.
         let sidecar = error_sidecar_path(env.paths.as_ref(), "vim", "aliases.zsh");
         env.fs.mkdir_all(sidecar.parent().unwrap()).unwrap();
         env.fs.write_file(&sidecar, b"old failure\n").unwrap();
@@ -392,7 +389,6 @@ mod tests {
         assert_eq!(report.checked, 1);
         assert!(report.failures.is_empty());
         assert!(report.missing_interpreters.contains("zsh"));
-        // Sidecar untouched.
         assert!(env.fs.exists(&sidecar));
         assert_eq!(env.fs.read_to_string(&sidecar).unwrap(), "old failure\n");
     }

--- a/crates/dodot-lib/src/shell/validate.rs
+++ b/crates/dodot-lib/src/shell/validate.rs
@@ -5,7 +5,7 @@
 //! `dodot up` time instead of silently breaking the user's next shell
 //! startup. The interpreter's stderr (which carries `file: line N:
 //! error_message`) is preserved verbatim into a sidecar file under the
-//! handler datastore so `dodot status` can show it later (3c).
+//! handler datastore so `dodot status` can show it later.
 //!
 //! This module does not invoke the staged file. It only parses it.
 //! `bash -n` / `zsh -n` are syntax-only — no commands run, no side
@@ -118,7 +118,7 @@ pub struct ShellValidationFailure {
 }
 
 /// Subdirectory (under each pack's shell handler dir) where sidecar
-/// `.err` files live. Public so 3c (`status`) can read it back.
+/// `.err` files live. Public so `status` can read it back.
 pub const ERRORS_SUBDIR: &str = ".errors";
 
 /// Path of the sidecar error file for one source.

--- a/crates/dodot-lib/src/testing/mod.rs
+++ b/crates/dodot-lib/src/testing/mod.rs
@@ -1,5 +1,3 @@
-//! Test infrastructure for dodot.
-//!
 //! Provides [`TempEnvironment`] — an isolated, real-filesystem test
 //! environment with builder-pattern setup and rich assertion helpers.
 //!
@@ -56,16 +54,13 @@ static SHELL_ENV_LOCK: Mutex<()> = Mutex::new(());
 /// }
 /// ```
 pub struct ShellEnvGuard {
-    // The mutex guard is `'static` because the underlying mutex is
-    // a `static`. Holding it for the lifetime of `Self` keeps the
-    // lock until `drop` runs.
+    // The static guard keeps the process-global lock until `drop`.
     _lock: MutexGuard<'static, ()>,
     prev: Option<String>,
 }
 
 impl ShellEnvGuard {
-    /// Take the lock, set `$SHELL` to `value`. Restores the
-    /// previous value on drop.
+    /// Sets `$SHELL` while holding the lock and restores it on drop.
     pub fn set(value: &str) -> Self {
         let lock = SHELL_ENV_LOCK
             .lock()
@@ -75,8 +70,7 @@ impl ShellEnvGuard {
         Self { _lock: lock, prev }
     }
 
-    /// Take the lock, unset `$SHELL`. Restores the previous value
-    /// on drop.
+    /// Unsets `$SHELL` while holding the lock and restores it on drop.
     pub fn unset() -> Self {
         let lock = SHELL_ENV_LOCK
             .lock()
@@ -105,19 +99,14 @@ impl Drop for ShellEnvGuard {
 /// All XDG paths, HOME, and DOTFILES_ROOT point inside the temp dir.
 /// The directory is cleaned up when this struct is dropped.
 pub struct TempEnvironment {
-    /// Held to keep the temp directory alive for the lifetime of the env.
     _temp_dir: TempDir,
 
-    /// Simulated HOME directory.
     pub home: PathBuf,
 
-    /// Simulated dotfiles root (DOTFILES_ROOT).
     pub dotfiles_root: PathBuf,
 
-    /// Simulated XDG data dir for dodot.
     pub data_dir: PathBuf,
 
-    /// Simulated XDG config home (e.g. for symlink target mapping).
     pub config_home: PathBuf,
 
     /// Simulated `~/Library/Application Support` root. Pinned to a
@@ -125,15 +114,12 @@ pub struct TempEnvironment {
     /// `app_aliases` tests behave identically on Linux and macOS.
     pub app_support: PathBuf,
 
-    /// Real filesystem handle.
     pub fs: Arc<OsFs>,
 
-    /// Path resolver with all paths pointing at the temp directory.
     pub paths: Arc<XdgPather>,
 }
 
 impl TempEnvironment {
-    /// Start building a new test environment.
     pub fn builder() -> TempEnvironmentBuilder {
         TempEnvironmentBuilder {
             packs: Vec::new(),
@@ -143,7 +129,6 @@ impl TempEnvironment {
 
     // ── Assertion helpers ───────────────────────────────────────────
 
-    /// Assert that a symlink exists at `link` and points to `target`.
     pub fn assert_symlink(&self, link: &Path, target: &Path) {
         assert!(
             self.fs.is_symlink(link),
@@ -164,7 +149,6 @@ impl TempEnvironment {
         );
     }
 
-    /// Assert that a file exists at `path` with exactly `expected` contents.
     pub fn assert_file_contents(&self, path: &Path, expected: &str) {
         let actual = self
             .fs
@@ -178,7 +162,6 @@ impl TempEnvironment {
         );
     }
 
-    /// Assert that a file or directory exists at `path`.
     pub fn assert_exists(&self, path: &Path) {
         assert!(
             self.fs.exists(path),
@@ -187,7 +170,6 @@ impl TempEnvironment {
         );
     }
 
-    /// Assert that nothing exists at `path`.
     pub fn assert_not_exists(&self, path: &Path) {
         assert!(
             !self.fs.exists(path),
@@ -196,7 +178,6 @@ impl TempEnvironment {
         );
     }
 
-    /// Assert that `path` is a directory.
     pub fn assert_dir_exists(&self, path: &Path) {
         assert!(
             self.fs.is_dir(path),
@@ -222,10 +203,8 @@ impl TempEnvironment {
     ) {
         let datastore_link = self.paths.handler_data_dir(pack, handler).join(filename);
 
-        // Datastore link -> source
         self.assert_symlink(&datastore_link, source);
 
-        // User link -> datastore link
         self.assert_symlink(user_path, &datastore_link);
     }
 
@@ -244,7 +223,6 @@ impl TempEnvironment {
         }
     }
 
-    /// Assert that a sentinel file exists for a pack/handler.
     pub fn assert_sentinel(&self, pack: &str, handler: &str, sentinel: &str) {
         let sentinel_path = self.paths.handler_data_dir(pack, handler).join(sentinel);
         assert!(
@@ -255,8 +233,6 @@ impl TempEnvironment {
         );
     }
 
-    /// Assert a rendered (non-symlink) file exists in the datastore
-    /// with the expected content.
     pub fn assert_rendered_file(&self, pack: &str, handler: &str, filename: &str, expected: &str) {
         let path = self.paths.handler_data_dir(pack, handler).join(filename);
         assert!(
@@ -281,7 +257,6 @@ impl TempEnvironment {
         );
     }
 
-    /// Assert that a path is a regular file (not a symlink) with expected content.
     pub fn assert_regular_file(&self, path: &Path, expected: &str) {
         assert!(self.fs.exists(path), "expected {} to exist", path.display());
         assert!(
@@ -301,7 +276,6 @@ impl TempEnvironment {
         );
     }
 
-    /// Returns the list of file names in a directory.
     pub fn list_dir_names(&self, path: &Path) -> Vec<String> {
         self.fs
             .read_dir(path)
@@ -328,8 +302,6 @@ struct PackSpec {
 }
 
 impl TempEnvironmentBuilder {
-    /// Start defining a pack. Returns a [`PackSpecBuilder`] that must
-    /// be finished with [`.done()`](PackSpecBuilder::done).
     pub fn pack(self, name: &str) -> PackSpecBuilder {
         PackSpecBuilder {
             parent: self,
@@ -340,20 +312,16 @@ impl TempEnvironmentBuilder {
         }
     }
 
-    /// Add a file under the simulated HOME directory.
-    /// Useful for testing adopt (moving existing files into packs).
     pub fn home_file(mut self, relative_path: &str, contents: &str) -> Self {
         self.extra_home_files
             .push((relative_path.to_string(), contents.to_string()));
         self
     }
 
-    /// Build the environment, creating all directories and files.
     pub fn build(self) -> TempEnvironment {
         let temp_dir = TempDir::new().expect("failed to create temp directory");
         let fs = Arc::new(OsFs::new());
 
-        // Set up directory hierarchy
         let home = temp_dir.path().join("home");
         let dotfiles_root = home.join("dotfiles");
         let data_dir = home.join(".local").join("share").join("dodot");
@@ -367,7 +335,6 @@ impl TempEnvironmentBuilder {
         // make assertions about regardless of host OS.
         let app_support = home.join("Library").join("Application Support");
 
-        // Create base directories
         for dir in [
             &home,
             &dotfiles_root,
@@ -382,7 +349,6 @@ impl TempEnvironmentBuilder {
                 .unwrap_or_else(|e| panic!("failed to create {}: {e}", dir.display()));
         }
 
-        // Create packs
         for pack in &self.packs {
             let pack_dir = dotfiles_root.join(&pack.name);
             fs.mkdir_all(&pack_dir).unwrap();
@@ -406,7 +372,6 @@ impl TempEnvironmentBuilder {
             }
         }
 
-        // Create extra home files
         for (rel_path, contents) in &self.extra_home_files {
             let file_path = home.join(rel_path);
             if let Some(parent) = file_path.parent() {
@@ -415,7 +380,6 @@ impl TempEnvironmentBuilder {
             fs.write_file(&file_path, contents.as_bytes()).unwrap();
         }
 
-        // Build the pather with all paths pointing inside temp dir
         let paths = Arc::new(
             XdgPather::builder()
                 .home(&home)
@@ -452,26 +416,22 @@ pub struct PackSpecBuilder {
 }
 
 impl PackSpecBuilder {
-    /// Add a file to this pack.
     pub fn file(mut self, relative_path: &str, contents: &str) -> Self {
         self.files
             .push((relative_path.to_string(), contents.to_string()));
         self
     }
 
-    /// Set the `.dodot.toml` config for this pack.
     pub fn config(mut self, toml_contents: &str) -> Self {
         self.config = Some(toml_contents.to_string());
         self
     }
 
-    /// Mark this pack as ignored (creates `.dodotignore`).
     pub fn ignored(mut self) -> Self {
         self.dodotignore = true;
         self
     }
 
-    /// Finish this pack and return to the parent builder.
     pub fn done(mut self) -> TempEnvironmentBuilder {
         self.parent.packs.push(PackSpec {
             name: self.name,
@@ -499,15 +459,12 @@ mod tests {
             .done()
             .build();
 
-        // Home and dotfiles root exist
         env.assert_dir_exists(&env.home);
         env.assert_dir_exists(&env.dotfiles_root);
 
-        // Pack directories exist
         env.assert_dir_exists(&env.dotfiles_root.join("vim"));
         env.assert_dir_exists(&env.dotfiles_root.join("git"));
 
-        // Files have correct contents
         env.assert_file_contents(&env.dotfiles_root.join("vim/vimrc"), "set nocompatible");
         env.assert_file_contents(&env.dotfiles_root.join("vim/gvimrc"), "set guifont=Mono");
         env.assert_file_contents(
@@ -515,7 +472,6 @@ mod tests {
             "[user]\n  name = test",
         );
 
-        // XDG directories exist
         env.assert_dir_exists(&env.data_dir);
         env.assert_dir_exists(&env.config_home);
     }
@@ -618,10 +574,8 @@ mod tests {
     fn assert_no_handler_state_passes_when_empty() {
         let env = TempEnvironment::builder().build();
 
-        // No state dir exists at all -- should pass
         env.assert_no_handler_state("vim", "symlink");
 
-        // Empty state dir -- should also pass
         let dir = env.paths.handler_data_dir("vim", "symlink");
         env.fs.mkdir_all(&dir).unwrap();
         env.assert_no_handler_state("vim", "symlink");
@@ -666,14 +620,12 @@ mod tests {
             .done()
             .build();
 
-        // Each has its own isolated dotfiles
         env1.assert_exists(&env1.dotfiles_root.join("a/f1"));
         env1.assert_not_exists(&env1.dotfiles_root.join("b"));
 
         env2.assert_exists(&env2.dotfiles_root.join("b/f2"));
         env2.assert_not_exists(&env2.dotfiles_root.join("a"));
 
-        // Different temp directories
         assert_ne!(env1.home, env2.home);
     }
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,4 @@
-# pixi workspace — seeded by `shipit install` (the managed blocks below
-# need a valid manifest). Consumer-owned from here on: edit freely.
+# Consumer-owned Pixi workspace; Shipit owns only the marked blocks below.
 [workspace]
 name = "arthur-debert_dodot"
 channels = ["conda-forge"]
@@ -54,20 +53,8 @@ lefthook = "2.1.*"
 # >>> shipit-managed lint task (do not edit; regenerate via `shipit install`) >>>
 lint = "./bin/shipit lint"
 # <<< shipit-managed lint task <<<
-# The wf-checks LINT LANE's run (#236), byte-modeled on lex#829/shipit's own:
-# the lint toolchain (ruff/shfmt/prettier/markdownlint/actionlint/rust 1.96)
-# lives in THIS feature's env, so the lane task must resolve into the lint
-# env — the managed bare `lint` task is a fixed plain string that runs in the
-# default env, where none of those tools exist on a hosted runner and no lexd
-# is on PATH for the lex leg (this repo tracks `.lex` docs, which is what
-# makes the lex Lang of `shipit lint` run). lexd now rides the lint env as an
-# ordinary conda dep via the managed `shipit-lexd` feature wired into it
-# below — ADR-0066 retired the `provision lexd` verb this task used to call
-# inline, and shipit fails closed on a manifest that still calls it
-# (shipit#1070). Defined ONLY in this feature, so it
-# exists in EXACTLY ONE env (lint) and bare `pixi run lint-full` resolves
-# unambiguously — the wf-checks matrix job's `pixi run --locked lint-full`
-# and a laptop run are identical.
+# Keep this lane task in the lint feature so bare `pixi run lint-full` resolves
+# to the environment containing the managed linters and lexd (ADR-0066).
 lint-full = { cmd = "./bin/shipit lint" }
 
 [environments]
@@ -75,14 +62,8 @@ lint-full = { cmd = "./bin/shipit lint" }
 lint = ["lint", "shipit-lexd"]
 # <<< shipit-managed environments <<<
 
-# Consumer-owned dependencies (outside the shipit-managed blocks above),
-# modeled on lex (ADP02-WS02). The wf-checks TEST LANE runs the managed
-# `test` task (`pixi run --locked test` -> ./bin/shipit test -> cargo
-# nextest) on a hosted runner where nothing outside pixi is provisioned
-# (hosted images no longer carry Rust, and the pinned planner emits no
-# env/cache descriptors that would put a toolchain on PATH), so the default
-# env must carry the full `cargo nextest` stack itself. Same conda-forge rust
-# pin as the managed [feature.lint.dependencies] block.
+# The managed test task resolves in the default environment, so its Rust and
+# cargo-nextest toolchain must be available here on hosted runners.
 [dependencies]
 # >>> shipit-managed rust release toolchain (do not edit; regenerate via `shipit install`) >>>
 # The rust RELEASE toolchain (#801, closing open hole 1 of the TOL02-WS17


### PR DESCRIPTION
## Summary

Repository-wide comments-only cleanup delivered in three ordered delegated phases on one PR:

1. Production Rust comments and doc comments under `crates/`, excluding test-only regions.
2. Rust test comments across dedicated test/support files and inline `#[cfg(test)]` modules.
3. Hand-owned YAML/TOML comments; eligible Markdown was inspected but contained no HTML comments.

The cleanup removes process chronology, review/workstream provenance, duplicated explanations, stale future-tense claims, and self-evident narration. It preserves design rationale, compatibility and wire-format contracts, security boundaries, platform/tool quirks, edge-case intent, and durable ADR/spec/issue references.

## Verification

- `pixi run test` — 1,302/1,302 passed.
- `pixi run lint` — 13/13 passed; commit and push hooks passed.
- `cargo doc -p dodot-lib --no-deps` completed; no new documentation failure.
- Final cumulative diff audit over `origin/main..HEAD`: 125 files, all changed spans are recognized comments/doc comments, with seven trailing-comment edits whose executable prefixes are byte-identical; zero blank-line deltas.
- Shipit-managed files, projections, `.shipit.toml` machine state, and every marked `pixi.toml` managed block are byte-identical.
- No Rust code, test logic, identifiers, signatures, strings, YAML/TOML data, ordinary Markdown prose, generated files, or legal text changed.

## Context

**Why this approach.** Each large phase was fanned out into non-overlapping scopes, integrated in sequence on `issues/253/work`, and independently audited before the next phase. A final read-only audit reviewed all 1,112 hunks and its findings were corrected in `dd7f136`.

**Ownership boundary.** Workflow callers and consumer declaration comments are hand-owned even when they route through Shipit. Shipit-managed blocks and projected agent/workflow support files were excluded. Markdown product docs were inspected without modification because ordinary prose is not a comment and no eligible HTML comments existed.

**Out of scope.** This PR does not rewrite stale `.lex` reference paths, resolve unrelated terminology drift, fill documentation gaps, or change any executable behavior.

closes #253