### PR TITLE
INS01-WS02: Epic: Shell Hookup - Workstream: Verification probe + dodot install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "diffy",
  "flate2",
  "glob",
+ "libc",
  "minijinja",
  "plist",
  "serde",

--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -396,6 +396,27 @@ pub fn git_install_alias_handler(
     )?))
 }
 
+/// `dodot install [--write] [--rc <file>]` — report (or wire) the
+/// shell hookup.
+///
+/// Dry by default: without `--write` this only reads. `--write` splices
+/// the marked block into the resolved rc file and then spawns a shell
+/// to verify the result, so the command ends on a measurement rather
+/// than a promise (`docs/proposals/shell-hookup.lex` §4).
+pub fn install_handler(
+    matches: &clap::ArgMatches,
+    _ctx: &CommandContext,
+) -> HandlerResult<commands::install::InstallResult> {
+    let ctx = build_readonly_ctx(matches)?;
+    let opts = commands::install::InstallOptions {
+        write: matches.get_flag("write"),
+        rc: matches
+            .get_one::<String>("rc")
+            .map(std::path::PathBuf::from),
+    };
+    Ok(Output::Render(commands::install::install(&ctx, &opts)?))
+}
+
 /// `dodot template clean --path <path>` — git clean filter
 /// passthrough for template sources. Reads stdin (the working-tree
 /// source bytes), looks up the matching baseline in the cache,

--- a/crates/dodot-cli/src/help.rs
+++ b/crates/dodot-cli/src/help.rs
@@ -37,6 +37,7 @@ const HELP_TEXTS: &[(&str, &str)] = &[
     ("addignore", include_str!("help/addignore.txt")),
     ("tutorial", include_str!("help/tutorial.txt")),
     ("init-sh", include_str!("help/init-sh.txt")),
+    ("install", include_str!("help/install.txt")),
     ("plist", include_str!("help/plist.txt")),
     (
         "git-install-filters",

--- a/crates/dodot-cli/src/help/install.txt
+++ b/crates/dodot-cli/src/help/install.txt
@@ -1,0 +1,45 @@
+[header]dodot install[/header] — Wire dodot into your shell startup.
+
+[desc][item]dodot up[/item] proves your packs are deployed. It proves nothing about
+whether any shell ever [item]loads[/item] them — that takes one line in your
+shell's startup file, and this command owns that line.
+
+Run bare, it only reports: which shell you use, which file dodot
+would write to (resolving symlinks and [item]$ZDOTDIR[/item]), whether the hook
+is already there, and the exact line. Nothing is written.
+
+With [item]--write[/item], dodot adds its own marked block to that file and then
+[item]starts a shell to check that the hook actually fires[/item] — so you end on
+a measured answer, not a promise.[/desc]
+
+[header]USAGE[/header]
+  [usage]dodot install [--write] [--rc <file>][/usage]
+
+[header]OPTIONS[/header]
+  [item]--write[/item]         [desc]Write the hook block, then verify it. Safe to re-run:
+                  an existing block is replaced in place, never duplicated.[/desc]
+  [item]--rc <file>[/item]     [desc]Write to this file instead of the one dodot picks.[/desc]
+
+[header]WHAT GETS WRITTEN[/header]
+  [example]# >>> dodot shell hookup >>>
+  [ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ] && . "$HOME/.local/share/dodot/shell/dodot-init.sh"
+  # <<< dodot shell hookup <<<[/example]
+  [desc]Only that block. Everything else in the file is left untouched,
+  and deleting the block is a complete uninstall.[/desc]
+
+[header]WHICH FILE[/header]
+  [desc][dim]•[/dim] zsh — [item]${ZDOTDIR:-$HOME}/.zshrc[/item] ([item]~/.zshenv[/item] is checked for a [item]ZDOTDIR[/item] setting)
+  [dim]•[/dim] bash — [item]~/.bashrc[/item]; on macOS [item]~/.bash_profile[/item] is chained to it,
+    because Terminal opens login shells that never read [item]~/.bashrc[/item]
+  [dim]•[/dim] a missing file is created; a symlinked one is written [item]through[/item],
+    which lands the hook in your dotfiles repo — dodot says so when it does
+  [dim]•[/dim] any other shell — dodot refuses to guess and prints the line instead[/desc]
+
+[header]EXAMPLES[/header]
+  [example]dodot install                  [dim]# what would happen, and where[/dim]
+  dodot install --write          [dim]# do it, then verify it[/dim]
+  dodot install --write --rc ~/.config/sh/rc[/example]
+
+[header]SEE ALSO[/header]
+  [item]dodot init-sh[/item]                [desc]The script the hook sources; wire it by hand if you prefer[/desc]
+  [item]dodot status[/item]                 [desc]Reports whether shells are loading dodot[/desc]

--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -217,6 +217,7 @@ static TEMPLATE_ENTRIES: &[(&str, &str)] = &[
         "git-install-alias.jinja",
         render::TEMPLATE_GIT_INSTALL_ALIAS,
     ),
+    ("install.jinja", render::TEMPLATE_INSTALL),
     ("secret-probe.jinja", render::TEMPLATE_SECRET_PROBE),
     ("secret-list.jinja", render::TEMPLATE_SECRET_LIST),
 ];
@@ -338,6 +339,8 @@ fn build_app() -> App {
             "git-install-alias",
         )
         .expect("register git-install-alias")
+        .command("install", handlers::install_handler, "install")
+        .expect("register install")
         .command(
             "secret.probe",
             handlers::secret_probe_handler,
@@ -388,6 +391,7 @@ fn build_app() -> App {
                 title: "Misc".into(),
                 help: None,
                 commands: vec![
+                    Some("install".into()),
                     Some("transform".into()),
                     Some("refresh".into()),
                     Some("reset".into()),
@@ -603,6 +607,26 @@ fn build_clap_command() -> ClapCommand {
         )
         .subcommand(
             ClapCommand::new("init-sh").about("Print shell init script for eval in .zshrc/.bashrc"),
+        )
+        .subcommand(
+            ClapCommand::new("install")
+                .about("Wires dodot into your shell startup; --write applies it")
+                .arg(
+                    Arg::new("write")
+                        .long("write")
+                        .help(
+                            "Write the hook block to the startup file (idempotent), then verify \
+                             it by starting a shell. Without this flag the command only reports.",
+                        )
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("rc")
+                        .long("rc")
+                        .value_name("FILE")
+                        .help("Use this startup file instead of the one dodot would pick")
+                        .num_args(1),
+                ),
         )
         .subcommand(
             ClapCommand::new("git-show-alias")

--- a/crates/dodot-cli/src/tutorial.rs
+++ b/crates/dodot-cli/src/tutorial.rs
@@ -275,6 +275,12 @@ impl TutorialEnv {
             verbose: false,
             host_facts: std::sync::Arc::new(dodot_lib::gates::HostFacts::detect()),
             env_init_gen: dodot_lib::shell::activation::read_env_stamp(),
+            // The tutorial narrates its own steps and prompts between
+            // them; spawning a shell mid-walkthrough would print over
+            // that script. Evidence only here — the user's next real
+            // `dodot up` measures.
+            shell_probe: dodot_lib::shell::ProbePolicy::Never,
+            shell_env: dodot_lib::shell::ShellEnv::from_process(),
         }
     }
 }

--- a/crates/dodot-lib/Cargo.toml
+++ b/crates/dodot-lib/Cargo.toml
@@ -13,6 +13,10 @@ confique = "0.4"
 diffy = "0.4"
 flate2 = "1"
 glob = "0.3"
+# Two Unix facts std does not expose: killing a process group (the
+# shell-hookup probe's timeout, `shell::probe`) and the login shell in
+# the user database (`shell::rc`).
+libc = "0.2"
 minijinja = "2"
 plist = "1.7"
 serde = { version = "1", features = ["derive"] }

--- a/crates/dodot-lib/src/commands/fill.rs
+++ b/crates/dodot-lib/src/commands/fill.rs
@@ -166,6 +166,8 @@ mod tests {
             verbose: false,
             host_facts: Arc::new(crate::gates::HostFacts::detect()),
             env_init_gen: None,
+            shell_probe: crate::shell::ProbePolicy::Never,
+            shell_env: crate::shell::ShellEnv::default(),
         }
     }
 

--- a/crates/dodot-lib/src/commands/git_alias.rs
+++ b/crates/dodot-lib/src/commands/git_alias.rs
@@ -377,6 +377,8 @@ mod tests {
             verbose: false,
             host_facts: Arc::new(crate::gates::HostFacts::detect()),
             env_init_gen: None,
+            shell_probe: crate::shell::ProbePolicy::Never,
+            shell_env: crate::shell::ShellEnv::default(),
         }
     }
 

--- a/crates/dodot-lib/src/commands/git_filters.rs
+++ b/crates/dodot-lib/src/commands/git_filters.rs
@@ -495,6 +495,8 @@ mod tests {
             verbose: false,
             host_facts: Arc::new(crate::gates::HostFacts::detect()),
             env_init_gen: None,
+            shell_probe: crate::shell::ProbePolicy::Never,
+            shell_env: crate::shell::ShellEnv::default(),
         }
     }
 

--- a/crates/dodot-lib/src/commands/install.rs
+++ b/crates/dodot-lib/src/commands/install.rs
@@ -136,8 +136,9 @@ pub fn install(ctx: &ExecutionContext, opts: &InstallOptions) -> Result<InstallR
     })
 }
 
