### PR TITLE
down: remove the live destination symlink on teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+- fix: `dodot down` and the deploy-then-ignore sweep now remove the live destination symlink a deployment created (e.g. `~/.config/<pack>/<file>`), instead of leaving it dangling after the datastore state is swept; a destination the user repointed elsewhere is never touched, and an orphaned pack (deleted from the repo) still can't have its links recovered (#225)
+
 ## 5.5.0 - 2026-08-15
 
 - feat: `dodot up` and `dodot status` now report whether shells are actually loading dodot, instead of reporting green on a deployment no shell ever activates — the generated init script leaves evidence it ran (a generation stamp and a heartbeat), and the states are surfaced as healthy, "this shell predates your last `up`", or "no shell has loaded dodot yet" (#262)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ## Unreleased
 
-- fix: `dodot down` and the deploy-then-ignore sweep now remove the live destination symlink a deployment created (e.g. `~/.config/<pack>/<file>`), instead of leaving it dangling after the datastore state is swept; a destination the user repointed elsewhere is never touched, and an orphaned pack (deleted from the repo) still can't have its links recovered (#225)
-
 ## 5.5.0 - 2026-08-15
 
 - feat: `dodot up` and `dodot status` now report whether shells are actually loading dodot, instead of reporting green on a deployment no shell ever activates — the generated init script leaves evidence it ran (a generation stamp and a heartbeat), and the states are surfaced as healthy, "this shell predates your last `up`", or "no shell has loaded dodot yet" (#262)

--- a/CHANGELOG/unreleased-teardown-live-symlinks.md
+++ b/CHANGELOG/unreleased-teardown-live-symlinks.md
@@ -1,0 +1,1 @@
+- fix: `dodot down` and the deploy-then-ignore sweep now remove the live destination symlink a deployment created (e.g. `~/.config/<pack>/<file>`), instead of leaving it dangling after the datastore state is swept; a destination the user repointed elsewhere is never touched, and an orphaned pack (deleted from the repo) still can't have its links recovered (#225)

--- a/crates/dodot-lib/src/commands/down.rs
+++ b/crates/dodot-lib/src/commands/down.rs
@@ -9,6 +9,11 @@
 //!
 //! Dry-run keeps the per-handler "would remove" rendering.
 //!
+//! Teardown removes the *live* destination symlinks a deployment
+//! created (issue #225), not just the datastore state — otherwise every
+//! `down` leaves dangling links in the user's config tree. See
+//! [`orchestration::remove_live_user_links`] for the scoping rules.
+//!
 //! Besides packs discovered in the repo, `down` also removes *orphaned*
 //! datastore state — state for packs deleted from the dotfiles root
 //! since they were deployed (issue #255). A no-args `down` sweeps every
@@ -16,7 +21,8 @@
 //! form) even though the repo scan no longer knows it. Orphans can't
 //! render through `status` (there is no pack to show), so a real run
 //! reports what it swept via the warnings channel; dry-run lists them
-//! with the same "would remove" rows as normal packs.
+//! with the same "would remove" rows as normal packs. An orphan's live
+//! links are unrecoverable (nothing left to replan) and stay behind.
 
 use tracing::{debug, info};
 
@@ -98,6 +104,9 @@ pub fn down(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> Result<Pa
                 ctx,
             )?);
         } else {
+            // Live destination symlinks first, while the datastore
+            // paths they point at still identify them as ours (#225).
+            orchestration::remove_live_user_links(pack, ctx)?;
             for handler in &handlers {
                 ctx.datastore.remove_state(&pack.name, handler)?;
             }

--- a/crates/dodot-lib/src/commands/status.rs
+++ b/crates/dodot-lib/src/commands/status.rs
@@ -339,9 +339,11 @@ fn verify_symlink(
         //
         // Symlinks at the target are NOT conflicts: the executor's
         // create_user_link gracefully replaces them (correct ones are
-        // left alone, wrong/dangling ones are removed and recreated). A
-        // dangling symlink left over from `dodot down` is the canonical
-        // case — flagging it as a conflict would be a false positive.
+        // left alone, wrong/dangling ones are removed and recreated).
+        // `down` removes its live links itself (#225), but dangling
+        // symlinks still occur — an orphaned pack's sweep, an older
+        // dodot, an interrupted teardown — and flagging them as
+        // conflicts would be a false positive.
         //
         // #44: a non-symlink file whose content is byte-identical to the
         // source is also NOT a conflict — the executor will auto-replace

--- a/crates/dodot-lib/src/commands/tests/mod.rs
+++ b/crates/dodot-lib/src/commands/tests/mod.rs
@@ -1562,6 +1562,53 @@ fn down_removes_live_user_symlink() {
 }
 
 #[test]
+fn down_removes_live_external_user_link() {
+    // The externals handler's `Fetch` intents also create user links,
+    // but theirs point *deeper* into the handler data dir
+    // (`external/<name>/<file>`, not the dir itself) — which is why the
+    // teardown scoping is a prefix check rather than exact-path
+    // equality. This pins the `Fetch` branch of
+    // `remove_live_user_links` end to end (#225).
+    use sha2::{Digest, Sha256};
+
+    let env = TempEnvironment::builder().pack("shared").done().build();
+    let mut ctx = make_ctx(&env);
+    // The externals handler is CodeExecution-category, which the test
+    // ctx's default `no_provision: true` skips at planning time — for
+    // deploy *and* for the teardown replan alike.
+    ctx.no_provision = false;
+
+    let body: &[u8] = b"#!/bin/sh\nexport SHARED=1\n";
+    let src = env.home.join("aliases-src.sh");
+    env.fs.write_file(&src, body).unwrap();
+    let externals = format!(
+        "[aliases]\ntype = \"file\"\nurl = \"file://{}\"\ntarget = \"~/.config/shared/aliases.sh\"\nsha256 = \"{:x}\"\n",
+        src.display(),
+        Sha256::digest(body),
+    );
+    env.fs
+        .write_file(
+            &env.dotfiles_root.join("shared/externals.toml"),
+            externals.as_bytes(),
+        )
+        .unwrap();
+
+    commands::up::up(None, &ctx).unwrap();
+    let user_path = env.config_home.join("shared/aliases.sh");
+    assert!(
+        env.fs.is_symlink(&user_path),
+        "up should deploy the external as a live user link"
+    );
+
+    commands::down::down(None, &ctx).unwrap();
+
+    assert!(
+        !env.fs.is_symlink(&user_path) && !env.fs.exists(&user_path),
+        "down must remove live links of Fetch intents too, not just the symlink handler's (#225)"
+    );
+}
+
+#[test]
 fn down_ignore_sweep_removes_live_user_symlink() {
     // Deploy-then-ignore: the pack drops out of discovery, so only the
     // ignored-pack sweep can tear it down — including the live symlink

--- a/crates/dodot-lib/src/commands/tests/mod.rs
+++ b/crates/dodot-lib/src/commands/tests/mod.rs
@@ -1521,11 +1521,12 @@ fn down_removes_deployed_state() {
     let down_result = commands::down::down(None, &ctx).unwrap();
     assert!(down_result.message.is_some());
 
-    // After down, all files should be plain pending. The user-side
-    // symlinks left dangling by `down` are NOT conflicts — the executor's
-    // create_user_link gracefully replaces them on the next `up`.
-    // `PendingConflict` only fires when the executor would
-    // actually refuse: non-symlink + exists.
+    // After down, all files should be plain pending. `down` removes the
+    // live destination symlinks it created (#225); even a dangling
+    // symlink left at a target (older dodot, orphan sweep) is NOT a
+    // conflict — the executor's create_user_link gracefully replaces
+    // symlinks on the next `up`. `PendingConflict` only fires when the
+    // executor would actually refuse: non-symlink + exists.
     let status = commands::status::status(None, &ctx).unwrap();
     for file in &status.packs[0].files {
         assert_eq!(
@@ -1534,6 +1535,137 @@ fn down_removes_deployed_state() {
             file.name, file.status
         );
     }
+}
+
+#[test]
+fn down_removes_live_user_symlink() {
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "x")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+
+    commands::up::up(None, &ctx).unwrap();
+    let user_path = env.config_home.join("vim/vimrc");
+    assert!(
+        env.fs.is_symlink(&user_path),
+        "up should create the live symlink"
+    );
+
+    commands::down::down(None, &ctx).unwrap();
+
+    assert!(
+        !env.fs.is_symlink(&user_path) && !env.fs.exists(&user_path),
+        "down must remove the live destination symlink, not leave it dangling (#225)"
+    );
+}
+
+#[test]
+fn down_ignore_sweep_removes_live_user_symlink() {
+    // Deploy-then-ignore: the pack drops out of discovery, so only the
+    // ignored-pack sweep can tear it down — including the live symlink
+    // at the deploy destination (#225).
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "x")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+
+    commands::up::up(None, &ctx).unwrap();
+    let user_path = env.config_home.join("vim/vimrc");
+    assert!(env.fs.is_symlink(&user_path));
+
+    env.fs
+        .write_file(&env.dotfiles_root.join("vim/.dodotignore"), b"")
+        .unwrap();
+    commands::down::down(None, &ctx).unwrap();
+
+    assert!(
+        !env.fs.is_symlink(&user_path) && !env.fs.exists(&user_path),
+        "ignore sweep via down must remove the live destination symlink (#225)"
+    );
+}
+
+#[test]
+fn up_ignore_sweep_removes_live_user_symlink() {
+    // Same as above but through `up` — marking a deployed pack ignored
+    // and re-running `up` is the issue's original repro (#225).
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "x")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+
+    commands::up::up(None, &ctx).unwrap();
+    let user_path = env.config_home.join("vim/vimrc");
+    assert!(env.fs.is_symlink(&user_path));
+
+    env.fs
+        .write_file(&env.dotfiles_root.join("vim/.dodotignore"), b"")
+        .unwrap();
+    commands::up::up(None, &ctx).unwrap();
+
+    assert!(
+        !env.fs.is_symlink(&user_path) && !env.fs.exists(&user_path),
+        "ignore sweep via up must remove the live destination symlink (#225)"
+    );
+}
+
+#[test]
+fn down_preserves_user_symlink_pointing_elsewhere() {
+    // A symlink at the deploy destination that the user repointed at
+    // something outside the pack's datastore subtree is not ours to
+    // remove — teardown only deletes links it created.
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "x")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+
+    commands::up::up(None, &ctx).unwrap();
+
+    let user_path = env.config_home.join("vim/vimrc");
+    let other = env.home.join("other-vimrc");
+    env.fs.write_file(&other, b"mine").unwrap();
+    env.fs.remove_file(&user_path).unwrap();
+    env.fs.symlink(&other, &user_path).unwrap();
+
+    commands::down::down(None, &ctx).unwrap();
+
+    env.assert_symlink(&user_path, &other);
+}
+
+#[test]
+fn down_leaves_live_links_of_orphaned_packs() {
+    // Documented limitation: a pack deleted from the dotfiles repo
+    // can't be replanned, so its deploy destinations are unrecoverable —
+    // the orphan sweep (#255) removes the datastore state but must
+    // leave the (now dangling) live symlink behind rather than guess.
+    let env = TempEnvironment::builder()
+        .pack("vim")
+        .file("vimrc", "x")
+        .done()
+        .build();
+    let ctx = make_ctx(&env);
+
+    commands::up::up(None, &ctx).unwrap();
+    let user_path = env.config_home.join("vim/vimrc");
+    assert!(env.fs.is_symlink(&user_path));
+
+    env.fs
+        .remove_dir_all(&env.dotfiles_root.join("vim"))
+        .unwrap();
+    commands::down::down(None, &ctx).unwrap();
+
+    env.assert_no_handler_state("vim", "symlink");
+    assert!(
+        env.fs.is_symlink(&user_path),
+        "orphaned pack's live link is unrecoverable and stays (dangling) by design"
+    );
 }
 
 // ── list ────────────────────────────────────────────────────

