### PR TITLE
Sweep orphaned datastore state for packs deleted from the repo

### DIFF
--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -8,6 +8,15 @@
 //! line.
 //!
 //! Dry-run keeps the per-handler "would remove" rendering.
+//!
+//! Besides packs discovered in the repo, `down` also removes *orphaned*
+//! datastore state — state for packs deleted from the dotfiles root
+//! since they were deployed (issue #255). A no-args `down` sweeps every
+//! orphan; `down <pack>` accepts an orphaned pack name (dir or display
+//! form) even though the repo scan no longer knows it. Orphans can't
+//! render through `status` (there is no pack to show), so a real run
+//! reports what it swept via the warnings channel; dry-run lists them
+//! with the same "would remove" rows as normal packs.
 
 use tracing::{debug, info};
 
@@ -23,9 +32,26 @@ use crate::Result;
 pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<PackStatusResult> {
     info!(dry_run = ctx.dry_run, "starting down command");
 
+    // Orphaned state: datastore subtrees whose pack no longer exists in
+    // the dotfiles root. Scanned before validation so `dodot down
+    // <orphan>` is accepted instead of rejected as PackNotFound — the
+    // repo scan can't know a deleted pack, but the datastore does.
+    // (#255)
+    let orphan_dirs = orchestration::scan_orphaned(ctx)?;
+    let matches_orphan = |name: &str| {
+        orphan_dirs
+            .iter()
+            .any(|d| d == name || packs::display_name_for(d) == name)
+    };
+
     let mut warnings = Vec::new();
     if let Some(names) = pack_filter {
-        warnings = orchestration::validate_pack_names(names, ctx)?;
+        let repo_names: Vec<String> = names
+            .iter()
+            .filter(|n| !matches_orphan(n))
+            .cloned()
+            .collect();
+        warnings = orchestration::validate_pack_names(&repo_names, ctx)?;
     }
 
     let root_config = ctx.config_manager.root_config()?;
@@ -65,12 +91,67 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         affected_packs.push(pack.display_name.clone());
 
         if ctx.dry_run {
-            dry_run_display.push(build_dry_run_display(pack, &handlers, ctx)?);
+            dry_run_display.push(build_dry_run_display(
+                &pack.name,
+                &pack.display_name,
+                &handlers,
+                ctx,
+            )?);
         } else {
             for handler in &handlers {
                 ctx.datastore.remove_state(&pack.name, handler)?;
             }
         }
+    }
+
+    // Remove orphaned state (#255). Unfiltered for a no-args run —
+    // `down` removes *all* deployed state, including state for packs
+    // the repo has since deleted. A filtered run only touches orphans
+    // named in the filter (scoped intent); any orphan left behind is
+    // warned about below so the user knows a plain `dodot down` clears
+    // it. Orphans can't render through the post-removal status pass
+    // (there is no pack in the repo to show), so a real run reports
+    // them via the warnings channel instead.
+    let selected_orphans: Vec<String> = match pack_filter {
+        None => orphan_dirs.clone(),
+        Some(names) => orphan_dirs
+            .iter()
+            .filter(|d| {
+                names
+                    .iter()
+                    .any(|n| n == *d || n == packs::display_name_for(d))
+            })
+            .cloned()
+            .collect(),
+    };
+    for dir in &selected_orphans {
+        info!(pack = %dir, "removing orphaned pack state");
+        any_removed = true;
+        if ctx.dry_run {
+            let handlers = ctx.datastore.list_pack_handlers(dir)?;
+            dry_run_display.push(build_dry_run_display(
+                dir,
+                packs::display_name_for(dir),
+                &handlers,
+                ctx,
+            )?);
+        }
+    }
+    if !ctx.dry_run && !selected_orphans.is_empty() {
+        orchestration::sweep_pack_state(&selected_orphans, ctx)?;
+        warnings.push(format!(
+            "removed state for packs no longer in {}: {}",
+            ctx.paths.dotfiles_root().display(),
+            display_names(&selected_orphans),
+        ));
+    }
+    let remaining_orphans: Vec<String> = orphan_dirs
+        .iter()
+        .filter(|d| !selected_orphans.contains(d))
+        .cloned()
+        .collect();
+    if !remaining_orphans.is_empty() {
+        warnings.push(orchestration::orphan_warning(&remaining_orphans, ctx));
     }
 
     // Sweep stale state for now-ignored packs so the regenerated
