### PR TITLE
Redesign shared status output columns

### DIFF
--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -221,12 +221,25 @@ static TEMPLATE_ENTRIES: &[(&str, &str)] = &[
     ("secret-list.jinja", render::TEMPLATE_SECRET_LIST),
 ];
 
+fn pack_status_width(terminal_width: Option<usize>) -> usize {
+    terminal_width.unwrap_or(80)
+}
+
 fn build_app() -> App {
     App::builder()
         .help_handling(true)
         .templates(EmbeddedTemplates::new(TEMPLATE_ENTRIES, ""))
         .styles(standout::embed_styles!("src/styles"))
         .default_theme("dodot")
+        // Human pack-status rows fill the detected terminal width. Pipes and
+        // other width-less render targets use the same stable 80-column
+        // fallback as the library renderer and fixed-width tests.
+        .context_fn(
+            "terminal_width",
+            |ctx: &standout::context::RenderContext<'_>| {
+                pack_status_width(ctx.terminal_width).into()
+            },
+        )
         .command("status", handlers::status_handler, "pack-status")
         .expect("register status")
         .command("up", handlers::up_handler, "pack-status")
@@ -897,4 +910,15 @@ fn build_clap_command() -> ClapCommand {
                         ),
                 ),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pack_status_width;
+
+    #[test]
+    fn pack_status_width_uses_standout_value_with_80_column_fallback() {
+        assert_eq!(pack_status_width(Some(132)), 132);
+        assert_eq!(pack_status_width(None), 80);
+    }
 }

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -67,7 +67,7 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
     }
 
     // Discover `.dodotignore`-marked packs so `down` reports them in the
-    // same "Ignored Packs" section `status` shows and sweeps any stale
+    // same ignored rows `status` shows and sweeps any stale
     // datastore state they left behind. (issue #222)
     let ignored = orchestration::scan_ignored(pack_filter, ctx)?;
 
@@ -206,7 +206,7 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
         warnings,
         notes: Vec::new(),
         conflicts: Vec::new(),
-        ignored_packs: ignored.display_names,
+        ignored_packs: ignored.display_packs,
         inactive_packs: Vec::new(),
         view_mode: ctx.view_mode.as_str().into(),
         group_mode: ctx.group_mode.as_str().into(),

