### PR TITLE
Add `dodot reset`: factory-reset all dodot state

### DIFF
--- a/CHANGELOG/unreleased-reset-command.md
+++ b/CHANGELOG/unreleased-reset-command.md
@@ -1,0 +1,1 @@
+- feat: new `dodot reset` command — factory-reset everything dodot owns under its data dir (`~/.local/share/dodot`) as a troubleshooting escape hatch; confirms interactively by default, `--force` skips the prompt, `--dry-run` previews, and the dotfiles repo is never touched (#256)

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -161,6 +161,45 @@ fn print_warnings(warnings: &[String]) {
     }
 }
 
+/// `dodot reset [--dry-run] [--force]` — factory-reset all dodot-owned
+/// state under the data dir (troubleshooting escape hatch, issue #256).
+///
+/// Destructive, so it confirms first: interactive y/N prompt (default
+/// No) on a TTY, `--force` to skip it — the only way to run reset
+/// non-interactively. `--dry-run` needs no confirmation (it mutates
+/// nothing) and previews the removals. A declined prompt exits
+/// silently with a stderr note; nothing is removed.
+pub fn reset_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::MessageResult> {
+    let ctx = build_ctx(matches)?;
+    let force = flag_or_false(matches, "force");
+
+    if !ctx.dry_run && !force {
+        if !crate::interactive::stdin_is_tty() {
+            return Err(anyhow::anyhow!(
+                "dodot reset wipes all dodot state and needs confirmation.\n  \
+                 Re-run with --force to skip the prompt, or --dry-run to preview."
+            ));
+        }
+        let data_dir = ctx.paths.data_dir().display().to_string();
+        let confirmed = crate::interactive::prompt_confirm(&[
+            &format!("This removes everything dodot has set up ({data_dir}):"),
+            "deployed symlinks stop working, shell wiring is gone, and install",
+            "scripts / Brewfiles will run again on the next `dodot up`.",
+            "Your dotfiles repo is not touched.",
+        ])?;
+        if !confirmed {
+            eprintln!("Reset cancelled — nothing removed.");
+            return Ok(Output::Silent);
+        }
+    }
+
+    let result = commands::reset::reset(&ctx)?;
+    Ok(Output::Render(result))
+}
+
 pub fn list_handler(
     matches: &clap::ArgMatches,
     _ctx: &CommandContext,

--- a/crates/dodot-cli/src/help.rs
+++ b/crates/dodot-cli/src/help.rs
@@ -47,6 +47,7 @@ const HELP_TEXTS: &[(&str, &str)] = &[
         include_str!("help/git-show-filters.txt"),
     ),
     ("prompts", include_str!("help/prompts.txt")),
+    ("reset", include_str!("help/reset.txt")),
     ("config", include_str!("help/config.txt")),
     (
         "probe.deployment-map",

--- a/crates/dodot-cli/src/help/dodot.txt
+++ b/crates/dodot-cli/src/help/dodot.txt
@@ -32,6 +32,7 @@ always live — the deployed file [item]is[/item] the source file, through a sym
   [item]tutorial[/item]      [desc]Interactive walkthrough using your real dotfiles[/desc]
   [item]init-sh[/item]       [desc]Print the shell init script (eval in your rc file)[/desc]
   [item]config[/item]        [desc]Inspect, generate, or edit configuration[/desc]
+  [item]reset[/item]         [desc]Resets all dodot setup, useful for troubleshooting[/desc]
   [item]help[/item]          [desc]Print help for a command, e.g. [item]dodot help up[/item][/desc]
 
 [header]GLOBAL OPTIONS[/header]

--- a/crates/dodot-cli/src/help/reset.txt
+++ b/crates/dodot-cli/src/help/reset.txt
@@ -1,0 +1,37 @@
+[header]dodot reset[/header] — Factory-reset all dodot state. A troubleshooting escape hatch.
+
+[desc]Removes everything dodot owns under its data directory
+([item]~/.local/share/dodot[/item]): the per-pack datastore, the generated shell init
+script, the deployment map, probe reports, and prompt/tutorial state. The
+next [item]dodot up[/item] rebuilds all of it from scratch.
+
+Your dotfiles repo is [item]not[/item] touched — sources stay exactly where they are.
+Deployed symlinks in [item]$HOME[/item] are also left in place; they dangle until the
+next [item]up[/item] re-links them, same as after [item]down[/item].
+
+You should never [item]need[/item] this. Reach for it when dodot's state got wrecked in
+a way the normal commands can't express — a moved dotfiles clone, leftovers
+from an older dodot — and you just want working shells back.[/desc]
+
+[header]USAGE[/header]
+  [usage]dodot reset [OPTIONS][/usage]
+
+[header]OPTIONS[/header]
+  [item]--dry-run[/item]      [desc]List what would be removed without making changes[/desc]
+  [item]--force[/item]        [desc]Skip the confirmation prompt (required when stdin is
+                 not a terminal)[/desc]
+
+[header]EXAMPLES[/header]
+  [example]dodot reset --dry-run   [dim]# see what a reset would remove[/dim]
+  dodot reset             [dim]# asks y/N, then wipes dodot's state[/dim]
+  dodot reset --force     [dim]# no prompt (scripts, CI)[/dim]
+  dodot up                [dim]# afterwards: redeploy everything[/dim][/example]
+
+[header]NOTES[/header]
+  [desc]Like [item]down[/item], code-execution side effects (packages a Brewfile installed,
+  files an [item]install.sh[/item] created) are not undone — but their run-once records
+  are, so the next [item]up[/item] runs install scripts and Brewfiles again.[/desc]
+
+[header]SEE ALSO[/header]
+  [item]dodot down[/item]     [desc]Targeted removal for specific packs[/desc]
+  [item]dodot up[/item]       [desc]Redeploy after a reset[/desc]

--- a/crates/dodot-cli/src/interactive.rs
+++ b/crates/dodot-cli/src/interactive.rs
@@ -48,3 +48,26 @@ pub fn prompt_yes_no_show(prompt_lines: &[&str]) -> io::Result<YesNoShow> {
         _ => YesNoShow::No,
     })
 }
