### PR TITLE
Redesign shared pack status output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ nvim/
 ```sh
 $ dodot status nvim
 
-nvim/aliases.sh                  ⚙ pending
-nvim/bin                         + pending
+nvim/aliases.sh                  ⚙ not sourced
+nvim/bin                         + not in PATH
 nvim/init.lua                    ➞ pending
 nvim/lua                         ➞ pending
-nvim/Brewfile                    ⚙ pending
+nvim/Brewfile                    ⚙ brew packages not installed
 ```
 
 Pack-root entries default to `$XDG_CONFIG_HOME/<pack>/<name>` — the pack name namespaces config under XDG, matching the convention modern tools (nvim, helix, ghostty, kitty, …) follow. Files like `~/.bashrc` that legacy tools expect in `$HOME` go through `force_home` (auto-handled for canonical names) or the per-file `home.X` opt-in prefix.

--- a/README.md
+++ b/README.md
@@ -62,12 +62,11 @@ nvim/
 ```sh
 $ dodot status nvim
 
-nvim
-    aliases.sh  ⚙ shell profile               pending
-    bin         + $PATH/bin                   pending
-    init.lua    ➞ ~/.config/nvim/init.lua     pending
-    lua         ➞ ~/.config/nvim/lua          pending
-    Brewfile    ⚙ brew install                pending
+nvim/aliases.sh                  ⚙ pending
+nvim/bin                         + pending
+nvim/init.lua                    ➞ pending
+nvim/lua                         ➞ pending
+nvim/Brewfile                    ⚙ pending
 ```
 
 Pack-root entries default to `$XDG_CONFIG_HOME/<pack>/<name>` — the pack name namespaces config under XDG, matching the convention modern tools (nvim, helix, ghostty, kitty, …) follow. Files like `~/.bashrc` that legacy tools expect in `$HOME` go through `force_home` (auto-handled for canonical names) or the per-file `home.X` opt-in prefix.
@@ -78,11 +77,10 @@ Preview with `dodot up --dry-run`, then deploy:
 $ dodot up nvim
 
 Packs deployed.