--- a/crates/dodot-lib/src/packs/orchestration/mod.rs
+++ b/crates/dodot-lib/src/packs/orchestration/mod.rs
@@ -261,10 +261,13 @@ pub fn scan_ignored(pack_filter: Option<&[String]>, ctx: &ExecutionContext) -> R
 ///
 /// Either way the regenerated init script is driven entirely off the
 /// datastore `packs/` tree, so leftover state keeps getting sourced on
-/// every shell startup until it is removed. Datastore is keyed by
-/// on-disk directory name, not display name. Returns the dir names that
-/// actually had state removed, so the caller can reflect "something was
-/// deactivated" in its message.
+/// every shell startup until it is removed. Before a pack's datastore
+/// state goes, its live destination symlinks are removed too (via
+/// [`remove_live_user_links`], issue #225) — except for orphans, whose
+/// deploy destinations can no longer be replanned. Datastore is keyed
+/// by on-disk directory name, not display name. Returns the dir names
+/// that actually had state removed, so the caller can reflect
+/// "something was deactivated" in its message.
 pub fn sweep_pack_state(dir_names: &[String], ctx: &ExecutionContext) -> Result<Vec<String>> {
     let mut swept = Vec::new();
     for dir in dir_names {
@@ -273,12 +276,102 @@ pub fn sweep_pack_state(dir_names: &[String], ctx: &ExecutionContext) -> Result<
             continue;
         }
         swept.push(dir.clone());
+        remove_live_user_links_for_dir(dir, ctx)?;
         for handler in handlers {
             debug!(pack = %dir, %handler, "sweeping stale pack state");
             ctx.datastore.remove_state(dir, &handler)?;
         }
     }
     Ok(swept)