-/// Write the marked block, plus the macOS bash chain when that is what
-/// stands between the block and a login shell reading it.
+/// Write the marked block, plus — only when the ladder itself chose
+/// `~/.bashrc` — the macOS bash chain, which is what stands between
+/// that file and a login shell reading it.
 fn write_hookup(
     ctx: &ExecutionContext,
     shell: Option<HookupShell>,
@@ -162,8 +163,25 @@ fn write_hookup(
     // and never `.bashrc` — where the block just landed. Without the
     // chain the hook is written and never read, which is the exact
     // silent failure this epic exists to kill.
-    if shell == Some(HookupShell::Bash) && ctx.host_facts.os == "darwin" {
-        if let Some(profile) = rc::bash_chain_target(ctx.fs.as_ref(), home) {
+    //
+    // Only when the block landed in `~/.bashrc` itself: the chain is
+    // rung 2 of the ladder, and `--rc` overrides the whole ladder
+    // (spec §4.3 rung 5). Chaining for an override would be wrong at
+    // both ends — pointless for a file login shells already read, and
+    // destructive when the override *is* `~/.bash_profile`, where the
+    // chain block's identical markers would replace the hook block
+    // written a few lines above. The nominal path is what matters: a
+    // symlinked `~/.bashrc` is still the file bash opens.
+    if shell == Some(HookupShell::Bash)
+        && ctx.host_facts.os == "darwin"
+        && target.nominal() == home.join(".bashrc")
+    {
+        // Never the file we just wrote, for the same marker-collision
+        // reason — a `~/.bashrc` symlinked at a profile is pathological
+        // but must not cost the user their hook.
+        if let Some(profile) =
+            rc::bash_chain_target(ctx.fs.as_ref(), home).filter(|p| p != &target.path)
+        {
             rc::write_block(
                 ctx.fs.as_ref(),
                 &profile,

--- a/crates/dodot-lib/src/commands/install.rs
+++ b/crates/dodot-lib/src/commands/install.rs
@@ -1,0 +1,233 @@
+//! `dodot install` — wiring dodot into shell startup
+//! (`docs/proposals/shell-hookup.lex` §4).
+//!
+//! Everything dodot verified before this epic lived in the deployment
+//! layer; the hookup — the one line in an rc file that makes any of it
+//! reach a terminal — was wired by hand, outside dodot's machinery.
+//! This command closes that: it names the shell, names the file, shows
+//! the line, and with `--write` puts it there and then *measures*
+//! whether a new shell picks it up.
+//!
+//! # Dry by default
+//!
+//! The bare invocation is strictly read-only: no rc file is touched
+//! and no shell is spawned. dodot never modifies shell startup unasked
+//! (spec §9), and the dry run is what lets the user see the decision
+//! before delegating it — the failure mode conda's managed block is
+//! remembered for.
+//!
+//! # Write, then verify
+//!
+//! `--write` splices dodot's marked block into the resolved rc file
+//! ([`crate::shell::rc`]) and re-runs the probe against the just-written
+//! state, so the command ends on a measured verdict rather than a
+//! promise. The block holds a guarded *direct source* of the generated
+//! script — not `eval "$(dodot init-sh)"` — because sourcing a file
+//! costs no binary invocation per shell start and cannot deadlock on a
+//! `dodot` that is not on `PATH` until dodot's own init puts it there
+//! (spec §4.2). Hand-wired `eval` hookups keep working untouched; the
+//! evidence rides inside the emitted script either way.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+use crate::packs::orchestration::ExecutionContext;
+use crate::shell::activation::{self, ActivationNotice};
+use crate::shell::probe;
+use crate::shell::rc::{self, BlockOutcome, HookupShell, RcTarget};
+use crate::{DodotError, Result};
+
+/// What the caller asked for.
+#[derive(Debug, Clone, Default)]
+pub struct InstallOptions {
+    /// Write the marked block (and then verify). Without it, the
+    /// command only reports.
+    pub write: bool,
+    /// `--rc <file>`: override the resolution ladder entirely.
+    pub rc: Option<PathBuf>,
+}
+
+/// Everything `dodot install` reports, dry or written.
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallResult {
+    /// The detected shell (`"zsh"`), or `None` when only `--rc` made
+    /// this run possible.
+    pub shell: Option<String>,
+    /// The rc file, `~/`-relative for display.
+    pub rc_path: String,
+    /// Present when the rc file is a symlink: the path the ladder
+    /// picked, before resolution. Written *through*, never replaced.
+    pub rc_link_source: Option<String>,
+    /// Whether that file exists now — after this run, so a `--write`
+    /// that created it reports `true`. A dry run's `false` is the
+    /// "`--write` would create it" case.
+    pub rc_exists: bool,
+    /// How the hook is wired in that file now, after this run:
+    /// `managed-block`, `manual`, or `absent`. What *changed* is
+    /// [`outcome`](Self::outcome).
+    pub hook_presence: String,
+    /// The exact line dodot writes (and that a user can paste).
+    pub hook_line: String,
+    /// True when this run wrote to disk.
+    pub wrote: bool,
+    /// What the write did — `None` on a dry run.
+    pub outcome: Option<String>,
+    /// What was done or noticed along the way: ZDOTDIR resolution, the
+    /// symlink write-through, the macOS `.bash_profile` chain.
+    pub notes: Vec<String>,
+    /// The activation verdict — measured after `--write`, read from
+    /// evidence alone on a dry run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shell_hookup: Option<ActivationNotice>,
+}
+
+/// Run `dodot install`.
+///
+/// Refuses rather than guesses when `$SHELL` names a shell with no
+/// canonical rc file in the ladder (spec §4.3 rung 1): the error
+/// carries the hook line and points at `--rc`, which is strictly more
+/// useful than writing a bashrc snippet for a fish user.
+pub fn install(ctx: &ExecutionContext, opts: &InstallOptions) -> Result<InstallResult> {
+    let home = ctx.paths.home_dir();
+    let init_script = ctx.paths.init_script_path();
+    let hook_line = activation::hook_line(&init_script, home);
+    let shell = ctx.shell_env.hookup_shell();
+
+    if shell.is_none() && opts.rc.is_none() {
+        return Err(DodotError::Other(refusal(&ctx.shell_env.shell, &hook_line)));
+    }
+
+    let target = rc::resolve_rc(
+        ctx.fs.as_ref(),
+        home,
+        shell,
+        &ctx.shell_env,
+        opts.rc.as_deref(),
+    );
+    let mut notes = target.notes.clone();
+
+    let outcome = if opts.write {
+        Some(write_hookup(ctx, shell, &target, &hook_line, &mut notes)?)
+    } else {
+        None
+    };
+    // Read the file's state *after* any write, so every field
+    // describes the world as it stands now and `outcome` alone
+    // carries what changed. Reporting the pre-write state next to
+    // "created it" would have the report contradict itself.
+    let presence = rc::scan_hook_file(ctx.fs.as_ref(), &target.path);
+    let exists = target.exists || opts.write;
+
+    Ok(InstallResult {
+        shell: shell.map(|s| s.as_str().to_string()),
+        rc_path: rc::display_home_relative(&target.path, home),
+        rc_link_source: target
+            .link_source
+            .as_deref()
+            .map(|p| rc::display_home_relative(p, home)),
+        rc_exists: exists,
+        hook_presence: presence.as_str().to_string(),
+        hook_line,
+        wrote: opts.write,
+        outcome: outcome.map(|o| o.as_str().to_string()),
+        notes,
+        shell_hookup: verdict(ctx, opts, &target),
+    })
+}
+
+/// Write the marked block, plus the macOS bash chain when that is what
+/// stands between the block and a login shell reading it.
+fn write_hookup(
+    ctx: &ExecutionContext,
+    shell: Option<HookupShell>,
+    target: &RcTarget,
+    hook_line: &str,
+    notes: &mut Vec<String>,
+) -> Result<BlockOutcome> {
+    let home = ctx.paths.home_dir();
+    let outcome = rc::write_block(
+        ctx.fs.as_ref(),
+        &target.path,
+        &rc::render_block(&[hook_line]),
+    )?;
+    if outcome == BlockOutcome::Created {
+        notes.push(format!(
+            "created {}",
+            rc::display_home_relative(&target.path, home)
+        ));
+    }
+
+    // macOS Terminal opens *login* shells, which read `.bash_profile`
+    // and never `.bashrc` — where the block just landed. Without the
+    // chain the hook is written and never read, which is the exact
+    // silent failure this epic exists to kill.
+    if shell == Some(HookupShell::Bash) && ctx.host_facts.os == "darwin" {
+        if let Some(profile) = rc::bash_chain_target(ctx.fs.as_ref(), home) {
+            rc::write_block(
+                ctx.fs.as_ref(),
+                &profile,
+                &rc::render_block(&[rc::BASH_CHAIN_LINE]),
+            )?;
+            notes.push(format!(
+                "macOS opens login shells: chained {} to ~/.bashrc",
+                rc::display_home_relative(&profile, home)
+            ));
+        }
+    }
+    Ok(outcome)
+}
+
+/// The activation verdict to report.
+///
+/// After `--write` this is a measurement: the probe runs unconditionally
+/// against the state we just wrote, because "I wrote it" is the moment a
+/// measured answer is worth a shell spawn (spec §4.2) — the signal gate
+/// governs `up`, not this. A dry run measures nothing and reports the
+/// evidence it can read for free.
+fn verdict(
+    ctx: &ExecutionContext,
+    opts: &InstallOptions,
+    target: &RcTarget,
+) -> Option<ActivationNotice> {
+    let reference = activation::read_script_generation(ctx.fs.as_ref(), ctx.paths.as_ref());
+    let evidence = activation::notice_for(
+        ctx.fs.as_ref(),
+        ctx.paths.as_ref(),
+        ctx.env_init_gen,
+        reference,
+        true,
+    );
+    let Some(timeout) = ctx.shell_probe.timeout().filter(|_| opts.write) else {
+        return evidence;
+    };
+    if !ctx.fs.exists(&ctx.paths.init_script_path()) {
+        // Nothing to activate yet: the hook is wired, and the user's
+        // next `dodot up` is what gives it something to source.
+        return evidence;
+    }
+    // The diagnosis talks about the file we just wrote — including a
+    // `--rc` override, which the ladder would not have found itself.
+    probe::measure(
+        ctx.fs.as_ref(),
+        ctx.paths.as_ref(),
+        timeout,
+        &ctx.shell_env,
+        Some(&target.path),
+        reference,
+        evidence,
+    )
+}
+
+/// The honest refusal for a shell dodot has no rc guess for.
+fn refusal(shell: &Option<String>, hook_line: &str) -> String {
+    let named = match shell.as_deref() {
+        Some(s) if !s.is_empty() => format!("your shell ({s})"),
+        _ => "your shell ($SHELL is not set)".to_string(),
+    };
+    format!(
+        "dodot can wire up bash and zsh; it will not guess an rc file for {named}. \
+         Add this line to whatever file your shell reads at startup: {hook_line} \
+         — or point dodot at it with `dodot install --write --rc <file>`."
+    )
+}

--- a/crates/dodot-lib/src/commands/mod.rs
+++ b/crates/dodot-lib/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod fill;
 pub mod git_alias;
 pub mod git_filters;
 pub mod init;
+pub mod install;
 pub mod list;
 pub mod probe;
 pub mod prompts;

--- a/crates/dodot-lib/src/commands/prompts.rs
+++ b/crates/dodot-lib/src/commands/prompts.rs
@@ -173,6 +173,8 @@ mod tests {
             verbose: false,
             host_facts: Arc::new(crate::gates::HostFacts::detect()),
             env_init_gen: None,
+            shell_probe: crate::shell::ProbePolicy::Never,
+            shell_env: crate::shell::ShellEnv::default(),
         }
     }
 

--- a/crates/dodot-lib/src/commands/refresh.rs
+++ b/crates/dodot-lib/src/commands/refresh.rs
@@ -219,6 +219,8 @@ mod tests {
             verbose: false,
             host_facts: Arc::new(crate::gates::HostFacts::detect()),
             env_init_gen: None,
+            shell_probe: crate::shell::ProbePolicy::Never,
+            shell_env: crate::shell::ShellEnv::default(),
         }
     }
 

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -1279,6 +1279,8 @@ mod tests {
             verbose: false,
             host_facts: Arc::new(crate::gates::HostFacts::detect()),
             env_init_gen: None,
+            shell_probe: crate::shell::ProbePolicy::Never,
+            shell_env: crate::shell::ShellEnv::default(),
         }
     }
 

--- a/crates/dodot-lib/src/commands/template_install_filter.rs
+++ b/crates/dodot-lib/src/commands/template_install_filter.rs
@@ -340,6 +340,8 @@ mod tests {
             verbose: false,
             host_facts: Arc::new(crate::gates::HostFacts::detect()),
             env_init_gen: None,
+            shell_probe: crate::shell::ProbePolicy::Never,
+            shell_env: crate::shell::ShellEnv::default(),
         }
     }
 

--- a/crates/dodot-lib/src/commands/tests/activation.rs
+++ b/crates/dodot-lib/src/commands/tests/activation.rs
@@ -154,8 +154,8 @@ fn the_never_activated_notice_renders_as_a_prominent_block() {
         "the warning must reach rendered output: {text}"
     );
     assert!(
-        text.contains("Add this to your shell rc file"),
-        "the hook line must reach rendered output: {text}"
+        text.contains("dodot install --write") && text.contains("dodot-init.sh"),
+        "the fix — the command and the manual line — must reach rendered output: {text}"
     );
 
     let tagged = render::render("pack-status", &result, OutputMode::TermDebug).unwrap();

--- a/crates/dodot-lib/src/commands/tests/hookup.rs
+++ b/crates/dodot-lib/src/commands/tests/hookup.rs
@@ -1,0 +1,273 @@
+//! Which commands measure shell activation, and when
+//! (`docs/proposals/shell-hookup.lex` §3.1, §5, §9).
+//!
+//! `shell::probe` covers the spawn mechanics and the verdict rendering;
+//! this file covers the decision *around* them — the gate that keeps a
+//! healthy machine from ever paying for a shell spawn, the commands
+//! that are allowed to spawn one at all, and the verdict taking
+//! precedence over the evidence guess it corrects.
+//!
+//! Every context here carries a fabricated `$SHELL` — a script written
+//! into the test's temp home — so nothing in this file runs the
+//! developer's real shell or reads their real rc files. A test that
+//! wants "no probe happened" asserts on a marker file the fabricated
+//! shell would have created had it run.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use super::support::make_ctx;
+use crate::commands::{status, up};
+use crate::fs::Fs;
+use crate::packs::orchestration::ExecutionContext;
+use crate::paths::Pather;
+use crate::shell::activation::{self, INIT_GEN_ENV};
+use crate::shell::{ProbePolicy, ShellEnv};
+use crate::testing::TempEnvironment;
+
+fn env_with_shell_pack() -> TempEnvironment {
+    TempEnvironment::builder()
+        .pack("vim")
+        .file("aliases.sh", "alias vi=vim")
+        .done()
+        .build()
+}
+
+/// Where a fabricated shell records that it ran. Its absence after a
+/// command is the proof that no probe happened.
+fn spawn_marker(env: &TempEnvironment) -> PathBuf {
+    env.home.join("probe-ran.marker")
+}
+
+/// Write a fake `$SHELL` that touches the spawn marker, then behaves
+/// as `rc_behaviour` says before running the probe command.
+///
+/// Named `zsh` on purpose: the basename is what the rc ladder reads,
+/// so the failed-probe diagnosis resolves `~/.zshrc` *inside the test's
+/// temp home* — a real ladder walk, still nowhere near the developer's
+/// own rc file.
+fn fake_shell(env: &TempEnvironment, rc_behaviour: &str) -> PathBuf {
+    let path = env.home.join("fake-bin/zsh");
+    env.fs.mkdir_all(path.parent().unwrap()).unwrap();
+    let script = format!(
+        "#!/bin/sh\n: > {marker}\n{rc_behaviour}\neval \"$2\"\n",
+        marker = spawn_marker(env).display(),
+    );
+    env.fs
+        .write_file_with_mode(&path, script.as_bytes(), 0o755)
+        .unwrap();
+    path
+}
+
+/// A context allowed to probe, wired to a fabricated shell.
+fn probing_ctx(env: &TempEnvironment, rc_behaviour: &str) -> ExecutionContext {
+    let shell = fake_shell(env, rc_behaviour);
+    let mut ctx = make_ctx(env);
+    ctx.shell_probe = ProbePolicy::Gated {
+        timeout: Duration::from_secs(10),
+    };
+    ctx.shell_env = ShellEnv {
+        shell: Some(shell.display().to_string()),
+        zdotdir: None,
+    };
+    ctx
+}
+
+/// An rc behaviour that sources dodot's real generated init script —
+/// a genuine activation, heartbeat and all.
+fn sources_dodot(env: &TempEnvironment) -> String {
+    format!(". \"{}\"", env.paths.init_script_path().display())
+}
+
+fn simulate_activation(env: &TempEnvironment, generation: u64) {
+    env.fs.mkdir_all(&env.paths.probes_hookup_dir()).unwrap();
+    env.fs
+        .write_file(
+            &env.paths.hookup_heartbeat_path(),
+            generation.to_string().as_bytes(),
+        )
+        .unwrap();
+}
+
+// ── The gate ────────────────────────────────────────────────────
+
+#[test]
+fn a_healthy_machine_never_spawns_a_probe() {
+    let env = env_with_shell_pack();
+
+    // One `up` to deploy, then a heartbeat at that generation: some
+    // shell has activated since the last regeneration, which is proof
+    // enough. The gate must stop before the spawn.
+    up::up(None, &make_ctx(&env)).unwrap();
+    let generation =
+        activation::read_script_generation(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+    simulate_activation(&env, generation);
+
+    let ctx = probing_ctx(&env, &sources_dodot(&env));
+    let result = up::up(None, &ctx).unwrap();
+
+    assert!(
+        !env.fs.exists(&spawn_marker(&env)),
+        "a fresh heartbeat is proof; spawning a shell anyway is the cost we promised not to pay"
+    );
+    assert_eq!(result.shell_hookup, None);
+}
+
+#[test]
+fn a_live_shell_is_proof_enough_on_its_own() {
+    let env = env_with_shell_pack();
+    up::up(None, &make_ctx(&env)).unwrap();
+    let generation =
+        activation::read_script_generation(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+
+    let mut ctx = probing_ctx(&env, &sources_dodot(&env));
+    ctx.env_init_gen = Some(generation);
+    up::up(None, &ctx).unwrap();
+
+    assert!(
+        !env.fs.exists(&spawn_marker(&env)),
+        "the calling shell carries a current stamp — nothing left to measure"
+    );
+}
+
+#[test]
+fn status_never_spawns_a_shell_whatever_the_policy_says() {
+    // Spec §9: status reports evidence; only `up` and `install` may
+    // spawn. The policy below says probing is allowed, and status
+    // must still refuse.
+    let env = env_with_shell_pack();
+    up::up(None, &make_ctx(&env)).unwrap();
+
+    let ctx = probing_ctx(&env, &sources_dodot(&env));
+    let result = status::status(None, &ctx).unwrap();
+
+    assert!(!env.fs.exists(&spawn_marker(&env)));
+    assert_eq!(
+        result.shell_hookup.map(|n| n.state),
+        Some("never-activated".into()),
+        "status still reports, from evidence alone"
+    );
+}
+
+#[test]
+fn a_dry_run_measures_nothing() {
+    let env = env_with_shell_pack();
+    let mut ctx = probing_ctx(&env, &sources_dodot(&env));
+    ctx.dry_run = true;
+
+    up::up(None, &ctx).unwrap();
+
+    assert!(
+        !env.fs.exists(&spawn_marker(&env)),
+        "a dry run wrote no script; measuring would report on a world it did not create"
+    );
+}
+
+// ── The measurement ─────────────────────────────────────────────
+
+#[test]
+fn a_first_up_ends_on_a_measured_verdict_when_the_shell_activates() {
+    let env = env_with_shell_pack();
+    let ctx = probing_ctx(&env, &sources_dodot(&env));
+
+    let result = up::up(None, &ctx).unwrap();
+
+    assert!(
+        env.fs.exists(&spawn_marker(&env)),
+        "the probe must have run"
+    );
+    let notice = result
+        .shell_hookup
+        .expect("a measured verdict is the point of the first up");
+    assert_eq!(notice.state, "healthy");
+    assert_eq!(notice.severity, "ok");
+    assert!(
+        notice.message.contains("verified"),
+        "measured, not inferred: {}",
+        notice.message
+    );
+}
+
+#[test]
+fn a_first_up_whose_shell_does_not_activate_names_the_missing_hook() {
+    let env = env_with_shell_pack();
+    // The shell runs and sources nothing — the fresh-install story.
+    let ctx = probing_ctx(&env, "# no dodot hook here");
+
+    let result = up::up(None, &ctx).unwrap();
+
+    let notice = result.shell_hookup.expect("a broken hookup is news");
+    assert_eq!(notice.state, "verified-broken");
+    assert_eq!(notice.severity, "error");
+    let hint = notice.hint.unwrap();
+    assert!(
+        hint.contains("dodot install --write"),
+        "the fix must be named: {hint}"
+    );
+}
+
+#[test]
+fn a_measured_broken_hookup_beats_the_stale_shell_guess() {
+    // The carried-over WS01 problem: with evidence alone, a hookup
+    // that worked and then broke reads as a stale shell, so the user
+    // is told to open a new shell — which fixes nothing. Once the
+    // probe has run and found no stamp, the measurement wins.
+    let env = env_with_shell_pack();
+    up::up(None, &make_ctx(&env)).unwrap();
+    let generation =
+        activation::read_script_generation(env.fs.as_ref(), env.paths.as_ref()).unwrap();
+    // A shell activated once, before the current generation...
+    simulate_activation(&env, generation - 1);
+
+    // ...and today's shell no longer loads dodot at all.
+    let ctx = probing_ctx(&env, "# the hook line was deleted");
+    let result = up::up(None, &ctx).unwrap();
+
+    let notice = result.shell_hookup.unwrap();
+    assert_eq!(notice.state, "verified-broken");
+    assert!(
+        !notice.hint.unwrap().contains("Open a new shell"),
+        "no new shell fixes a deleted hook line"
+    );
+}
+
+#[test]
+fn an_unverifiable_probe_degrades_instead_of_wedging_up() {
+    let env = env_with_shell_pack();
+    let mut ctx = probing_ctx(&env, &sources_dodot(&env));
+    // A $SHELL that cannot be executed at all.
+    ctx.shell_env = ShellEnv {
+        shell: Some(env.home.join("not-a-real-shell").display().to_string()),
+        zdotdir: None,
+    };
+
+    let result = up::up(None, &ctx).expect("a failed probe must never wedge `up`");
+
+    let notice = result
+        .shell_hookup
+        .expect("evidence still has something to say");
+    assert_eq!(
+        notice.state, "never-activated",
+        "degrade to the evidence answer"
+    );
+    let hint = notice.hint.unwrap();
+    assert!(
+        hint.contains("could not verify") && hint.contains("not measured activation"),
+        "the degradation must be labeled, not passed off as a measurement: {hint}"
+    );
+}
+
+#[test]
+fn the_probed_shell_does_not_inherit_this_processs_stamp() {
+    // An inherited stamp would make an unhooked shell look verified.
+    let env = env_with_shell_pack();
+    let _guard = crate::testing::EnvVarGuard::set(INIT_GEN_ENV, "999999");
+    let ctx = probing_ctx(&env, "# sources nothing");
+
+    let result = up::up(None, &ctx).unwrap();
+
+    assert_eq!(
+        result.shell_hookup.map(|n| n.state),
+        Some("verified-broken".into())
+    );
+}

--- a/crates/dodot-lib/src/commands/tests/install.rs
+++ b/crates/dodot-lib/src/commands/tests/install.rs
@@ -1,0 +1,400 @@
+//! `dodot install` — the rc-file ladder, the marked block, and the
+//! refusals (`docs/proposals/shell-hookup.lex` §4).
+//!
+//! Every context here carries a *fabricated* shell environment and the
+//! default `ProbePolicy::Never`, so nothing in this file can reach the
+//! developer's real `$SHELL` or their real `~/.zshrc`. The measured
+//! half — spawning a shell and reading the stamp back — is tested in
+//! `shell::probe` against fabricated shell scripts.
+
+use crate::commands::install::*;
+use crate::fs::Fs;
+use crate::packs::orchestration::ExecutionContext;
+use crate::shell::rc::{BLOCK_END, BLOCK_START};
+use crate::shell::ShellEnv;
+use crate::testing::TempEnvironment;
+
+/// A context whose shell environment is fabricated — never the
+/// developer's own. `shell_probe` stays `Never`, so nothing here
+/// spawns a process.
+fn ctx_for(env: &TempEnvironment, shell_env: ShellEnv) -> ExecutionContext {
+    let mut ctx = super::support::make_ctx(env);
+    ctx.shell_env = shell_env;
+    ctx
+}
+
+fn zsh_env() -> ShellEnv {
+    ShellEnv {
+        shell: Some("/bin/zsh".into()),
+        zdotdir: None,
+    }
+}
+
+fn dry() -> InstallOptions {
+    InstallOptions::default()
+}
+
+fn write() -> InstallOptions {
+    InstallOptions {
+        write: true,
+        rc: None,
+    }
+}
+
+// ── Dry ─────────────────────────────────────────────────────
+
+#[test]
+fn dry_run_reports_everything_and_writes_nothing() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+    let rc_path = env.home.join(".zshrc");
+
+    let r = install(&ctx, &dry()).unwrap();
+
+    assert_eq!(r.shell.as_deref(), Some("zsh"));
+    assert_eq!(r.rc_path, "~/.zshrc");
+    assert!(!r.rc_exists);
+    assert_eq!(r.hook_presence, "absent");
+    assert!(
+        r.hook_line.contains("dodot-init.sh") && r.hook_line.starts_with("[ -f "),
+        "the guarded direct-source line, not an eval: {}",
+        r.hook_line
+    );
+    assert!(!r.wrote);
+    assert_eq!(r.outcome, None);
+    assert!(
+        !env.fs.exists(&rc_path),
+        "a bare `dodot install` must not create anything"
+    );
+}
+
+#[test]
+fn dry_run_reports_an_existing_hook_as_present() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+    env.fs
+        .write_file(&env.home.join(".zshrc"), b"eval \"$(dodot init-sh)\"\n")
+        .unwrap();
+
+    let r = install(&ctx, &dry()).unwrap();
+    assert_eq!(
+        r.hook_presence, "manual",
+        "a hand-wired eval hookup is present and must be left alone"
+    );
+}
+
+#[test]
+fn an_unsupported_shell_is_refused_with_the_line_and_the_escape_hatch() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(
+        &env,
+        ShellEnv {
+            shell: Some("/usr/bin/fish".into()),
+            zdotdir: None,
+        },
+    );
+
+    let err = install(&ctx, &write()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("fish"), "{msg}");
+    assert!(msg.contains("dodot-init.sh"), "must print the line: {msg}");
+    assert!(msg.contains("--rc"), "must name the escape hatch: {msg}");
+}
+
+#[test]
+fn an_unsupported_shell_still_works_when_rc_is_given() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(
+        &env,
+        ShellEnv {
+            shell: Some("/usr/bin/fish".into()),
+            zdotdir: None,
+        },
+    );
+    let custom = env.home.join("config.fish");
+
+    let r = install(
+        &ctx,
+        &InstallOptions {
+            write: true,
+            rc: Some(custom.clone()),
+        },
+    )
+    .unwrap();
+    assert_eq!(r.shell, None);
+    assert!(env
+        .fs
+        .read_to_string(&custom)
+        .unwrap()
+        .contains(BLOCK_START));
+}
+
+// ── Write ───────────────────────────────────────────────────
+
+#[test]
+fn write_creates_a_missing_rc_with_the_marked_block() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+
+    let r = install(&ctx, &write()).unwrap();
+    assert!(r.wrote);
+    assert_eq!(r.outcome.as_deref(), Some("created"));
+    // The report describes the world after the run, not before it.
+    assert!(r.rc_exists);
+    assert_eq!(r.hook_presence, "managed-block");
+
+    let body = env.fs.read_to_string(&env.home.join(".zshrc")).unwrap();
+    assert!(body.contains(BLOCK_START) && body.contains(BLOCK_END));
+    assert!(
+        body.contains(&r.hook_line),
+        "the block must carry the one hook line: {body}"
+    );
+    assert!(
+        !body.contains("dodot init-sh"),
+        "direct source, not eval: {body}"
+    );
+}
+
+#[test]
+fn write_is_idempotent_and_never_duplicates_the_block() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+    let rc_path = env.home.join(".zshrc");
+    env.fs
+        .write_file(&rc_path, b"export PATH=/usr/local/bin:$PATH\n")
+        .unwrap();
+
+    let first = install(&ctx, &write()).unwrap();
+    assert_eq!(first.outcome.as_deref(), Some("appended"));
+    let after_first = env.fs.read_to_string(&rc_path).unwrap();
+
+    let second = install(&ctx, &write()).unwrap();
+    assert_eq!(second.outcome.as_deref(), Some("unchanged"));
+    assert_eq!(env.fs.read_to_string(&rc_path).unwrap(), after_first);
+    assert_eq!(after_first.matches(BLOCK_START).count(), 1);
+    assert!(
+        after_first.starts_with("export PATH=/usr/local/bin:$PATH\n"),
+        "user content must survive: {after_first}"
+    );
+}
+
+#[test]
+fn an_existing_eval_hookup_is_left_exactly_where_it_is() {
+    // Compatibility (spec §6): people who wired `eval "$(dodot
+    // init-sh)"` by hand keep working, and `--write` is additive —
+    // dodot owns its block and nothing else in the file.
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+    let rc_path = env.home.join(".zshrc");
+    let manual = "# my rc\neval \"$(dodot init-sh)\"\nalias ll='ls -l'\n";
+    env.fs.write_file(&rc_path, manual.as_bytes()).unwrap();
+
+    install(&ctx, &write()).unwrap();
+
+    let body = env.fs.read_to_string(&rc_path).unwrap();
+    assert!(
+        body.starts_with(manual),
+        "the hand-wired hookup must survive verbatim: {body}"
+    );
+    assert!(body.contains(BLOCK_START));
+}
+
+#[test]
+fn write_replaces_a_stale_block_in_place() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+    let rc_path = env.home.join(".zshrc");
+    let stale = format!("{BLOCK_START}\n. \"$HOME/old/path/dodot-init.sh\"\n{BLOCK_END}\n");
+    env.fs.write_file(&rc_path, stale.as_bytes()).unwrap();
+
+    let r = install(&ctx, &write()).unwrap();
+    assert_eq!(r.outcome.as_deref(), Some("replaced"));
+    let body = env.fs.read_to_string(&rc_path).unwrap();
+    assert!(!body.contains("old/path"), "{body}");
+    assert_eq!(body.matches(BLOCK_START).count(), 1);
+}
+
+#[test]
+fn write_follows_a_symlinked_rc_into_the_dotfiles_repo() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+    let repo_rc = env.home.join("dotfiles/zsh/zshrc");
+    env.fs.mkdir_all(repo_rc.parent().unwrap()).unwrap();
+    env.fs.write_file(&repo_rc, b"# repo rc\n").unwrap();
+    env.fs.symlink(&repo_rc, &env.home.join(".zshrc")).unwrap();
+
+    let r = install(&ctx, &write()).unwrap();
+
+    assert!(env
+        .fs
+        .read_to_string(&repo_rc)
+        .unwrap()
+        .contains(BLOCK_START));
+    assert!(
+        env.fs.is_symlink(&env.home.join(".zshrc")),
+        "the link itself must survive — we write through it"
+    );
+    assert_eq!(r.rc_link_source.as_deref(), Some("~/.zshrc"));
+    assert!(
+        r.notes.iter().any(|n| n.contains("dotfiles/zsh/zshrc")),
+        "landing in the repo must be announced: {:?}",
+        r.notes
+    );
+}
+
+#[test]
+fn write_honors_the_zdotdir_ladder() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(
+        &env,
+        ShellEnv {
+            shell: Some("/bin/zsh".into()),
+            zdotdir: Some("$HOME/.config/zsh".into()),
+        },
+    );
+
+    let r = install(&ctx, &write()).unwrap();
+    assert_eq!(r.rc_path, "~/.config/zsh/.zshrc");
+    assert!(env
+        .fs
+        .read_to_string(&env.home.join(".config/zsh/.zshrc"))
+        .unwrap()
+        .contains(BLOCK_START));
+}
+
+#[test]
+fn rc_override_wins_over_the_whole_ladder() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+    let custom = env.home.join("somewhere/else.sh");
+
+    let r = install(
+        &ctx,
+        &InstallOptions {
+            write: true,
+            rc: Some(custom.clone()),
+        },
+    )
+    .unwrap();
+    assert_eq!(r.rc_path, "~/somewhere/else.sh");
+    assert!(env.fs.exists(&custom));
+    assert!(
+        !env.fs.exists(&env.home.join(".zshrc")),
+        "the ladder's target must be left alone when --rc is given"
+    );
+}
+
+#[test]
+fn macos_bash_gets_the_login_shell_chain() {
+    let env = TempEnvironment::builder().build();
+    let mut ctx = ctx_for(
+        &env,
+        ShellEnv {
+            shell: Some("/bin/bash".into()),
+            zdotdir: None,
+        },
+    );
+    ctx.host_facts = std::sync::Arc::new(crate::gates::HostFacts {
+        os: "darwin".into(),
+        arch: "arm64".into(),
+        hostname: None,
+        username: None,
+    });
+
+    let r = install(&ctx, &write()).unwrap();
+
+    assert_eq!(r.rc_path, "~/.bashrc");
+    let profile = env
+        .fs
+        .read_to_string(&env.home.join(".bash_profile"))
+        .unwrap();
+    assert!(
+        profile.contains(".bashrc"),
+        "Terminal opens login shells; without the chain the hook is never read: {profile}"
+    );
+    assert!(
+        r.notes.iter().any(|n| n.contains("login shells")),
+        "the extra file must be announced: {:?}",
+        r.notes
+    );
+}
+
+#[test]
+fn linux_bash_gets_no_profile_chain() {
+    let env = TempEnvironment::builder().build();
+    let mut ctx = ctx_for(
+        &env,
+        ShellEnv {
+            shell: Some("/bin/bash".into()),
+            zdotdir: None,
+        },
+    );
+    ctx.host_facts = std::sync::Arc::new(crate::gates::HostFacts {
+        os: "linux".into(),
+        arch: "x86_64".into(),
+        hostname: None,
+        username: None,
+    });
+
+    install(&ctx, &write()).unwrap();
+    assert!(
+        !env.fs.exists(&env.home.join(".bash_profile")),
+        "the chain is a macOS-only fix; elsewhere .bashrc is read directly"
+    );
+}
+
+// ── Rendering ───────────────────────────────────────────────
+
+/// Render an `InstallResult` through the real template.
+fn rendered(result: &InstallResult, mode: standout_render::OutputMode) -> String {
+    standout_render::render_with_output(
+        crate::render::TEMPLATE_INSTALL,
+        result,
+        &crate::render::create_theme(),
+        mode,
+    )
+    .expect("the install template must render")
+}
+
+#[test]
+fn the_dry_report_reaches_rendered_output() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+    let r = install(&ctx, &dry()).unwrap();
+
+    let text = rendered(&r, standout_render::OutputMode::Text);
+    assert!(text.contains("--write"), "{text}");
+    assert!(text.contains("zsh"), "{text}");
+    assert!(text.contains("~/.zshrc"), "{text}");
+    assert!(text.contains(&r.hook_line), "{text}");
+
+    // Every style tag the template uses must exist in the theme —
+    // an unknown one renders as `[name?]` in TermDebug.
+    let tagged = rendered(&r, standout_render::OutputMode::TermDebug);
+    for line in tagged.lines() {
+        assert!(!line.contains("?]"), "unknown style tag: {line}");
+    }
+}
+
+#[test]
+fn the_written_report_names_the_file_and_the_notes() {
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+    let r = install(&ctx, &write()).unwrap();
+
+    let text = rendered(&r, standout_render::OutputMode::Text);
+    assert!(text.contains("~/.zshrc"), "{text}");
+    assert!(text.contains("created"), "{text}");
+}
+
+#[test]
+fn nothing_spawns_a_shell_when_the_policy_says_never() {
+    // The whole suite runs with `ProbePolicy::Never`, so this pins
+    // the guarantee itself: a written install with no probe policy
+    // still reports, from evidence, without measuring.
+    let env = TempEnvironment::builder().build();
+    let ctx = ctx_for(&env, zsh_env());
+    let r = install(&ctx, &write()).unwrap();
+    // No init script deployed yet, so evidence has nothing to say.
+    assert_eq!(r.shell_hookup, None);
+}