-nvim
-    init.lua    ➞ ~/.config/nvim/init.lua    deployed
-    lua         ➞ ~/.config/nvim/lua         deployed
-    aliases.sh  ⚙ shell profile               sourced
-    Brewfile    ⚙ brew install              installed
+nvim/init.lua                    ➞ linked
+nvim/lua                         ➞ linked
+nvim/aliases.sh                  ⚙ sourced
+nvim/Brewfile                    ⚙ installed
 ```
 
 Edit your config -- changes are immediate:

--- a/crates/dodot-cli/src/styles/dodot.css
+++ b/crates/dodot-cli/src/styles/dodot.css
@@ -11,6 +11,7 @@
 .error                { font-weight: bold; }
 .dry-run              { font-style: italic; }
 .dim                  { dim: true; }
+.diagnostic-command   { dim: true; }
 .header               { font-weight: bold; }
 .conflict-banner      { font-weight: bold; }
 .conflict-header      { font-weight: bold; }

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -142,7 +142,7 @@ impl Health {
                 _ => "pending".into(),
             },
             Health::Deployed => match handler {
-                "symlink" => "deployed".into(),
+                "symlink" => "linked".into(),
                 "shell" => "sourced".into(),
                 "path" => "in PATH".into(),
                 "install" | "homebrew" | "nix" => run_once_status_messages(handler).deployed,

--- a/crates/dodot-lib/src/commands/tests/mod.rs
+++ b/crates/dodot-lib/src/commands/tests/mod.rs
@@ -453,7 +453,7 @@ fn up_and_status_produce_matching_labels() {
     );
 
     // Spot-check the actual labels: should be the steady-state vocabulary
-    // ("deployed", "sourced", "in PATH"), not the executor vocabulary
+    // ("linked", "sourced", "in PATH"), not the executor vocabulary
     // ("staged X", "executed: X").
     let labels: Vec<&str> = up_labels.values().map(String::as_str).collect();
     assert!(
@@ -465,8 +465,8 @@ fn up_and_status_produce_matching_labels() {
         "expected shell handler to render as 'sourced', got: {labels:?}"
     );
     assert!(
-        labels.contains(&"deployed"),
-        "expected symlink handler to render as 'deployed', got: {labels:?}"
+        labels.contains(&"linked"),
+        "expected symlink handler to render as 'linked', got: {labels:?}"
     );
     assert!(
         labels.iter().all(|l| !l.starts_with("staged ")),
@@ -879,19 +879,20 @@ fn pack_status_renders_flaky_timeline_with_semantic_styles() {
     let result = commands::status::status(None, &ctx).unwrap();
     let out = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
 
-    // Row: newest run failed → broken verdict + warning-styled marker.
+    // Row: newest run failed → whole-row broken verdict + plain marker.
     assert!(
-        out.contains("[broken]exited 1[/broken] [warning][1][/warning]"),
-        "row should carry broken verdict + warning marker, got:\n{out}"
+        out.contains("[broken]vim/aliases.sh") && out.contains("⚙ exited 1 [1][/broken]"),
+        "row should carry broken verdict + marker, got:\n{out}"
     );
-    // Footnote: warning marker, ✓/✗ timeline oldest→newest, warning
-    // prose with the probe command in normal emphasis.
+    // Footnote: plain marker, ✓/✗ timeline oldest→newest, warning
+    // prose around a muted normal-colour probe command.
     assert!(
         out.contains(
-            "[warning][1][/warning] [deployed]✓[/deployed] [deployed]✓[/deployed] \
+            "[1] [deployed]✓[/deployed] [deployed]✓[/deployed] \
              [deployed]✓[/deployed] [error]✗[/error] [error]✗[/error] \
-             [warning]2 of the last 5 runs failed, see[/warning] \
-             dodot probe shell-init vim/aliases.sh [warning]for more.[/warning]"
+             [warning]2 of the last 5 runs failed, see [/warning]\
+             [diagnostic-command]dodot probe shell-init vim/aliases.sh[/diagnostic-command]\
+             [warning] for more.[/warning]"
         ),
         "footnote should render the styled timeline, got:\n{out}"
     );
@@ -928,14 +929,15 @@ fn pack_status_renders_latest_success_row_green_with_warning_marker() {
     let out = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
 
     assert!(
-        out.contains("[deployed]sourced[/deployed] [warning][1][/warning]"),
-        "currently-clean row stays deployed-styled with a warning marker, got:\n{out}"
+        out.contains("[deployed]vim/aliases.sh") && out.contains("⚙ sourced [1][/deployed]"),
+        "currently-clean row stays deployed-styled with a marker, got:\n{out}"
     );
     assert!(
         out.contains(
             "[error]✗[/error] [deployed]✓[/deployed] \
-             [warning]1 of the last 2 runs failed, see[/warning] \
-             dodot probe shell-init vim/aliases.sh [warning]for more.[/warning]"
+             [warning]1 of the last 2 runs failed, see [/warning]\
+             [diagnostic-command]dodot probe shell-init vim/aliases.sh[/diagnostic-command]\
+             [warning] for more.[/warning]"
         ),
         "timeline reads oldest→newest so the last symbol matches the row, got:\n{out}"
     );
@@ -957,7 +959,7 @@ fn pack_status_renders_unobserved_shell_row_as_pending() {
     let out = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
 
     assert!(
-        out.contains("[pending]not sourced[/pending]"),
+        out.contains("[pending]vim/aliases.sh") && out.contains("⚙ not sourced[/pending]"),
         "unobserved deployed shell file renders the pending presentation, got:\n{out}"
     );
     assert!(!out.contains("Warnings:"), "got:\n{out}");
@@ -1849,7 +1851,7 @@ fn status_verified_deployed_after_up() {
     let result = commands::status::status(None, &ctx).unwrap();
     let file = &result.packs[0].files[0];
     assert_eq!(file.status, "deployed", "should be verified deployed");
-    assert_eq!(file.status_label, "deployed");
+    assert_eq!(file.status_label, "linked");
 }
 
 #[test]
@@ -2381,6 +2383,122 @@ fn short_mode_renders_one_line_per_pack_with_count() {
     assert!(
         !output.contains("init.lua"),
         "short mode should not render individual files: {output}"
+    );
+}
+
+#[test]
+fn full_mode_renders_flat_status_styled_file_rows() {
+    use crate::commands::{DisplayFile, DisplayPack, PackStatusResult};
+
+    let result = PackStatusResult {
+        message: None,
+        dry_run: false,
+        packs: vec![DisplayPack::new(
+            "vim".into(),
+            vec![DisplayFile {
+                name: "init.lua".into(),
+                symbol: "➞".into(),
+                description: "SHOULD NOT RENDER".into(),
+                status: "deployed".into(),
+                status_label: "linked".into(),
+                handler: "symlink".into(),
+                note_ref: None,
+            }],
+        )],
+        warnings: Vec::new(),
+        notes: Vec::new(),
+        conflicts: Vec::new(),
+        ignored_packs: Vec::new(),
+        inactive_packs: Vec::new(),
+        view_mode: "full".into(),
+        group_mode: "name".into(),
+        diffs: Vec::new(),
+    };
+
+    let output = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
+
+    assert!(
+        output.contains("[deployed]vim/init.lua"),
+        "row should start with the pack/file path under the row status tag: {output}"
+    );
+    assert!(
+        output.contains("➞ linked[/deployed]"),
+        "handler icon and status label should share the row status tag: {output}"
+    );
+    assert!(
+        !output.contains("[pack-name]vim[/pack-name]"),
+        "full output should not render pack-only header rows: {output}"
+    );
+    assert!(
+        !output.contains("SHOULD NOT RENDER"),
+        "full output should not include the handler-description column: {output}"
+    );
+}
+
+#[test]
+fn diagnostics_render_severity_headings_plain_markers_and_muted_commands() {
+    use crate::commands::{DisplayNote, PackStatusResult};
+
+    let result = PackStatusResult {
+        message: None,
+        dry_run: false,
+        packs: Vec::new(),
+        warnings: Vec::new(),
+        notes: vec![
+            DisplayNote {
+                body: "target exists".into(),
+                hint: None,
+                kind: "error".into(),
+                timeline: None,
+                command: Some("dodot status git".into()),
+            },
+            DisplayNote {
+                body: "1 of the last 2 runs failed".into(),
+                hint: None,
+                kind: "warning".into(),
+                timeline: Some(vec![false, true]),
+                command: Some("dodot probe shell-init vim/aliases.sh".into()),
+            },
+        ],
+        conflicts: Vec::new(),
+        ignored_packs: Vec::new(),
+        inactive_packs: Vec::new(),
+        view_mode: "full".into(),
+        group_mode: "name".into(),
+        diffs: Vec::new(),
+    };
+
+    let output = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
+
+    assert!(output.contains("[error]Errors:[/error]"), "got:\n{output}");
+    assert!(
+        output.contains("[warning]Warnings:[/warning]"),
+        "got:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "[1] [error]target exists, see [/error]\
+             [diagnostic-command]dodot status git[/diagnostic-command]\
+             [error] for more.[/error]"
+        ),
+        "error note should keep marker plain and command muted: {output}"
+    );
+    assert!(
+        output.contains(
+            "[2] [error]✗[/error] [deployed]✓[/deployed] \
+             [warning]1 of the last 2 runs failed, see [/warning]\
+             [diagnostic-command]dodot probe shell-init vim/aliases.sh[/diagnostic-command]\
+             [warning] for more.[/warning]"
+        ),
+        "warning note should keep marker plain, timeline styled, and command muted: {output}"
+    );
+    assert!(
+        !output.contains("[warning][2][/warning]"),
+        "diagnostic list markers should not carry severity styling: {output}"
+    );
+    assert!(
+        !output.contains("`dodot"),
+        "diagnostic commands should render without Markdown backticks: {output}"
     );
 }
 