+}
+
+/// Remove the live destination symlinks a pack's deployment created —
+/// the teardown counterpart of the executor's user-link creation
+/// (issue #225).
+///
+/// Removing datastore state alone leaves the user-facing symlink (e.g.
+/// `~/.config/vim/vimrc` → `<datastore>/packs/vim/symlink/vimrc`)
+/// dangling in the user's config tree. This replans the pack passively
+/// — the same single source of target truth `status` uses; teardown
+/// must not re-derive deploy paths either — and removes each planned
+/// destination (`Link` and `Fetch` intents, the two that create user
+/// links) only when it is a symlink pointing into that intent's handler
+/// data dir. A destination the user repointed elsewhere, or another
+/// pack's link at the same path, is never touched.
+///
+/// Best-effort on the planning side: a pack whose plan cannot be
+/// computed (e.g. a config error in a now-ignored pack) is skipped with
+/// a debug log — datastore teardown must proceed regardless. Removal
+/// failures do propagate. Returns the number of links removed.
+pub fn remove_live_user_links(pack: &Pack, ctx: &ExecutionContext) -> Result<usize> {
+    let plan = match planning::plan_pack(pack, ctx, crate::preprocessing::PreprocessMode::Passive) {
+        Ok(plan) => plan,
+        Err(e) => {
+            debug!(
+                pack = %pack.name,
+                error = %e,
+                "cannot plan pack for live-link teardown; skipping"
+            );
+            return Ok(0);
+        }
+    };
+    let mut removed = 0;
+    for intent in &plan.intents {
+        let (pack_name, handler, user_path) = match intent {
+            crate::operations::HandlerIntent::Link {
+                pack,
+                handler,
+                user_path,
+                ..
+            }
+            | crate::operations::HandlerIntent::Fetch {
+                pack,
+                handler,
+                user_path,
+                ..
+            } => (pack, handler, user_path),
+            _ => continue,
+        };
+        if !ctx.fs.is_symlink(user_path) {
+            continue;
+        }
+        let handler_dir = ctx.paths.handler_data_dir(pack_name, handler);
+        match ctx.fs.readlink(user_path) {
+            Ok(target) if target.starts_with(&handler_dir) => {
+                debug!(pack = %pack.name, path = %user_path.display(), "removing live user link");
+                ctx.fs.remove_file(user_path)?;
+                removed += 1;
+            }
+            _ => {}
+        }
+    }
+    Ok(removed)
+}
+
+/// [`remove_live_user_links`] keyed by on-disk directory name, for the
+/// sweep paths that only know datastore keys. A dir that no longer
+/// exists under the dotfiles root (an orphan, issue #255) is skipped:
+/// with the pack sources gone there is nothing to replan, so its live
+/// links cannot be recovered — the one teardown case that still leaves
+/// a dangling link behind.
+fn remove_live_user_links_for_dir(dir: &str, ctx: &ExecutionContext) -> Result<usize> {
+    let path = ctx.paths.dotfiles_root().join(dir);
+    if !ctx.fs.is_dir(&path) {
+        return Ok(0);
+    }
+    let pack_config = match ctx.config_manager.config_for_pack(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            debug!(
+                pack = %dir,
+                error = %e,
+                "cannot load pack config for live-link teardown; skipping"
+            );
+            return Ok(0);
+        }
+    };
+    let pack = Pack::new(dir.to_string(), path, pack_config.to_handler_config());
+    remove_live_user_links(&pack, ctx)
 }
 
 /// Count of the given pack dirs that currently hold datastore state,