+
+/// Ask a y/N question on stderr and return whether the user confirmed.
+///
+/// `prompt_lines` are printed verbatim (one per line); a final
+/// `Proceed? [y/N]` marker is appended automatically. Unlike
+/// [`prompt_yes_no_show`], empty input maps to **No** — this is the
+/// prompt for destructive actions (`dodot reset`), where a stray
+/// Enter must never wipe state.
+pub fn prompt_confirm(prompt_lines: &[&str]) -> io::Result<bool> {
+    let mut stderr = io::stderr().lock();
+    for line in prompt_lines {
+        writeln!(stderr, "{line}")?;
+    }
+    write!(stderr, "Proceed? [y/N] ")?;
+    stderr.flush()?;
+
+    let mut buf = String::new();
+    let stdin = io::stdin();
+    stdin.lock().read_line(&mut buf)?;
+    let answer = buf.trim().to_ascii_lowercase();
+
+    Ok(matches!(answer.as_str(), "y" | "yes"))
+}

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -299,6 +299,8 @@ fn build_app() -> App {
         .expect("register transform.install-hook")
         .command("refresh", handlers::refresh_handler, "refresh")
         .expect("register refresh")
+        .command("reset", handlers::reset_handler, "message")
+        .expect("register reset")
         .command(
             "template.install-filter",
             handlers::template_install_filter_handler,
@@ -375,6 +377,7 @@ fn build_app() -> App {
                 commands: vec![
                     Some("transform".into()),
                     Some("refresh".into()),
+                    Some("reset".into()),
                     Some("tutorial".into()),
                     Some("init-sh".into()),
                     Some("prompts".into()),
@@ -775,6 +778,22 @@ fn build_clap_command() -> ClapCommand {
                          templates. Read-only. Useful before the first `dodot up` \
                          to inventory which providers a repo needs.",
                     ),
+                ),
+        )
+        .subcommand(
+            ClapCommand::new("reset")
+                .about("Resets all dodot setup, useful for troubleshooting")
+                .arg(
+                    Arg::new("dry-run")
+                        .long("dry-run")
+                        .help("Show what would be removed without making changes")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("force")
+                        .long("force")
+                        .help("Skip the confirmation prompt (required when stdin is not a terminal)")
+                        .action(ArgAction::SetTrue),
                 ),
         )
         .subcommand(

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod list;
 pub mod probe;
 pub mod prompts;
 pub mod refresh;
+pub mod reset;
 pub mod secret;
 pub mod status;
 pub mod template_clean;
@@ -233,7 +234,9 @@ impl DisplayConflict {
     }
 }
 
-fn shorten_path(p: &std::path::Path, home: &std::path::Path) -> String {
+/// Display a path as `~/...` when it lives under `home`. Shared by
+/// conflict display and `reset`'s data-dir headline.
+pub(crate) fn shorten_path(p: &std::path::Path, home: &std::path::Path) -> String {
     if let Ok(rel) = p.strip_prefix(home) {
         format!("~/{}", rel.display())
     } else {

--- a/crates/dodot-lib/src/commands/reset.rs
+++ b/crates/dodot-lib/src/commands/reset.rs
@@ -1,0 +1,90 @@
+//! `reset` command — factory-reset all dodot-owned state.
+//!
+//! Removes every top-level entry under the data dir
+//! (`~/.local/share/dodot`): `packs/`, the generated shell init,
+//! `deployment-map.tsv`, probes, prompts and tutorial state —
+//! everything dodot owns, including entries future versions may add.
+//! The data dir itself is kept (empty); the next `dodot up` rebuilds
+//! from scratch.
+//!
+//! What reset deliberately does NOT touch:
+//!
+//! - The dotfiles repo — sources are the user's, never dodot's.
+//! - Deploy-target symlinks in `$HOME` / `$XDG_CONFIG_HOME`. Wiping
+//!   the datastore leaves them dangling until the next `up` re-links
+//!   them, exactly like after `down`.
+//! - The cache dir (`~/.cache/dodot`). Its contents are rederivable
+//!   and self-heal on the next `up`; a troubleshooting reset gains
+//!   nothing from chasing them.
+//!
+//! This is the troubleshooting escape hatch for "how did it get into
+//! THIS state" situations (issue #256): orphaned datastore entries
+//! after a dotfiles-repo move, stale layouts from older dodot
+//! versions. It should never be *needed*, but when it is, it beats
+//! asking users to hand-`rm -rf` internals.
+//!
+//! Confirmation policy lives in the CLI handler (interactive prompt /
+//! `--force`), not here — this function assumes the caller already
+//! decided to proceed. `ctx.dry_run` previews the removals without
+//! mutating anything.
+
+use tracing::info;
+
+use crate::commands::{shorten_path, MessageResult};
+use crate::packs::orchestration::ExecutionContext;
+use crate::Result;
+
+/// Run the `reset` command: remove every top-level entry under the
+/// data dir. Honors `ctx.dry_run` (list, don't remove). Returns a
+/// `MessageResult` whose details name each removed entry (directories
+/// with a trailing `/`), sorted by name.
+pub fn reset(ctx: &ExecutionContext) -> Result<MessageResult> {
+    let data_dir = ctx.paths.data_dir().to_path_buf();
+    let display_dir = shorten_path(&data_dir, ctx.paths.home_dir());
+    info!(data_dir = %data_dir.display(), dry_run = ctx.dry_run, "starting reset command");
+
+    let entries = if ctx.fs.is_dir(&data_dir) {
+        ctx.fs.read_dir(&data_dir)?
+    } else {
+        Vec::new()
+    };
+
+    if entries.is_empty() {
+        return Ok(MessageResult {
+            message: format!("Nothing to reset — no dodot state under {display_dir}."),
+            details: Vec::new(),
+        });
+    }
+
+    let mut details = Vec::new();
+    for entry in &entries {
+        let label = if entry.is_dir {
+            format!("{}/", entry.name)
+        } else {
+            entry.name.clone()
+        };
+        if ctx.dry_run {
+            details.push(format!("would remove {label}"));
+        } else {
+            info!(entry = %entry.path.display(), "removing");
+            // `read_dir` reports symlinks as `is_symlink` (not
+            // `is_dir`), so links land in the `remove_file` arm and
+            // are removed without following — reset never deletes
+            // through a link.
+            if entry.is_dir {
+                ctx.fs.remove_dir_all(&entry.path)?;
+            } else {
+                ctx.fs.remove_file(&entry.path)?;
+            }
+            details.push(format!("removed {label}"));
+        }
+    }
+
+    let message = if ctx.dry_run {
+        format!("Would reset all dodot state under {display_dir}.")
+    } else {
+        format!("All dodot state under {display_dir} removed. Run `dodot up` to redeploy.")
+    };
+
+    Ok(MessageResult { message, details })
+}

--- a/crates/dodot-lib/src/commands/tests/mod.rs
+++ b/crates/dodot-lib/src/commands/tests/mod.rs
@@ -3,6 +3,7 @@
 mod adopt;
 mod gating;
 mod probe;
+mod reset;
 mod support;
 
 #[allow(unused_imports)]

--- a/crates/dodot-lib/src/commands/tests/reset.rs
+++ b/crates/dodot-lib/src/commands/tests/reset.rs
@@ -1,0 +1,156 @@
+//! Tests for `dodot reset` — the factory-reset escape hatch.
+
+use crate::commands;
+use crate::fs::Fs;
+use crate::paths::Pather;
+use crate::testing::TempEnvironment;
+
+use super::support::make_ctx;
+
+/// Drop representative dodot-owned state under the env's data dir:
+/// the datastore tree, the deployment map, shell init, probes, and
+/// prompts/tutorial state.
+fn seed_data_dir(env: &TempEnvironment) {
+    let data = env.paths.data_dir().to_path_buf();
+    let fs = &env.fs;
+    fs.mkdir_all(&data.join("packs").join("vim").join("symlink"))
+        .unwrap();
+    fs.write_file(
+        &data.join("packs").join("vim").join("symlink").join("vimrc"),
+        b"link",
+    )
+    .unwrap();
+    fs.mkdir_all(&data.join("shell")).unwrap();
+    fs.write_file(&data.join("shell").join("dodot-init.sh"), b"# init")
+        .unwrap();
+    fs.mkdir_all(&data.join("probes").join("shell-init"))
+        .unwrap();
+    fs.write_file(&data.join("deployment-map.tsv"), b"a\tb\n")
+        .unwrap();
+    fs.write_file(&data.join("prompts.json"), b"{}").unwrap();
+    fs.write_file(&data.join("tutorial.json"), b"{}").unwrap();
+}
+
+#[test]
+fn reset_removes_everything_under_data_dir() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+    seed_data_dir(&env);
+    let ctx = make_ctx(&env);
+
+    let result = commands::reset::reset(&ctx).unwrap();
+
+    let data = env.paths.data_dir();
+    assert!(env.fs.is_dir(data), "data dir itself is kept");
+    assert!(
+        env.fs.read_dir(data).unwrap().is_empty(),
+        "data dir must be empty after reset"
+    );
+    assert!(result.message.contains("Run `dodot up` to redeploy"));
+    // read_dir sorts by name, so details are deterministic.
+    assert_eq!(
+        result.details,
+        vec![
+            "removed deployment-map.tsv",
+            "removed packs/",
+            "removed probes/",
+            "removed prompts.json",
+            "removed shell/",
+            "removed tutorial.json",
+        ]
+    );
+}
+
+#[test]
+fn reset_does_not_touch_the_dotfiles_repo() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+    seed_data_dir(&env);
+    let ctx = make_ctx(&env);
+
+    commands::reset::reset(&ctx).unwrap();
+
+    assert!(
+        env.fs.exists(&env.dotfiles_root.join("vim").join("vimrc")),
+        "sources must survive a reset"
+    );
+}
+
+#[test]
+fn reset_dry_run_lists_without_removing() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+    seed_data_dir(&env);
+    let mut ctx = make_ctx(&env);
+    ctx.dry_run = true;
+
+    let result = commands::reset::reset(&ctx).unwrap();
+
+    assert!(result.message.starts_with("Would reset"));
+    assert!(result
+        .details
+        .iter()
+        .all(|d| d.starts_with("would remove ")));
+    assert_eq!(result.details.len(), 6);
+    let data = env.paths.data_dir();
+    assert_eq!(
+        env.fs.read_dir(data).unwrap().len(),
+        6,
+        "dry-run must not remove anything"
+    );
+}
+
+#[test]
+fn reset_with_no_state_reports_nothing_to_do() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+    // TempEnvironment pre-creates empty `packs/` and `shell/` dirs;
+    // clear them so this exercises the truly-empty data dir.
+    for entry in env.fs.read_dir(env.paths.data_dir()).unwrap() {
+        env.fs.remove_dir_all(&entry.path).unwrap();
+    }
+    let ctx = make_ctx(&env);
+
+    let result = commands::reset::reset(&ctx).unwrap();
+
+    assert!(result.message.starts_with("Nothing to reset"));
+    assert!(result.details.is_empty());
+}
+
+/// A top-level symlink in the data dir is removed as a link — reset
+/// must not follow it and delete the target's contents.
+#[test]
+fn reset_removes_symlink_entries_without_following() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompatible")
+        .done()
+        .build();
+    let data = env.paths.data_dir().to_path_buf();
+    env.fs.mkdir_all(&data).unwrap();
+    // Link inside the data dir pointing at the dotfiles repo.
+    env.fs
+        .symlink(&env.dotfiles_root.join("vim"), &data.join("stray-link"))
+        .unwrap();
+    let ctx = make_ctx(&env);
+
+    commands::reset::reset(&ctx).unwrap();
+
+    assert!(!env.fs.is_symlink(&data.join("stray-link")));
+    assert!(
+        env.fs.exists(&env.dotfiles_root.join("vim").join("vimrc")),
+        "reset must not delete through a symlink"
+    );
+}