--- a/crates/dodot-lib/src/handlers/homebrew.rs
+++ b/crates/dodot-lib/src/handlers/homebrew.rs
@@ -40,7 +40,7 @@ impl RunOnceCommand for BrewfileCommand {
     }
 
     fn status_deployed(&self) -> &str {
-        "brew packages installed"
+        "installed"
     }
 
     fn status_pending(&self) -> &str {
@@ -67,7 +67,7 @@ mod tests {
     fn brewfile_command_identity() {
         assert_eq!(BrewfileCommand.handler_name(), HANDLER_HOMEBREW);
         assert_eq!(BrewfileCommand.phase(), ExecutionPhase::Provision);
-        assert_eq!(BrewfileCommand.status_deployed(), "brew packages installed");
+        assert_eq!(BrewfileCommand.status_deployed(), "installed");
         assert_eq!(
             BrewfileCommand.status_pending(),
             "brew packages not installed"

--- a/crates/dodot-lib/src/handlers/run_once.rs
+++ b/crates/dodot-lib/src/handlers/run_once.rs
@@ -131,7 +131,7 @@ pub trait RunOnceCommand: Send + Sync {
 
     /// Human-readable status message when a current-hash sentinel
     /// exists. Default: `"ran"`. Override for per-handler copy
-    /// (e.g. `"brew packages installed"`).
+    /// (e.g. `"installed"`).
     fn status_deployed(&self) -> &str {
         "ran"
     }

--- a/crates/dodot-lib/src/handlers/symlink/mod.rs
+++ b/crates/dodot-lib/src/handlers/symlink/mod.rs
@@ -167,7 +167,7 @@ impl Handler for SymlinkHandler {
             handler: HANDLER_SYMLINK.into(),
             deployed: has_state,
             message: if has_state {
-                "symlink deployed".into()
+                "linked".into()
             } else {
                 "symlink pending".into()
             },

--- a/crates/dodot-lib/src/handlers/symlink/mod.rs
+++ b/crates/dodot-lib/src/handlers/symlink/mod.rs
@@ -169,7 +169,7 @@ impl Handler for SymlinkHandler {
             message: if has_state {
                 "linked".into()
             } else {
-                "symlink pending".into()
+                "pending".into()
             },
         })
     }

--- a/crates/dodot-lib/src/handlers/symlink/tests/integration.rs
+++ b/crates/dodot-lib/src/handlers/symlink/tests/integration.rs
@@ -5,18 +5,54 @@
 #![allow(unused_imports)]
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
+use crate::datastore::{DataStore, FilesystemDataStore, NoopCommandRunner};
 use crate::handlers::symlink::*;
 use crate::handlers::{Handler, HandlerConfig, HandlerScope, HANDLER_SYMLINK};
 use crate::operations::HandlerIntent;
 use crate::packs::Pack;
 use crate::paths::Pather;
 use crate::rules::RuleMatch;
+use crate::testing::TempEnvironment;
 
 use super::{default_config, test_pather};
 
 // ── Routing-override conflicts ──────────────────────────────
+
+#[test]
+fn check_status_uses_steady_state_messages() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "set nocompat")
+        .done()
+        .build();
+    let ds = FilesystemDataStore::new(
+        env.fs.clone(),
+        env.paths.clone(),
+        Arc::new(NoopCommandRunner),
+    );
+    let handler = SymlinkHandler;
+
+    let pending = handler
+        .check_status(Path::new("vimrc"), "vim", &ds)
+        .unwrap();
+
+    assert!(!pending.deployed);
+    assert_eq!(pending.message, "pending");
+
+    let source = env.dotfiles_root.join("vim/vimrc");
+    ds.create_data_link("vim", HANDLER_SYMLINK, &source)
+        .unwrap();
+
+    let linked = handler
+        .check_status(Path::new("vimrc"), "vim", &ds)
+        .unwrap();
+
+    assert!(linked.deployed);
+    assert_eq!(linked.message, "linked");
+}
 
 #[test]
 fn targets_plus_home_prefix_is_a_conflict() {

--- a/crates/dodot-lib/src/templates/pack-status.jinja
+++ b/crates/dodot-lib/src/templates/pack-status.jinja
@@ -2,11 +2,14 @@
 {%- if view_mode == "short" -%}
 {{ pack.name | col(32) }} ({{ pack.summary_count }}) [{{ pack.summary_status }}]{{ pack.summary_status }}[/{{ pack.summary_status }}]
 {% else -%}
-[pack-name]{{ pack.name }}[/pack-name]
-{% for file in pack.files %}  {{ file.name | col(24) }} [handler-symbol]{{ file.symbol }}[/handler-symbol] [description]{{ file.description | col(30) }}[/description]  [{{ file.status }}]{{ file.status_label }}[/{{ file.status }}]{% if file.note_ref %}{% if notes[file.note_ref - 1].kind == "warning" %} [warning][{{ file.note_ref }}][/warning]{% else %} [dim][{{ file.note_ref }}][/dim]{% endif %}{% endif %}
+{% for file in pack.files %}[{{ file.status }}]{{ (pack.name ~ "/" ~ file.name) | col(32) }} {{ file.symbol }} {{ file.status_label }}{% if file.note_ref %} [{{ file.note_ref }}]{% endif %}[/{{ file.status }}]
 {% endfor %}
 {%- endif -%}
 {%- endmacro -%}
+{%- macro render_note(note, index) -%}
+  [{{ index }}] {% if note.timeline %}{% for ok in note.timeline %}{% if ok %}[deployed]✓[/deployed] {% else %}[error]✗[/error] {% endif %}{% endfor %}{% endif %}[{{ note.kind }}]{{ note.body }}{% if note.command %}, see [/{{ note.kind }}][diagnostic-command]{{ note.command }}[/diagnostic-command][{{ note.kind }}] for more.{% endif %}[/{{ note.kind }}]
+{% if note.hint %}      [{{ note.kind }}]hint: {{ note.hint }}[/{{ note.kind }}]
+{% endif %}{%- endmacro -%}
 {% if conflicts %}[conflict-banner] ✗ Cross-pack conflicts detected — see details below [/conflict-banner]
 {% endif %}{% if message %}[message]{{ message }}[/message]
 {% endif %}{% if dry_run %}[dry-run]  (dry run — no changes made)[/dry-run]
@@ -27,13 +30,10 @@
 {% endfor %}{% endif %}{% if inactive_packs %}[pack-name]Inactive on this OS[/pack-name]
 {% for name in inactive_packs %}  [ignored-pack]{{ name }}[/ignored-pack]
 {% endfor %}{% endif %}{% endif %}{% if notes %}{% set error_notes = notes | selectattr("kind", "equalto", "error") | list %}{% set warning_notes = notes | selectattr("kind", "equalto", "warning") | list %}{% if error_notes %}
-[header]Errors:[/header]
-{% for note in notes %}{% if note.kind == "error" %}  [dim][{{ loop.index }}][/dim] {{ note.body }}
-{% if note.hint %}      [dim]hint:[/dim] {{ note.hint }}
-{% endif %}{% endif %}{% endfor %}{% endif %}{% if warning_notes %}
-[header]Warnings:[/header]
-{% for note in notes %}{% if note.kind == "warning" %}  [warning][{{ loop.index }}][/warning] {% if note.timeline %}{% for ok in note.timeline %}{% if ok %}[deployed]✓[/deployed] {% else %}[error]✗[/error] {% endif %}{% endfor %}{% endif %}{% if note.command %}[warning]{{ note.body }}, see[/warning] {{ note.command }} [warning]for more.[/warning]{% else %}[warning]{{ note.body }}[/warning]{% endif %}
-{% endif %}{% endfor %}{% endif %}{% endif %}{% if conflicts %}
+[error]Errors:[/error]
+{% for note in notes %}{% if note.kind == "error" %}{{ render_note(note, loop.index) }}{% endif %}{% endfor %}{% endif %}{% if warning_notes %}
+[warning]Warnings:[/warning]
+{% for note in notes %}{% if note.kind == "warning" %}{{ render_note(note, loop.index) }}{% endif %}{% endfor %}{% endif %}{% endif %}{% if conflicts %}
 [conflict-header] Cross-pack conflicts [/conflict-header]
 {% for c in conflicts %}
 {% if c.kind == "symlink" %}The target path [conflict-target]{{ c.target }}[/conflict-target] would be used by multiple packs:

--- a/docs/user/commands/status.lex
+++ b/docs/user/commands/status.lex
@@ -14,7 +14,7 @@ The read-only "what does dodot see?" command. For every pack and every source fi
 
     For each active pack:
 
-    - Every source file dodot saw, with the handler symbol, the deploy target, and the current deployment status.
+    - Every source file dodot saw, as `pack/file` with the handler symbol and current deployment status.
     - Files filtered out (`ignore` / `skip` / `gate`) and why they were filtered.
     - Files affected by preprocessing — under their *post-preprocessing* filename, not the source filename. (A source `config.toml.tmpl` shows as `config.toml`.)
 
@@ -26,7 +26,7 @@ The read-only "what does dodot see?" command. For every pack and every source fi
     Status states for a single row, by handler family:
 
         | Handler family    | Pending             | Deployed                          | Error                                                |
-        | symlink           | not yet linked      | linked at the deploy target       | target exists but isn't dodot's, or the link is broken |
+        | symlink           | pending             | linked                            | target exists but isn't dodot's, or the link is broken |
         | shell / path      | not registered      | registered in shell-init / PATH   | (rare — registration writes are atomic)              |
         | install / homebrew| sentinel missing    | sentinel matches current source   | sentinel exists but its checksum no longer matches   |
 

--- a/docs/user/commands/status.lex
+++ b/docs/user/commands/status.lex
@@ -25,10 +25,10 @@ The read-only "what does dodot see?" command. For every pack and every source fi
 
     Status states for a single row, by handler family:
 
-        | Handler family    | Pending             | Deployed                          | Error                                                |
-        | symlink           | pending             | linked                            | target exists but isn't dodot's, or the link is broken |
-        | shell / path      | not registered      | registered in shell-init / PATH   | (rare — registration writes are atomic)              |
-        | install / homebrew| sentinel missing    | sentinel matches current source   | sentinel exists but its checksum no longer matches   |
+        | Handler family    | Pending                                  | Deployed            | Error                                                |
+        | symlink           | pending                                  | linked              | target exists but isn't dodot's, or the link is broken |
+        | shell / path      | not sourced / not in PATH                | sourced / in PATH   | (rare — registration writes are atomic)              |
+        | install / homebrew| brew packages not installed              | ran / installed     | sentinel exists but its checksum no longer matches   |
 
     :: table align=llll ::
 

--- a/docs/user/conditional-running.lex
+++ b/docs/user/conditional-running.lex
@@ -165,9 +165,8 @@ Conditional Running
     Status output (running on linux):
 
         $ dodot status
-          shared-tools/
-            vimrc                  ➞ ~/.config/vim/vimrc       deployed
-            …
+          shared-tools/vimrc                 ➞ linked
+          …
           Inactive on this OS
             mac-tools (os=darwin, current=linux)
 

--- a/docs/user/getting-started.lex
+++ b/docs/user/getting-started.lex
@@ -51,12 +51,11 @@ Getting started
         $ cd ~/dotfiles
         $ dodot status nvim
 
-        nvim
-            aliases.sh  ⚙ shell profile               pending
-            bin         + $PATH/bin                   pending
-            init.lua    ➞ ~/.config/nvim/init.lua     pending
-            lua         ➞ ~/.config/nvim/lua          pending
-            Brewfile    ⚙ brew install                pending
+        nvim/aliases.sh                  ⚙ pending
+        nvim/bin                         + pending
+        nvim/init.lua                    ➞ pending
+        nvim/lua                         ➞ pending
+        nvim/Brewfile                    ⚙ pending
 
     :: shell ::
 
@@ -73,11 +72,10 @@ Getting started
         $ dodot up nvim
 
         Packs deployed.
-        nvim
-            init.lua    ➞ ~/.config/nvim/init.lua    deployed
-            lua         ➞ ~/.config/nvim/lua         deployed
-            aliases.sh  ⚙ shell profile               sourced
-            Brewfile    ⚙ brew install              installed
+        nvim/init.lua                    ➞ linked
+        nvim/lua                         ➞ linked
+        nvim/aliases.sh                  ⚙ sourced
+        nvim/Brewfile                    ⚙ installed
 
     :: shell ::
 

--- a/docs/user/getting-started.lex
+++ b/docs/user/getting-started.lex
@@ -51,11 +51,11 @@ Getting started
         $ cd ~/dotfiles
         $ dodot status nvim
 
-        nvim/aliases.sh                  ⚙ pending
-        nvim/bin                         + pending
+        nvim/aliases.sh                  ⚙ not sourced
+        nvim/bin                         + not in PATH
         nvim/init.lua                    ➞ pending
         nvim/lua                         ➞ pending
-        nvim/Brewfile                    ⚙ pending
+        nvim/Brewfile                    ⚙ brew packages not installed
 
     :: shell ::
 

--- a/docs/user/handlers/homebrew.lex
+++ b/docs/user/handlers/homebrew.lex
@@ -26,7 +26,7 @@ Runs `brew bundle` against your source `Brewfile` once per content-hash, tracked
     `dodot up` and `dodot status` report one of three states for the Brewfile:
 
     - **`brew packages not installed`** — no sentinel exists. `dodot up` will run `brew bundle` on the next invocation.
-    - **`brew packages installed`** — a sentinel exists for the *current* content hash. The bundle has run, and the source hasn't changed since. `dodot up` is a no-op.
+    - **`installed`** — a sentinel exists for the *current* content hash. The bundle has run, and the source hasn't changed since. `dodot up` is a no-op.
     - **`brew packages older version (N lines added, M removed)`** — a sentinel exists, but for a *different* content hash. The bundle ran successfully against an earlier version of the Brewfile, and you've edited it since. `dodot up` does not auto-rerun. To apply the edits, run `dodot up --provision-rerun`.
 
     For sentinels written before the snapshot convention was introduced, the third state shows `brew packages older version (no diff data)` — the run state is still tracked, but dodot has no record of the prior content to summarize what changed. Manual `brew uninstall` of packages the Brewfile still lists likewise stays sticky: the sentinel records "we ran with this content," and dodot considers the work done until the file changes or `--provision-rerun` is passed.

--- a/docs/user/secrets.lex
+++ b/docs/user/secrets.lex
@@ -53,7 +53,7 @@ Secrets
         port = 5432
 
         $ dodot up app
-        ... symlink:  app/config.toml -> ~/.config/app/config.toml: deployed
+        app/config.toml                   ➞ linked
 
         $ cat ~/.config/app/config.toml
         db_password = "hunter2"
@@ -124,7 +124,7 @@ Secrets
         # identity defaults to ~/.config/age/identity.txt; override here if needed.
 
         $ dodot up ssh
-        ... symlink:  ssh/id_ed25519 -> ~/.config/ssh/id_ed25519: deployed
+        ssh/id_ed25519                    ➞ linked
 
         $ ls -la ~/.local/share/dodot/packs/ssh/preprocessed/id_ed25519
         -rw-------  ...  id_ed25519

--- a/docs/user/templates.lex
+++ b/docs/user/templates.lex
@@ -24,7 +24,7 @@ Template Expansion
         name = "Alice"
 
         $ dodot up git
-        ... symlink:  git/gitconfig -> ~/.gitconfig: deployed
+        git/gitconfig                     ➞ linked
 
         $ cat ~/.gitconfig
         [user]

--- a/tests/e2e/bats/test_down.bats
+++ b/tests/e2e/bats/test_down.bats
@@ -44,9 +44,9 @@ teardown() {
     [ "$status" -eq 0 ]
     assert_output_contains "dry run"
 
-    # State should still be deployed
+    # State should still be linked.
     run dodot status
-    assert_output_contains "deployed"
+    assert_output_contains "linked"
 }
 
 @test "down removes selected packs only" {
@@ -56,11 +56,11 @@ teardown() {
     dodot up
     dodot down vim
 
-    # vim should be pending, git still deployed
+    # vim should be pending, git still linked.
     run dodot status vim
     assert_output_contains "pending"
     run dodot status git
-    assert_output_contains "deployed"
+    assert_output_contains "linked"
 }
 
 @test "down on already-inactive packs is safe" {

--- a/tests/e2e/bats/test_file_prefixes.bats
+++ b/tests/e2e/bats/test_file_prefixes.bats
@@ -40,18 +40,25 @@ expected_app_root() {
     assert_exists "$root/global-settings.json"
 }
 
-@test "status shows app. file deploy path with prefix stripped" {
+@test "status JSON reports app. file target with prefix stripped" {
     create_pack_file "vscode" "app.global-settings.json" '{"x": 1}'
+    dodot up
 
-    run dodot status
+    run dodot status --output json
     [ "$status" -eq 0 ]
-    # The mapping line shows source `app.global-settings.json` ➞ deploy
-    # path under app_support; the deploy half drops the `app.` prefix.
+    local target
     if [[ "$(uname)" == "Darwin" ]]; then
-        assert_output_contains "Application Support/global-settings.json"
+        target="~/Library/Application Support/global-settings.json"
     else
-        assert_output_contains ".config/global-settings.json"
+        target="~/.config/global-settings.json"
     fi
+    jq -e --arg target "$target" '
+        .packs[]
+        | select(.name == "vscode")
+        | .files[]
+        | select(.name == "app.global-settings.json")
+        | .description == $target
+    ' <<<"$output" >/dev/null
 }
 
 # ── xdg. file prefix ────────────────────────────────────────────

--- a/tests/e2e/bats/test_home_prefix.bats
+++ b/tests/e2e/bats/test_home_prefix.bats
@@ -44,24 +44,32 @@ teardown() {
 
 # ── Status display ──────────────────────────────────────────────
 
-@test "status shows ~/.bashrc not ~/.home.bashrc" {
+@test "status JSON routes home.bashrc to ~/.bashrc" {
     create_pack_file "shell" "home.bashrc" "# bashrc"
 
-    run dodot status
+    run dodot status --output json
     [ "$status" -eq 0 ]
-    assert_output_contains "~/.bashrc"
-    assert_output_not_contains "~/.home.bashrc"
+    jq -e '
+        .packs[]
+        | select(.name == "shell")
+        | .files[]
+        | select(.name == "home.bashrc")
+        | .description == "~/.bashrc"
+    ' <<<"$output" >/dev/null
 }
 
-@test "status shows correct target for mix of home. and regular files" {
+@test "status JSON reports targets for multiple home. files" {
     create_pack_file "vim" "home.vimrc" "set nocompatible"
     create_pack_file "vim" "home.gvimrc" "set guifont=Mono"
 
-    run dodot status
+    run dodot status --output json
     [ "$status" -eq 0 ]
-    assert_output_contains "~/.vimrc"
-    assert_output_contains "~/.gvimrc"
-    assert_output_not_contains "~/.home.vimrc"
+    jq -e '
+        .packs[]
+        | select(.name == "vim")
+        | any(.files[]; .name == "home.vimrc" and .description == "~/.vimrc")
+          and any(.files[]; .name == "home.gvimrc" and .description == "~/.gvimrc")
+    ' <<<"$output" >/dev/null
 }
 
 # ── Subdirectory files are NOT stripped ──────────────────────────
@@ -77,11 +85,15 @@ teardown() {
     # ~/.config/app/subdir/, not ~/.config/subdir/.
     create_pack_file "app" "subdir/home.conf" "config"
 
-    run dodot status
+    run dodot status --output json
     [ "$status" -eq 0 ]
-    # Status shows the wholesale subdir entry, not the nested file.
-    assert_output_contains "subdir"
-    assert_output_contains "~/.config/app/subdir"
+    jq -e '
+        .packs[]
+        | select(.name == "app")
+        | .files[]
+        | select(.name == "subdir")
+        | .description == "~/.config/app/subdir"
+    ' <<<"$output" >/dev/null
 
     # After deploy, the nested file is reachable through the dir symlink,
     # and its name retains the literal `home.` prefix (no stripping).
@@ -96,24 +108,44 @@ teardown() {
     create_pack_file "shell" "home.bashrc" "# my bashrc"
 
     # Status before deploy
-    run dodot status
-    assert_output_contains "~/.bashrc"
-    assert_output_contains "pending"
+    run dodot status --output json
+    [ "$status" -eq 0 ]
+    jq -e '
+        .packs[]
+        | select(.name == "shell")
+        | .files[]
+        | select(.name == "home.bashrc")
+        | .description == "~/.bashrc" and .status_label == "pending"
+    ' <<<"$output" >/dev/null
 
     # Deploy
     dodot up
     assert_exists "$HOME/.bashrc"
 
     # Status after deploy
-    run dodot status
-    assert_output_contains "linked"
+    run dodot status --output json
+    [ "$status" -eq 0 ]
+    jq -e '
+        .packs[]
+        | select(.name == "shell")
+        | .files[]
+        | select(.name == "home.bashrc")
+        | .status_label == "linked"
+    ' <<<"$output" >/dev/null
 
     # Down
     dodot down
 
     # Status after down
-    run dodot status
-    assert_output_contains "pending"
+    run dodot status --output json
+    [ "$status" -eq 0 ]
+    jq -e '
+        .packs[]
+        | select(.name == "shell")
+        | .files[]
+        | select(.name == "home.bashrc")
+        | .status_label == "pending"
+    ' <<<"$output" >/dev/null
 
     # Source file still in pack (unchanged)
     assert_exists "$DOTFILES_ROOT/shell/home.bashrc"

--- a/tests/e2e/bats/test_home_prefix.bats
+++ b/tests/e2e/bats/test_home_prefix.bats
@@ -106,7 +106,7 @@ teardown() {
 
     # Status after deploy
     run dodot status
-    assert_output_contains "deployed"
+    assert_output_contains "linked"
 
     # Down
     dodot down

--- a/tests/e2e/bats/test_lifecycle.bats
+++ b/tests/e2e/bats/test_lifecycle.bats
@@ -25,10 +25,10 @@ teardown() {
     [ "$status" -eq 0 ]
     assert_output_contains "deployed"
 
-    # 3. Status after up — deployed
+    # 3. Status after up — linked
     run dodot status
     [ "$status" -eq 0 ]
-    assert_output_contains "deployed"
+    assert_output_contains "linked"
 
     # Symlinks exist
     assert_exists "$HOME/.vimrc"
@@ -51,7 +51,7 @@ teardown() {
 
     dodot up
     run dodot status
-    assert_output_contains "deployed"
+    assert_output_contains "linked"
 
     dodot down
     run dodot status
@@ -60,7 +60,7 @@ teardown() {
     # Re-deploy
     dodot up
     run dodot status
-    assert_output_contains "deployed"
+    assert_output_contains "linked"
 
     # Symlink chain works
     assert_file_contains "$HOME/.vimrc" "set nocompatible"
@@ -80,7 +80,7 @@ teardown() {
 
     # All handlers should be active
     run dodot status
-    assert_output_contains "deployed"
+    assert_output_contains "linked"
     assert_output_not_contains "not sourced"
     assert_output_contains "sourced"
     assert_output_contains "in PATH"
@@ -100,7 +100,7 @@ teardown() {
     # Deploy only vim
     dodot up vim
     run dodot status vim
-    assert_output_contains "deployed"
+    assert_output_contains "linked"
     run dodot status git
     assert_output_contains "pending"
 

--- a/tests/e2e/bats/test_status.bats
+++ b/tests/e2e/bats/test_status.bats
@@ -20,7 +20,7 @@ teardown() {
     assert_output_contains "pending"
 }
 
-@test "status shows deployed after up" {
+@test "status shows linked after up" {
     create_pack_file "vim" "home.vimrc" "set nocompatible"
 
     dodot up
@@ -28,7 +28,7 @@ teardown() {
     [ "$status" -eq 0 ]
     assert_output_contains "vim"
     assert_output_contains "vimrc"
-    assert_output_contains "deployed"
+    assert_output_contains "linked"
 }
 
 @test "status filters by pack name" {


### PR DESCRIPTION
closes #267

## Context

This keeps the change in the shared `pack-status` template so `status`, `up`, `down`, and other pack-status callers render the same shape: full rows are now `pack/file  <handler icon> <status>`, without pack-only headers or the handler-description column. The domain/status bucket remains `deployed` for structured consumers; only requested user-facing copy changes to symlink `linked` and Homebrew `installed`.

Diagnostics now render errors and warnings through one template macro: severity-coloured headings/prose, normal-text list markers, retained shell timeline symbols, and optional see-more commands in the `diagnostic-command` semantic tag. The producers still provide body and command separately; the template does not extract commands from prose.

Self-check: the implementer brief did not name governing Spec/ADR docs, so I treated that mandatory slot as missing. I checked the issue boundaries plus `docs/dev/cli-output.lex` and the Standout rendering/testing guidance: command/domain code still returns structured data, while MiniJinja/CSS own presentation.

Out of scope: deployment semantics, health classification, pack discovery, grouped/short mode behavior, and structured output shape beyond the requested status-label/copy consequences. Do not re-open the removed target/description column in full rows; target inspection remains available through structured/probe surfaces.

Real CLI term-debug smoke used an isolated temporary dotfiles root with a symlink target conflict plus shell history. Captured boundaries included:

```text
[warning]git/home.gitconfig               ➞ pending [1][/warning]
[deployed]vim/aliases.sh                   ⚙ sourced [2][/deployed]
[error]Errors:[/error]
[1] [error]~/.gitconfig (existing file) — `dodot up` will refuse without `--force`[/error]
[warning]Warnings:[/warning]
[2] [error]✗[/error] [deployed]✓[/deployed] [warning]1 of the last 2 runs failed, see [/warning][diagnostic-command]dodot probe shell-init vim/aliases.sh[/diagnostic-command][warning] for more.[/warning]
```

## Verification

- `cargo test -p dodot-lib commands::tests::`
- `pixi run test`
- `pixi run lint --fix`
- `pixi run test`
- Commit and push hooks ran `pixi run lint` successfully