--- a/docs/user/commands/addignore.lex
+++ b/docs/user/commands/addignore.lex
@@ -28,7 +28,7 @@ Idempotent: safe to run again on an already-ignored directory. To reverse, remov
 
 4. Watch out for
 
-    - *Add the marker AFTER `dodot down`, not before.* If the directory was previously deployed, adding `.dodotignore` makes it invisible to discovery — but `dodot up` and `dodot down` only reconcile *discovered* packs, so the previously-deployed symlinks are *not* cleaned up automatically. Run `dodot down <pack>` *first*, then `dodot addignore <pack>`. See [./../handlers/controlling-activation.lex] §4.
+    - *Previously-deployed state is swept on the next run.* If the directory was already deployed, adding `.dodotignore` makes it invisible to discovery, but both `dodot up` and `dodot down` sweep the leftover state of now-ignored packs — datastore entries, shell-init sourcing, and the live symlinks alike. Run either command after adding the marker to finish the cleanup. See [./../handlers/controlling-activation.lex] §4.
     - *Different from `[pack] ignore`.* `addignore` skips the *whole directory* as a pack. To skip individual files *inside* a pack that's otherwise active, use `[pack] ignore` patterns in `.dodot.toml` instead.
     - *Different from `[mappings] ignore` / `[mappings] skip`.* Those drop matched source files from handler dispatch, but the file is still discovered. `.dodotignore` stops discovery one layer earlier.
     - *No `dodot addignore --remove`.* The reverse is `rm <pack>/.dodotignore` by hand. (Idempotent on add, manual on undo — fits the "git is your history" posture.)

