### PR TITLE
docs: Add v5.4.1 release note for shared status row refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+- fix: active shared `status` / `up` / `down` rows now render pack, handler icon, filename, and terminal-edge status; the pack name appears only on its first file row, leaving subsequent pack cells blank; existing alignment, middle truncation, right-aligned status, styling, short view, and explicit ignored-row `∅ | pack | .dodotignore | ignored` layout remain intact (#273, #274)
+
 ## 5.4.0 - 2026-08-13
 
 - feat: shared `status` / `up` / `down` rows now use icon, pack, filename, and terminal-edge status columns; icon and filename are muted, pack is regular, and only the full status is severity-colored; filenames clip to preserve long right-aligned statuses; ignored packs render as `∅ <pack> .dodotignore ignored` after a blank separator with no `Ignored Packs` heading (#269, #270)

--- a/CHANGELOG/unreleased-status-row-refinement.md
+++ b/CHANGELOG/unreleased-status-row-refinement.md
@@ -1,0 +1,1 @@
+- fix: active shared `status` / `up` / `down` rows now render pack, handler icon, filename, and terminal-edge status; the pack name appears only on its first file row, leaving subsequent pack cells blank; existing alignment, middle truncation, right-aligned status, styling, short view, and explicit ignored-row `∅ | pack | .dodotignore | ignored` layout remain intact (#273, #274)


### PR DESCRIPTION
closes #275