--- a/crates/dodot-lib/src/commands/tests/install.rs
+++ b/crates/dodot-lib/src/commands/tests/install.rs
@@ -319,6 +319,133 @@ fn macos_bash_gets_the_login_shell_chain() {
     );
 }
 
+/// The chain is rung 2 of the ladder, and `--rc` overrides the whole
+/// ladder (spec §4.3 rung 5). Chaining an override that points at the
+/// profile would write a second block with the *same markers* over the
+/// hook block, leaving the user a file that chains to a `.bashrc`
+/// nobody wired — and a report claiming `managed-block`.
+#[test]
+fn an_rc_override_at_the_profile_keeps_its_hook_and_gets_no_chain() {
+    let env = TempEnvironment::builder().build();
+    let mut ctx = ctx_for(
+        &env,
+        ShellEnv {
+            shell: Some("/bin/bash".into()),
+            zdotdir: None,
+        },
+    );
+    ctx.host_facts = std::sync::Arc::new(crate::gates::HostFacts {
+        os: "darwin".into(),
+        arch: "arm64".into(),
+        hostname: None,
+        username: None,
+    });
+    let profile = env.home.join(".bash_profile");
+
+    let r = install(
+        &ctx,
+        &InstallOptions {
+            write: true,
+            rc: Some(profile.clone()),
+        },
+    )
+    .unwrap();
+
+    let body = env.fs.read_to_string(&profile).unwrap();
+    assert!(
+        body.contains(&r.hook_line),
+        "the hook the user asked for must survive the chain step: {body}"
+    );
+    assert_eq!(
+        body.matches(BLOCK_START).count(),
+        1,
+        "one block, and it is the hook's: {body}"
+    );
+    assert!(
+        !body.contains(".bashrc"),
+        "login shells read this file directly; there is nothing to chain to: {body}"
+    );
+    assert_eq!(r.hook_presence, "managed-block");
+}
+
+/// A `--rc` override anywhere else is left alone too — no chain, and no
+/// `~/.bash_profile` conjured next to a file the user chose.
+#[test]
+fn an_rc_override_elsewhere_gets_no_macos_chain() {
+    let env = TempEnvironment::builder().build();
+    let mut ctx = ctx_for(
+        &env,
+        ShellEnv {
+            shell: Some("/bin/bash".into()),
+            zdotdir: None,
+        },
+    );
+    ctx.host_facts = std::sync::Arc::new(crate::gates::HostFacts {
+        os: "darwin".into(),
+        arch: "arm64".into(),
+        hostname: None,
+        username: None,
+    });
+    let custom = env.home.join(".config/bash/rc.sh");
+
+    install(
+        &ctx,
+        &InstallOptions {
+            write: true,
+            rc: Some(custom.clone()),
+        },
+    )
+    .unwrap();
+
+    assert!(env
+        .fs
+        .read_to_string(&custom)
+        .unwrap()
+        .contains(BLOCK_START));
+    assert!(
+        !env.fs.exists(&env.home.join(".bash_profile")),
+        "--rc overrides the whole ladder, chain included"
+    );
+}
+
+/// The chain still fires for a `~/.bashrc` that lives in a dotfiles
+/// repo: bash opens `~/.bashrc` whatever it points at, so the nominal
+/// path is what the rung-2 rule reads.
+#[test]
+fn macos_bash_chains_a_symlinked_bashrc_too() {
+    let env = TempEnvironment::builder().build();
+    let mut ctx = ctx_for(
+        &env,
+        ShellEnv {
+            shell: Some("/bin/bash".into()),
+            zdotdir: None,
+        },
+    );
+    ctx.host_facts = std::sync::Arc::new(crate::gates::HostFacts {
+        os: "darwin".into(),
+        arch: "arm64".into(),
+        hostname: None,
+        username: None,
+    });
+    let repo_rc = env.home.join("dotfiles/bash/bashrc");
+    env.fs.mkdir_all(repo_rc.parent().unwrap()).unwrap();
+    env.fs.write_file(&repo_rc, b"# repo rc\n").unwrap();
+    env.fs.symlink(&repo_rc, &env.home.join(".bashrc")).unwrap();
+
+    install(&ctx, &write()).unwrap();
+
+    assert!(env
+        .fs
+        .read_to_string(&repo_rc)
+        .unwrap()
+        .contains(BLOCK_START));
+    assert!(env
+        .fs
+        .read_to_string(&env.home.join(".bash_profile"))
+        .unwrap()
+        .contains(".bashrc"));
+}
+
 #[test]
 fn linux_bash_gets_no_profile_chain() {
     let env = TempEnvironment::builder().build();

--- a/crates/dodot-lib/src/commands/tests/mod.rs
+++ b/crates/dodot-lib/src/commands/tests/mod.rs
@@ -3,6 +3,8 @@
 mod activation;
 mod adopt;
 mod gating;
+mod hookup;
+mod install;
 mod probe;
 mod reset;
 mod support;

--- a/crates/dodot-lib/src/commands/tests/support.rs
+++ b/crates/dodot-lib/src/commands/tests/support.rs
@@ -87,6 +87,8 @@ pub(super) fn make_ctx(env: &TempEnvironment) -> ExecutionContext {
         verbose: false,
         host_facts: Arc::new(crate::gates::HostFacts::detect()),
         env_init_gen: None,
+        shell_probe: crate::shell::ProbePolicy::Never,
+        shell_env: crate::shell::ShellEnv::default(),
     }
 }
 