--- a/docs/user/commands/addignore.lex
+++ b/docs/user/commands/addignore.lex
@@ -28,7 +28,7 @@ Idempotent: safe to run again on an already-ignored directory. To reverse, remov
 
 4. Watch out for
 
-    - *Previously-deployed state is swept on the next run.* If the directory was already deployed, adding `.dodotignore` makes it invisible to discovery, but both `dodot up` and `dodot down` sweep the leftover state of now-ignored packs — datastore entries, shell-init sourcing, and the live symlinks alike. Run either command after adding the marker to finish the cleanup. See [./../handlers/controlling-activation.lex] §4.
+    - *Previously-deployed state is swept on the next run.* If the directory was already deployed, adding `.dodotignore` makes it invisible to discovery, but both `dodot up` and `dodot down` sweep the leftover state of now-ignored packs — datastore entries, shell-init sourcing, and (best-effort) the live symlinks. Run either command after adding the marker to finish the cleanup. See [./../handlers/controlling-activation.lex] §4.
     - *Different from `[pack] ignore`.* `addignore` skips the *whole directory* as a pack. To skip individual files *inside* a pack that's otherwise active, use `[pack] ignore` patterns in `.dodot.toml` instead.
     - *Different from `[mappings] ignore` / `[mappings] skip`.* Those drop matched source files from handler dispatch, but the file is still discovered. `.dodotignore` stops discovery one layer earlier.
     - *No `dodot addignore --remove`.* The reverse is `rm <pack>/.dodotignore` by hand. (Idempotent on add, manual on undo — fits the "git is your history" posture.)

--- a/docs/user/commands/down.lex
+++ b/docs/user/commands/down.lex
@@ -8,7 +8,7 @@ Your dotfiles repo is not touched. `down` only retracts the bookkeeping; the sou
 1. When you reach for it
 
     - You're temporarily moving away from a pack you don't want active right now.
-    - You've added a `.dodotignore` marker to a deployed pack. The pack drops out of discovery, but both `dodot up` and `dodot down` sweep the leftover state of now-ignored packs — datastore entries and the live symlinks alike — so either command finishes the cleanup.
+    - You've added a `.dodotignore` marker to a deployed pack. The pack drops out of discovery, but both `dodot up` and `dodot down` sweep the leftover state of now-ignored packs — datastore entries always, live symlinks as long as the pack's sources can still be read (see "What `down` does *not* do" below) — so either command finishes the cleanup.
     - You're cleaning up after experimenting — running `dodot down` with no arguments tears every pack down at once.
     - You want a fresh re-execute of an install script: `down` followed by `up` clears the sentinel and re-runs.
 
@@ -26,7 +26,7 @@ Your dotfiles repo is not touched. `down` only retracts the bookkeeping; the sou
     - It does not modify or delete anything in your dotfiles repo. Source files survive.
     - It does not roll back code-execution side-effects. Packages installed by `brew bundle`, files created by `install.sh`, system defaults written via `defaults write` — those are system state, not dodot state. Cleanup is the script author's job.
     - It does not show `.dodotignore`'d packs in its output — discovery skips them — but any state left from a deploy-before-ignore is still swept, live symlinks included.