### PR DESCRIPTION
closes #256

## What

New `dodot reset` command (MISC group: "Resets all dodot setup, useful for troubleshooting") — the one-shot factory reset for when dodot's state got wrecked in a way `up`/`down`/`status` can't express (e.g. orphaned datastore entries after a dotfiles-repo move, #255).

- Removes every top-level entry under the data dir (`~/.local/share/dodot`): `packs/`, the generated shell init, `deployment-map.tsv`, probes, prompts and tutorial state — everything dodot owns, including entries future versions add. The data dir itself is kept (empty); `dodot up` rebuilds from scratch.
- **Destructive → confirm:** interactive y/N prompt on a TTY (default **No** — unlike the existing `[Y/n/show]` prompt, a stray Enter must not wipe state); `--force` skips it and is required when stdin is not a terminal (matches the existing `--force` convention on `up`/`adopt`). Declined prompt exits silently with a stderr note.
- **`--dry-run`** lists what would be removed, consistent with `up`/`down`.
- Prints the next-step hint: ``Run `dodot up` to redeploy.``
- Never touches the dotfiles repo or deploy-target symlinks in `$HOME` (they dangle until the next `up`, same as after `down`). Symlink entries inside the data dir are removed as links, never followed.

## Context

- **Why this approach:** the lib command (`commands::reset`) enumerates and removes top-level data-dir entries generically rather than naming each known path — so state added by future dodot versions (the "stale generations from older layouts" case in the issue) is wiped too. Confirmation policy lives in the CLI handler; the lib function assumes the caller decided, mirroring how the rest of the command API splits policy from mechanism. Renders through the existing `MessageResult`/`message` template.
- **Deliberately out of scope / do NOT "fix":**
  - The cache dir (`~/.cache/dodot`) is left alone — the issue scopes reset to the data dir; cache contents (preprocessor baselines, brew probe cache) are rederivable and self-heal on the next `up`.
  - No user-doc snippet (`docs/user/commands/reset.lex`) — user docs are in a deliberate vetted-atoms phase with `:: verified ::` stamping; a drive-by doc would bypass that discipline. Hand-written `--help` text (`help/reset.txt`) and the top-level help MISC entry are included.
  - Chasing dangling deploy-target symlinks in `$HOME` is explicitly not reset's job (per the issue).
- **Self-check:** verified with `pixi run test` (1307 passed) and an end-to-end smoke run in an isolated `$HOME` (non-TTY refusal, dry-run, force, empty-state cases). The spawn brief did not name governing ADR/Spec docs or a Brief-template decision-boundary list for this issue — flagging per protocol; the self-check was done against the issue text and `docs/user`/help conventions instead.

## Testing

- 5 new lib tests (`commands/tests/reset.rs`): full wipe with deterministic detail lines, repo untouched, dry-run mutates nothing, empty-state message, symlink-entry not followed.
- Full suite green: 1307 tests; lint suite green via commit/push hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)