@@ -118,5 +120,7 @@ pub(super) fn make_ctx_with_runner(
         verbose: false,
         host_facts: Arc::new(crate::gates::HostFacts::detect()),
         env_init_gen: None,
+        shell_probe: crate::shell::ProbePolicy::Never,
+        shell_env: crate::shell::ShellEnv::default(),
     }
 }

--- a/crates/dodot-lib/src/commands/transform/test_support.rs
+++ b/crates/dodot-lib/src/commands/transform/test_support.rs
@@ -48,5 +48,7 @@ pub(super) fn make_ctx(env: &TempEnvironment) -> ExecutionContext {
         verbose: false,
         host_facts: Arc::new(crate::gates::HostFacts::detect()),
         env_init_gen: None,
+        shell_probe: crate::shell::ProbePolicy::Never,
+        shell_env: crate::shell::ShellEnv::default(),
     }
 }

--- a/crates/dodot-lib/src/commands/up.rs
+++ b/crates/dodot-lib/src/commands/up.rs
@@ -367,18 +367,31 @@ pub fn up(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pack
 ///
 /// A fresh install has no heartbeat and no stamp, so this is where the
 /// new-user failure story gets caught: at the end of a green first
-/// `up`, pointing at the manual hook line. WS02 replaces that
-/// evidence-only warning with the probe's measured verdict.
+/// `up`. And it is the one place a *measurement* is worth its cost —
+/// when the cheap signals come back inconclusive, `up` spawns the
+/// user's shell and reports what actually happened
+/// (`shell::probe::notice_with_probe`, spec §3.1). A green first `up`
+/// ends on a measured verdict, not a promise; a healthy machine never
+/// spawns anything.
 ///
-/// A `--dry-run` deployed nothing and wrote no init script, so this
-/// stays silent there (see `activation::notice_for`).
+/// A `--dry-run` regenerated no script, so measuring the current one
+/// would report on a world this run did not create — evidence only
+/// there, which `activation::notice_for` keeps silent anyway when
+/// nothing has ever been deployed.
 fn activation_notice(
     ctx: &ExecutionContext,
     pre_up_generation: Option<u64>,
 ) -> Option<crate::shell::ActivationNotice> {
-    crate::shell::activation::notice_for(
+    let policy = if ctx.dry_run {
+        crate::shell::ProbePolicy::Never
+    } else {
+        ctx.shell_probe
+    };
+    crate::shell::probe::notice_with_probe(
         ctx.fs.as_ref(),
         ctx.paths.as_ref(),
+        &policy,
+        &ctx.shell_env,
         ctx.env_init_gen,
         pre_up_generation,
         false,

--- a/crates/dodot-lib/src/packs/context.rs
+++ b/crates/dodot-lib/src/packs/context.rs
@@ -79,6 +79,27 @@ pub struct ExecutionContext {
     /// evaluation is a function of its inputs and tests can inject a
     /// stamp instead of mutating process-global environment.
     pub env_init_gen: Option<u64>,
+    /// Whether this invocation may spawn a shell to *measure*
+    /// activation — signal 3 of the hookup ladder
+    /// (`docs/proposals/shell-hookup.lex` §3).
+    ///
+    /// Defaults to
+    /// [`ProbePolicy::Never`](crate::shell::ProbePolicy::Never)
+    /// everywhere except [`Self::production`], so no test can spawn a
+    /// real shell by forgetting to opt out; probe tests opt *in*, with
+    /// a fabricated shell in `shell_env`. `status` never probes
+    /// whatever this says (spec §9) — it reads evidence only.
+    pub shell_probe: crate::shell::ProbePolicy,
+    /// The user's shell and `$ZDOTDIR`, snapshotted once.
+    ///
+    /// One source of truth for two consumers that must agree: the
+    /// probe spawns `shell_env.shell`, and the rc ladder
+    /// ([`crate::shell::rc`]) resolves the file that same shell reads
+    /// — so a failed probe's diagnosis always names the rc file of the
+    /// shell that was actually measured. Default (both `None`) in
+    /// tests, which is why a test that never opts in cannot reach the
+    /// developer's real `~/.zshrc` either.
+    pub shell_env: crate::shell::ShellEnv,
 }
 
 impl ExecutionContext {
@@ -150,6 +171,8 @@ impl ExecutionContext {
             verbose,
             host_facts: Arc::new(HostFacts::detect()),
             env_init_gen: crate::shell::activation::read_env_stamp(),
+            shell_probe: crate::shell::ProbePolicy::production(),
+            shell_env: crate::shell::ShellEnv::from_process(),
         })
     }
 }

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -586,6 +586,8 @@ mod tests {
             verbose: false,
             host_facts: Arc::new(crate::gates::HostFacts::detect()),
             env_init_gen: None,
+            shell_probe: crate::shell::ProbePolicy::Never,
+            shell_env: crate::shell::ShellEnv::default(),
         };
 
         let result = execute(&TestUpCommand, None, &ctx).unwrap();

--- a/crates/dodot-lib/src/packs/orchestration/test_support.rs
+++ b/crates/dodot-lib/src/packs/orchestration/test_support.rs
@@ -66,6 +66,8 @@ pub(super) fn make_context(env: &TempEnvironment) -> ExecutionContext {
         verbose: false,
         host_facts: Arc::new(crate::gates::HostFacts::detect()),
         env_init_gen: None,
+        shell_probe: crate::shell::ProbePolicy::Never,
+        shell_env: crate::shell::ShellEnv::default(),
     }
 }
 

--- a/crates/dodot-lib/src/render/mod.rs
+++ b/crates/dodot-lib/src/render/mod.rs
@@ -173,6 +173,10 @@ pub const TEMPLATE_TEMPLATE_INSTALL_FILTER: &str =
 /// `dodot transform status` per-file state list.
 pub const TEMPLATE_TRANSFORM_STATUS: &str = include_str!("../templates/transform-status.jinja");
 
+/// `dodot install` — the shell, the resolved rc file, the hook line,
+/// and (after `--write`) the probe's measured verdict.
+pub const TEMPLATE_INSTALL: &str = include_str!("../templates/install.jinja");
+
 /// `dodot git-show-alias` print-for-paste output.
 pub const TEMPLATE_GIT_SHOW_ALIAS: &str = include_str!("../templates/git-show-alias.jinja");
 

--- a/crates/dodot-lib/src/shell/activation.rs
+++ b/crates/dodot-lib/src/shell/activation.rs
@@ -37,9 +37,13 @@
 //!   mark the invoking shell stale on every single `up`, which is noise,
 //!   not news.
 //!
-//! The empirical probe (spec §3) and `dodot install` (spec §4) are not
-//! part of this module: the states below are decided on evidence alone,
-//! and the never-activated notice points at the manual hook line.
+//! The empirical probe (spec §3) lives in [`crate::shell::probe`] and
+//! the rc-file machinery behind `dodot install` (spec §4) in
+//! [`crate::shell::rc`]. Everything below is decided on evidence
+//! alone; a caller that is allowed to spawn a shell goes through
+//! [`probe::notice_with_probe`](crate::shell::probe::notice_with_probe)
+//! instead, which starts here and only measures when these signals
+//! come back inconclusive.
 
 use std::path::Path;
 
@@ -145,9 +149,16 @@ pub enum HeartbeatState {
     Absent,
 }
 
-/// The user-facing activation state (spec §5). `verified broken` is
-/// deliberately absent: it requires the probe, which this slice does
-/// not ship.
+/// The user-facing activation state (spec §5).
+///
+/// The first three are decided on evidence alone. [`VerifiedBroken`]
+/// is the one state only a measurement can reach — see
+/// [`crate::shell::probe`] — and it takes precedence over the others
+/// when the probe has run: with evidence alone, a hookup that used to
+/// work and then broke looks like a stale shell, so the user gets
+/// "open a new shell" for a problem no new shell will fix.
+///
+/// [`VerifiedBroken`]: ActivationState::VerifiedBroken
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActivationState {
     /// Evidence says shells are loading dodot at the current
@@ -159,6 +170,9 @@ pub enum ActivationState {
     StaleShell,
     /// No evidence of any activation, ever. The new-user failure story.
     NeverActivated,
+    /// The probe spawned a shell and it did not load dodot. Measured,
+    /// not inferred.
+    VerifiedBroken,
 }
 
 impl ActivationState {
@@ -169,6 +183,7 @@ impl ActivationState {
             ActivationState::Healthy => "healthy",
             ActivationState::StaleShell => "stale-shell",
             ActivationState::NeverActivated => "never-activated",
+            ActivationState::VerifiedBroken => "verified-broken",
         }
     }
 }
@@ -328,12 +343,31 @@ impl ActivationNotice {
                 severity: "warning".into(),
                 message: "Deployed, but no shell has loaded dodot yet.".into(),
                 hint: Some(format!(
-                    "Add this to your shell rc file, then open a new shell: {hook_line}"
+                    "Run `dodot install --write` to wire it up, or add this to your shell rc \
+                     file yourself: {hook_line}"
+                )),
+            }),
+            // Only the probe reaches this state, and it renders its own
+            // diagnosis (`probe::Verdict::notice`). This arm is the
+            // answer for a caller that folds the state through the
+            // evidence path anyway: same headline, generic next step.
+            ActivationState::VerifiedBroken => Some(ActivationNotice {
+                state: state.as_str().into(),
+                severity: "error".into(),
+                message: VERIFIED_BROKEN_MESSAGE.into(),
+                hint: Some(format!(
+                    "Run `dodot install --write` to wire the hook, or add this to your shell rc \
+                     file yourself: {hook_line}"
                 )),
             }),
         }
     }
 }
+
+/// Headline for a hookup the probe measured as broken. Shared so the
+/// evidence path and [`crate::shell::probe`] can never drift into two
+/// different phrasings of the same finding.
+pub const VERIFIED_BROKEN_MESSAGE: &str = "Deployed, but a new shell did not load dodot.";
 
 /// The rc-file line that wires a shell up to the generated init
 /// script, with the home prefix written back as `$HOME`.