-    - It can't recover the live symlinks of a pack you've *deleted* from your dotfiles repo. The orphaned datastore state is swept, but with the pack's sources gone the deploy destinations can't be recomputed, so those links are left dangling.
+    - It can't recover the live symlinks of a pack whose deploy destinations can't be recomputed: one you've *deleted* from your dotfiles repo, or one whose config no longer loads. The datastore state is still swept — link removal is the best-effort half of teardown, never a blocker for the rest — but those links are left dangling.
 
 3. Flags
 

--- a/docs/user/commands/down.lex
+++ b/docs/user/commands/down.lex
@@ -8,7 +8,7 @@ Your dotfiles repo is not touched. `down` only retracts the bookkeeping; the sou
 1. When you reach for it
 
     - You're temporarily moving away from a pack you don't want active right now.
-    - You're about to add a `.dodotignore` marker — run `dodot down <pack>` *first*, so the deployed state gets cleaned up. Once the marker is in place, the pack is no longer discovered, and `down` can't see it either.
+    - You've added a `.dodotignore` marker to a deployed pack. The pack drops out of discovery, but both `dodot up` and `dodot down` sweep the leftover state of now-ignored packs — datastore entries and the live symlinks alike — so either command finishes the cleanup.
     - You're cleaning up after experimenting — running `dodot down` with no arguments tears every pack down at once.
     - You want a fresh re-execute of an install script: `down` followed by `up` clears the sentinel and re-runs.
 
@@ -17,14 +17,16 @@ Your dotfiles repo is not touched. `down` only retracts the bookkeeping; the sou
     For each pack in scope, dodot:
 
     - lists every handler that has stored state for the pack (`symlink`, `shell`, `path`, `install`, `homebrew`, …);
-    - removes the entire on-disk state directory for each — clearing symlinks, shell-source registrations, PATH entries, and content-hashed sentinels;
+    - removes the live symlinks it deployed into your config tree (e.g. `~/.config/<pack>/<file>`) — only ones still pointing into dodot's data directory; a link you've repointed elsewhere is left alone;
+    - removes the entire on-disk state directory for each handler — clearing datastore symlinks, shell-source registrations, PATH entries, and content-hashed sentinels;
     - regenerates the shell init script and the deployment map without the removed packs.
 
     What `down` does *not* do:
 
     - It does not modify or delete anything in your dotfiles repo. Source files survive.
     - It does not roll back code-execution side-effects. Packages installed by `brew bundle`, files created by `install.sh`, system defaults written via `defaults write` — those are system state, not dodot state. Cleanup is the script author's job.
-    - It does not work on `.dodotignore`'d packs. Discovery skips them, so `down` doesn't see them either.
+    - It does not show `.dodotignore`'d packs in its output — discovery skips them — but any state left from a deploy-before-ignore is still swept, live symlinks included.
+    - It can't recover the live symlinks of a pack you've *deleted* from your dotfiles repo. The orphaned datastore state is swept, but with the pack's sources gone the deploy destinations can't be recomputed, so those links are left dangling.
 
 3. Flags
 
@@ -55,4 +57,4 @@ Your dotfiles repo is not touched. `down` only retracts the bookkeeping; the sou
     - *`down` clears provisioning sentinels.* `dodot down git` followed by `dodot up git` will *re-run* `install.sh` and `brew bundle` because their content-hash sentinels were removed. That's usually what you want when intentionally tearing down; it can surprise if you only meant to retract symlinks. Pass `--no-provision` on the subsequent `up` to skip the re-execution.
     - *Already-open shells lag.* `down` regenerates `dodot-init.sh`, but a shell session that's already open keeps its current `$PATH` and sourced functions until you re-source the rc or open a new shell.
     - *Side-effects don't undo themselves.* If `install.sh` did `mkdir ~/foo`, that directory is still there after `down`. If `brew bundle` installed a hundred packages, they're still installed. Plan provisioning scripts to be idempotent and (where it matters) to track their own undo state, so re-runs after `down` are safe.
-    - *Add the `.dodotignore` marker AFTER `down`, not before.* See [./../handlers/controlling-activation.lex] §4.
+    - *Run `down` BEFORE deleting a pack from your repo.* Once the sources are gone, only the datastore state can be swept — the live symlinks stay behind, dangling. On `.dodotignore` ordering, relax: the sweep cleans up either way. See [./../handlers/controlling-activation.lex] §4.

--- a/docs/user/filters.lex
+++ b/docs/user/filters.lex
@@ -57,7 +57,7 @@ Filters & ignores — keeping files out of dodot's way
 
     To reverse: `rm <dir>/.dodotignore`. dodot doesn't ship an `addignore --remove`; deletion is by hand on purpose, matching the "git is your history" posture.
 