--- a/crates/dodot-lib/src/commands/list.rs
+++ b/crates/dodot-lib/src/commands/list.rs
@@ -52,9 +52,9 @@ pub fn list(ctx: &ExecutionContext) -> Result<ListResult> {
         ));
     }
     for dir in scanned.ignored {
-        let display = packs::display_name_for(&dir).to_string();
+        let display = dir.display_name.clone();
         entries.push((
-            dir,
+            dir.name,
             ListPack {
                 name: display,
                 ignored: true,

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -336,11 +336,12 @@ pub struct PackStatusResult {
     /// Cross-pack conflicts to display at the end of the output.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub conflicts: Vec<DisplayConflict>,
-    /// Names of pack-shaped directories skipped because they carry a
-    /// `.dodotignore` marker. Surfaced by `status` so users aren't
-    /// baffled when a directory they expected doesn't appear.
+    /// Pack-shaped directories skipped because they carry an ignore marker,
+    /// including the matching marker filename used by the shared status row.
+    /// Surfaced by `status`, `up`, and `down` so users aren't baffled when a
+    /// directory they expected doesn't appear.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub ignored_packs: Vec<String>,
+    pub ignored_packs: Vec<crate::packs::IgnoredPack>,
     /// Packs gated out by `[pack] os` on the current host. Each entry
     /// is a pre-formatted display string (e.g. `"mac-tools (os=darwin,
     /// current=linux)"`) so the template renders them under their own
@@ -352,8 +353,8 @@ pub struct PackStatusResult {
     /// each pack to a single summary line.
     pub view_mode: String,
     /// `"name"` (default) lists packs in their discovery order;
-    /// `"status"` groups packs under Ignored / Deployed / Pending /
-    /// Error banners.
+    /// `"status"` groups active packs under Deployed / Pending / Error
+    /// banners. Ignored rows follow the groups after a blank separator.
     pub group_mode: String,
     /// Unified diffs for run-once files whose recorded content hash
     /// no longer matches the source on disk. Populated only when the

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -683,11 +683,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
 
     if let Some(names) = pack_filter {
         all_packs.retain(|p| names.iter().any(|n| n == &p.display_name || n == &p.name));
-        ignored_packs.retain(|name| {
-            names
-                .iter()
-                .any(|n| n == name || n == crate::packs::display_name_for(name))
-        });
+        ignored_packs.retain(|p| names.iter().any(|n| n == &p.name || n == &p.display_name));
     }
 
     let registry = handlers::create_registry(ctx.fs.as_ref(), ctx.command_runner.as_ref());
@@ -1028,15 +1024,6 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         warnings.extend(collect_drift_warnings(ctx, &active_packs)?);
     }
 
-    // Surface ignored packs by their display name, not the raw
-    // on-disk directory — the prefix grammar must stay invisible to
-    // the rendered "Ignored Packs" section just like every other
-    // user-facing surface.
-    let ignored_display: Vec<String> = ignored_packs
-        .iter()
-        .map(|d| crate::packs::display_name_for(d).to_string())
-        .collect();
-
     Ok(PackStatusResult {
         message: None,
         dry_run: false,
@@ -1044,7 +1031,7 @@ pub fn status(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<
         warnings,
         notes,
         conflicts: display_conflicts,
-        ignored_packs: ignored_display,
+        ignored_packs,
         inactive_packs,
         view_mode: ctx.view_mode.as_str().into(),
         group_mode: ctx.group_mode.as_str().into(),

--- a/crates/dodot-lib/src/commands/tests/gating.rs
+++ b/crates/dodot-lib/src/commands/tests/gating.rs
@@ -1194,7 +1194,7 @@ fn up_skips_mappings_gated_template() {
 //
 // Two contracts:
 //   1. `up`, `down`, and `status` produce the SAME view for an ignored
-//      pack — the warning + the "Ignored Packs" section — instead of
+//      pack — the warning plus the ignored row — instead of
 //      `up` printing a bare "Packs deployed." with no mention of the
 //      pack.
 //   2. A pack deployed and *then* marked `.dodotignore` must have its
@@ -1202,7 +1202,11 @@ fn up_skips_mappings_gated_template() {
 //      read/sourced again (the gpg `alias.zsh` scenario).
 
 fn ignored_section(result: &commands::PackStatusResult) -> Vec<String> {
-    result.ignored_packs.clone()
+    result
+        .ignored_packs
+        .iter()
+        .map(|p| p.name.clone())
+        .collect()
 }
 
 fn warns_ignored(result: &commands::PackStatusResult, name: &str) -> bool {
@@ -1236,7 +1240,7 @@ fn up_down_status_agree_for_explicitly_requested_ignored_pack() {
         assert_eq!(
             ignored_section(r),
             vec!["gpg".to_string()],
-            "{label} must list gpg in the Ignored Packs section"
+            "{label} must list gpg in the ignored rows"
         );
         assert!(
             warns_ignored(r, "gpg"),
@@ -1417,10 +1421,10 @@ fn filtered_up_sweeps_now_ignored_pack_outside_the_filter() {
         "now-ignored pack must not survive a filtered up; init was:\n{init}"
     );
     // gpg is outside the filter, so it does NOT appear in this run's
-    // Ignored Packs section — reporting stays scoped to the request.
+    // ignored rows — reporting stays scoped to the request.
     assert!(
-        !up.ignored_packs.contains(&"gpg".to_string()),
-        "filtered up should not report unrelated ignored packs"
+        !up.ignored_packs.iter().any(|p| p.name == "gpg"),
+        "gpg should not be reported as ignored for a direct `up vim`"
     );
 }
 

--- a/crates/dodot-lib/src/commands/tests/mod.rs
+++ b/crates/dodot-lib/src/commands/tests/mod.rs
@@ -226,7 +226,7 @@ fn status_lists_ignored_packs() {
     );
     assert!(
         ignored_row.contains("[dim].dodotignore")
-            && ignored_row.contains("[/dim]              [ignored-pack]ignored"),
+            && ignored_row.contains("[/dim] [ignored-pack]ignored"),
         "{ignored_row}"
     );
     assert!(
@@ -2465,7 +2465,7 @@ fn full_mode_renders_80_column_rows_with_isolated_status_style() {
                 symbol: "➞".into(),
                 description: "SHOULD NOT RENDER".into(),
                 status: "deployed".into(),
-                status_label: "linked".into(),
+                status_label: "stale: user link missing, re-deploy to fix".into(),
                 handler: "symlink".into(),
                 note_ref: None,
             }],
@@ -2489,8 +2489,8 @@ fn full_mode_renders_80_column_rows_with_isolated_status_style() {
     );
     assert!(row.contains('…'), "long filenames should clip: {row:?}");
     assert!(
-        row.ends_with("linked"),
-        "status should touch column 80: {row:?}"
+        row.ends_with("stale: user link missing, re-deploy to fix"),
+        "full status should survive and touch column 80: {row:?}"
     );
 
     let output = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
@@ -2504,14 +2504,12 @@ fn full_mode_renders_80_column_rows_with_isolated_status_style() {
         "row should contain the pack name: {output}"
     );
     assert!(
-        output.contains("[dim]a-very-long-")
-            && output.contains('…')
-            && output.contains("config.toml[/dim]"),
+        output.contains("[dim]a-very") && output.contains('…') && output.contains("ig.toml[/dim]"),
         "row should contain the dimmed, middle-clipped file name: {output}"
     );
     assert!(
-        output.contains("[deployed]linked[/deployed]"),
-        "row should contain the deployed status tag: {output}"
+        output.contains("[deployed]stale: user link missing, re-deploy to fix[/deployed]"),
+        "row should contain the full deployed status tag: {output}"
     );
     assert!(
         !output.contains("[deployed]vim"),

--- a/crates/dodot-lib/src/commands/tests/mod.rs
+++ b/crates/dodot-lib/src/commands/tests/mod.rs
@@ -201,17 +201,52 @@ fn status_lists_ignored_packs() {
             .collect::<Vec<_>>(),
         vec!["vim"]
     );
-    assert_eq!(result.ignored_packs, vec!["disabled".to_string()]);
+    assert_eq!(result.ignored_packs.len(), 1);
+    assert_eq!(result.ignored_packs[0].name, "disabled");
+    assert_eq!(result.ignored_packs[0].display_name, "disabled");
+    assert_eq!(result.ignored_packs[0].ignore_file, ".dodotignore");
 
     let output = render::render("pack-status", &result, OutputMode::Text).unwrap();
-    assert!(output.contains("Ignored Packs"), "output: {output}");
-    assert!(output.contains("disabled"), "output: {output}");
+    assert!(!output.contains("Ignored Packs"), "output: {output}");
+    assert!(
+        output.contains("\n\n∅ disabled"),
+        "ignored row should follow active rows after one blank line: {output}"
+    );
+    assert!(output.contains(".dodotignore"), "output: {output}");
+    assert!(output.ends_with("ignored\n"), "output: {output}");
+
+    let styled = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
+    let ignored_row = styled
+        .lines()
+        .find(|line| line.contains("disabled"))
+        .expect("ignored row");
+    assert!(
+        ignored_row.starts_with("[dim]∅[/dim] disabled"),
+        "{ignored_row}"
+    );
+    assert!(
+        ignored_row.contains("[dim].dodotignore")
+            && ignored_row.contains("[/dim]              [ignored-pack]ignored"),
+        "{ignored_row}"
+    );
+    assert!(
+        ignored_row.ends_with("[ignored-pack]ignored[/ignored-pack]"),
+        "{ignored_row}"
+    );
+    assert!(
+        !ignored_row.contains("[ignored-pack]disabled"),
+        "{ignored_row}"
+    );
+
+    let json = render::render("pack-status", &result, OutputMode::Json).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(value["ignored_packs"][0]["ignore_file"], ".dodotignore");
 }
 
 #[test]
 fn status_pack_filter_applies_to_ignored_packs() {
     // `dodot status <name>` should narrow both the main listing and the
-    // ignored-packs section to just the requested name.
+    // ignored rows to just the requested name.
     let env = TempEnvironment::builder()
         .pack("vim")
         .file("vimrc", "x")
@@ -231,7 +266,19 @@ fn status_pack_filter_applies_to_ignored_packs() {
     let result = commands::status::status(Some(&filter), &ctx).unwrap();
 
     assert!(result.packs.is_empty(), "filter should exclude vim");
-    assert_eq!(result.ignored_packs, vec!["disabled".to_string()]);
+    let ignored_names: Vec<String> = result
+        .ignored_packs
+        .iter()
+        .map(|p| p.name.clone())
+        .collect();
+    assert_eq!(ignored_names, vec!["disabled".to_string()]);
+
+    let output = render::render("pack-status", &result, OutputMode::Text).unwrap();
+    assert!(!output.starts_with('\n'), "ignored-only output: {output:?}");
+    assert!(
+        output.starts_with("∅ disabled"),
+        "ignored-only output: {output:?}"
+    );
 }
 
 // ── status: correct target paths ────────────────────────────
@@ -879,10 +926,16 @@ fn pack_status_renders_flaky_timeline_with_semantic_styles() {
     let result = commands::status::status(None, &ctx).unwrap();
     let out = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
 
-    // Row: newest run failed → whole-row broken verdict + plain marker.
+    // Row: newest run failed, but only the status text carries the verdict.
     assert!(
-        out.contains("[broken]vim/aliases.sh") && out.contains("⚙ exited 1 [1][/broken]"),
-        "row should carry broken verdict + marker, got:\n{out}"
+        out.contains("[dim]⚙[/dim] vim")
+            && out.contains("[dim]aliases.sh")
+            && out.contains("[broken]exited 1[/broken] [dim][1][/dim]"),
+        "row should isolate the broken verdict to its status, got:\n{out}"
+    );
+    assert!(
+        !out.contains("[broken]vim"),
+        "pack must stay unstyled: {out}"
     );
     // Footnote: plain marker, ✓/✗ timeline oldest→newest, warning
     // prose around a muted normal-colour probe command.
@@ -929,8 +982,14 @@ fn pack_status_renders_latest_success_row_green_with_warning_marker() {
     let out = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
 
     assert!(
-        out.contains("[deployed]vim/aliases.sh") && out.contains("⚙ sourced [1][/deployed]"),
-        "currently-clean row stays deployed-styled with a marker, got:\n{out}"
+        out.contains("[dim]⚙[/dim] vim")
+            && out.contains("[dim]aliases.sh")
+            && out.contains("[deployed]sourced[/deployed] [dim][1][/dim]"),
+        "currently-clean row styles only its status and marker, got:\n{out}"
+    );
+    assert!(
+        !out.contains("[deployed]vim"),
+        "pack must stay unstyled: {out}"
     );
     assert!(
         out.contains(
@@ -959,8 +1018,14 @@ fn pack_status_renders_unobserved_shell_row_as_pending() {
     let out = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
 
     assert!(
-        out.contains("[pending]vim/aliases.sh") && out.contains("⚙ not sourced[/pending]"),
-        "unobserved deployed shell file renders the pending presentation, got:\n{out}"
+        out.contains("[dim]⚙[/dim] vim")
+            && out.contains("[dim]aliases.sh")
+            && out.contains("[pending]not sourced[/pending]"),
+        "unobserved shell row styles only its pending status, got:\n{out}"
+    );
+    assert!(
+        !out.contains("[pending]vim"),
+        "pack must stay unstyled: {out}"
     );
     assert!(!out.contains("Warnings:"), "got:\n{out}");
     assert!(!out.contains("Errors:"), "got:\n{out}");
@@ -2387,7 +2452,7 @@ fn short_mode_renders_one_line_per_pack_with_count() {
 }
 
 #[test]
-fn full_mode_renders_flat_status_styled_file_rows() {
+fn full_mode_renders_80_column_rows_with_isolated_status_style() {
     use crate::commands::{DisplayFile, DisplayPack, PackStatusResult};
 
     let result = PackStatusResult {
@@ -2396,7 +2461,7 @@ fn full_mode_renders_flat_status_styled_file_rows() {
         packs: vec![DisplayPack::new(
             "vim".into(),
             vec![DisplayFile {
-                name: "init.lua".into(),
+                name: "a-very-long-middle-section-that-must-be-clipped-config.toml".into(),
                 symbol: "➞".into(),
                 description: "SHOULD NOT RENDER".into(),
                 status: "deployed".into(),
@@ -2415,20 +2480,44 @@ fn full_mode_renders_flat_status_styled_file_rows() {
         diffs: Vec::new(),
     };
 
+    let text = render::render("pack-status", &result, OutputMode::Text).unwrap();
+    let row = text.lines().next().expect("status row");
+    assert_eq!(standout_render::tabular::display_width(row), 80, "{row:?}");
+    assert!(
+        row.starts_with("➞ vim                  "),
+        "filename should start in column 24 after a 20-column pack: {row:?}"
+    );
+    assert!(row.contains('…'), "long filenames should clip: {row:?}");
+    assert!(
+        row.ends_with("linked"),
+        "status should touch column 80: {row:?}"
+    );
+
     let output = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();
 
     assert!(
-        output.contains("[deployed]vim/init.lua"),
-        "row should start with the pack/file path under the row status tag: {output}"
+        output.contains("[dim]➞[/dim]"),
+        "row should contain the dimmed icon: {output}"
     );
     assert!(
-        output.contains("➞ linked[/deployed]"),
-        "handler icon and status label should share the row status tag: {output}"
+        output.contains(" vim "),
+        "row should contain the pack name: {output}"
     );
     assert!(
-        !output.contains("[pack-name]vim[/pack-name]"),
-        "full output should not render pack-only header rows: {output}"
+        output.contains("[dim]a-very-long-")
+            && output.contains('…')
+            && output.contains("config.toml[/dim]"),
+        "row should contain the dimmed, middle-clipped file name: {output}"
     );
+    assert!(
+        output.contains("[deployed]linked[/deployed]"),
+        "row should contain the deployed status tag: {output}"
+    );
+    assert!(
+        !output.contains("[deployed]vim"),
+        "pack must be regular: {output}"
+    );
+    assert_eq!(output.matches("[deployed]").count(), 1, "{output}");
     assert!(
         !output.contains("SHOULD NOT RENDER"),
         "full output should not include the handler-description column: {output}"

--- a/crates/dodot-lib/src/commands/tests/probe.rs
+++ b/crates/dodot-lib/src/commands/tests/probe.rs
@@ -895,7 +895,9 @@ fn by_status_folds_ignored_packs_into_ignored_group() {
 
     let output = render::render("pack-status", &result, OutputMode::Text).unwrap();
 
-    assert!(output.contains("Ignored Packs"), "output: {output}");
+    assert!(!output.contains("Ignored Packs"), "output: {output}");
+    assert!(output.contains(".dodotignore"), "output: {output}");
+    assert!(output.contains("\n\n∅ disabled"), "output: {output}");
     assert!(output.contains("disabled"), "output: {output}");
     assert!(output.contains("Pending Packs"), "output: {output}");
 }

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -61,7 +61,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
     };
 
     // Discover `.dodotignore`-marked packs so we can both report them in
-    // the same "Ignored Packs" section `status` shows and sweep any
+    // the same ignored rows `status` shows and sweep any
     // stale datastore state they left behind. Without the sweep, a pack
     // deployed before it was ignored keeps getting sourced from the
     // regenerated init script. (issue #222)
@@ -334,7 +334,7 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
         warnings: planning_warnings,
         notes,
         conflicts: Vec::new(),
-        ignored_packs: ignored.display_names,
+        ignored_packs: ignored.display_packs,
         inactive_packs: Vec::new(),
         view_mode: ctx.view_mode.as_str().into(),
         group_mode: ctx.group_mode.as_str().into(),

--- a/crates/dodot-lib/src/packs/context.rs
+++ b/crates/dodot-lib/src/packs/context.rs
@@ -57,7 +57,7 @@ pub struct ExecutionContext {
     pub view_mode: crate::commands::ViewMode,
     /// How packs are ordered in pack-status output: `Name` (flat
     /// alphabetical / discovery order) or `Status` (grouped under
-    /// Ignored / Deployed / Pending / Error banners). Consumed by
+    /// Deployed / Pending / Error banners, followed by ignored rows). Consumed by
     /// every command that renders through the `pack-status` template;
     /// ignored by commands that emit `message` / `list` output.
     pub group_mode: crate::commands::GroupMode,

--- a/crates/dodot-lib/src/packs/mod.rs
+++ b/crates/dodot-lib/src/packs/mod.rs
@@ -177,11 +177,22 @@ fn detect_display_collisions(packs: &[Pack]) -> Result<()> {
     Ok(())
 }
 
-/// Result of scanning the dotfiles root: active packs + names of
+/// A pack that was skipped during discovery, e.g. via `.dodotignore`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct IgnoredPack {
+    /// On-disk directory name, retained for filtering and datastore sweeping.
+    pub name: String,
+    /// User-facing pack name with any ordering prefix removed.
+    pub display_name: String,
+    /// Marker file that caused discovery to ignore this pack.
+    pub ignore_file: String,
+}
+
+/// Result of scanning the dotfiles root: active packs plus metadata for
 /// pack-shaped directories skipped via `.dodotignore`.
 pub struct DiscoveredPacks {
     pub packs: Vec<Pack>,
-    pub ignored: Vec<String>,
+    pub ignored: Vec<IgnoredPack>,
 }
 
 /// Scan the dotfiles root once, partitioning pack-shaped directories into
@@ -243,7 +254,11 @@ pub fn scan_packs(
         }
 
         if fs.exists(&entry.path.join(".dodotignore")) {
-            ignored.push(name.clone());
+            ignored.push(IgnoredPack {
+                name: name.clone(),
+                display_name: display_name_for(name).to_string(),
+                ignore_file: ".dodotignore".into(),
+            });
             continue;
         }
 
@@ -255,7 +270,7 @@ pub fn scan_packs(
     }
 
     packs.sort_by(|a, b| a.name.cmp(&b.name));
-    ignored.sort();
+    ignored.sort_by(|a, b| a.name.cmp(&b.name));
 
     detect_display_collisions(&packs)?;
 
@@ -385,7 +400,7 @@ mod tests {
             .pack("vim")
             .file("vimrc", "x")
             .done()
-            .pack("disabled")
+            .pack("010-disabled")
             .file("stuff", "x")
             .ignored()
             .done()
@@ -400,7 +415,18 @@ mod tests {
         assert_eq!(names, vec!["vim"]);
         assert_eq!(
             result.ignored,
-            vec!["disabled".to_string(), "old".to_string()]
+            vec![
+                IgnoredPack {
+                    name: "010-disabled".into(),
+                    display_name: "disabled".into(),
+                    ignore_file: ".dodotignore".into(),
+                },
+                IgnoredPack {
+                    name: "old".into(),
+                    display_name: "old".into(),
+                    ignore_file: ".dodotignore".into(),
+                },
+            ]
         );
     }
 

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -195,8 +195,8 @@ pub fn prepare_packs(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> 
 /// Result of [`scan_ignored`]: the `.dodotignore`-marked packs split by
 /// the two distinct jobs they serve.
 ///
-/// Reporting (the "Ignored Packs" section) is scoped to what the user
-/// asked about, so it respects `pack_filter`. The stale-state sweep is
+/// Reporting (the ignored rows) is scoped to what the user asked about, so
+/// it respects `pack_filter`. The stale-state sweep is
 /// **not** — the init script is regenerated from the *whole* datastore,
 /// so a filtered `dodot up <other-pack>` must still tear down every
 /// now-ignored pack's leftover state, or it would keep getting sourced.
@@ -205,10 +205,9 @@ pub struct IgnoredScan {
     /// pack, ignoring `pack_filter`. Used by [`sweep_pack_state`] so
     /// the global init regeneration never re-sources a stale pack.
     pub sweep_dir_names: Vec<String>,
-    /// Display names (prefix stripped) of the ignored packs that match
-    /// `pack_filter`, for the rendered "Ignored Packs" section — same
-    /// form and scope `status` surfaces.
-    pub display_names: Vec<String>,
+    /// Display metadata for ignored packs that match `pack_filter`, for the
+    /// rendered ignored rows — the same form and scope `status` surfaces.
+    pub display_packs: Vec<crate::packs::IgnoredPack>,
 }
 
 /// Scan the dotfiles root for `.dodotignore`-marked packs.
@@ -217,7 +216,7 @@ pub struct IgnoredScan {
 /// `status` all need so the three commands report (and sweep) the same
 /// set — the divergence that let `dodot up <ignored>` print a generic
 /// "Packs deployed." while `dodot status <ignored>` showed the pack in
-/// its "Ignored Packs" section (issue #222). The returned
+/// its ignored rows (issue #222). The returned
 /// [`IgnoredScan`] separates the filtered reporting set from the
 /// unfiltered sweep set; see its docs for why they differ.
 pub fn scan_ignored(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<IgnoredScan> {
@@ -229,20 +228,20 @@ pub fn scan_ignored(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> R
     )?
     .ignored;
 
-    let display_names = all_ignored
+    let sweep_dir_names: Vec<String> = all_ignored.iter().map(|p| p.name.clone()).collect();
+
+    let display_packs = all_ignored
         .iter()
-        .filter(|dir| match pack_filter {
+        .filter(|p| match pack_filter {
             None => true,
-            Some(names) => names
-                .iter()
-                .any(|n| n == *dir || n == packs::display_name_for(dir)),
+            Some(names) => names.iter().any(|n| n == &p.name || n == &p.display_name),
         })
-        .map(|d| packs::display_name_for(d).to_string())
+        .cloned()
         .collect();
 
     Ok(IgnoredScan {
-        sweep_dir_names: all_ignored,
-        display_names,
+        sweep_dir_names,
+        display_packs,
     })
 }
 

--- a/crates/dodot-lib/src/packs/orchestration/resolve.rs
+++ b/crates/dodot-lib/src/packs/orchestration/resolve.rs
@@ -36,9 +36,9 @@ pub fn resolve_pack_dir_name(input: &str, ctx: &ExecutionContext) -> crate::Resu
     if let Some(dir) = scanned
         .ignored
         .iter()
-        .find(|d| d.as_str() == input || packs::display_name_for(d) == input)
+        .find(|d| d.name == *input || d.display_name == *input)
     {
-        return Ok(dir.clone());
+        return Ok(dir.name.clone());
     }
     Err(crate::DodotError::PackNotFound { name: input.into() })
 }
@@ -70,7 +70,7 @@ pub fn validate_pack_names(names: &[String], ctx: &ExecutionContext) -> crate::R
         if scanned
             .ignored
             .iter()
-            .any(|dir| dir == input || packs::display_name_for(dir) == input)
+            .any(|dir| dir.name == *input || dir.display_name == *input)
         {
             warnings.push(format!("warning: pack '{}' is ignored, skipping", input));
             continue;

--- a/crates/dodot-lib/src/templates/pack-status.jinja
+++ b/crates/dodot-lib/src/templates/pack-status.jinja
@@ -1,8 +1,9 @@
 {%- set output_width = terminal_width | default(80) -%}
-{%- set file_tbl = tabular([{"width": 1, "style": "dim"}, {"width": 20}, {"width": "fill", "truncate": "middle", "style": "dim"}, {"width": 20, "align": "right", "anchor": "right"}], separator=" ", width=output_width) -%}
 {%- macro render_row(icon, pack_name, file_name, status_tag, status_label, note_ref) -%}
 {%- set right_col = "[" ~ status_tag ~ "]" ~ status_label ~ "[/" ~ status_tag ~ "]" -%}
 {%- if note_ref %}{% set right_col = right_col ~ " [dim][" ~ note_ref ~ "][/dim]" %}{% endif -%}
+{%- set status_width = right_col | display_width -%}
+{%- set file_tbl = tabular([{"width": 1, "style": "dim"}, {"width": 20}, {"width": "fill", "truncate": "middle", "style": "dim"}, {"width": status_width, "align": "right", "anchor": "right"}], separator=" ", width=output_width) -%}
 {{ file_tbl.row([
   icon,
   pack_name,

--- a/crates/dodot-lib/src/templates/pack-status.jinja
+++ b/crates/dodot-lib/src/templates/pack-status.jinja
@@ -1,10 +1,25 @@
+{%- set output_width = terminal_width | default(80) -%}
+{%- set file_tbl = tabular([{"width": 1, "style": "dim"}, {"width": 20}, {"width": "fill", "truncate": "middle", "style": "dim"}, {"width": 20, "align": "right", "anchor": "right"}], separator=" ", width=output_width) -%}
+{%- macro render_row(icon, pack_name, file_name, status_tag, status_label, note_ref) -%}
+{%- set right_col = "[" ~ status_tag ~ "]" ~ status_label ~ "[/" ~ status_tag ~ "]" -%}
+{%- if note_ref %}{% set right_col = right_col ~ " [dim][" ~ note_ref ~ "][/dim]" %}{% endif -%}
+{{ file_tbl.row([
+  icon,
+  pack_name,
+  file_name,
+  right_col
+]) }}
+{%- endmacro -%}
 {%- macro render_pack(pack, view_mode, notes) -%}
 {%- if view_mode == "short" -%}
 {{ pack.name | col(32) }} ({{ pack.summary_count }}) [{{ pack.summary_status }}]{{ pack.summary_status }}[/{{ pack.summary_status }}]
 {% else -%}
-{% for file in pack.files %}[{{ file.status }}]{{ (pack.name ~ "/" ~ file.name) | col(32) }} {{ file.symbol }} {{ file.status_label }}{% if file.note_ref %} [{{ file.note_ref }}]{% endif %}[/{{ file.status }}]
+{% for file in pack.files %}{{ render_row(file.symbol, pack.name, file.name, file.status, file.status_label, file.note_ref) }}
 {% endfor %}
 {%- endif -%}
+{%- endmacro -%}
+{%- macro render_ignored_pack(pack) -%}
+{{ render_row("∅", pack.display_name, pack.ignore_file, "ignored-pack", "ignored", none) }}
 {%- endmacro -%}
 {%- macro render_note(note, index) -%}
   [{{ index }}] {% if note.timeline %}{% for ok in note.timeline %}{% if ok %}[deployed]✓[/deployed] {% else %}[error]✗[/error] {% endif %}{% endfor %}{% endif %}[{{ note.kind }}]{{ note.body }}{% if note.command %}, see [/{{ note.kind }}][diagnostic-command]{{ note.command }}[/diagnostic-command][{{ note.kind }}] for more.{% endif %}[/{{ note.kind }}]
@@ -13,21 +28,20 @@
 {% if conflicts %}[conflict-banner] ✗ Cross-pack conflicts detected — see details below [/conflict-banner]
 {% endif %}{% if message %}[message]{{ message }}[/message]
 {% endif %}{% if dry_run %}[dry-run]  (dry run — no changes made)[/dry-run]
-{% endif %}{% if group_mode == "status" %}{% if ignored_packs %}[group-banner-ignored]Ignored Packs[/group-banner-ignored]
-{% for name in ignored_packs %}  [ignored-pack]{{ name }}[/ignored-pack]
-{% endfor %}
-{% endif %}{% if inactive_packs %}[group-banner-ignored]Inactive on this OS[/group-banner-ignored]
-{% for name in inactive_packs %}  [ignored-pack]{{ name }}[/ignored-pack]
-{% endfor %}
-{% endif %}{% set deployed_group = packs | selectattr("summary_status", "equalto", "deployed") | list %}{% if deployed_group %}[group-banner-deployed]Deployed Packs[/group-banner-deployed]
+{% endif %}{% if group_mode == "status" %}{% set deployed_group = packs | selectattr("summary_status", "equalto", "deployed") | list %}{% if deployed_group %}[group-banner-deployed]Deployed Packs[/group-banner-deployed]
 {% for pack in deployed_group %}{{ render_pack(pack, view_mode, notes) }}{% endfor %}
 {% endif %}{% set pending_group = packs | selectattr("summary_status", "equalto", "pending") | list %}{% if pending_group %}[group-banner-pending]Pending Packs[/group-banner-pending]
 {% for pack in pending_group %}{{ render_pack(pack, view_mode, notes) }}{% endfor %}
 {% endif %}{% set error_group = packs | selectattr("summary_status", "equalto", "error") | list %}{% if error_group %}[group-banner-error]Error Packs[/group-banner-error]
 {% for pack in error_group %}{{ render_pack(pack, view_mode, notes) }}{% endfor %}
-{% endif %}{% else %}{% for pack in packs %}{{ render_pack(pack, view_mode, notes) }}{% endfor %}{% if ignored_packs %}[pack-name]Ignored Packs[/pack-name]
-{% for name in ignored_packs %}  [ignored-pack]{{ name }}[/ignored-pack]
-{% endfor %}{% endif %}{% if inactive_packs %}[pack-name]Inactive on this OS[/pack-name]
+{% endif %}{% if ignored_packs %}{% if packs %}
+{% endif %}{% for pack in ignored_packs %}{{ render_ignored_pack(pack) }}{% endfor %}
+{% endif %}{% if inactive_packs %}[group-banner-ignored]Inactive on this OS[/group-banner-ignored]
+{% for name in inactive_packs %}  [ignored-pack]{{ name }}[/ignored-pack]
+{% endfor %}
+{% endif %}{% else %}{% for pack in packs %}{{ render_pack(pack, view_mode, notes) }}{% endfor %}{% if ignored_packs %}{% if packs %}
+{% endif %}{% for pack in ignored_packs %}{{ render_ignored_pack(pack) }}{% endfor %}
+{% endif %}{% if inactive_packs %}[pack-name]Inactive on this OS[/pack-name]
 {% for name in inactive_packs %}  [ignored-pack]{{ name }}[/ignored-pack]
 {% endfor %}{% endif %}{% endif %}{% if notes %}{% set error_notes = notes | selectattr("kind", "equalto", "error") | list %}{% set warning_notes = notes | selectattr("kind", "equalto", "warning") | list %}{% if error_notes %}
 [error]Errors:[/error]

--- a/docs/user/commands/status.lex
+++ b/docs/user/commands/status.lex
@@ -14,7 +14,7 @@ The read-only "what does dodot see?" command. For every pack and every source fi
 
     For each active pack:
 
-    - Every source file dodot saw, as `pack/file` with the handler symbol and current deployment status.
+    - Every source file dodot saw, as separate icon, pack, filename, and status columns. The icon and filename are muted, the pack is regular, and only the status carries its severity colour.
     - Files filtered out (`ignore` / `skip` / `gate`) and why they were filtered.
     - Files affected by preprocessing — under their *post-preprocessing* filename, not the source filename. (A source `config.toml.tmpl` shows as `config.toml`.)
 
@@ -22,6 +22,7 @@ The read-only "what does dodot see?" command. For every pack and every source fi
 
     - Cross-pack conflicts surface as warnings on the affected rows, with both packs named so the conflict is visible without having to run `up`.
     - Packs whose `[pack] os` doesn't match the current host show in a separate "inactive on this OS" section.
+    - Packs carrying `.dodotignore` follow the active rows after a blank line. They use `∅` as the icon, `.dodotignore` as the filename, and `ignored` as the status; there is no separate heading.
 
     Status states for a single row, by handler family:
 
@@ -49,6 +50,8 @@ The read-only "what does dodot see?" command. For every pack and every source fi
     - `⚙` shell source / homebrew
     - `+` added to `$PATH`
     - `×` install script
+
+    Full rows expand to the detected terminal width. The pack column is padded so filenames align, status is right-aligned to the terminal edge, and long filenames are clipped in the middle with an ellipsis. When terminal width cannot be detected, dodot uses 80 columns.
 
 4. Examples
 

--- a/tests/e2e/bats/test_addignore.bats
+++ b/tests/e2e/bats/test_addignore.bats
@@ -45,9 +45,11 @@ teardown() {
     dodot addignore scratch
     run dodot status
     [ "$status" -eq 0 ]
-    # Ignored packs appear under "Ignored Packs" so users aren't
-    # baffled, but their contents are not scanned.
-    assert_output_contains "Ignored Packs"
+    # Ignored packs use the shared status-row vocabulary, but their contents
+    # are not scanned.
+    assert_output_contains "∅ scratch"
+    assert_output_contains ".dodotignore"
+    assert_output_not_contains "Ignored Packs"
     assert_output_contains "scratch"
     assert_output_not_contains "notes"
 }

--- a/tests/e2e/bats/test_realistic.bats
+++ b/tests/e2e/bats/test_realistic.bats
@@ -131,9 +131,11 @@ teardown() {
 @test "ignored packs excluded from status and up" {
     run dodot status
     [ "$status" -eq 0 ]
-    # The ignored pack appears under "Ignored Packs" so users aren't
-    # baffled, but its contents are not scanned.
-    assert_output_contains "Ignored Packs"
+    # The ignored pack appears as a normal status row with its marker file,
+    # but its contents are not scanned.
+    assert_output_contains "∅ ignored-pack"
+    assert_output_contains ".dodotignore"
+    assert_output_not_contains "Ignored Packs"
     assert_output_not_contains "notes.txt"
 
     dodot up

--- a/tests/e2e/bats/test_realistic.bats
+++ b/tests/e2e/bats/test_realistic.bats
@@ -133,7 +133,7 @@ teardown() {
     [ "$status" -eq 0 ]
     # The ignored pack appears as a normal status row with its marker file,
     # but its contents are not scanned.
-    assert_output_contains "∅ ignored-pack"
+    assert_output_contains "∅ disabled"
     assert_output_contains ".dodotignore"
     assert_output_not_contains "Ignored Packs"
     assert_output_not_contains "notes.txt"

--- a/tests/e2e/bats/test_status.bats
+++ b/tests/e2e/bats/test_status.bats
@@ -59,7 +59,14 @@ teardown() {
 
     # Source the generated init script in a real shell so a clean
     # run is observed (writes a shell-init profile).
-    bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+    # macOS still ships Bash 3.2, which lacks EPOCHREALTIME and therefore
+    # cannot emit shell-init profiles. Prefer zsh when it is available;
+    # Linux CI falls back to its profiling-capable Bash.
+    if command -v zsh >/dev/null 2>&1; then
+        zsh -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+    else
+        bash -c ". \"$XDG_DATA_HOME/dodot/shell/dodot-init.sh\""
+    fi
 
     run dodot status
     [ "$status" -eq 0 ]
@@ -97,11 +104,12 @@ teardown() {
     run dodot status
     [ "$status" -eq 0 ]
     assert_output_contains "vim"
-    # Ignored packs are not scanned/deployed, but are listed under an
-    # "Ignored Packs" heading so users aren't baffled when a directory
-    # they expected doesn't appear in the main listing.
-    assert_output_contains "Ignored Packs"
+    # Ignored packs are not scanned/deployed, but are listed with a ∅
+    # icon and .dodotignore reason so users aren't baffled when a
+    # directory they expected doesn't appear in the main listing.
+    assert_output_contains "∅"
     assert_output_contains "disabled"
+    assert_output_contains ".dodotignore"
     # The ignored pack's contents should NOT be scanned or shown.
     assert_output_not_contains "file"
 }


### PR DESCRIPTION
closes #269

## Context

The shared pack-status presentation used by `status`, `up`, and `down` now renders icon, pack, filename, and right-anchored status columns through Standout’s tabular template facilities. The renderer receives the actual terminal width from Standout, with an 80-column fallback for non-terminal/test contexts, and applies semantic styling only to the status cell while muting icons and filenames.

Ignored packs now travel through the same structured row model: discovery retains both the displayed pack name and the matching `.dodotignore` marker filename, and the template renders `∅`, pack, marker, and `ignored` after a blank separator without a heading. Structured output remains data-driven rather than parsing terminal text.

The status documentation and affected unit/e2e expectations were updated. The status e2e test now uses zsh when available because macOS Bash 3.2 lacks `EPOCHREALTIME`; Linux CI continues to use Bash.

Out of scope: deployment, conflict, filtering, and stale-state semantics; the ADR-0033/shipit pin reconciliation noted by the development environment.

Verification:
- `pixi run test` — 1327/1327 passed
- `cargo build --release --bin dodot` — passed
- `pixi run lint --fix` — 13 checks passed
- `lexd check docs/user/commands/status.lex` — passed
- `bats tests/e2e/bats/test_status.bats` — standalone invocation cannot load `tests/e2e/bats/helpers/setup.bash`, which release-core injects in CI
- canonical release-core `bin/check-e2e test_status.bats` with its injected harness — 14/14 passed