@@ -343,9 +377,10 @@ impl ActivationNotice {
 /// line source a literal `~` path once pasted. Quoting itself is not
 /// optional — it is what keeps a home directory with spaces working.
 ///
-/// This is the manual hook: `dodot install` (spec §4) lands in a later
-/// work stream, and until it does, telling the user to run a command
-/// that doesn't exist is worse than telling them nothing.
+/// The single source of truth for the hook line. `dodot install
+/// --write` writes exactly this string inside its marked block
+/// ([`crate::shell::rc`]), and every message that offers a manual
+/// alternative prints it — one line, one definition.
 pub fn hook_line(init_script_path: &Path, home: &Path) -> String {
     let shown = match init_script_path.strip_prefix(home) {
         Ok(rel) => format!("$HOME/{}", rel.display()),
@@ -524,9 +559,10 @@ mod tests {
             hint.contains(&hook),
             "hint should carry the hook line: {hint}"
         );
-        // WS02 ships `dodot install`; until then, pointing at it would
-        // be pointing at a command that does not exist.
-        assert!(!hint.contains("dodot install"), "hint: {hint}");
+        // WS02 ships `dodot install`, so the hint now leads with the
+        // command that does this for you — the manual line stays for
+        // users who would rather wire it themselves.
+        assert!(hint.contains("dodot install --write"), "hint: {hint}");
     }
 
     #[test]

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -9,7 +9,9 @@
 //! - Changes to the datastore layout only need to happen in Rust
 //!
 //! The generated script is written to `data_dir/shell/dodot-init.sh`.
-//! Users source it from their shell profile:
+//! `dodot install --write` wires the line below into the user's rc
+//! file ([`rc`]), and [`probe`] measures whether a new shell actually
+//! runs it. Users can also add it by hand:
 //!
 //! ```sh
 //! [ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ] && . "$HOME/.local/share/dodot/shell/dodot-init.sh"
@@ -62,8 +64,12 @@ use crate::paths::Pather;
 use crate::Result;
 
 pub mod activation;
+pub mod probe;
+pub mod rc;
 pub mod validate;
 pub use activation::{ActivationNotice, ActivationState, INIT_GEN_ENV};
+pub use probe::ProbePolicy;
+pub use rc::ShellEnv;
 pub use validate::{
     error_sidecar_path, validate_shell_sources, NoopSyntaxChecker, ShellValidationFailure,
     ShellValidationReport, SyntaxCheckResult, SyntaxChecker, SystemSyntaxChecker, ERRORS_SUBDIR,

--- a/crates/dodot-lib/src/shell/probe.rs
+++ b/crates/dodot-lib/src/shell/probe.rs
@@ -1,0 +1,845 @@
+//! The verification probe — measuring whether a *new* shell would
+//! activate dodot (`docs/proposals/shell-hookup.lex` §3).
+//!
+//! Signals 1 and 2 (the environment stamp and the heartbeat, both in
+//! [`crate::shell::activation`]) answer "is this shell live?" and "has
+//! any shell activated?". Neither answers the question a fresh install
+//! or a freshly broken hookup actually poses: *would the next terminal
+//! the user opens load dodot?* Only running one answers that, so when
+//! the cheap signals come back inconclusive, dodot spawns the user's
+//! shell and reads the stamp back out of it.
+//!
+//! # Gating
+//!
+//! [`gate_says_probe`] is the whole cost story. A current stamp or a
+//! fresh heartbeat means shells are activating, and the probe never
+//! runs. The first real shell activation writes the heartbeat and
+//! retires the probe until the hookup actually breaks — so a healthy
+//! machine pays nothing, forever. `dodot status` never spawns a shell
+//! at all (spec §9); only `up` and `install` may, and only through
+//! [`ProbePolicy::Gated`], which every non-production
+//! [`ExecutionContext`](crate::packs::ExecutionContext) leaves at
+//! [`ProbePolicy::Never`].
+//!
+//! # Mechanics
+//!
+//! User rc files prompt, hang, `exec` into multiplexers, and fail in
+//! creative ways, so [`run`] is defensive by construction: interactive
+//! non-login shell (the mode that reads the file the hook lives in),
+//! stdin from `/dev/null`, output captured, a hard timeout that kills
+//! the whole process group, and `DODOT_INIT_*` scrubbed from the child
+//! environment — an inherited stamp would be a false positive every
+//! time the probe runs from an already-live shell.
+//!
+//! # Verdicts
+//!
+//! [`Verdict`] keeps three outcomes apart because they demand
+//! different action: verified, verified-broken (with the static rc
+//! scan splitting *hook absent* from *hook present but never
+//! reached*), and couldn't-verify, which degrades to the scan's answer
+//! labeled as configuration state. A probe failure never wedges `up`.
+
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::fs::Fs;
+use crate::paths::Pather;
+use crate::shell::activation::{
+    self, ActivationNotice, ActivationState, HeartbeatState, StampState, INIT_GEN_ENV,
+};
+use crate::shell::rc::{self, HookPresence, ShellEnv};
+
+/// Prefix the probe command prints its stamp behind, so the one bit we
+/// read survives arbitrary rc noise on the same stream.
+pub const PROBE_MARKER: &str = "dodot-probe-gen:";
+
+/// How long a spawned shell gets before its process group is killed.
+/// Spec §3.2 calls for "order of 5 seconds": long enough for a heavy
+/// rc file, short enough that a hung one is not a hung `dodot up`.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Environment prefix scrubbed from the probed shell.
+const SCRUB_PREFIX: &str = "DODOT_INIT_";
+
+/// How long to wait between liveness checks on the spawned shell.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+// ── Policy ──────────────────────────────────────────────────────
+
+/// Whether a command may spawn a shell while judging activation.
+///
+/// *Which* shell is not this type's business — that comes from the
+/// context's [`ShellEnv`], the same value the rc ladder reads, so a
+/// probe can never measure one shell while the diagnosis names another
+/// shell's rc file.
+///
+/// Defaults to [`ProbePolicy::Never`], which is what makes "no test
+/// ever spawns the developer's real shell" a property of the type
+/// rather than of everyone's discipline: only
+/// [`ExecutionContext::production`](crate::packs::ExecutionContext::production)
+/// opts in, and probe tests opt in with a fabricated shell.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ProbePolicy {
+    /// Report from evidence alone. Every test context, and `status`
+    /// no matter the context.
+    #[default]
+    Never,
+    /// Spawn the shell when [`gate_says_probe`] says the cheap signals
+    /// are inconclusive, giving it `timeout` to finish starting up.
+    Gated { timeout: Duration },
+}
+
+impl ProbePolicy {
+    /// The production policy: gated, with the standard timeout.
+    pub fn production() -> Self {
+        ProbePolicy::Gated {
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+
+    /// The timeout when spawning is allowed at all, else `None`.
+    pub fn timeout(&self) -> Option<Duration> {
+        match self {
+            ProbePolicy::Never => None,
+            ProbePolicy::Gated { timeout } => Some(*timeout),
+        }
+    }
+}
+
+/// Whether the cheap signals leave anything worth measuring.
+///
+/// A current stamp means the calling shell is live; a fresh heartbeat
+/// means some shell activated since the last regeneration. Either is
+/// proof enough, and proof is cheaper than measurement. Only when
+/// neither holds — the fresh-install and broken-hook cases, precisely
+/// — is a shell spawn justified (spec §3.1).
+pub fn gate_says_probe(stamp: StampState, heartbeat: HeartbeatState) -> bool {
+    !matches!(stamp, StampState::Current) && !matches!(heartbeat, HeartbeatState::Fresh)
+}
+
+// ── Running one ─────────────────────────────────────────────────
+
+/// What one shell spawn reported back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeOutcome {
+    /// The shell finished and printed a parseable generation stamp.
+    Stamp(u64),
+    /// The shell finished and printed no stamp — it did not source
+    /// dodot's init script.
+    NoStamp,
+    /// The shell outlived its timeout; its process group was killed.
+    TimedOut,
+    /// The shell could not be run at all.
+    SpawnFailed(String),
+}
+
+/// The line the probe prints before spawning. The probe is announced,
+/// never covert (spec §3.2): every terminal open runs the user's rc
+/// anyway, and the only unacceptable version of this is a silent one.
+pub fn announcement(shell: &Path) -> String {
+    let name = shell
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("your shell");
+    format!("verifying shell integration ({name})…")
+}
+
+/// The command handed to the spawned shell: print the stamp we may or
+/// may not have inherited from its rc, behind a marker.
+fn probe_command() -> String {
+    format!("printf '{PROBE_MARKER}%s\\n' \"${{{INIT_GEN_ENV}-}}\"")
+}
+
+/// Extract the stamp from captured probe output.
+///
+/// Scans every line for the marker and takes the last one: an rc file
+/// is free to print whatever it likes before our command runs, and the
+/// probe reads exactly one bit out of the noise.
+pub fn parse_probe_output(stdout: &str) -> Option<u64> {
+    stdout
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix(PROBE_MARKER))
+        .filter_map(activation::parse_generation)
+        .next_back()
+}
+
+/// Spawn `shell` interactively and read the stamp back.
+///
+/// Safe against hostile rc files by construction — see the module
+/// docstring. Never returns an error: every failure mode is an
+/// outcome, because a probe that could not run must degrade, not
+/// propagate (spec §3.3).
+pub fn run(shell: &Path, timeout: Duration) -> ProbeOutcome {
+    let mut command = Command::new(shell);
+    command
+        // Interactive non-login: the mode that reads the rc file the
+        // hook lives in.
+        .arg("-ic")
+        .arg(probe_command())
+        // No tty, nothing to read: an rc file that prompts gets EOF
+        // instead of blocking forever.
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for key in scrubbed_keys(std::env::vars().map(|(k, _)| k)) {
+        command.env_remove(key);
+    }
+    // Its own process group, so a timeout can take out everything the
+    // rc file spawned, not just the shell we can see.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let mut child = match command.spawn() {
+        Ok(c) => c,
+        Err(e) => return ProbeOutcome::SpawnFailed(format!("{e}")),
+    };
+    let pid = child.id();
+
+    // Drain both pipes off-thread: a chatty rc file that fills a pipe
+    // buffer would otherwise deadlock against our own wait loop.
+    let stdout = child.stdout.take().map(drain);
+    let stderr = child.stderr.take().map(drain);
+
+    let deadline = Instant::now() + timeout;
+    let timed_out = loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break false,
+            Ok(None) => {}
+            Err(e) => return ProbeOutcome::SpawnFailed(format!("{e}")),
+        }
+        if Instant::now() >= deadline {
+            kill_process_group(pid);
+            // Reap: the group is dead, so this returns promptly and we
+            // leave no zombie behind.
+            let _ = child.wait();
+            break true;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    };
+
+    let captured = stdout.and_then(|h| h.join().ok()).unwrap_or_default();
+    drop(stderr.map(|h| h.join()));
+
+    if timed_out {
+        return ProbeOutcome::TimedOut;
+    }
+    // A nonzero exit is not a failed probe: unrelated rc breakage
+    // fails loudly and still activates dodot. The stamp is the bit.
+    match parse_probe_output(&captured) {
+        Some(generation) => ProbeOutcome::Stamp(generation),
+        None => ProbeOutcome::NoStamp,
+    }
+}
+
+/// Read a child pipe to end on its own thread.
+fn drain<R: Read + Send + 'static>(mut pipe: R) -> std::thread::JoinHandle<String> {
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = pipe.read_to_end(&mut buf);
+        String::from_utf8_lossy(&buf).into_owned()
+    })
+}
+
+/// The environment keys the child must not inherit.
+///
+/// The child inherits our exports, and this process may well have been
+/// started *by* an activated shell — an inherited stamp would make
+/// every probe from a live shell report success regardless of what the
+/// spawned one did (spec §3.2).
+pub fn scrubbed_keys(keys: impl Iterator<Item = String>) -> Vec<String> {
+    keys.filter(|k| k.starts_with(SCRUB_PREFIX)).collect()
+}
+
+/// Kill the probed shell's whole process group.
+///
+/// The shell was spawned as its own group leader, so its pid is the
+/// group id and a negative-pid signal reaches every process the rc
+/// file started — the `exec`-into-a-multiplexer case, where killing
+/// only the shell we can see would leave the real hang behind.
+#[cfg(unix)]
+fn kill_process_group(pid: u32) {
+    // SAFETY: `kill` is a plain syscall wrapper with no memory
+    // effects. A negative pid addresses the process group; the group
+    // is one we created via `process_group(0)`, so we are not
+    // signalling anything we did not spawn. A failure (the group
+    // already exited) is nothing to handle.
+    unsafe {
+        libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+    }
+}
+
+// ── Verdicts ────────────────────────────────────────────────────
+
+/// Why a measured-broken hookup is broken (spec §3.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Diagnosis {
+    /// The hook is not in the rc file the shell reads.
+    HookAbsent { rc: String },
+    /// The hook is there, but the shell never got to it — something
+    /// earlier in the file is failing.
+    HookNotReached { rc: String },
+    /// The shell activated, but from an init script older than the one
+    /// on disk. The hookup works; what it sources is stale.
+    StaleScript { found: u64, expected: u64 },
+    /// No rc file could be named (unsupported shell), so the scan has
+    /// nothing to say. The hook line is all we can offer.
+    Unknown,
+}
+
+/// The measured answer to "would a new shell activate dodot?"
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Verdict {
+    /// Measured ✓ — the spawned shell reported the current generation.
+    Verified { generation: u64 },
+    /// The shell ran and did not activate dodot.
+    Broken { diagnosis: Diagnosis },
+    /// The measurement itself failed. Degrade to configuration state.
+    Unverified { reason: String },
+}
+
+impl Verdict {
+    /// Fold one spawn's outcome into a verdict, using the static rc
+    /// scan only where spec §2.2 allows it: to explain a failure.
+    pub fn from_outcome(
+        outcome: ProbeOutcome,
+        reference: Option<u64>,
+        hook: Option<(HookPresence, String)>,
+    ) -> Verdict {
+        match outcome {
+            ProbeOutcome::Stamp(found) => {
+                match activation::classify_stamp(Some(found), reference) {
+                    StampState::Current => Verdict::Verified { generation: found },
+                    // Unreachable in practice — a new shell sources the
+                    // script we just wrote — but a real answer beats
+                    // rounding it up to "verified".
+                    _ => Verdict::Broken {
+                        diagnosis: Diagnosis::StaleScript {
+                            found,
+                            expected: reference.unwrap_or(found),
+                        },
+                    },
+                }
+            }
+            ProbeOutcome::NoStamp => Verdict::Broken {
+                diagnosis: match hook {
+                    Some((presence, rc)) if presence.is_present() => {
+                        Diagnosis::HookNotReached { rc }
+                    }
+                    Some((_, rc)) => Diagnosis::HookAbsent { rc },
+                    None => Diagnosis::Unknown,
+                },
+            },
+            ProbeOutcome::TimedOut => Verdict::Unverified {
+                reason: "your shell did not finish starting up in time".into(),
+            },
+            ProbeOutcome::SpawnFailed(e) => Verdict::Unverified {
+                reason: format!("could not run your shell ({e})"),
+            },
+        }
+    }
+
+    /// Render the verdict for `up` / `install` output.
+    ///
+    /// `evidence` is the notice the signal ladder alone produced, and
+    /// `hook_line` the manual line to fall back on. A couldn't-verify
+    /// verdict degrades to `evidence`, clearly labeled as
+    /// configuration state rather than measured activation; the other
+    /// two verdicts are measurements and take precedence over it —
+    /// including over the stale-shell advice, which is the wrong
+    /// answer for a hookup that just measured broken.
+    pub fn notice(
+        &self,
+        evidence: Option<ActivationNotice>,
+        hook_line: &str,
+    ) -> Option<ActivationNotice> {
+        match self {
+            Verdict::Verified { .. } => Some(ActivationNotice {
+                state: ActivationState::Healthy.as_str().into(),
+                severity: "ok".into(),
+                message: "Shell hookup verified: a new shell loads dodot.".into(),
+                hint: None,
+            }),
+            Verdict::Broken { diagnosis } => Some(ActivationNotice {
+                state: ActivationState::VerifiedBroken.as_str().into(),
+                severity: "error".into(),
+                message: activation::VERIFIED_BROKEN_MESSAGE.into(),
+                hint: Some(match diagnosis {
+                    Diagnosis::HookAbsent { rc } => format!(
+                        "The dodot hook is missing from {rc} — run `dodot install --write` to add it."
+                    ),
+                    Diagnosis::HookNotReached { rc } => format!(
+                        "The dodot hook is in {rc} but was never reached — something earlier in \
+                         that file is failing before it."
+                    ),
+                    Diagnosis::StaleScript { found, expected } => format!(
+                        "Your shell sourced an older init script (generation {found}, current is \
+                         {expected}) — check for a second dodot hook or a stale copy."
+                    ),
+                    Diagnosis::Unknown => format!(
+                        "dodot could not tell which rc file your shell reads. Add this line to it: \
+                         {hook_line}"
+                    ),
+                }),
+            }),
+            Verdict::Unverified { reason } => {
+                let mut notice = evidence?;
+                notice.hint = Some(match notice.hint.take() {
+                    Some(hint) => format!(
+                        "{hint} (dodot could not verify by running your shell — {reason} — so this \
+                         reports your configuration, not measured activation.)"
+                    ),
+                    None => format!(
+                        "dodot could not verify by running your shell — {reason} — so this reports \
+                         your configuration, not measured activation."
+                    ),
+                });
+                Some(notice)
+            }
+        }
+    }
+}
+
+// ── The measured path ───────────────────────────────────────────
+
+/// Run the probe and turn it into a notice, doing the rc scan for the
+/// diagnosis.
+///
+/// `reference` is the generation a shell started now would pick up
+/// (the script on disk), and `evidence` the signals-only notice this
+/// replaces when the measurement succeeds. `rc_override` names the
+/// file the diagnosis should talk about when the caller already knows
+/// it (`dodot install --rc`), instead of re-walking the ladder.
+pub fn measure(
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+    timeout: Duration,
+    shell_env: &ShellEnv,
+    rc_override: Option<&Path>,
+    reference: Option<u64>,
+    evidence: Option<ActivationNotice>,
+) -> Option<ActivationNotice> {
+    let hook_line = activation::hook_line(&paths.init_script_path(), paths.home_dir());
+    let Some(shell) = shell_env.shell.as_deref().map(Path::new) else {
+        return Verdict::Unverified {
+            reason: "$SHELL is not set".into(),
+        }
+        .notice(evidence, &hook_line);
+    };
+
+    eprintln!("{}", announcement(shell));
+    let outcome = run(shell, timeout);
+    let hook = scan_for_diagnosis(fs, paths, shell_env, rc_override);
+    Verdict::from_outcome(outcome, reference, hook).notice(evidence, &hook_line)
+}
+
+/// The rc file the shell should be reading and what it says about the
+/// hook — the input to the wrong-file / broken-rc diagnosis split.
+///
+/// `None` when there is no override and the shell is one dodot has no
+/// canonical rc for; the verdict then says so rather than naming a
+/// file it guessed.
+fn scan_for_diagnosis(
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+    shell_env: &ShellEnv,
+    rc_override: Option<&Path>,
+) -> Option<(HookPresence, String)> {
+    let home = paths.home_dir();
+    let path = match rc_override {
+        Some(p) => p.to_path_buf(),
+        None => rc::resolve_rc(fs, home, Some(shell_env.hookup_shell()?), shell_env, None).path,
+    };
+    Some((
+        rc::scan_hook_file(fs, &path),
+        rc::display_home_relative(&path, home),
+    ))
+}
+
+/// Evaluate shell activation for a command that is allowed to measure.
+///
+/// Evidence first, always: [`gate_says_probe`] has to agree before a
+/// shell is spawned, so the steady-state cost of this call on a
+/// healthy machine is the two signal reads it would have done anyway.
+///
+/// `reference_for_gate` is the generation the *evidence* is judged
+/// against (for `up`, the pre-regeneration one — see
+/// `up::activation_notice`), while the probe is judged against the
+/// script on disk, which is what a shell started now would source.
+pub fn notice_with_probe(
+    fs: &dyn Fs,
+    paths: &dyn Pather,
+    policy: &ProbePolicy,
+    shell_env: &ShellEnv,
+    env_stamp: Option<u64>,
+    reference_for_gate: Option<u64>,
+    quiet_ok: bool,
+) -> Option<ActivationNotice> {
+    let evidence = activation::notice_for(fs, paths, env_stamp, reference_for_gate, quiet_ok);
+    let Some(timeout) = policy.timeout() else {
+        return evidence;
+    };
+    if !fs.exists(&paths.init_script_path()) {
+        // Nothing deployed: there is no hookup to measure yet.
+        return evidence;
+    }
+    let stamp = activation::classify_stamp(env_stamp, reference_for_gate);
+    let heartbeat =
+        activation::classify_heartbeat(activation::read_heartbeat(fs, paths), reference_for_gate);
+    if !gate_says_probe(stamp, heartbeat) {
+        return evidence;
+    }
+    let reference = activation::read_script_generation(fs, paths);
+    measure(fs, paths, timeout, shell_env, None, reference, evidence)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_gate_fires_only_when_both_cheap_signals_are_inconclusive() {
+        use HeartbeatState as H;
+        use StampState as S;
+        let matrix = [
+            // A live shell is proof; never probe.
+            (S::Current, H::Absent, false),
+            (S::Current, H::Fresh, false),
+            (S::Current, H::Old, false),
+            // Some shell activated since the last regeneration; proof
+            // enough, whatever this process inherited.
+            (S::Absent, H::Fresh, false),
+            (S::Stale, H::Fresh, false),
+            // Fresh install: nothing has ever activated.
+            (S::Absent, H::Absent, true),
+            // Previously working, now nothing since the regeneration —
+            // the broken-hook case the probe exists for.
+            (S::Absent, H::Old, true),
+            (S::Stale, H::Old, true),
+            (S::Stale, H::Absent, true),
+        ];
+        for (stamp, heartbeat, expected) in matrix {
+            assert_eq!(
+                gate_says_probe(stamp, heartbeat),
+                expected,
+                "stamp={stamp:?} heartbeat={heartbeat:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_stamp_is_read_out_of_arbitrary_rc_noise() {
+        let noisy = format!(
+            "Welcome to your shell!\n[oh-my-zsh] update available\n{PROBE_MARKER}1755200000\n"
+        );
+        assert_eq!(parse_probe_output(&noisy), Some(1_755_200_000));
+        // No stamp exported: the marker is there, the value is empty.
+        assert_eq!(parse_probe_output(&format!("{PROBE_MARKER}\n")), None);
+        assert_eq!(parse_probe_output("nothing at all\n"), None);
+    }
+
+    #[test]
+    fn only_the_init_stamp_family_is_scrubbed() {
+        let keys = [
+            "DODOT_INIT_GEN",
+            "DODOT_INIT_ANYTHING",
+            "DODOT_DATA_DIR",
+            "PATH",
+            "HOME",
+        ]
+        .into_iter()
+        .map(String::from);
+        assert_eq!(
+            scrubbed_keys(keys),
+            vec!["DODOT_INIT_GEN".to_string(), "DODOT_INIT_ANYTHING".into()]
+        );
+    }
+
+    #[test]
+    fn the_announcement_names_the_shell_being_run() {
+        assert_eq!(
+            announcement(Path::new("/bin/zsh")),
+            "verifying shell integration (zsh)…"
+        );
+    }
+
+    // ── Verdicts ────────────────────────────────────────────────
+
+    fn hook(presence: HookPresence) -> Option<(HookPresence, String)> {
+        Some((presence, "~/.zshrc".to_string()))
+    }
+
+    #[test]
+    fn a_current_stamp_is_a_measured_verification() {
+        let v = Verdict::from_outcome(
+            ProbeOutcome::Stamp(100),
+            Some(100),
+            hook(HookPresence::ManagedBlock),
+        );
+        assert_eq!(v, Verdict::Verified { generation: 100 });
+        let notice = v.notice(None, "HOOK").unwrap();
+        assert_eq!(notice.state, "healthy");
+        assert_eq!(notice.severity, "ok");
+        assert!(notice.message.contains("verified"), "{}", notice.message);
+    }
+
+    #[test]
+    fn no_stamp_plus_no_hook_names_the_file_and_the_command() {
+        let v = Verdict::from_outcome(ProbeOutcome::NoStamp, Some(100), hook(HookPresence::Absent));
+        assert_eq!(
+            v,
+            Verdict::Broken {
+                diagnosis: Diagnosis::HookAbsent {
+                    rc: "~/.zshrc".into()
+                }
+            }
+        );
+        let notice = v.notice(None, "HOOK").unwrap();
+        assert_eq!(notice.state, "verified-broken");
+        assert_eq!(notice.severity, "error");
+        let hint = notice.hint.unwrap();
+        assert!(hint.contains("~/.zshrc"), "{hint}");
+        assert!(hint.contains("dodot install --write"), "{hint}");
+    }
+
+    #[test]
+    fn no_stamp_with_the_hook_present_blames_the_rc_file_instead() {
+        for presence in [HookPresence::ManagedBlock, HookPresence::Manual] {
+            let v = Verdict::from_outcome(ProbeOutcome::NoStamp, Some(100), hook(presence));
+            let hint = v.notice(None, "HOOK").unwrap().hint.unwrap();
+            assert!(
+                hint.contains("never reached"),
+                "{presence:?} should diagnose a broken rc, not a missing hook: {hint}"
+            );
+            assert!(
+                !hint.contains("dodot install --write"),
+                "adding the hook again fixes nothing here: {hint}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unknown_shell_falls_back_to_the_hook_line() {
+        let v = Verdict::from_outcome(ProbeOutcome::NoStamp, Some(100), None);
+        assert_eq!(
+            v,
+            Verdict::Broken {
+                diagnosis: Diagnosis::Unknown
+            }
+        );
+        let hint = v.notice(None, "THE-HOOK-LINE").unwrap().hint.unwrap();
+        assert!(hint.contains("THE-HOOK-LINE"), "{hint}");
+    }
+
+    #[test]
+    fn a_stale_sourced_script_is_reported_as_such() {
+        let v = Verdict::from_outcome(
+            ProbeOutcome::Stamp(90),
+            Some(100),
+            hook(HookPresence::ManagedBlock),
+        );
+        assert_eq!(
+            v,
+            Verdict::Broken {
+                diagnosis: Diagnosis::StaleScript {
+                    found: 90,
+                    expected: 100
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn a_failed_measurement_degrades_to_the_evidence_notice() {
+        let evidence = ActivationNotice {
+            state: "never-activated".into(),
+            severity: "warning".into(),
+            message: "Deployed, but no shell has loaded dodot yet.".into(),
+            hint: Some("Add this to your rc file: HOOK".into()),
+        };
+        for outcome in [
+            ProbeOutcome::TimedOut,
+            ProbeOutcome::SpawnFailed("no such file".into()),
+        ] {
+            let v = Verdict::from_outcome(outcome, Some(100), hook(HookPresence::Absent));
+            let notice = v.notice(Some(evidence.clone()), "HOOK").unwrap();
+            // The evidence verdict survives untouched...
+            assert_eq!(notice.state, "never-activated");
+            assert_eq!(notice.severity, "warning");
+            // ...but is labeled as configuration, not measurement.
+            let hint = notice.hint.unwrap();
+            assert!(hint.starts_with("Add this to your rc file: HOOK"), "{hint}");
+            assert!(hint.contains("could not verify"), "{hint}");
+            assert!(hint.contains("not measured activation"), "{hint}");
+        }
+    }
+
+    #[test]
+    fn a_failed_measurement_with_nothing_to_degrade_to_stays_silent() {
+        // Healthy-and-quiet evidence plus an unrunnable shell is not a
+        // reason to invent a warning.
+        let v = Verdict::Unverified {
+            reason: "boom".into(),
+        };
+        assert_eq!(v.notice(None, "HOOK"), None);
+    }
+
+    // ── Spawn mechanics, against fabricated shells ──────────────
+    //
+    // Every test below runs a shell script this file wrote into a
+    // temp dir. None of them can reach the developer's real `$SHELL`
+    // or their real rc files — which is the whole point: the probe's
+    // job is surviving hostile rc behaviour, and the only way to test
+    // that is to fabricate the hostility.
+
+    use crate::testing::TempEnvironment;
+    use std::path::PathBuf;
+
+    /// Write an executable fake `$SHELL`.
+    ///
+    /// It is invoked exactly as the real thing is — `<shell> -ic
+    /// '<command>'` — so `$2` is the probe command, and `eval "$2"` is
+    /// the fake's stand-in for "run the command after the rc file".
+    /// What each fixture puts *before* that line is the rc behaviour
+    /// under test.
+    fn fake_shell(env: &TempEnvironment, name: &str, rc_behaviour: &str) -> PathBuf {
+        let path = env.home.join(name);
+        let script = format!("#!/bin/sh\n{rc_behaviour}\neval \"$2\"\n");
+        env.fs
+            .write_file_with_mode(&path, script.as_bytes(), 0o755)
+            .unwrap();
+        path
+    }
+
+    #[test]
+    fn a_shell_that_activates_reports_the_stamp() {
+        let env = TempEnvironment::builder().build();
+        let shell = fake_shell(
+            &env,
+            "activating-shell",
+            &format!("export {INIT_GEN_ENV}=1755200000"),
+        );
+        assert_eq!(
+            run(&shell, Duration::from_secs(10)),
+            ProbeOutcome::Stamp(1_755_200_000)
+        );
+    }
+
+    #[test]
+    fn a_shell_with_no_hook_reports_no_stamp() {
+        let env = TempEnvironment::builder().build();
+        let shell = fake_shell(&env, "bare-shell", "echo 'welcome to your shell'");
+        assert_eq!(run(&shell, Duration::from_secs(10)), ProbeOutcome::NoStamp);
+    }
+
+    #[test]
+    fn rc_noise_and_a_nonzero_exit_do_not_fail_a_successful_probe() {
+        // Unrelated rc breakage is loud and irrelevant: the shell
+        // still sourced dodot, so the probe still says verified.
+        let env = TempEnvironment::builder().build();
+        let path = env.home.join("noisy-shell");
+        let script = format!(
+            "#!/bin/sh\n\
+             echo 'error: some unrelated rc line failed' >&2\n\
+             echo 'p10k wants your attention'\n\
+             export {INIT_GEN_ENV}=42\n\
+             eval \"$2\"\n\
+             exit 3\n"
+        );
+        env.fs
+            .write_file_with_mode(&path, script.as_bytes(), 0o755)
+            .unwrap();
+        assert_eq!(run(&path, Duration::from_secs(10)), ProbeOutcome::Stamp(42));
+    }
+
+    #[test]
+    fn a_hanging_rc_times_out_and_takes_its_children_with_it() {
+        let env = TempEnvironment::builder().build();
+        let pidfile = env.home.join("grandchild.pid");
+        // A shell that hangs *and* leaves a background process behind
+        // — the `exec`-into-a-multiplexer shape. Killing only the
+        // shell we can see would leave that process running forever.
+        let path = env.home.join("hanging-shell");
+        let script = format!(
+            "#!/bin/sh\nsh -c 'echo $$ > {pid}; sleep 300' &\nsleep 300\n",
+            pid = pidfile.display()
+        );
+        env.fs
+            .write_file_with_mode(&path, script.as_bytes(), 0o755)
+            .unwrap();
+
+        let start = Instant::now();
+        let outcome = run(&path, Duration::from_millis(500));
+        assert_eq!(outcome, ProbeOutcome::TimedOut);
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "the timeout must not wait out the rc file: {:?}",
+            start.elapsed()
+        );
+
+        let pid: i32 = wait_for_pidfile(&env, &pidfile);
+        assert!(
+            wait_until_dead(pid),
+            "pid {pid} survived the timeout: the process *group* was not killed"
+        );
+    }
+
+    /// Read the grandchild's pid, giving the fake shell a moment to
+    /// have written it.
+    fn wait_for_pidfile(env: &TempEnvironment, pidfile: &Path) -> i32 {
+        for _ in 0..100 {
+            if let Ok(text) = env.fs.read_to_string(pidfile) {
+                if let Ok(pid) = text.trim().parse() {
+                    return pid;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        panic!("the fake shell never recorded its background child's pid");
+    }
+
+    /// Poll `kill(pid, 0)` until the process is gone. Reparenting to
+    /// init reaps it, so this converges quickly — but not instantly,
+    /// which is why it polls instead of asserting once.
+    fn wait_until_dead(pid: i32) -> bool {
+        for _ in 0..100 {
+            // SAFETY: signal 0 sends nothing; it only asks whether the
+            // pid can be signalled, which is the liveness check here.
+            let alive = unsafe { libc::kill(pid, 0) } == 0;
+            if !alive {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        false
+    }
+
+    #[test]
+    fn an_inherited_stamp_is_scrubbed_before_the_child_sees_it() {
+        // The probe often runs *from* a live shell, which exports the
+        // stamp. Without scrubbing, a totally unhooked shell would
+        // still hand it back and every probe would report success.
+        let env = TempEnvironment::builder().build();
+        let _guard = crate::testing::EnvVarGuard::set(INIT_GEN_ENV, "999999");
+        let shell = fake_shell(&env, "inheriting-shell", "# sources nothing");
+        assert_eq!(
+            run(&shell, Duration::from_secs(10)),
+            ProbeOutcome::NoStamp,
+            "an inherited stamp must not count as this shell's activation"
+        );
+    }
+
+    #[test]
+    fn a_shell_that_cannot_be_run_is_a_couldnt_verify_not_a_panic() {
+        let env = TempEnvironment::builder().build();
+        let missing = env.home.join("no-such-shell");
+        assert!(matches!(
+            run(&missing, Duration::from_secs(5)),
+            ProbeOutcome::SpawnFailed(_)
+        ));
+    }
+}

--- a/crates/dodot-lib/src/shell/rc.rs
+++ b/crates/dodot-lib/src/shell/rc.rs
@@ -173,6 +173,17 @@ pub struct RcTarget {
     pub notes: Vec<String>,
 }
 
+impl RcTarget {
+    /// The path the ladder (or `--rc`) named, before symlink
+    /// resolution — the file *the shell* opens at startup, which is
+    /// what rung-2 rules are about. [`path`](Self::path) is where the
+    /// bytes land; a symlinked `~/.bashrc` is still `~/.bashrc` to
+    /// bash.
+    pub fn nominal(&self) -> &Path {
+        self.link_source.as_deref().unwrap_or(&self.path)
+    }
+}
+
 /// Resolve the rc file for `shell`, honoring an explicit `--rc`
 /// override (spec §4.3).
 ///
@@ -530,6 +541,11 @@ fn is_manual_hook_line(line: &str) -> bool {
 /// `.profile` and never `.bashrc` — where the hook block lands. If
 /// neither profile reaches `.bashrc`, the hook is written but never
 /// read, which is exactly the silent failure this epic exists to kill.
+///
+/// Only ask this when the hook block actually landed in `~/.bashrc`:
+/// the returned profile is written with the same managed-block markers,
+/// so chaining a file that already holds the hook block would replace
+/// the hook with the chain line.
 pub fn bash_chain_target(fs: &dyn Fs, home: &Path) -> Option<PathBuf> {
     for name in [".bash_profile", ".profile"] {
         let path = home.join(name);

--- a/crates/dodot-lib/src/shell/rc.rs
+++ b/crates/dodot-lib/src/shell/rc.rs
@@ -1,0 +1,874 @@
+//! Where the shell hookup lives — shell detection, the rc-file
+//! ladder, and dodot's marked block
+//! (`docs/proposals/shell-hookup.lex` §4).
+//!
+//! Two consumers share this module, and the split matters:
+//!
+//! - `dodot install` uses it to *choose a write target* and to write
+//!   the marked block ([`resolve_rc`], [`apply_block`]).
+//! - The verification probe uses it to *turn a failed measurement into
+//!   a diagnosis* ([`scan_hook`]) — hook absent from the expected rc
+//!   versus hook present but never reached.
+//!
+//! Those are the only two jobs a static rc scan is allowed to do
+//! (spec §2.2). It is never the verdict on whether shells activate:
+//! rc files chain, hide behind symlinks, and get sourced from places
+//! no scan enumerates. The probe measures; this module guesses, and
+//! the marked block makes the guess reversible.
+//!
+//! Everything here is a pure function of its inputs plus an injected
+//! [`Fs`] — `$SHELL` and `$ZDOTDIR` arrive as a [`ShellEnv`] value
+//! rather than being read at the point of use, so the ladder is
+//! table-testable without mutating process-global environment.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::fs::Fs;
+use crate::Result;
+
+/// Opening marker of dodot's managed hook block.
+pub const BLOCK_START: &str = "# >>> dodot shell hookup >>>";
+
+/// Closing marker of dodot's managed hook block.
+pub const BLOCK_END: &str = "# <<< dodot shell hookup <<<";
+
+/// The line a macOS `.bash_profile` needs so Terminal's login shells
+/// reach `.bashrc` — where the hook block lands (spec §4.3 rung 2).
+pub const BASH_CHAIN_LINE: &str = "[ -f \"$HOME/.bashrc\" ] && . \"$HOME/.bashrc\"";
+
+/// Guard against a symlink cycle while resolving an rc path. Well
+/// past any legitimate dotfiles-repo chain.
+const MAX_SYMLINK_HOPS: usize = 32;
+
+// ── Shell detection ─────────────────────────────────────────────
+
+/// A shell dodot knows how to wire up.
+///
+/// Deliberately narrower than the set dodot *generates init for*
+/// (POSIX sh, bash, zsh): the resolution ladder in spec §4.3 defines
+/// a canonical interactive rc for bash and zsh only. A plain `sh`
+/// reads whatever `$ENV` points at, which is not a guess worth making
+/// — that user gets the honest refusal plus the hook line, same as a
+/// fish user, and `--rc` if they know better.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookupShell {
+    Bash,
+    Zsh,
+}
+
+impl HookupShell {
+    /// Detect from a `$SHELL`-style path by basename.
+    ///
+    /// A leading `-` is stripped first: that is the login-shell
+    /// `argv[0]` convention (`-zsh`), and it shows up in `$SHELL` on
+    /// hosts that copy `argv[0]` into it.
+    pub fn from_shell_path(path: &str) -> Option<Self> {
+        let base = Path::new(path).file_name()?.to_str()?;
+        match base.strip_prefix('-').unwrap_or(base) {
+            "bash" => Some(HookupShell::Bash),
+            "zsh" => Some(HookupShell::Zsh),
+            _ => None,
+        }
+    }
+
+    /// Stable lowercase name, used in output and serialization.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HookupShell::Bash => "bash",
+            HookupShell::Zsh => "zsh",
+        }
+    }
+}
+
+/// The process-environment inputs the rc ladder reads.
+///
+/// Passed as a value so the ladder stays pure: production snapshots
+/// it once via [`ShellEnv::from_process`], tests construct one
+/// directly instead of mutating `$SHELL` / `$ZDOTDIR` under a global
+/// lock.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ShellEnv {
+    /// The user's shell — `$SHELL`, or the login shell from the user
+    /// database when `$SHELL` is unset (spec §4.3 rung 1).
+    pub shell: Option<String>,
+    /// `$ZDOTDIR`, when the environment carries one. Absent means the
+    /// zsh rung peeks at `~/.zshenv` instead.
+    pub zdotdir: Option<String>,
+}
+
+impl ShellEnv {
+    /// Snapshot the real environment, applying the login-shell
+    /// fallback for an unset (or empty) `$SHELL`.
+    pub fn from_process() -> Self {
+        let shell = std::env::var("SHELL")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .or_else(login_shell_from_user_db);
+        Self {
+            shell,
+            zdotdir: std::env::var("ZDOTDIR").ok().filter(|s| !s.is_empty()),
+        }
+    }
+
+    /// The shell this environment names, or `None` when it is unset or
+    /// one dodot refuses to guess an rc file for.
+    pub fn hookup_shell(&self) -> Option<HookupShell> {
+        self.shell.as_deref().and_then(HookupShell::from_shell_path)
+    }
+}
+
+/// The login shell recorded for this uid in the user database.
+///
+/// The fallback for an unset `$SHELL` (spec §4.3 rung 1). Reads the
+/// passwd entry rather than `/etc/passwd` directly because macOS
+/// serves user records from Directory Services, where the file is
+/// nearly empty.
+///
+/// `getpwuid` returns a pointer into libc's static storage, so it is
+/// not thread-safe against a concurrent caller in the same process.
+/// dodot is a one-shot CLI that calls this at most once per
+/// invocation, from context construction, before any worker threads
+/// exist.
+fn login_shell_from_user_db() -> Option<String> {
+    // SAFETY: `getpwuid` takes a plain uid and returns either null or
+    // a pointer to a `passwd` in libc-owned static storage, valid
+    // until the next passwd-database call in this process. We read
+    // `pw_shell` (a NUL-terminated C string) and copy it out
+    // immediately, before any such call can happen.
+    unsafe {
+        let entry = libc::getpwuid(libc::getuid());
+        if entry.is_null() || (*entry).pw_shell.is_null() {
+            return None;
+        }
+        std::ffi::CStr::from_ptr((*entry).pw_shell)
+            .to_str()
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    }
+}
+
+// ── The rc ladder ───────────────────────────────────────────────
+
+/// The rc file `dodot install` reads and (with `--write`) writes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RcTarget {
+    /// The file to actually touch — symlinks fully resolved, because
+    /// a symlinked rc is written *through* (spec §4.3 rung 4).
+    pub path: PathBuf,
+    /// The path the ladder picked before symlink resolution, when the
+    /// two differ. `Some` here is what the caller announces: landing
+    /// the hook in someone's dotfiles repo is the desired outcome,
+    /// doing it silently is how trust is lost.
+    pub link_source: Option<PathBuf>,
+    /// Whether [`path`](Self::path) exists today. A missing rc is
+    /// still the right target — a fresh machine has no `.zshrc` —
+    /// and `--write` creates it (rung 3).
+    pub exists: bool,
+    /// Everything about this resolution the user should be told:
+    /// where `ZDOTDIR` came from, which symlink was followed.
+    pub notes: Vec<String>,
+}
+
+/// Resolve the rc file for `shell`, honoring an explicit `--rc`
+/// override (spec §4.3).
+///
+/// `explicit` short-circuits rungs 1–2 entirely, but still goes
+/// through symlink resolution: `--rc` says *which* file, not "skip
+/// the write-through announcement".
+pub fn resolve_rc(
+    fs: &dyn Fs,
+    home: &Path,
+    shell: Option<HookupShell>,
+    env: &ShellEnv,
+    explicit: Option<&Path>,
+) -> RcTarget {
+    let mut notes = Vec::new();
+
+    let nominal = match (explicit, shell) {
+        (Some(p), _) => absolutize(p, home),
+        (None, Some(HookupShell::Bash)) => home.join(".bashrc"),
+        (None, Some(HookupShell::Zsh)) => {
+            let (dir, note) = zdotdir(fs, home, env);
+            if let Some(note) = note {
+                notes.push(note);
+            }
+            dir.join(".zshrc")
+        }
+        // Callers refuse before reaching here; `~/.profile` keeps the
+        // type total without inventing a shell-specific guess.
+        (None, None) => home.join(".profile"),
+    };
+
+    let resolved = resolve_symlinks(fs, &nominal);
+    let link_source = (resolved != nominal).then(|| nominal.clone());
+    if let Some(src) = &link_source {
+        notes.push(format!(
+            "{} → {} — writing there",
+            display_home_relative(src, home),
+            display_home_relative(&resolved, home)
+        ));
+    }
+
+    RcTarget {
+        exists: fs.exists(&resolved),
+        link_source,
+        notes,
+        path: resolved,
+    }
+}
+
+/// The directory zsh reads `.zshrc` from, and how we know.
+///
+/// `$ZDOTDIR` when the environment carries it; otherwise a peek at
+/// `~/.zshenv`, since that is the one file zsh always reads and thus
+/// the only legal place `ZDOTDIR` can be set before `.zshrc` is
+/// looked up (spec §4.3 rung 2).
+fn zdotdir(fs: &dyn Fs, home: &Path, env: &ShellEnv) -> (PathBuf, Option<String>) {
+    if let Some(z) = env.zdotdir.as_deref() {
+        let dir = expand_home(z, home);
+        return (
+            dir.clone(),
+            Some(format!("ZDOTDIR is set: zsh reads {}", dir.display())),
+        );
+    }
+    let zshenv = home.join(".zshenv");
+    if fs.exists(&zshenv) {
+        if let Ok(text) = fs.read_to_string(&zshenv) {
+            if let Some(raw) = parse_zdotdir_assignment(&text) {
+                let dir = expand_home(&raw, home);
+                return (
+                    dir.clone(),
+                    Some(format!(
+                        "~/.zshenv sets ZDOTDIR={}: zsh reads {}",
+                        raw,
+                        dir.display()
+                    )),
+                );
+            }
+        }
+    }
+    (home.to_path_buf(), None)
+}
+
+/// Extract the value of the last `ZDOTDIR=` assignment in `.zshenv`
+/// text, ignoring comments. Quotes are stripped; `$HOME` / `~` stay
+/// in the returned string for [`expand_home`] to deal with.
+pub fn parse_zdotdir_assignment(text: &str) -> Option<String> {
+    text.lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.starts_with('#') {
+                return None;
+            }
+            let rest = line
+                .strip_prefix("export ")
+                .unwrap_or(line)
+                .trim_start()
+                .strip_prefix("ZDOTDIR=")?;
+            // Stop at a trailing comment or a command separator; an
+            // unquoted value cannot contain either.
+            let value = rest.split(['#', ';']).next().unwrap_or(rest).trim();
+            let value = value
+                .strip_prefix('"')
+                .and_then(|v| v.strip_suffix('"'))
+                .or_else(|| value.strip_prefix('\'').and_then(|v| v.strip_suffix('\'')))
+                .unwrap_or(value);
+            (!value.is_empty()).then(|| value.to_string())
+        })
+        .next_back()
+}
+
+/// Expand a leading `$HOME`, `${HOME}`, or `~` against `home`.
+fn expand_home(raw: &str, home: &Path) -> PathBuf {
+    for prefix in ["${HOME}", "$HOME", "~"] {
+        if let Some(rest) = raw.strip_prefix(prefix) {
+            let rest = rest.trim_start_matches('/');
+            return if rest.is_empty() {
+                home.to_path_buf()
+            } else {
+                home.join(rest)
+            };
+        }
+    }
+    absolutize(Path::new(raw), home)
+}
+
+/// Anchor a relative path at `home`; absolute paths pass through.
+fn absolutize(path: &Path, home: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        home.join(path)
+    }
+}
+
+/// Follow a chain of symlinks to the file that actually holds the
+/// bytes, so a write lands in the dotfiles repo rather than replacing
+/// the link.
+///
+/// Bounded and total: a cycle, a broken link, or an unreadable link
+/// stops the walk and yields the last path we could name, which is
+/// the same path a plain write would have used.
+fn resolve_symlinks(fs: &dyn Fs, path: &Path) -> PathBuf {
+    let mut current = path.to_path_buf();
+    for _ in 0..MAX_SYMLINK_HOPS {
+        if !fs.is_symlink(&current) {
+            break;
+        }
+        let Ok(target) = fs.readlink(&current) else {
+            break;
+        };
+        let next = if target.is_absolute() {
+            target
+        } else {
+            current
+                .parent()
+                .map(|p| p.join(&target))
+                .unwrap_or_else(|| target.clone())
+        };
+        if next == current {
+            break;
+        }
+        current = next;
+    }
+    current
+}
+
+/// Render a path as `~/…` when it sits under `home`.
+pub fn display_home_relative(path: &Path, home: &Path) -> String {
+    match path.strip_prefix(home) {
+        Ok(rel) => format!("~/{}", rel.display()),
+        Err(_) => path.display().to_string(),
+    }
+}
+
+// ── The marked block ────────────────────────────────────────────
+
+/// What writing the block did to an rc file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BlockOutcome {
+    /// The rc file did not exist; it now holds just our block.
+    Created,
+    /// The block was added to an rc file that had no dodot block.
+    Appended,
+    /// An existing block was rewritten in place — never duplicated.
+    Replaced,
+    /// The file already carried exactly this block. No write.
+    Unchanged,
+}
+
+impl BlockOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BlockOutcome::Created => "created",
+            BlockOutcome::Appended => "appended",
+            BlockOutcome::Replaced => "replaced",
+            BlockOutcome::Unchanged => "unchanged",
+        }
+    }
+}
+
+/// Render the managed block around one or more body lines.
+pub fn render_block(body: &[&str]) -> String {
+    let mut out = String::with_capacity(BLOCK_START.len() + BLOCK_END.len() + 128);
+    out.push_str(BLOCK_START);
+    out.push('\n');
+    for line in body {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str(BLOCK_END);
+    out.push('\n');
+    out
+}
+
+/// Byte range of the managed block inside `text`, trailing newline
+/// included. `None` when either marker is missing — a half-written
+/// block is treated as "no block", so the next `--write` appends a
+/// complete one instead of splicing into garbage.
+pub fn find_block(text: &str) -> Option<(usize, usize)> {
+    let start = text.find(BLOCK_START)?;
+    let after_start = start + BLOCK_START.len();
+    let end_rel = text[after_start..].find(BLOCK_END)?;
+    let end = after_start + end_rel + BLOCK_END.len();
+    let end = if text.as_bytes().get(end) == Some(&b'\n') {
+        end + 1
+    } else {
+        end
+    };
+    Some((start, end))
+}
+
+/// Splice `block` into `existing` rc text (or into nothing, for a file
+/// that does not exist yet), returning the new content and what
+/// happened.
+///
+/// Strictly idempotent: an existing block is replaced where it stands,
+/// never duplicated, and identical content is a no-op. Everything
+/// outside the markers is preserved byte for byte — dodot writes one
+/// block and touches nothing else (spec §1.5).
+pub fn apply_block(existing: Option<&str>, block: &str) -> (String, BlockOutcome) {
+    let Some(existing) = existing else {
+        return (block.to_string(), BlockOutcome::Created);
+    };
+    if let Some((start, end)) = find_block(existing) {
+        if &existing[start..end] == block {
+            return (existing.to_string(), BlockOutcome::Unchanged);
+        }
+        let mut out = String::with_capacity(existing.len() + block.len());
+        out.push_str(&existing[..start]);
+        out.push_str(block);
+        out.push_str(&existing[end..]);
+        return (out, BlockOutcome::Replaced);
+    }
+    let mut out = existing.to_string();
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    if !out.is_empty() && !out.ends_with("\n\n") {
+        out.push('\n');
+    }
+    out.push_str(block);
+    (out, BlockOutcome::Appended)
+}
+
+/// Write the managed block to `path`, creating the file (and its
+/// parent) when missing. Returns without writing when the block is
+/// already exactly right.
+pub fn write_block(fs: &dyn Fs, path: &Path, block: &str) -> Result<BlockOutcome> {
+    let existing = if fs.exists(path) {
+        Some(fs.read_to_string(path)?)
+    } else {
+        None
+    };
+    let (content, outcome) = apply_block(existing.as_deref(), block);
+    if outcome != BlockOutcome::Unchanged {
+        if let Some(parent) = path.parent() {
+            fs.mkdir_all(parent)?;
+        }
+        fs.write_file(path, content.as_bytes())?;
+    }
+    Ok(outcome)
+}
+
+// ── The static scan ─────────────────────────────────────────────
+
+/// What an rc file says about the hookup — configuration state, never
+/// activation state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HookPresence {
+    /// dodot's managed block is there.
+    ManagedBlock,
+    /// A hook is there, wired by hand — `eval "$(dodot init-sh)"` or a
+    /// direct source of the generated script. Left strictly alone:
+    /// existing hookups keep working untouched (spec §6).
+    Manual,
+    /// Nothing in this file mentions dodot's init script.
+    Absent,
+}
+
+impl HookPresence {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HookPresence::ManagedBlock => "managed-block",
+            HookPresence::Manual => "manual",
+            HookPresence::Absent => "absent",
+        }
+    }
+
+    /// Whether the hook is wired at all, however it got there.
+    pub fn is_present(self) -> bool {
+        !matches!(self, HookPresence::Absent)
+    }
+}
+
+/// Classify rc text by which kind of dodot hook it carries.
+pub fn scan_hook(text: &str) -> HookPresence {
+    if find_block(text).is_some() {
+        return HookPresence::ManagedBlock;
+    }
+    if text.lines().any(is_manual_hook_line) {
+        return HookPresence::Manual;
+    }
+    HookPresence::Absent
+}
+
+/// Read `path` and classify it. A missing or unreadable file reads as
+/// [`HookPresence::Absent`] — for the diagnosis split, "we could not
+/// see a hook" and "there is no hook" call for the same next step.
+pub fn scan_hook_file(fs: &dyn Fs, path: &Path) -> HookPresence {
+    if !fs.exists(path) {
+        return HookPresence::Absent;
+    }
+    fs.read_to_string(path)
+        .map(|t| scan_hook(&t))
+        .unwrap_or(HookPresence::Absent)
+}
+
+/// A hand-wired hook line: either form, as long as it is not
+/// commented out.
+fn is_manual_hook_line(line: &str) -> bool {
+    let line = line.trim();
+    if line.starts_with('#') {
+        return false;
+    }
+    line.contains("dodot init-sh") || line.contains("dodot-init.sh")
+}
+
+// ── macOS bash chain ────────────────────────────────────────────
+
+/// The profile that needs a `.bashrc` chain, or `None` when one
+/// already chains (spec §4.3 rung 2).
+///
+/// macOS Terminal spawns *login* shells, which read `.bash_profile` /
+/// `.profile` and never `.bashrc` — where the hook block lands. If
+/// neither profile reaches `.bashrc`, the hook is written but never
+/// read, which is exactly the silent failure this epic exists to kill.
+pub fn bash_chain_target(fs: &dyn Fs, home: &Path) -> Option<PathBuf> {
+    for name in [".bash_profile", ".profile"] {
+        let path = home.join(name);
+        if !fs.exists(&path) {
+            continue;
+        }
+        let chains = fs
+            .read_to_string(&path)
+            .map(|t| {
+                t.lines()
+                    .any(|l| !l.trim().starts_with('#') && l.contains(".bashrc"))
+            })
+            .unwrap_or(false);
+        if chains {
+            return None;
+        }
+    }
+    Some(home.join(".bash_profile"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TempEnvironment;
+
+    fn env_zsh() -> ShellEnv {
+        ShellEnv {
+            shell: Some("/bin/zsh".into()),
+            zdotdir: None,
+        }
+    }
+
+    // ── Shell detection ─────────────────────────────────────────
+
+    #[test]
+    fn shell_detection_reads_the_basename_and_refuses_the_rest() {
+        let cases = [
+            ("/bin/zsh", Some(HookupShell::Zsh)),
+            ("/usr/local/bin/bash", Some(HookupShell::Bash)),
+            ("zsh", Some(HookupShell::Zsh)),
+            // Login-shell argv[0] convention.
+            ("-zsh", Some(HookupShell::Zsh)),
+            ("/usr/bin/fish", None),
+            ("/bin/sh", None),
+            ("/opt/nu", None),
+            ("", None),
+        ];
+        for (raw, expected) in cases {
+            assert_eq!(HookupShell::from_shell_path(raw), expected, "raw={raw:?}");
+        }
+    }
+
+    // ── The ladder ──────────────────────────────────────────────
+
+    #[test]
+    fn zsh_targets_zshrc_and_bash_targets_bashrc() {
+        let env = TempEnvironment::builder().build();
+        let home = env.home.clone();
+
+        let zsh = resolve_rc(
+            env.fs.as_ref(),
+            &home,
+            Some(HookupShell::Zsh),
+            &env_zsh(),
+            None,
+        );
+        assert_eq!(zsh.path, home.join(".zshrc"));
+        assert!(!zsh.exists, "a fresh home has no .zshrc — still the target");
+        assert!(zsh.notes.is_empty());
+
+        let bash = resolve_rc(
+            env.fs.as_ref(),
+            &home,
+            Some(HookupShell::Bash),
+            &ShellEnv {
+                shell: Some("/bin/bash".into()),
+                zdotdir: None,
+            },
+            None,
+        );
+        assert_eq!(bash.path, home.join(".bashrc"));
+    }
+
+    #[test]
+    fn zdotdir_from_the_environment_moves_the_target_and_is_announced() {
+        let env = TempEnvironment::builder().build();
+        let home = env.home.clone();
+        let shell_env = ShellEnv {
+            shell: Some("/bin/zsh".into()),
+            zdotdir: Some("$HOME/.config/zsh".into()),
+        };
+
+        let target = resolve_rc(
+            env.fs.as_ref(),
+            &home,
+            Some(HookupShell::Zsh),
+            &shell_env,
+            None,
+        );
+        assert_eq!(target.path, home.join(".config/zsh/.zshrc"));
+        assert!(
+            target.notes.iter().any(|n| n.contains("ZDOTDIR")),
+            "the move must be announced: {:?}",
+            target.notes
+        );
+    }
+
+    #[test]
+    fn zdotdir_is_peeked_out_of_zshenv_when_the_environment_is_silent() {
+        // `.zshenv` is the one file zsh always reads, so it is the
+        // legal place ZDOTDIR gets set — and dodot, invoked from
+        // anywhere, won't have it in its own environment.
+        let env = TempEnvironment::builder().build();
+        let home = env.home.clone();
+        env.fs
+            .write_file(
+                &home.join(".zshenv"),
+                b"# my zshenv\nexport ZDOTDIR=\"$HOME/dotfiles/zsh\"\n",
+            )
+            .unwrap();
+
+        let target = resolve_rc(
+            env.fs.as_ref(),
+            &home,
+            Some(HookupShell::Zsh),
+            &env_zsh(),
+            None,
+        );
+        assert_eq!(target.path, home.join("dotfiles/zsh/.zshrc"));
+        assert!(
+            target.notes.iter().any(|n| n.contains(".zshenv")),
+            "notes should say where ZDOTDIR came from: {:?}",
+            target.notes
+        );
+    }
+
+    #[test]
+    fn zdotdir_parsing_handles_quotes_comments_and_overrides() {
+        assert_eq!(
+            parse_zdotdir_assignment("export ZDOTDIR=\"$HOME/a\"\n"),
+            Some("$HOME/a".into())
+        );
+        assert_eq!(
+            parse_zdotdir_assignment("ZDOTDIR='/tmp/z'\n"),
+            Some("/tmp/z".into())
+        );
+        assert_eq!(
+            parse_zdotdir_assignment("ZDOTDIR=~/zsh # trailing comment\n"),
+            Some("~/zsh".into())
+        );
+        // Commented-out assignments don't count.
+        assert_eq!(parse_zdotdir_assignment("# ZDOTDIR=/nope\n"), None);
+        assert_eq!(parse_zdotdir_assignment("export PATH=/bin\n"), None);
+        // Last assignment wins, same as the shell would see it.
+        assert_eq!(
+            parse_zdotdir_assignment("ZDOTDIR=/first\nZDOTDIR=/second\n"),
+            Some("/second".into())
+        );
+    }
+
+    #[test]
+    fn a_symlinked_rc_is_written_through_and_announced() {
+        let env = TempEnvironment::builder().build();
+        let home = env.home.clone();
+        let repo_rc = home.join("dotfiles/zsh/zshrc");
+        env.fs.mkdir_all(repo_rc.parent().unwrap()).unwrap();
+        env.fs.write_file(&repo_rc, b"# real rc\n").unwrap();
+        env.fs.symlink(&repo_rc, &home.join(".zshrc")).unwrap();
+
+        let target = resolve_rc(
+            env.fs.as_ref(),
+            &home,
+            Some(HookupShell::Zsh),
+            &env_zsh(),
+            None,
+        );
+        assert_eq!(
+            target.path, repo_rc,
+            "the write must land in the repo, not replace the link"
+        );
+        assert_eq!(target.link_source, Some(home.join(".zshrc")));
+        assert!(target.exists);
+        let note = target.notes.join(" ");
+        assert!(
+            note.contains("~/.zshrc") && note.contains("dotfiles/zsh/zshrc"),
+            "write-through must be announced, not silent: {note}"
+        );
+    }
+
+    #[test]
+    fn explicit_rc_overrides_the_whole_ladder() {
+        let env = TempEnvironment::builder().build();
+        let home = env.home.clone();
+        let custom = home.join("elsewhere/rc.sh");
+
+        let target = resolve_rc(
+            env.fs.as_ref(),
+            &home,
+            Some(HookupShell::Zsh),
+            &ShellEnv {
+                shell: Some("/bin/zsh".into()),
+                zdotdir: Some("/somewhere/else".into()),
+            },
+            Some(&custom),
+        );
+        assert_eq!(target.path, custom);
+    }
+
+    // ── The marked block ────────────────────────────────────────
+
+    #[test]
+    fn block_is_created_appended_replaced_and_then_left_alone() {
+        let block = render_block(&["HOOK v1"]);
+
+        let (created, outcome) = apply_block(None, &block);
+        assert_eq!(outcome, BlockOutcome::Created);
+        assert_eq!(created, block);
+
+        let (appended, outcome) = apply_block(Some("export PATH=/bin\n"), &block);
+        assert_eq!(outcome, BlockOutcome::Appended);
+        assert!(appended.starts_with("export PATH=/bin\n"));
+        assert!(appended.contains("HOOK v1"));
+
+        let (unchanged, outcome) = apply_block(Some(&appended), &block);
+        assert_eq!(outcome, BlockOutcome::Unchanged);
+        assert_eq!(unchanged, appended);
+
+        let v2 = render_block(&["HOOK v2"]);
+        let (replaced, outcome) = apply_block(Some(&appended), &v2);
+        assert_eq!(outcome, BlockOutcome::Replaced);
+        assert!(replaced.contains("HOOK v2"));
+        assert!(!replaced.contains("HOOK v1"));
+        assert_eq!(
+            replaced.matches(BLOCK_START).count(),
+            1,
+            "a re-run replaces, it never duplicates"
+        );
+        assert!(replaced.starts_with("export PATH=/bin\n"));
+    }
+
+    #[test]
+    fn content_around_the_block_survives_a_replacement() {
+        let before = "# top\n";
+        let after = "# bottom\n";
+        let text = format!("{before}{}{after}", render_block(&["OLD"]));
+        let (out, outcome) = apply_block(Some(&text), &render_block(&["NEW"]));
+        assert_eq!(outcome, BlockOutcome::Replaced);
+        assert!(out.starts_with(before), "{out:?}");
+        assert!(out.ends_with(after), "{out:?}");
+    }
+
+    #[test]
+    fn a_half_written_block_is_appended_to_not_spliced_into() {
+        let broken = format!("{BLOCK_START}\ntruncated\n");
+        assert!(find_block(&broken).is_none());
+        let (out, outcome) = apply_block(Some(&broken), &render_block(&["HOOK"]));
+        assert_eq!(outcome, BlockOutcome::Appended);
+        assert!(out.contains("HOOK"));
+    }
+
+    #[test]
+    fn write_block_creates_the_file_and_stays_idempotent_on_disk() {
+        let env = TempEnvironment::builder().build();
+        let rc = env.home.join(".config/zsh/.zshrc");
+        let block = render_block(&["HOOK"]);
+
+        assert_eq!(
+            write_block(env.fs.as_ref(), &rc, &block).unwrap(),
+            BlockOutcome::Created
+        );
+        let first = env.fs.read_to_string(&rc).unwrap();
+        assert_eq!(
+            write_block(env.fs.as_ref(), &rc, &block).unwrap(),
+            BlockOutcome::Unchanged
+        );
+        assert_eq!(env.fs.read_to_string(&rc).unwrap(), first);
+    }
+
+    // ── The scan ────────────────────────────────────────────────
+
+    #[test]
+    fn scan_tells_managed_manual_and_absent_apart() {
+        assert_eq!(
+            scan_hook(&render_block(&["whatever"])),
+            HookPresence::ManagedBlock
+        );
+        assert_eq!(
+            scan_hook("eval \"$(dodot init-sh)\"\n"),
+            HookPresence::Manual
+        );
+        assert_eq!(
+            scan_hook(". \"$HOME/.local/share/dodot/shell/dodot-init.sh\"\n"),
+            HookPresence::Manual
+        );
+        assert_eq!(scan_hook("alias ll='ls -l'\n"), HookPresence::Absent);
+        // A commented-out hook is exactly the "broken hook" story —
+        // it must not read as present.
+        assert_eq!(
+            scan_hook("# eval \"$(dodot init-sh)\"\n"),
+            HookPresence::Absent
+        );
+    }
+
+    #[test]
+    fn scanning_a_missing_file_is_absent_not_an_error() {
+        let env = TempEnvironment::builder().build();
+        assert_eq!(
+            scan_hook_file(env.fs.as_ref(), &env.home.join(".zshrc")),
+            HookPresence::Absent
+        );
+    }
+
+    // ── macOS bash chain ────────────────────────────────────────
+
+    #[test]
+    fn bash_chain_is_needed_until_some_profile_sources_bashrc() {
+        let env = TempEnvironment::builder().build();
+        let home = env.home.clone();
+
+        // No profile at all: Terminal's login shell would never read
+        // .bashrc, so the chain is needed.
+        assert_eq!(
+            bash_chain_target(env.fs.as_ref(), &home),
+            Some(home.join(".bash_profile"))
+        );
+
+        // A .profile that chains counts — we don't insist on our own file.
+        env.fs
+            .write_file(&home.join(".profile"), b". \"$HOME/.bashrc\"\n")
+            .unwrap();
+        assert_eq!(bash_chain_target(env.fs.as_ref(), &home), None);
+    }
+
+    #[test]
+    fn a_commented_chain_does_not_count() {
+        let env = TempEnvironment::builder().build();
+        env.fs
+            .write_file(&env.home.join(".bash_profile"), b"# . ~/.bashrc\n")
+            .unwrap();
+        assert!(bash_chain_target(env.fs.as_ref(), &env.home).is_some());
+    }
+}

--- a/crates/dodot-lib/src/templates/install.jinja
+++ b/crates/dodot-lib/src/templates/install.jinja
@@ -1,0 +1,22 @@
+{% if wrote and outcome == "unchanged" %}[message]{{ rc_path }} already has dodot's hook block — nothing to change.[/message]
+{% elif wrote %}[message]Wired dodot into {{ rc_path }} ({{ outcome }}).[/message]
+{% else %}[message]dodot install — nothing written yet. Re-run with --write to apply.[/message]
+{% endif %}
+[header]Shell[/header]
+  {% if shell %}{{ shell }}{% else %}unknown (writing where --rc points){% endif %}
+[header]Startup file[/header]
+  {{ rc_path }}{% if not rc_exists %} [dim](does not exist yet; --write creates it)[/dim]{% endif %}
+[header]Hook[/header]
+{% if hook_presence == "managed-block" %}  [deployed]present[/deployed] [dim](dodot's managed block)[/dim]
+{% elif hook_presence == "manual" %}  [deployed]present[/deployed] [dim](wired by hand — dodot leaves it alone)[/dim]
+{% else %}  [pending]not found in that file[/pending]
+{% endif %}  [usage]{{ hook_line }}[/usage]
+{% if notes %}[header]Notes[/header]
+{% for note in notes %}  [dim]{{ note }}[/dim]
+{% endfor %}{% endif %}{% if shell_hookup %}
+{% if shell_hookup.severity == "error" %}[error]✗ {{ shell_hookup.message }}[/error]
+{% elif shell_hookup.severity == "warning" %}[warning]⚠ {{ shell_hookup.message }}[/warning]
+{% elif shell_hookup.severity == "ok" %}[deployed]✓ {{ shell_hookup.message }}[/deployed]
+{% else %}[message]{{ shell_hookup.message }}[/message]
+{% endif %}{% if shell_hookup.hint %}  [dim]{{ shell_hookup.hint }}[/dim]
+{% endif %}{% endif %}

--- a/crates/dodot-lib/src/testing/mod.rs
+++ b/crates/dodot-lib/src/testing/mod.rs
@@ -25,11 +25,15 @@ use tempfile::TempDir;
 use crate::fs::{Fs, OsFs};
 use crate::paths::{Pather, XdgPather};
 
-/// Shared lock for tests that mutate `$SHELL`. `std::env::set_var` /
-/// `remove_var` are process-global, and cargo runs tests in
-/// parallel — without this lock, two tests touching `$SHELL` can
-/// interleave and observe each other's writes. Held by
-/// [`ShellEnvGuard`] for the duration of the guard's lifetime.
+/// Shared lock for tests that mutate the process environment.
+/// `std::env::set_var` / `remove_var` are process-global, and cargo
+/// runs tests in parallel — without this lock, two tests touching the
+/// environment can interleave and observe each other's writes. Held by
+/// [`ShellEnvGuard`] and [`EnvVarGuard`] for the duration of the
+/// guard's lifetime.
+///
+/// One lock for every variable, not one per name: the lock is not
+/// reentrant, so a single test must hold at most one guard at a time.
 static SHELL_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 /// RAII guard that takes the shared `$SHELL` lock, sets `$SHELL` to
@@ -89,6 +93,47 @@ impl Drop for ShellEnvGuard {
         match self.prev.take() {
             Some(p) => std::env::set_var("SHELL", p),
             None => std::env::remove_var("SHELL"),
+        }
+    }
+}
+
+/// [`ShellEnvGuard`] for an arbitrary variable — same lock, same
+/// restore-on-drop (including on panic), same one-guard-at-a-time
+/// rule.
+///
+/// Used where the value under test *is* an inherited environment
+/// variable: the shell-hookup probe scrubbing `DODOT_INIT_*` out of
+/// the shell it spawns, for instance, can only be tested by first
+/// putting one there.
+pub struct EnvVarGuard {
+    _lock: MutexGuard<'static, ()>,
+    key: String,
+    prev: Option<String>,
+}
+
+impl EnvVarGuard {
+    /// Sets `key` while holding the lock and restores it on drop.
+    pub fn set(key: &str, value: &str) -> Self {
+        let lock = SHELL_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let prev = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self {
+            _lock: lock,
+            key: key.to_string(),
+            prev,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // Restore before `_lock` drops — fields drop in declaration
+        // order, so the next guard sees a clean baseline.
+        match self.prev.take() {
+            Some(p) => std::env::set_var(&self.key, p),
+            None => std::env::remove_var(&self.key),
         }
     }
 }


### PR DESCRIPTION
Implements the measured half of epic INS01 — for #263.

`dodot up` proved the datastore was correct and said nothing about whether any shell would ever *source* the init script. WS01 added the evidence (stamp + heartbeat); this work stream adds the two pieces that turn evidence into an answer and a fix: the gated empirical **probe** (spec §3) and **`dodot install`** (spec §4).

## What's here

- **`shell::probe`** — spawns `$SHELL` interactive non-login and reads the stamp back. Gated on WS01's ladder (current stamp *or* fresh heartbeat ⇒ no probe), so a healthy machine never pays for a spawn and the first real activation retires the probe. stdin from `/dev/null`, output drained off-thread, hard 5s timeout with a **process-group** kill, `DODOT_INIT_*` scrubbed from the child, announced on stderr before it runs. Three verdicts: `verified`, `verified-broken` (static rc scan splits *hook absent from the expected rc* vs *hook present but never reached*), `couldn't-verify` (degrades to the scan, labeled as configuration state — never wedges `up`).
- **`shell::rc`** — shell detection, the resolution ladder (ZDOTDIR incl. the `~/.zshenv` peek; bash + the macOS `.bash_profile` chain; missing files created; symlinks written **through** and announced; `--rc` overriding everything), and the strictly idempotent marked block.
- **`dodot install [--write] [--rc <file>]`** — MISC group. Dry by default; `--write` splices the block and re-runs the probe, so it ends on a measurement rather than a promise.
- **`up`** reports the measured verdict when the gate fires. **`status` still never spawns anything.**

## Context

**Why this approach.**

- *One source of truth per fact.* The hook line stays `activation::hook_line` (WS01) — `--write` writes *that* string inside the block, no second copy. `ExecutionContext` gains one `ShellEnv` (shell + `$ZDOTDIR`) that both the probe and the rc ladder read, so a failed probe's diagnosis can never name a different shell's rc file than the one measured.
- *No test can spawn a real shell by omission.* `ProbePolicy` defaults to `Never`; only `ExecutionContext::production` opts in. Every probe test opts in explicitly with a fabricated `$SHELL` script inside a temp `HOME`. Nothing in the suite touches a real `~/.zshrc` or the developer's shell.
- *`libc` is a new direct dependency* (already in the lock transitively) for exactly two things std does not expose: `kill(-pgid)` for the spec-mandated process-group timeout, and `getpwuid` for the login-shell fallback when `$SHELL` is unset. Two small `unsafe` blocks, each with a SAFETY note; the crate had none before.
- *`ActivationState` gains `VerifiedBroken`*, and it outranks `StaleShell` when the probe has run. That closes the WS01 carry-over the brief called out: on evidence alone, a previously-working-then-broken hookup reads as a stale shell, so users were told to open a new shell for a problem no new shell fixes.
- *WS01's never-activated hint now points at `dodot install --write`* (keeping the manual line), since the command it referred to now exists. WS01's test asserting the opposite is flipped, with the reason in the comment.
- *`install`'s report describes the world after the run*, with `outcome` carrying what changed — reporting pre-write state next to "created it" had the output contradict itself.

**Self-check against the governing docs.** Diff checked against `docs/proposals/shell-hookup.lex` §3 (gating, mechanics, all three verdicts), §4 (dry default, marked block, full rc ladder), §6 (portability, no telemetry, `eval "$(dodot init-sh)"` hookups untouched — tested), §7 (every listed probe and install test case), and §9 (nothing auto-written without `--write`; `status` never probes — tested). No ADRs govern this slice. Built on WS01's `shell/activation.rs` vocabulary throughout (`classify_stamp`, `classify_heartbeat`, `read_script_generation`, `hook_line`); nothing re-derived.

**Out of scope / deliberately not built.** fish + nushell init generation, a general `dodot doctor`, uninstall beyond removing the marked block, auto-writing without `--write`, probing from `status`. User docs and onboarding are WS03. No changelog fragment: this targets `INS01/umbrella`, not `main`.

**One deliberate scope call to flag.** Spec §3.1 mentions `status` reporting "the last probe verdict" — that would need a persisted verdict in the data dir. It is in no acceptance criterion, and persisting it is a storage-shaped decision, so `status` here reports signals 1–2 only. Easy follow-up if wanted.

**What NOT to "fix".** The three-diagnosis split includes a `StaleScript` arm beyond the spec's two — it is unreachable in normal operation (a new shell sources the script we just wrote) and exists so a stamp older than the reference reports honestly instead of rounding up to "verified". Plain `sh` is refused by the ladder rather than guessed at (spec defines no canonical interactive rc for it); the refusal prints the hook line and points at `--rc`.

## Verification

`pixi run test` — 1408 tests, all green. Lint gate green via the commit/push hooks (clippy `-D warnings`, fmt, lexd). Also exercised end-to-end against a real zsh in a throwaway `HOME`: fresh `up` probes and diagnoses the missing hook → `install --write` writes the block and reports the measured ✓ → the next `up` does not spawn anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)