-    If the pack was previously deployed, the next `dodot up` or `dodot down` sweeps its leftover state — datastore entries, shell-init sourcing, and the live symlinks it deployed. No particular ordering of marker-vs-`down` is required; just run one of the two afterwards to finish the cleanup.
+    If the pack was previously deployed, the next `dodot up` or `dodot down` sweeps its leftover state — datastore entries, shell-init sourcing, and the live symlinks it deployed. No particular ordering of marker-vs-`down` is required; just run one of the two afterwards to finish the cleanup. The symlink half is best-effort: a pack dodot can no longer read (deleted sources, broken config) keeps its links — see [./commands/down.lex].
 
 4. Whole pattern invisible at scan time — `[pack] ignore`
 

--- a/docs/user/filters.lex
+++ b/docs/user/filters.lex
@@ -57,7 +57,7 @@ Filters & ignores — keeping files out of dodot's way
 
     To reverse: `rm <dir>/.dodotignore`. dodot doesn't ship an `addignore --remove`; deletion is by hand on purpose, matching the "git is your history" posture.
 
-    Critical sequencing: if the pack was previously deployed, run `dodot down <pack>` *first*, then add the marker. `up` and `down` only walk *discovered* packs — adding the marker first hides the pack from discovery and leaves the deployed symlinks behind.
+    If the pack was previously deployed, the next `dodot up` or `dodot down` sweeps its leftover state — datastore entries, shell-init sourcing, and the live symlinks it deployed. No particular ordering of marker-vs-`down` is required; just run one of the two afterwards to finish the cleanup.
 
 4. Whole pattern invisible at scan time — `[pack] ignore`
 
@@ -152,7 +152,7 @@ Filters & ignores — keeping files out of dodot's way
 9. Watch out for
 
     - *Override replaces, doesn't merge.* Setting `[mappings] skip = ["TODO.md"]` drops the README/LICENSE defaults from that scope. Re-list the defaults if you want to keep them.
-    - *`.dodotignore` after `down`, not before.* Adding the marker to a previously-deployed pack hides it from discovery; `up` and `down` only reconcile discovered packs. Run `dodot down <pack>` first, then add the marker — otherwise the deployed symlinks stay live.
+    - *`.dodotignore` needs one more run to clean up.* Adding the marker to a previously-deployed pack hides it from discovery, but its leftover state is swept by the next `dodot up` or `dodot down` — live symlinks included. The marker alone doesn't undeploy anything until one of those runs.
     - *`[mappings] ignore` is per-pack-or-root.* Like every `[mappings]` key, it's set in `.dodot.toml` and replaces (not merges) at the pack level. Pack-level setting wins for that pack; root-level applies to every pack that doesn't override.
     - *`protected_paths` is separate.* dodot also refuses to symlink a curated list of security-sensitive paths (SSH private keys, `.gnupg`, AWS credentials, …). That's enforced by the symlink handler, not the filter layer — see [./paths.lex] §6.
 
@@ -162,7 +162,7 @@ Filters & ignores — keeping files out of dodot's way
 
     For `[mappings]` filters, `dodot up` reconciles per-pack state on every run, so adding `*.bak` to `[mappings] ignore` cleans up any previously-deployed `*.bak` symlinks for that pack on the next `up`.
 
-    `.dodotignore` is the exception (see §9). The marker hides discovery; reconciliation walks discovery; so `down` *before* adding the marker is the safe sequence.
+    `.dodotignore` takes one more run (see §9). The marker hides discovery, and the next `up` or `down` sweeps the pack's leftover deployed state.
 
 11. See also
 

--- a/docs/user/handlers/controlling-activation.lex
+++ b/docs/user/handlers/controlling-activation.lex
@@ -93,6 +93,6 @@ By default, dodot processes every directory it finds under the dotfiles root and
 
     For `[mappings]` and `[mappings.gates]` filters, `dodot up` reconciles per-pack state on every run, so adding (say) `*.bak` to `[mappings] ignore` cleans up any previously-deployed `*.bak` symlinks for that pack on the next `up`.
 