@@ -81,11 +162,11 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
     // something was deactivated. The count is computed in both dry-run
     // and real runs so `down --dry-run` reports the same outcome a real
     // run would produce; only the mutation is gated on `!dry_run`.
-    if orchestration::ignored_packs_with_state(&ignored.sweep_dir_names, ctx)? > 0 {
+    if orchestration::packs_with_state(&ignored.sweep_dir_names, ctx)? > 0 {
         any_removed = true;
     }
     if !ctx.dry_run {
-        orchestration::sweep_ignored_state(&ignored.sweep_dir_names, ctx)?;
+        orchestration::sweep_pack_state(&ignored.sweep_dir_names, ctx)?;
     }
 
     if !ctx.dry_run {
@@ -128,18 +209,32 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
     })
 }
 
+/// Render the given orphaned pack dir names as user-facing display
+/// names, comma-joined, for the warnings channel.
+fn display_names(dirs: &[String]) -> String {
+    dirs.iter()
+        .map(|d| packs::display_name_for(d))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Build the per-pack dry-run display: lists what would be removed,
 /// per-handler. For symlink handlers we list individual data-link entries
 /// since the user usually wants to know which files would be affected.
+///
+/// Takes the datastore key (`dir_name`) and user-facing name separately
+/// so orphaned packs — which have no repo-side [`packs::Pack`] — render
+/// the same way as discovered ones.
 fn build_dry_run_display(
-    pack: &packs::Pack,
+    dir_name: &str,
+    display_name: &str,
     handlers: &[String],
     ctx: &ExecutionContext,
 ) -> Result<DisplayPack> {
     let mut files = Vec::new();
     for handler in handlers {
         if handler == HANDLER_SYMLINK {
-            let handler_dir = ctx.paths.handler_data_dir(&pack.name, handler);
+            let handler_dir = ctx.paths.handler_data_dir(dir_name, handler);
             let entries = ctx.fs.read_dir(&handler_dir)?;
             for entry in entries {
                 files.push(DisplayFile {
@@ -164,5 +259,5 @@ fn build_dry_run_display(
             });
         }
     }
-    Ok(DisplayPack::new(pack.display_name.clone(), files))
+    Ok(DisplayPack::new(display_name.to_string(), files))
 }

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -140,7 +140,12 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
     if !ctx.dry_run && !selected_orphans.is_empty() {
         orchestration::sweep_pack_state(&selected_orphans, ctx)?;
         warnings.push(format!(
-            "removed state for packs no longer in {}: {}",
+            "removed state for {} no longer in {}: {}",
+            if selected_orphans.len() == 1 {
+                "pack"
+            } else {
+                "packs"
+            },
             ctx.paths.dotfiles_root().display(),
             display_names(&selected_orphans),
         ));

--- a/crates/dodot-lib/src/commands/tests/gating.rs
+++ b/crates/dodot-lib/src/commands/tests/gating.rs
@@ -1481,3 +1481,200 @@ fn up_mixed_selection_deploys_active_and_reports_ignored() {
     assert_eq!(ignored_section(&up), ignored_section(&status));
     assert!(warns_ignored(&up, "gpg"));
 }
+
+// ── issue #255: orphaned datastore state ────────────────────
+//
+// A pack deployed and then DELETED from the dotfiles repo leaves its
+// datastore subtree behind: pack discovery enumerates the repo, so
+// `up`/`down` never visit the stale state, while the init script and
+// deployment map are regenerated from the whole datastore — the orphan
+// keeps getting sourced in every shell. `down` must sweep orphans;
+// `up` must surface them.
+
+/// Deploy vim + emacs, then delete emacs from the repo — emacs state
+/// becomes orphaned.
+fn orphaned_emacs_env() -> (TempEnvironment, ExecutionContext) {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .pack("emacs")
+        .file("alias.zsh", "alias e='emacs -nw'")
+        .done()
+        .build();
+
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+    assert!(!ctx
+        .datastore
+        .list_pack_handlers("emacs")
+        .unwrap()
+        .is_empty());
+
+    env.fs
+        .remove_dir_all(&env.dotfiles_root.join("emacs"))
+        .unwrap();
+    (env, ctx)
+}
+
+#[test]
+fn down_no_args_sweeps_orphaned_pack_state() {
+    let (env, ctx) = orphaned_emacs_env();
+
+    let down = commands::down::down(None, &ctx).unwrap();
+
+    assert!(
+        ctx.datastore
+            .list_pack_handlers("emacs")
+            .unwrap()
+            .is_empty(),
+        "down must sweep datastore state for a pack deleted from the repo"
+    );
+    let init = env
+        .fs
+        .read_to_string(&ctx.paths.init_script_path())
+        .unwrap();
+    assert!(
+        !init.contains("emacs/alias.zsh"),
+        "init script must stop sourcing an orphaned pack; was:\n{init}"
+    );
+    assert_eq!(down.message.as_deref(), Some("Packs deactivated."));
+    assert!(
+        down.warnings.iter().any(|w| w.contains("emacs")),
+        "down should report which orphaned packs it removed state for; warnings: {:?}",
+        down.warnings
+    );
+}
+
+#[test]
+fn down_accepts_orphaned_pack_name() {
+    let (_env, ctx) = orphaned_emacs_env();
+
+    let down = commands::down::down(Some(&["emacs".to_string()]), &ctx).unwrap();
+
+    assert!(
+        ctx.datastore
+            .list_pack_handlers("emacs")
+            .unwrap()
+            .is_empty(),
+        "`down <pack>` must work for an orphaned pack name"
+    );
+    // vim was not in the filter — its state must survive.
+    assert!(
+        !ctx.datastore.list_pack_handlers("vim").unwrap().is_empty(),
+        "filtered down must not touch packs outside the filter"
+    );
+    assert_eq!(down.message.as_deref(), Some("Packs deactivated."));
+}
+
+#[test]
+fn down_resolves_orphan_by_display_name() {
+    // Orphan keyed by its on-disk dir name `010-emacs`; the user types
+    // the display name `emacs`, same as for a live pack.
+    let env = TempEnvironment::builder()
+        .pack("010-emacs")
+        .file("alias.zsh", "alias e='emacs -nw'")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+    commands::up::up(None, &ctx).unwrap();
+    env.fs
+        .remove_dir_all(&env.dotfiles_root.join("010-emacs"))
+        .unwrap();
+
+    commands::down::down(Some(&["emacs".to_string()]), &ctx).unwrap();
+
+    assert!(
+        ctx.datastore
+            .list_pack_handlers("010-emacs")
+            .unwrap()
+            .is_empty(),
+        "orphan must resolve via display name like a live pack"
+    );
+}
+
+#[test]
+fn down_unknown_name_still_errors_when_orphans_exist() {
+    let (_env, ctx) = orphaned_emacs_env();
+
+    let err = commands::down::down(Some(&["nope".to_string()]), &ctx).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::DodotError::PackNotFound { ref name } if name == "nope"
+    ));
+}
+
+#[test]
+fn down_dry_run_reports_orphaned_pack() {
+    let (_env, ctx) = orphaned_emacs_env();
+
+    let mut dry_ctx = make_ctx(&_env);
+    dry_ctx.dry_run = true;
+    let down = commands::down::down(None, &dry_ctx).unwrap();
+
+    assert_eq!(down.message.as_deref(), Some("Packs deactivated."));
+    assert!(
+        !ctx.datastore
+            .list_pack_handlers("emacs")
+            .unwrap()
+            .is_empty(),
+        "down --dry-run must not remove orphaned state"
+    );
+    // The would-be-swept orphan renders like any other pack removal.
+    let emacs = down
+        .packs
+        .iter()
+        .find(|p| p.name == "emacs")
+        .expect("dry-run must list the orphaned pack");
+    assert!(
+        emacs
+            .files
+            .iter()
+            .any(|f| f.status_label.contains("would remove")),
+        "orphan rows should carry the dry-run 'would remove' label"
+    );
+}
+
+#[test]
+fn filtered_down_leaves_unrelated_orphans_and_warns() {
+    let (_env, ctx) = orphaned_emacs_env();
+
+    let down = commands::down::down(Some(&["vim".to_string()]), &ctx).unwrap();
+
+    assert!(
+        !ctx.datastore
+            .list_pack_handlers("emacs")
+            .unwrap()
+            .is_empty(),
+        "a filtered down must not sweep orphans outside the filter"
+    );
+    assert!(
+        down.warnings
+            .iter()
+            .any(|w| w.contains("emacs") && w.contains("dodot down")),
+        "filtered down should warn about orphans it left behind; warnings: {:?}",
+        down.warnings
+    );
+}
+
+#[test]
+fn up_warns_about_orphaned_state_without_sweeping() {
+    let (_env, ctx) = orphaned_emacs_env();
+
+    let up = commands::up::up(None, &ctx).unwrap();
+
+    assert!(
+        up.warnings
+            .iter()
+            .any(|w| w.contains("emacs") && w.contains("dodot down")),
+        "up must surface orphaned state; warnings: {:?}",
+        up.warnings
+    );
+    assert!(
+        !ctx.datastore
+            .list_pack_handlers("emacs")
+            .unwrap()
+            .is_empty(),
+        "up must not sweep orphaned state (misresolved-root safety)"
+    );
+}

--- a/crates/dodot-lib/src/commands/tests/gating.rs
+++ b/crates/dodot-lib/src/commands/tests/gating.rs
@@ -1606,9 +1606,9 @@ fn down_unknown_name_still_errors_when_orphans_exist() {
 
 #[test]
 fn down_dry_run_reports_orphaned_pack() {
-    let (_env, ctx) = orphaned_emacs_env();
+    let (env, ctx) = orphaned_emacs_env();
 
-    let mut dry_ctx = make_ctx(&_env);
+    let mut dry_ctx = make_ctx(&env);
     dry_ctx.dry_run = true;
     let down = commands::down::down(None, &dry_ctx).unwrap();
 

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -67,6 +67,17 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     // regenerated init script. (issue #222)
     let ignored = orchestration::scan_ignored(pack_filter, ctx)?;
 
+    // Surface orphaned state — datastore subtrees for packs deleted
+    // from the dotfiles root since they were deployed. `up` only warns:
+    // the init script regenerated below still carries the orphans (it
+    // is driven off the whole datastore), and sweeping here would let a
+    // misresolved dotfiles root silently wipe legitimate state on
+    // deploy. `dodot down` is the removal path. (issue #255)
+    let orphaned = orchestration::scan_orphaned(ctx)?;
+    if !orphaned.is_empty() {
+        planning_warnings.push(orchestration::orphan_warning(&orphaned, ctx));
+    }
+
     // Phase 1: Discover packs and collect intents
     let packs = orchestration::prepare_packs(pack_filter, ctx)?;
 
@@ -205,7 +216,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         // the regenerated (global) init script below stops sourcing
         // them — unfiltered, since the init script covers every pack
         // regardless of this run's filter. (#222)
-        orchestration::sweep_ignored_state(&ignored.sweep_dir_names, ctx)?;
+        orchestration::sweep_pack_state(&ignored.sweep_dir_names, ctx)?;
         info!("regenerating shell init script");
         let root_config = ctx.config_manager.root_config()?;
         shell::write_init_script(

--- a/crates/dodot-lib/src/datastore/filesystem.rs
+++ b/crates/dodot-lib/src/datastore/filesystem.rs
@@ -397,6 +397,19 @@ impl DataStore for FilesystemDataStore {
         Ok(!entries.is_empty())
     }
 
+    fn list_packs(&self) -> Result<Vec<String>> {
+        let root = self.paths.packs_data_root();
+        if !self.fs.exists(&root) {
+            return Ok(Vec::new());
+        }
+        let entries = self.fs.read_dir(&root)?;
+        Ok(entries
+            .into_iter()
+            .filter(|e| e.is_dir)
+            .map(|e| e.name)
+            .collect())
+    }
+
     fn list_pack_handlers(&self, pack: &str) -> Result<Vec<String>> {
         let pack_dir = self.paths.pack_data_dir(pack);
         if !self.fs.exists(&pack_dir) {
@@ -904,6 +917,38 @@ mod tests {
 
         let handlers = ds.list_pack_handlers("nonexistent").unwrap();
         assert!(handlers.is_empty());
+    }
+
+    // ── list_packs ──────────────────────────────────────────────
+
+    #[test]
+    fn list_packs_returns_pack_dirs_with_state() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("vimrc", "x")
+            .done()
+            .pack("git")
+            .file("gitconfig", "y")
+            .done()
+            .build();
+        let (ds, _) = make_datastore(&env);
+
+        ds.create_data_link("vim", "symlink", &env.dotfiles_root.join("vim/vimrc"))
+            .unwrap();
+        ds.create_data_link("git", "symlink", &env.dotfiles_root.join("git/gitconfig"))
+            .unwrap();
+
+        let mut packs = ds.list_packs().unwrap();
+        packs.sort();
+        assert_eq!(packs, vec!["git", "vim"]);
+    }
+
+    #[test]
+    fn list_packs_empty_when_no_datastore() {
+        let env = TempEnvironment::builder().build();
+        let (ds, _) = make_datastore(&env);
+
+        assert!(ds.list_packs().unwrap().is_empty());
     }
 
     // ── list_handler_sentinels ──────────────────────────────────

--- a/crates/dodot-lib/src/datastore/mod.rs
+++ b/crates/dodot-lib/src/datastore/mod.rs
@@ -1,6 +1,6 @@
 //! State management for dodot.
 //!
-//! The [`DataStore`] trait defines dodot's 8-method storage API.
+//! The [`DataStore`] trait defines dodot's storage API.
 //! [`FilesystemDataStore`] implements it using symlinks and sentinel
 //! files on a real (or test) filesystem via the [`Fs`](crate::fs::Fs) trait.
 
@@ -57,6 +57,7 @@ pub enum DidRunStatus {
 /// - [`did_run`](DataStore::did_run) — three-way classification used
 ///   by the run-once handlers
 /// - [`has_handler_state`](DataStore::has_handler_state)
+/// - [`list_packs`](DataStore::list_packs)
 /// - [`list_pack_handlers`](DataStore::list_pack_handlers)
 /// - [`list_handler_sentinels`](DataStore::list_handler_sentinels)
 pub trait DataStore: Send + Sync {
@@ -131,6 +132,16 @@ pub trait DataStore: Send + Sync {
 
     /// Checks if any state exists for a pack/handler pair.
     fn has_handler_state(&self, pack: &str, handler: &str) -> Result<bool>;
+
+    /// Lists the pack directory names that have a subtree in the
+    /// datastore `packs/` tree.
+    ///
+    /// Names are on-disk directory names (datastore keys, e.g.
+    /// `010-nvim`), not display names. This is the enumeration source
+    /// for detecting state whose pack no longer exists in the dotfiles
+    /// root (issue #255) — unlike pack discovery, it walks the
+    /// *datastore*, so it sees packs the repo has since deleted.
+    fn list_packs(&self) -> Result<Vec<String>>;
 
     /// Lists handler names that have state for a pack.
     fn list_pack_handlers(&self, pack: &str) -> Result<Vec<String>>;

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -202,7 +202,7 @@ pub fn prepare_packs(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> 
 /// now-ignored pack's leftover state, or it would keep getting sourced.
 pub struct IgnoredScan {
     /// Raw on-disk directory names (datastore keys) for **every** ignored
-    /// pack, ignoring `pack_filter`. Used by [`sweep_ignored_state`] so
+    /// pack, ignoring `pack_filter`. Used by [`sweep_pack_state`] so
     /// the global init regeneration never re-sources a stale pack.
     pub sweep_dir_names: Vec<String>,
     /// Display names (prefix stripped) of the ignored packs that match
@@ -246,25 +246,27 @@ pub fn scan_ignored(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> R
     })
 }
 
-/// Tear down any leftover datastore state for `.dodotignore`-marked
-/// packs.
+/// Tear down all datastore state for the given pack dir names.
 ///
-/// A pack that was deployed and *then* marked ignored leaves its shell /
-/// path / symlink state in the datastore. Because the regenerated
-/// init script is driven entirely off the datastore `packs/` tree, that
-/// stale state keeps getting sourced on every shell startup even though
-/// the pack now reports as ignored — exactly the gpg `alias.zsh` error
-/// in issue #222. Removing the state here, before the caller regenerates
-/// the init script, makes "ignored" mean "nothing of this pack is read
-/// or deployed" across up/down.
+/// The stale-state sweep behind two symptoms of the same bug class:
 ///
-/// Pass the **unfiltered** [`IgnoredScan::sweep_dir_names`]: the init
-/// script is global, so even a filtered `up`/`down` must sweep every
-/// ignored pack or a now-ignored pack outside the filter would still be
-/// sourced. Datastore is keyed by on-disk directory name, not display
-/// name. Returns the dir names that actually had state removed, so the
-/// caller can reflect "something was deactivated" in its message.
-pub fn sweep_ignored_state(dir_names: &[String], ctx: &ExecutionContext) -> Result<Vec<String>> {
+/// - A pack deployed and *then* `.dodotignore`-marked leaves its shell /
+///   path / symlink state in the datastore (issue #222). Callers pass
+///   the **unfiltered** [`IgnoredScan::sweep_dir_names`] here: the init
+///   script is regenerated from the whole datastore, so even a filtered
+///   `up`/`down` must sweep every ignored pack or a now-ignored pack
+///   outside the filter would still be sourced.
+/// - A pack deployed and *then* deleted from the dotfiles repo leaves
+///   "orphaned" state the repo-driven pack discovery never visits
+///   (issue #255). `down` passes the [`scan_orphaned`] result here.
+///
+/// Either way the regenerated init script is driven entirely off the
+/// datastore `packs/` tree, so leftover state keeps getting sourced on
+/// every shell startup until it is removed. Datastore is keyed by
+/// on-disk directory name, not display name. Returns the dir names that
+/// actually had state removed, so the caller can reflect "something was
+/// deactivated" in its message.
+pub fn sweep_pack_state(dir_names: &[String], ctx: &ExecutionContext) -> Result<Vec<String>> {
     let mut swept = Vec::new();
     for dir in dir_names {
         let handlers = ctx.datastore.list_pack_handlers(dir)?;
@@ -273,17 +275,17 @@ pub fn sweep_ignored_state(dir_names: &[String], ctx: &ExecutionContext) -> Resu
         }
         swept.push(dir.clone());
         for handler in handlers {
-            debug!(pack = %dir, %handler, "sweeping state for now-ignored pack");
+            debug!(pack = %dir, %handler, "sweeping stale pack state");
             ctx.datastore.remove_state(dir, &handler)?;
         }
     }
     Ok(swept)
 }
 
-/// Count of ignored packs that currently hold datastore state, without
-/// removing anything. Lets `down --dry-run` report "would deactivate"
-/// consistently with what a real run would sweep.
-pub fn ignored_packs_with_state(dir_names: &[String], ctx: &ExecutionContext) -> Result<usize> {
+/// Count of the given pack dirs that currently hold datastore state,
+/// without removing anything. Lets `down --dry-run` report "would
+/// deactivate" consistently with what a real run would sweep.
+pub fn packs_with_state(dir_names: &[String], ctx: &ExecutionContext) -> Result<usize> {
     let mut n = 0;
     for dir in dir_names {
         if !ctx.datastore.list_pack_handlers(dir)?.is_empty() {
@@ -291,6 +293,54 @@ pub fn ignored_packs_with_state(dir_names: &[String], ctx: &ExecutionContext) ->
         }
     }
     Ok(n)
+}
+
+/// Scan the datastore for orphaned pack state: `packs/` subtrees that
+/// still hold handler state but whose pack directory no longer exists
+/// under the dotfiles root (issue #255).
+///
+/// Pack discovery enumerates the *repo*, so state keyed by a pack name
+/// the repo has since deleted is never visited by `up`/`down` — while
+/// the init script and deployment map are regenerated from the *whole*
+/// datastore, keeping the orphaned state live in every shell. `down`
+/// sweeps what this returns; `up` surfaces it as a warning (it does not
+/// sweep, so a misresolved dotfiles root can't silently wipe legitimate
+/// state on deploy).
+///
+/// Returns on-disk directory names (datastore keys), sorted. A datastore
+/// subtree with no handler state is not reported — there is nothing to
+/// remove.
+pub fn scan_orphaned(ctx: &ExecutionContext) -> Result<Vec<String>> {
+    let root = ctx.paths.dotfiles_root();
+    let mut orphans = Vec::new();
+    for dir in ctx.datastore.list_packs()? {
+        if ctx.fs.exists(&root.join(&dir)) {
+            continue;
+        }
+        if ctx.datastore.list_pack_handlers(&dir)?.is_empty() {
+            continue;
+        }
+        orphans.push(dir);
+    }
+    orphans.sort();
+    Ok(orphans)
+}
+
+/// The shared warning line for orphaned state left in place: `up` emits
+/// it whenever [`scan_orphaned`] finds anything, and a filtered `down`
+/// emits it for orphans outside its filter. Names render in display
+/// form (the form `dodot down <pack>` accepts).
+pub fn orphan_warning(dir_names: &[String], ctx: &ExecutionContext) -> String {
+    let names = dir_names
+        .iter()
+        .map(|d| packs::display_name_for(d))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "warning: packs with deployed state no longer exist in {}: {} — run `dodot down` to remove it",
+        ctx.paths.dotfiles_root().display(),
+        names,
+    )
 }
 
 /// Execute a pre-collected set of intents.

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -336,8 +336,13 @@ pub fn orphan_warning(dir_names: &[String], ctx: &ExecutionContext) -> String {
         .map(|d| packs::display_name_for(d))
         .collect::<Vec<_>>()
         .join(", ");
+    let (noun, verb, pronoun) = if dir_names.len() == 1 {
+        ("pack", "exists", "it")
+    } else {
+        ("packs", "exist", "them")
+    };
     format!(
-        "warning: packs with deployed state no longer exist in {}: {} — run `dodot down` to remove it",
+        "warning: {noun} with deployed state no longer {verb} in {}: {} — run `dodot down` to remove {pronoun}",
         ctx.paths.dotfiles_root().display(),
         names,
     )

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -93,9 +93,16 @@ pub trait Pather: Send + Sync {
         self.dotfiles_root().join(pack)
     }
 
+    /// Root of the per-pack datastore tree (e.g. `.../data/packs`).
+    /// Each child directory is one pack's state subtree, named by the
+    /// pack's on-disk directory name.
+    fn packs_data_root(&self) -> PathBuf {
+        self.data_dir().join("packs")
+    }
+
     /// Data directory for a specific pack (e.g. `.../data/packs/{pack}`).
     fn pack_data_dir(&self, pack: &str) -> PathBuf {
-        self.data_dir().join("packs").join(pack)
+        self.packs_data_root().join(pack)
     }
 
     /// Data directory for a specific handler within a pack


### PR DESCRIPTION
closes #255

## Context

**Why this approach.** The root cause is an enumeration mismatch: `up`/`down` iterate `discover_packs(dotfiles_root)` (the repo), while the init script and deployment map regenerate from the whole datastore — so state for a pack deleted from the repo is never visited but stays live in every shell. The fix mirrors the #222 ignored-pack sweep, as the issue suggests: `DataStore::list_packs()` gives the datastore-side enumeration, `scan_orphaned()` diffs it against the dotfiles root, and the existing sweep machinery (generalized `sweep_ignored_state` → `sweep_pack_state`, since both sweeps are the same mechanism) removes the state.

**Orphan definition.** A datastore `packs/` subtree with handler state whose directory no longer *exists* under the dotfiles root (`fs.exists` check). This matches the issue wording exactly and keeps the blast radius minimal — a config-pattern-ignored pack still on disk is not treated as orphaned (out of scope here, same as it was for #222).

**Behavior choices:**
- `dodot down` (no args) sweeps every orphan — down means "remove all deployed state".
- `dodot down <pack>` accepts an orphaned name (dir or display form; previously `PackNotFound`) and sweeps only what the filter names. A filtered run does **not** sweep unrelated orphans (scoped intent — the issue only mandates unfiltered sweeping for the no-args case); instead it warns about orphans left behind.
- Dry-run renders would-be-swept orphans with the same "would remove" rows as normal packs. A real run reports what it swept via the warnings channel, because orphans cannot render through the post-removal `status` pass (there is no repo pack to show).
- `dodot up` only warns (`run \`dodot down\` to remove it`) and never sweeps — the issue's caution that a misresolved dotfiles root must not wipe legitimate state on deploy.

**Out of scope / do not "fix":**
- Sweeping orphans on `up` (deliberate, per the misresolved-root caution above).
- Treating root-config pattern-ignored packs as orphans (they exist on disk; separate discussion if wanted).
- `status` surfacing orphans — the issue asks for `up`/`down` semantics only.
- The unfiltered ignored-pack sweep on filtered runs is pre-existing #222 behavior, unchanged.

**Verification.** `pixi run test` green (1311 tests, including 7 new integration tests in `gating.rs` covering no-args sweep, orphan-by-name, display-name resolution, unknown-name error, dry-run reporting, filtered-run warning, and up-warns-without-sweeping, plus 2 `list_packs` unit tests); `pixi run lint` green via the commit/push hooks. No governing ADR/Spec list was named in the brief (standalone issue); the self-check was against the issue's Expected section and the #222 sweep precedent it cites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)