-    `.dodotignore` is the exception. Dropping the marker into a previously-deployed pack stops it from being discovered on the next `dodot up` — but pack discovery is also what `up` and `down` walk to find packs to reconcile, so the pack's previously-deployed symlinks are *not* cleaned up automatically. Run `dodot down <pack>` *before* dropping the marker (or remove the marker, run `down`, re-add) to clean up the deployed state.
+    `.dodotignore` also cleans up on the next run. Dropping the marker into a previously-deployed pack stops it from being discovered — but both `dodot up` and `dodot down` sweep the leftover deployed state of every now-ignored pack: the datastore entries go, the shell init script stops sourcing it, and the live symlinks it deployed into your config tree are removed. No particular ordering of marker-then-down is required.
 
     Removing `.dodotignore` brings the pack back into discovery; the next `dodot up` reconciles and re-deploys it normally.

--- a/docs/user/handlers/controlling-activation.lex
+++ b/docs/user/handlers/controlling-activation.lex
@@ -93,6 +93,6 @@ By default, dodot processes every directory it finds under the dotfiles root and
 
     For `[mappings]` and `[mappings.gates]` filters, `dodot up` reconciles per-pack state on every run, so adding (say) `*.bak` to `[mappings] ignore` cleans up any previously-deployed `*.bak` symlinks for that pack on the next `up`.
 
-    `.dodotignore` also cleans up on the next run. Dropping the marker into a previously-deployed pack stops it from being discovered — but both `dodot up` and `dodot down` sweep the leftover deployed state of every now-ignored pack: the datastore entries go, the shell init script stops sourcing it, and the live symlinks it deployed into your config tree are removed. No particular ordering of marker-then-down is required.
+    `.dodotignore` also cleans up on the next run. Dropping the marker into a previously-deployed pack stops it from being discovered — but both `dodot up` and `dodot down` sweep the leftover deployed state of every now-ignored pack: the datastore entries go, the shell init script stops sourcing it, and the live symlinks it deployed into your config tree are removed. No particular ordering of marker-then-down is required. The live-symlink half is best-effort: dodot recomputes the destinations from the pack's sources, so a pack it can no longer read — deleted from the repo, or with a config that no longer loads — gets its datastore state swept but keeps its links (see [./../commands/down.lex]).
 
     Removing `.dodotignore` brings the pack back into discovery; the next `dodot up` reconciles and re-deploys it normally.


### PR DESCRIPTION
closes #225

## Context

**Why this approach.** Teardown (`dodot down` and the deploy-then-ignore sweep) removed datastore state but never the live symlink at the deploy destination, leaving it dangling. The fix adds `orchestration::remove_live_user_links`: it *passively replans* the pack — the same single-source-of-target-truth machinery `status` uses (re-deriving targets is the documented drift hazard) — and removes each planned destination (`Link` and `Fetch` intents, the two that create user links) **only when it is a symlink pointing into that intent's handler data dir**. A destination the user repointed elsewhere, or another pack's link at the same path, is never touched. Wired into the `down` main loop and into `sweep_pack_state`, so the ignored-pack sweep on both `up` and `down` cleans up too.

**Documented limitation (out of scope to "fix").** An orphaned pack (deleted from the dotfiles repo, #255) can't be replanned — its sources are gone, so its deploy destinations are unrecoverable. The orphan sweep still removes datastore state; the dangling link stays. Locked in by a test (`down_leaves_live_links_of_orphaned_packs`) and documented in `down.lex`.

**Do NOT "fix".** Planning failures during teardown are swallowed to a debug log on purpose: datastore teardown must proceed even when a now-ignored pack's config is broken. The prefix check (`target.starts_with(handler_dir)`) rather than exact-path equality is deliberate — it covers `Fetch` intents (whose datastore paths nest under `<handler>/<name>/<file>`) without mirroring per-handler filename derivation.

**Docs.** User docs that asserted the old behavior (`down.lex`, `addignore.lex`, `filters.lex`, `controlling-activation.lex` — all `:: verified ::`) carried "run `down` *before* adding `.dodotignore`" sequencing advice that #222+this change obsolete; updated in the same diff, claims verified against the new tests. Changelog fragment added and `CHANGELOG.md` re-rendered via `shipit changelog render`.

**Verification.** TDD: 5 new tests written red-first in `commands/tests/mod.rs` (down removes the live link; ignore-sweep via `up` and via `down`; foreign-link preservation; orphan limitation). Full suite `pixi run test`: 1429 passed. Lint ran via the commit hook.

**Brief-gap flag.** This spawn's brief did not carry the implementer BRIEF TEMPLATE's governing-docs (ADR/Spec) slot; self-check was done against the repo docs (`AGENTS.md`, `docs/user/*`, in-code design comments) instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)