### PR TITLE
RCS01-WS04: Epic: Shell Hookup Ergonomics - Workstream: Docs + acceptance

### DIFF
--- a/docs/proposals/shell-hookup-ergonomics.lex
+++ b/docs/proposals/shell-hookup-ergonomics.lex
@@ -88,14 +88,14 @@ Design Specification: Shell Hookup Ergonomics
 
         Line one states whether dodot is sourced in new shell sessions, colour-coded, and when it is not, the hint carries the fix. Line two is the evidence, dimmed. Proposed strings, to be pinned by the implementation and then documented once:
 
-        Footer states:
+        Footer states, quoted verbatim:
             | State | Line one | Line two |
-            | healthy | `Shell hookup: dodot is sourced in new shells.` | `Last loaded 4 minutes ago by dodot 5.6.0.` |
-            | version skew | `Shell hookup: your shells load a different dodot.` | `Last loaded 4 minutes ago by dodot 5.0.0 — you are running 5.6.0.` |
-            | stale shell | `Shell hookup: this shell predates your last \`dodot up\`.` | `Last loaded 4 minutes ago by dodot 5.6.0.` |
-            | this shell only | `Shell hookup: this shell did not load dodot.` | `Last loaded 2 days ago by dodot 5.6.0.` |
-            | never | `Shell hookup: no shell has loaded dodot yet.` | `Never loaded.` |
-            | verified broken | `Shell hookup: a new shell did not load dodot.` | `Last loaded 9 days ago by dodot ≤5.5.1.` |
+            | healthy | Shell hookup: dodot is sourced in new shells. | Last loaded 4 minutes ago by dodot 5.6.0. |
+            | version skew | Shell hookup: your shells load a different dodot. | Last loaded 4 minutes ago by dodot 5.0.0 — you are running 5.6.0. |
+            | stale shell | Shell hookup: this shell predates your last \`dodot up\`. | Last loaded 4 minutes ago by dodot 5.6.0. |
+            | this shell only | Shell hookup: this shell did not load dodot. | Last loaded 2 days ago by dodot 5.6.0. |
+            | never | Shell hookup: no shell has loaded dodot yet. | Never loaded. |
+            | verified broken | Shell hookup: a new shell did not load dodot. | Last loaded 9 days ago by dodot ≤5.5.1. |
 
             :: table align=lll header=1 ::
 

--- a/docs/proposals/shell-hookup-ergonomics.lex
+++ b/docs/proposals/shell-hookup-ergonomics.lex
@@ -3,6 +3,8 @@ Design Specification: Shell Hookup Ergonomics
     :: note ::
         *Status: proposed.* Epic RCS01. Successor to [./shipped/shell-hookup.lex] (INS01), which shipped the activation evidence this document extends. Read that first: the generation stamp, the heartbeat, the signal ladder, the probe, and `dodot install` are all defined there and assumed here.
 
+        Two shipped deviations, where the code is the authority. The diagnosis probe landed *inside* `dodot probe shell-init`, running by default — `--no-trace` opts out, a `<PACK[/FILE]>` argument suppresses it — not as the separate `dodot probe shell-hookup` command [#3.1] proposes (epic `#288`, decision 6). And the version-skew hint points at `$PATH` resolution generically ("check which one your PATH finds first") rather than naming both binary paths as [#2.3] promises; the probe is where both paths get named.
+
     INS01 taught dodot to ask whether any shell loads its init script. It answers that question with one bit — a generation number — and that bit turns out to be too narrow. A hookup can be wired, sourced on every shell start, and still broken, because the *binary* that generated the init script is not the binary the user runs. dodot cannot see that today, and the message it prints instead sends the user to the one fix that cannot work.
 
     This proposal widens the evidence to carry a version, replaces the single activation line with a two-line footer that says what happened and when, adds an on-demand probe that reports what `dodot` resolves to *at the hook line* rather than guessing, and moves the Homebrew bootstrap inside dodot so the shell rc no longer has to contain anything at all.
@@ -112,8 +114,8 @@ Design Specification: Shell Hookup Ergonomics
 
         Answering "what does `dodot` resolve to at the hook line" requires spawning the user's shell and running their whole rc under tracing. That is heavy, and `status` may not spawn anything at all. It therefore lands as `dodot probe shell-hookup`, on demand, in the existing `probe` family ([../user/commands/probe.lex]) where the slower, heavier-handed introspection already lives.
 
-        :: warning ::
-            `dodot probe shell-init` (profiling timings) and `dodot probe shell-hookup` (activation diagnosis) are one word apart and answer different questions. Either name the new command distinctly or accept the pairing knowingly; do not let it be decided by accident.
+        :: note ::
+            *Superseded by epic `#288`, decision 6.* No `dodot probe shell-hookup` command exists. The diagnosis shipped folded into `dodot probe shell-init`, which now traces the rc **by default**: startup timings and the hook-line verdict answer the same "what did my shell just do" question, so the one-word-apart naming hazard this section weighed was resolved by not minting a second name at all. `--no-trace` opts out; the passive views (a `<PACK[/FILE]>` filter, `--runs`, `--history`, `--errors-only`) never trace. See [../user/commands/probe.lex] §4.
 
     3.2. PATH at the Hook Line
 

--- a/docs/user/commands/init-sh.lex
+++ b/docs/user/commands/init-sh.lex
@@ -22,6 +22,8 @@ Both forms are fully supported and both leave the same activation evidence, so `
 
     The init script is intentionally flat — `source` and `export PATH=` lines, one per staged entry, with a `# [<pack>]` comment above each so you can tell what came from where. No logic at runtime, no datastore re-discovery. All the work happens at `dodot up` time, when the script is regenerated.
 
+    Two blocks precede the pack lines. The script exports its activation *evidence* (a generation stamp and the generating dodot's version) and touches a heartbeat file — what lets `dodot status` report whether shells actually load dodot ([./../shell-integration.lex] §5). And on a macOS host with Homebrew, the script opens with brew's environment, captured verbatim from `brew shellenv` at the last `dodot up` — so brew's `$PATH` exists before any pack script runs, with dodot's own additions below it winning. The `[shell] homebrew` key controls that block; [./../configuration.lex] §10 has the details and the cost.
+
     A pack with no shell or path handlers contributes nothing. A pack you took down with `dodot down` disappears entirely from the next regenerated script.
 
     On a fresh install with no packs deployed yet, `init-sh` emits the script header plus a "no shell scripts or PATH additions to load" comment. Sourcing that is harmless; it just doesn't do anything.
@@ -34,7 +36,7 @@ Both forms are fully supported and both leave the same activation evidence, so `
 
     What belongs *above* this line in the rc:
 
-    - `eval "$(/opt/homebrew/bin/brew shellenv)"` (or `/usr/local/bin/brew` on Intel) — Homebrew puts dodot itself on `$PATH`, so it has to run before dodot can be invoked.
+    - `eval "$(/opt/homebrew/bin/brew shellenv)"` (or `/usr/local/bin/brew` on Intel) — but only because this hookup form must *find* `dodot` on `$PATH` before the init script can run, and Homebrew may be what installed it. The init script itself already opens with brew's environment for everything after it ([#2]); dodot's managed block sources the script by absolute path and needs no brew line at all.
     - OS-level prereqs that block any pack from succeeding (xcode-select install prompt, license acceptance).
 
     Everything else — aliases, exports, functions, completions, prompt setup — belongs in a pack, not raw in your rc.

--- a/docs/user/commands/install.lex
+++ b/docs/user/commands/install.lex
@@ -108,7 +108,8 @@ Run it with `--write` and it splices its own marked block into that file, then s
         Notes
           created ~/.zshrc
 
-        ✓ Shell hookup verified: a new shell loads dodot.
+        ✓ Shell hookup: dodot is sourced in new shells.
+        Last loaded just now by dodot 5.6.0.
 
     :: shell ::
 
@@ -133,7 +134,7 @@ Run it with `--write` and it splices its own marked block into that file, then s
 
 6. Activation states
 
-    `dodot up` and `dodot status` report the same four states this command ends on. They are documented once, in [./../shell-integration.lex] §5.
+    `dodot up`, `dodot down`, and `dodot status` end on the same activation footer this command does. Every state and its exact message — including version skew — are documented once, in [./../shell-integration.lex] §5.
 
 7. Shells dodot will not guess for
 

--- a/docs/user/commands/install.lex
+++ b/docs/user/commands/install.lex
@@ -113,7 +113,7 @@ Run it with `--write` and it splices its own marked block into that file, then s
 
     :: shell ::
 
-    Three outcomes, kept apart because they call for different actions:
+    There are three outcomes, kept apart because they call for different actions.
 
     Verdicts:
         | Outcome         | What it means                                              |

--- a/docs/user/commands/probe.lex
+++ b/docs/user/commands/probe.lex
@@ -68,20 +68,29 @@ Reach for `probe` when `status` isn't enough — when something appears deployed
 
         :: text ::
 
-        The spawn is guarded the same way as every dodot shell probe: stdin from `/dev/null`, output captured, a hard timeout with a process-group kill, dodot's own evidence variables scrubbed. It never writes your rc. If your rc defeats the tracing (a `PS4` override, say), dodot retries against a temporary *copy* with a report line inserted — and says so: `(traced via a temporary copy of your rc — your real files were not touched)`. If your rc has no dodot hook at all, nothing is spawned and the report says `no dodot hook in ~/.zshrc — run `dodot install --write` to add one`.
+        The spawn is guarded the same way as every dodot shell probe: stdin from `/dev/null`, output captured, a hard timeout with a process-group kill, dodot's own evidence variables scrubbed. It never writes your rc. If your rc defeats the tracing (a `PS4` override, say), dodot retries against a temporary *copy* with a report line inserted — and says so: `(traced via a temporary copy of your rc — your real files were not touched)`. If your rc has no dodot hook at all, nothing is spawned and the report says so:
 
-        The result is the `Hook resolution` section: the rc file, the hook's line number, and a verdict. For the hand-wired `eval "$(dodot init-sh)"` hook, dodot reads `$PATH` *at the hook line* out of the trace and resolves `dodot` against it itself — naming every candidate it passed over (`passed over /usr/local/bin/dodot — dangling symlink`, `— not executable`, `— its directory does not exist`), which is exactly what `command -v` silently skips. Four verdicts:
+            no dodot hook in ~/.zshrc — run `dodot install --write` to add one
 
-        Hook-line verdicts (eval hook):
-            | Verdict                                                                          | What to do                                                                          |
-            | `the hook at <rc>:<line> never ran in a fresh shell`                             | The hook sits inside a branch that did not run, or the rc exits or execs away before reaching it. Move it somewhere unconditional. |
-            | `\`dodot\` is not resolvable at <rc>:<line>`                                     | At that point of your rc, nothing on `$PATH` provides dodot. The report prints the PATH it searched and the entries it skipped. |
-            | `your shells load a different dodot than the one running now`                    | The wired-but-dead case: both paths and both versions are printed. Remove or update the stale install your PATH finds first. |
-            | `\`dodot\` at <rc>:<line> resolves to the running binary — the hookup is sound`  | The hookup is fine; whatever you are chasing lives elsewhere.                       |
+        :: text ::
+
+        The result is the `Hook resolution` section: the rc file, the hook's line number, and a verdict. For the hand-wired `eval "$(dodot init-sh)"` hook, dodot reads `$PATH` *at the hook line* out of the trace and resolves `dodot` against it itself — naming every candidate it passed over (`passed over /usr/local/bin/dodot — dangling symlink`, `— not executable`, `— its directory does not exist`), which is exactly what `command -v` silently skips. There are four verdicts.
+
+        Hook-line verdicts (eval hook), quoted verbatim:
+            | Verdict                                                                        | What to do                                                                          |
+            | the hook at <rc>:<line> never ran in a fresh shell                             | The hook sits inside a branch that did not run, or the rc exits or execs away before reaching it. Move it somewhere unconditional. |
+            | \`dodot\` is not resolvable at <rc>:<line>                                     | At that point of your rc, nothing on `$PATH` provides dodot. The report prints the PATH it searched and the entries it skipped. |
+            | your shells load a different dodot than the one running now                    | The wired-but-dead case: both paths and both versions are printed. Remove or update the stale install your PATH finds first. |
+            | \`dodot\` at <rc>:<line> resolves to the running binary — the hookup is sound  | The hookup is fine; whatever you are chasing lives elsewhere.                       |
 
         :: table align=ll ::
 
-        For the managed file-source hook there is no PATH involved — the check is whether the sourced script exists at that point, and the verdicts are the matching pair: `the init script sourced at <rc>:<line> is present — the hookup is sound`, or the same location with `does not exist — run `dodot up` to regenerate it`.
+        For the managed file-source hook there is no PATH involved — the check is whether the sourced script exists at that point, and the verdicts are the matching pair:
+
+            the init script sourced at <rc>:<line> is present — the hookup is sound
+            the init script sourced at <rc>:<line> does not exist — run `dodot up` to regenerate it
+
+        :: text ::
 
         Opting out: `--no-trace` skips the spawn and reports recorded timings only. Every other view — a `<PACK>`/`<PACK/FILE>` filter, `--runs`, `--history`, `--errors-only` — is passive and never traces.
 

--- a/docs/user/commands/probe.lex
+++ b/docs/user/commands/probe.lex
@@ -1,9 +1,11 @@
 :: verified ::
 dodot probe
 
-The "lower-level introspection" command family. Read-only. Where `dodot status` shows you per-pack deployment, `probe` shows you what dodot wrote on disk, what the running shell init looks like in practice, and what the system around your packs (macOS apps, brew casks) actually has.
+The "lower-level introspection" command family. Where `dodot status` shows you per-pack deployment, `probe` shows you what dodot wrote on disk, what the running shell init looks like in practice, and what the system around your packs (macOS apps, brew casks) actually has.
 
-Reach for `probe` when `status` isn't enough — when something appears deployed but isn't behaving, when shell startup feels slow, or when you want to see exactly what dodot wrote where.
+The family is read-only with respect to dodot's state and your files: nothing in the datastore changes, and your rc is never written. One command goes further than reading: `probe shell-init` additionally *executes* your shell rc, once, to measure it — announced before it runs, under a hard timeout, and opt-out (see [#4]). Everything else only reads.
+
+Reach for `probe` when `status` isn't enough — when something appears deployed but isn't behaving, when shell startup feels slow, when the activation footer says your shells load a different dodot, or when you want to see exactly what dodot wrote where.
 
 1. Subcommands at a glance
 
@@ -11,7 +13,7 @@ Reach for `probe` when `status` isn't enough — when something appears deployed
         | Subcommand          | Answer it gives                                                                |
         | `deployment-map`    | Every dodot-owned symlink: where it lives, what it points back to.            |
         | `show-data-dir`     | Tree view of dodot's data directory (`$XDG_DATA_HOME/dodot`).                 |
-        | `shell-init`        | Per-source timings + exit codes from your most recent shell startup.          |
+        | `shell-init`        | Startup timings + a live diagnosis of what `dodot` resolves to at the hook line. |
         | `app` (macOS)       | App-support routing for a pack: folders, casks, bundles.                       |
 
     :: table align=ll ::
@@ -56,30 +58,58 @@ Reach for `probe` when `status` isn't enough — when something appears deployed
 
 4. probe shell-init
 
-    The shell init script (the one `eval "$(dodot init-sh)"` produces) optionally records, for every source it runs, how long the source took and what exit code resulted. `probe shell-init` is the read side of that data.
+    Two answers in one command: what your shell startup *cost*, and what your hookup actually *does*. The first is read from recorded data; the second is measured live, by default, every time you run the bare command.
 
-    Three views, by flag:
+    4.1. The hook-line trace (default)
 
-        | View                      | Effect                                                                         |
-        | (default)                 | Most recent run, sorted by time. Each source as a row.                         |
-        | `--runs [N]`              | Aggregate the last N runs into per-target `p50` / `p95` / `max`. Default N=10. |
-        | `--history`               | One summary row per recent run, newest first.                                  |
-        | `--errors-only`           | Every target with a non-zero exit across recent runs, sorted by failure count. |
-        | `<PACK>` / `<PACK/FILE>`  | Drill into one source — per-run exit codes and stderr.                         |
+        A hookup can be wired, fire on every shell start, and still be dead — because the `dodot` your rc resolves at the hook line is not the dodot you run at the prompt. No static scan can see that. So the bare `probe shell-init` spawns your shell once and runs your whole rc under tracing, announcing itself first:
 
-    :: table align=ll ::
+            tracing shell startup (zsh)… (runs your rc file once)
 
-    Useful for: hunting slow shell startup, finding a pack whose `aliases.sh` is failing silently, auditing what a teammate's pack actually does on login.
+        :: text ::
+
+        The spawn is guarded the same way as every dodot shell probe: stdin from `/dev/null`, output captured, a hard timeout with a process-group kill, dodot's own evidence variables scrubbed. It never writes your rc. If your rc defeats the tracing (a `PS4` override, say), dodot retries against a temporary *copy* with a report line inserted — and says so: `(traced via a temporary copy of your rc — your real files were not touched)`. If your rc has no dodot hook at all, nothing is spawned and the report says `no dodot hook in ~/.zshrc — run `dodot install --write` to add one`.
+
+        The result is the `Hook resolution` section: the rc file, the hook's line number, and a verdict. For the hand-wired `eval "$(dodot init-sh)"` hook, dodot reads `$PATH` *at the hook line* out of the trace and resolves `dodot` against it itself — naming every candidate it passed over (`passed over /usr/local/bin/dodot — dangling symlink`, `— not executable`, `— its directory does not exist`), which is exactly what `command -v` silently skips. Four verdicts:
+
+        Hook-line verdicts (eval hook):
+            | Verdict                                                                          | What to do                                                                          |
+            | `the hook at <rc>:<line> never ran in a fresh shell`                             | The hook sits inside a branch that did not run, or the rc exits or execs away before reaching it. Move it somewhere unconditional. |
+            | `\`dodot\` is not resolvable at <rc>:<line>`                                     | At that point of your rc, nothing on `$PATH` provides dodot. The report prints the PATH it searched and the entries it skipped. |
+            | `your shells load a different dodot than the one running now`                    | The wired-but-dead case: both paths and both versions are printed. Remove or update the stale install your PATH finds first. |
+            | `\`dodot\` at <rc>:<line> resolves to the running binary — the hookup is sound`  | The hookup is fine; whatever you are chasing lives elsewhere.                       |
+
+        :: table align=ll ::
+
+        For the managed file-source hook there is no PATH involved — the check is whether the sourced script exists at that point, and the verdicts are the matching pair: `the init script sourced at <rc>:<line> is present — the hookup is sound`, or the same location with `does not exist — run `dodot up` to regenerate it`.
+
+        Opting out: `--no-trace` skips the spawn and reports recorded timings only. Every other view — a `<PACK>`/`<PACK/FILE>` filter, `--runs`, `--history`, `--errors-only` — is passive and never traces.
+
+    4.2. Recorded timings
+
+        The shell init script optionally records, for every source it runs, how long the source took and what exit code resulted. The rest of `probe shell-init` is the read side of that data:
+
+            | View                      | Effect                                                                         |
+            | (default)                 | Most recent run, sorted by time. Each source as a row.                         |
+            | `--runs [N]`              | Aggregate the last N runs into per-target `p50` / `p95` / `max`. Default N=10. |
+            | `--history`               | One summary row per recent run, newest first.                                  |
+            | `--errors-only`           | Every target with a non-zero exit across recent runs, sorted by failure count. |
+            | `<PACK>` / `<PACK/FILE>`  | Drill into one source — per-run exit codes and stderr.                         |
+
+        :: table align=ll ::
+
+        Useful for: hunting slow shell startup, finding a pack whose `aliases.sh` is failing silently, auditing what a teammate's pack actually does on login.
 
     Examples:
 
-        dodot probe shell-init                     # most recent run
+        dodot probe shell-init                     # timings + the live hook trace
+        dodot probe shell-init --no-trace          # timings only, nothing spawned
         dodot probe shell-init --runs              # last 10 runs, p50/p95/max
         dodot probe shell-init --runs 50           # last 50 runs
         dodot probe shell-init --history           # one row per run
         dodot probe shell-init --errors-only       # only failures
-        dodot probe shell-init gpg                 # drill into one pack
-        dodot probe shell-init gpg/env.sh          # drill into one file
+        dodot probe shell-init gpg                 # drill into one pack (no trace)
+        dodot probe shell-init gpg/env.sh          # drill into one file (no trace)
 
     :: shell ::
 
@@ -108,6 +138,7 @@ Reach for `probe` when `status` isn't enough — when something appears deployed
 6. Watch out for
 
     - *`probe app` is macOS-acute.* On Linux, `app_support_dir` collapses onto `$XDG_CONFIG_HOME`, the brew/Spotlight enrichment doesn't apply, and the output is correspondingly thinner. The command isn't an error elsewhere; it just has less to say.
-    - *`probe shell-init` requires the timing wrapper.* The init script only writes timing data when `[shell_init].profiling.enabled = true` (see `dodot config get shell_init.profiling.enabled`). Without it the command reports "no profiles yet, open a new shell that sources `dodot-init.sh`."
+    - *`probe shell-init`'s timings require the timing wrapper.* The init script only writes timing data when `[shell_init].profiling.enabled = true` (see `dodot config get shell_init.profiling.enabled`). Without it the command reports "no profiles yet, open a new shell that sources `dodot-init.sh`." The hook-line trace needs no profiling — it measures live.
+    - *The default `probe shell-init` runs your rc.* Once, announced, in a throwaway shell — your rc's side effects (a `neofetch`, a network call) run with it. `--no-trace` if that matters right now.
     - *`probe deployment-map` shows only what dodot owns.* Files at the deploy target that dodot didn't create (regular files, foreign symlinks) don't appear here — `dodot status` is where those surface as conflicts or `error` rows.
     - *`show-data-dir --depth 8` can be a lot.* A repo with many packs and many handlers fills the tree quickly. Start at the default depth 4; deepen only when you're hunting a specific path.

--- a/docs/user/commands/status.lex
+++ b/docs/user/commands/status.lex
@@ -37,32 +37,16 @@ The read-only "what does dodot see?" command. For every pack and every source fi
 
 3. Shell hookup
 
-    Deploying a pack and a shell loading it are two different things, and `status` reports both. After the per-pack rows it prints one line about *activation*: whether any shell has sourced dodot's init script.
+    Deploying a pack and a shell loading it are two different things, and `status` reports both. After the per-pack rows it ends with a two-line *activation footer*: whether dodot is sourced in new shell sessions, and when it last was, by which dodot. The healthy case:
 
-        shell hookup: ok
-
-    :: shell ::
-
-    That is the healthy case. The others:
-
-        ⚠ Deployed, but no shell has loaded dodot yet.
-        Run `dodot install --write` to wire it up, or add this to your shell rc file yourself: [ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ] && . "$HOME/.local/share/dodot/shell/dodot-init.sh"
+        ✓ Shell hookup: dodot is sourced in new shells.
+        Last loaded 4 minutes ago by dodot 5.6.0.
 
     :: shell ::
 
-        This shell started before your last `dodot up`.
-        Open a new shell to pick up the current deployment.
+    When something needs doing — no shell has loaded dodot yet, this shell predates your last `up`, your shells load a *different* dodot than the one you are running — line one names the state and a hint carries the fix. Every state and its exact message are documented once, in [./../shell-integration.lex] §5.
 
-    :: shell ::
-
-        This shell hasn't loaded dodot.
-        ~/.zshrc doesn't have the dodot hook. Run `dodot install --write` to wire it up, or add this line yourself: [ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ] && . "$HOME/.local/share/dodot/shell/dodot-init.sh"
-
-    :: shell ::
-
-    `status` reads evidence the init script leaves behind — a generation stamp in your environment, a heartbeat file, and, when you run it from a terminal, the fact that the shell in front of you exported no stamp — and never starts a shell to find out. That keeps it as passive as the rest of the command (the last message's diagnosis comes from reading your rc file, not running it). The consequence is that `status` can say "no shell has loaded dodot yet", "this shell is stale", or "this shell hasn't loaded dodot", but it can never report the *measured* verdict: only `dodot up` and `dodot install --write` start a shell, and only they can tell you a hookup is verified broken.
-
-    The five activation states and what each means are documented once, in [./../shell-integration.lex] §5.
+    `status` reads evidence the init script leaves behind — a version-stamped generation in your environment, a heartbeat file, and, when you run it from a terminal, the fact that the shell in front of you exported no stamp — and never starts a shell to find out. That keeps it as passive as the rest of the command. The consequence is that `status` can report every evidence-based state, including version skew, but it can never report the *measured* verdict: only `dodot up` and `dodot install --write` start a shell, and only they can tell you a hookup is verified broken. For the deepest cut — which binary `dodot` resolves to at the hook line — run `dodot probe shell-init` ([./probe.lex] §4).
 
     Before anything is deployed there is no init script to load, so `status` says nothing about the hookup at all.
 

--- a/docs/user/commands/status.lex
+++ b/docs/user/commands/status.lex
@@ -12,13 +12,13 @@ The read-only "what does dodot see?" command. For every pack and every source fi
 
 2. What it shows
 
-    For each active pack:
+    For each active pack, `status` shows these rows.
 
     - Every source file dodot saw, as separate icon, pack, filename, and status columns. The icon and filename are muted, the pack is regular, and only the status carries its severity colour.
     - Files filtered out (`ignore` / `skip` / `gate`) and why they were filtered.
     - Files affected by preprocessing — under their *post-preprocessing* filename, not the source filename. (A source `config.toml.tmpl` shows as `config.toml`.)
 
-    Across packs:
+    Across packs, three more things surface.
 
     - Cross-pack conflicts surface as warnings on the affected rows, with both packs named so the conflict is visible without having to run `up`.
     - Packs whose `[pack] os` doesn't match the current host show in a separate "inactive on this OS" section.

--- a/docs/user/commands/up.lex
+++ b/docs/user/commands/up.lex
@@ -65,9 +65,9 @@ The "make my live config match what's in this repo" command. Discovers your pack
 
 6. The shell hookup check
 
-    A successful `up` proves your packs are deployed. It proves nothing about whether any shell will ever *load* them — those are two layers that fail independently, and the second is the one you actually experience. So `up` ends by reporting on it.
+    A successful `up` proves your packs are deployed. It proves nothing about whether any shell will ever *load* them — those are two layers that fail independently, and the second is the one you actually experience. So `up` ends with the activation footer: whether dodot is sourced in new shells, and when it last was, by which dodot version.
 
-    When it has evidence — a shell has loaded the current init script — `up` says nothing; there is nothing to say. When it has no evidence either way, it stops guessing and measures, announcing itself first:
+    When it has no evidence either way, it stops guessing and measures, announcing itself first:
 
         verifying shell integration (zsh)…
 
@@ -75,14 +75,15 @@ The "make my live config match what's in this repo" command. Discovers your pack
 
     That starts your shell (interactive, non-login, five-second timeout) and checks whether the init script ran in it. On a machine that was never wired up, the answer is no:
 
-        Deployed, but a new shell did not load dodot.
+        ✗ Shell hookup: a new shell did not load dodot.
         The dodot hook is missing from ~/.zshrc — run `dodot install --write` to add it.
+        Never loaded.
 
     :: shell ::
 
     The check is self-limiting. It fires when the cheap evidence is inconclusive — the fresh-install case and the broken-hookup case — and the first real shell activation retires it. A healthy machine never pays for a shell spawn. `--dry-run` never spawns one either.
 
-    See [./install.lex] for the fix, and [./../shell-integration.lex] §5 for the four activation states and the full set of messages.
+    See [./install.lex] for the fix, and [./../shell-integration.lex] §5 for the activation states and the full set of messages — including version skew, the state where your shells load a *different* dodot than the one you run.
 
 7. First-time-on-this-repo prompt
 

--- a/docs/user/commands/up.lex
+++ b/docs/user/commands/up.lex
@@ -81,7 +81,7 @@ The "make my live config match what's in this repo" command. Discovers your pack
 
     :: shell ::
 
-    The check is self-limiting. It fires when the cheap evidence is inconclusive — the fresh-install case and the broken-hookup case — and the first real shell activation retires it. A healthy machine never pays for a shell spawn. `--dry-run` never spawns one either.
+    The check is self-limiting. It fires when the cheap evidence is inconclusive — the fresh-install case and the broken-hookup case — and the first real shell activation retires it. A healthy machine never pays for a shell spawn. `--dry-run` never spawns one either — and on a machine where nothing has ever been deployed it has no init script to report on, so a dry run there ends with no footer at all.
 
     See [./install.lex] for the fix, and [./../shell-integration.lex] §5 for the activation states and the full set of messages — including version skew, the state where your shells load a *different* dodot than the one you run.
 

--- a/docs/user/configuration.lex
+++ b/docs/user/configuration.lex
@@ -519,11 +519,11 @@ Configuration
 
     :: toml ::
 
-    `homebrew` decides whether the init script opens with Homebrew's environment. With `"auto"` (the default), `dodot up` and `dodot down` ask `brew shellenv` for its bootstrap block and keep the answer — baked into the generated script as static text, and cached in dodot's datastore so `dodot init-sh` emits the same block without running `brew` either. Homebrew stays the authority on its own setup; a brew upgrade that changes the block is picked up by the next `dodot up`, the same refresh rule as everything else dodot generates. On a host without Homebrew, or off macOS, nothing is emitted; install brew and the next `dodot up` picks it up.
+    `homebrew` decides whether the init script opens with Homebrew's environment. With `"auto"` (the default), `dodot up` and `dodot down` ask `brew shellenv` for its bootstrap block and keep the answer — baked into the generated script as static text, and cached in dodot's datastore so `dodot init-sh` emits the same block without running `brew` either (only a cold or prefix-mismatched cache makes `init-sh` capture live, once, in memory). Homebrew stays the authority on its own setup; a brew upgrade that changes the block is picked up by the next `dodot up`, the same refresh rule as everything else dodot generates. On a host without Homebrew, or off macOS, nothing is emitted; install brew and the next `dodot up` picks it up.
 
     The block lands _first_, above the PATH additions your packs contribute, so your own entries stay ahead of brew's. That is what makes a `001-homebrew` bootstrap pack unnecessary: brew's environment is available to every pack script without any ordering work on your part.
 
-    What this costs your shell is the same under either hookup shape (see [./shell-integration.lex] for the two): each shell start pays only brew's own block re-execing `path_helper`, measured at 2-3 ms. The `brew shellenv` capture itself (twice — once for `sh`, once for `zsh`, 10-20 ms each on an Apple-silicon mac) is paid by `dodot up` and `dodot down`, never by a shell.
+    What this costs your shell is the same under either hookup shape (see [./shell-integration.lex] for the two): each shell start pays only the two process spawns of brew's own `path_helper` line, measured at 2-3 ms. The `brew shellenv` capture itself (twice — once for `sh`, once for `zsh`, 10-20 ms each on an Apple-silicon mac) is paid by `dodot up` and `dodot down`, never by a shell.
 
     :: note :: This is the one thing dodot puts on your shell startup path that spends processes. `homebrew = "off"` removes it entirely, and is also the setting to reach for if you'd rather bootstrap Homebrew yourself or want the init script to carry nothing but dodot's own lines.
 

--- a/docs/user/getting-started.lex
+++ b/docs/user/getting-started.lex
@@ -78,8 +78,9 @@ Getting started
                              ⚙ aliases.sh                              not sourced
                              ⚙ Brewfile                                  installed
 
-        Deployed, but a new shell did not load dodot.
+        ✗ Shell hookup: a new shell did not load dodot.
         The dodot hook is missing from ~/.zshrc — run `dodot install --write` to add it.
+        Never loaded.
 
     :: shell ::
 
@@ -125,11 +126,12 @@ Getting started
         Notes
           created ~/.zshrc
 
-        ✓ Shell hookup verified: a new shell loads dodot.
+        ✓ Shell hookup: dodot is sourced in new shells.
+        Last loaded just now by dodot 5.6.0.
 
     :: shell ::
 
-    That last line is measured, not assumed: dodot started a shell and confirmed the hook fired. Open a new terminal and your pack's aliases and `bin/` directory are there.
+    That footer is measured, not assumed: dodot started a shell and confirmed the hook fired — down to which dodot version the shell loaded, and when. Open a new terminal and your pack's aliases and `bin/` directory are there.
 
     Run it bare first — `dodot install` — if you'd rather see which file it picked before letting it write. Without `--write` nothing changes on disk. It writes one marked block and nothing else, so deleting that block is a complete uninstall.
 
@@ -154,7 +156,7 @@ Getting started
 
 8. Watch out for
 
-    - *Open shells lag.* `dodot up` regenerates the shell init script, but already-running shells hold their old environment. Open a new shell or re-source your rc. dodot says so when it notices: `This shell started before your last dodot up.`
+    - *Open shells lag.* `dodot up` regenerates the shell init script, but already-running shells hold their old environment. Open a new shell or re-source your rc. dodot says so when it notices: `Shell hookup: this shell predates your last dodot up.`
     - *Deployed is not activated.* A green `dodot up` proves your packs are in the datastore. Whether a shell loads them is a separate question, and it is the one [#6] answers. `dodot status` tells you which side of that line you're on.
     - *`dodot down` only sees discovered packs.* If you've added a `.dodotignore` marker to a pack, `down` won't reconcile it. See [./filters.lex] §3 for the safe sequence.
     - *Pack-root files only get the convention treatment.* Nested files (e.g. `pack/scripts/foo.sh`) fall through to the symlink handler — they aren't auto-sourced. That keeps window-manager helpers and similar scripts from being pulled into shell init.

--- a/docs/user/getting-started.lex
+++ b/docs/user/getting-started.lex
@@ -156,7 +156,7 @@ Getting started
 
 8. Watch out for
 
-    - *Open shells lag.* `dodot up` regenerates the shell init script, but already-running shells hold their old environment. Open a new shell or re-source your rc. dodot says so when it notices: `Shell hookup: this shell predates your last dodot up.`
+    - *Open shells lag.* `dodot up` regenerates the shell init script, but already-running shells hold their old environment. Open a new shell or re-source your rc. dodot says so when it notices: Shell hookup: this shell predates your last \`dodot up\`.
     - *Deployed is not activated.* A green `dodot up` proves your packs are in the datastore. Whether a shell loads them is a separate question, and it is the one [#6] answers. `dodot status` tells you which side of that line you're on.
     - *`dodot down` only sees discovered packs.* If you've added a `.dodotignore` marker to a pack, `down` won't reconcile it. See [./filters.lex] §3 for the safe sequence.
     - *Pack-root files only get the convention treatment.* Nested files (e.g. `pack/scripts/foo.sh`) fall through to the symlink handler — they aren't auto-sourced. That keeps window-manager helpers and similar scripts from being pulled into shell init.

--- a/docs/user/handlers/execution-order.lex
+++ b/docs/user/handlers/execution-order.lex
@@ -23,7 +23,9 @@ The order in which handlers run within a pack, and the order in which packs run 
 
     Across packs, dodot processes packs in lexicographic order of their on-disk directory names. For most pack arrangements that's `aws`, `git`, `nvim`, `zsh` — alphabetical, no surprises.
 
-    For the small handful of cases where pack-to-pack ordering matters — Homebrew's `shellenv` before anything that calls `brew`, `compinit` after completion plugins are on `$PATH`, … — name your pack directories with a numeric prefix so lexicographic order matches the order you want.
+    For the small handful of cases where pack-to-pack ordering matters — `compinit` after completion plugins are on `$PATH`, a helper function defined before the alias file that uses it, … — name your pack directories with a numeric prefix so lexicographic order matches the order you want.
+
+    The historically most common occasion for reaching for a prefix — a `001-homebrew` bootstrap pack, so brew's `shellenv` runs before anything that calls `brew` — is retired: the init script now opens with Homebrew's environment by itself, before any pack contribution ([./../configuration.lex] §10). The prefix grammar below is unchanged; it just has one less job.
 
 3. The ordering-prefix grammar
 

--- a/docs/user/shell-integration.lex
+++ b/docs/user/shell-integration.lex
@@ -95,7 +95,7 @@ Shell integration
 
 5. Activation states
 
-    Because the init script leaves evidence, every `dodot up`, `dodot down`, and `dodot status` ends with a *footer* about activation instead of assuming shells load dodot. Line one says whether dodot is sourced in new shell sessions, colour-coded by severity; when something needs doing, a hint follows. The last line, dimmed, is the evidence:
+    Because the init script leaves evidence, `dodot up`, `dodot down`, and `dodot status` end with a *footer* about activation instead of assuming shells load dodot. Line one says whether dodot is sourced in new shell sessions, colour-coded by severity; when something needs doing, a hint follows. The last line, dimmed, is the evidence:
 
         Last loaded 4 minutes ago by dodot 5.6.0.
 
@@ -103,17 +103,19 @@ Shell integration
 
     "Last loaded" is the heartbeat file's modification time — when a shell last actually sourced the init script, which is not the same as when `dodot up` generated it. The version is the dodot that generated the script that shell loaded. Evidence left by a dodot old enough to carry no version renders as `≤5.5.1` — the last release before the evidence learned to identify itself. When no shell has ever loaded dodot, the line reads `Never loaded.`; when the heartbeat's timestamp is unreadable, `Last loaded at an unknown time by dodot <version>.`
 
-    This section is where every state and its exact message live; other pages link here rather than repeating them. Seven states, seven different things to do:
+    One case has no footer at all: before a first deploy there is no init script on disk, so there is no hookup to have. `dodot status` on a machine where `dodot up` has never run says nothing about activation — and neither does a `dodot up --dry-run` there, which regenerates nothing. A real `up` writes the script before it reports, so it always ends on a footer.
 
-    Activation states:
-        | State            | Line one                                                          | What to do                                     |
-        | healthy          | `Shell hookup: dodot is sourced in new shells.`                   | Nothing.                                       |
-        | version skew     | `Shell hookup: your shells load a different dodot.`               | Find which install your PATH resolves first — see below. |
-        | empty script     | `Shell hookup: wired, but the init script is empty — nothing is deployed.` | `dodot up` — expected right after `dodot down`. |
-        | stale shell      | `Shell hookup: this shell predates your last \`dodot up\`.`       | Open a new shell.                              |
-        | this shell only  | `Shell hookup: this shell did not load dodot.`                    | What the hint names: the hook is missing from your rc (wire it), or it's there and this is likely an old shell (open a new one). |
-        | never activated  | `Shell hookup: no shell has loaded dodot yet.`                    | `dodot install --write`.                       |
-        | verified broken  | `Shell hookup: a new shell did not load dodot.`                   | Fix what the diagnosis names — see below.      |
+    This section is where every state and its exact message live; other pages link here rather than repeating them. There are seven states, and seven different things to do.
+
+    Activation states — line one, quoted verbatim:
+        | State            | Line one                                                                | What to do                                     |
+        | healthy          | Shell hookup: dodot is sourced in new shells.                           | Nothing.                                       |
+        | version skew     | Shell hookup: your shells load a different dodot.                       | Find which install your PATH resolves first — see below. |
+        | empty script     | Shell hookup: wired, but the init script is empty — nothing is deployed. | `dodot up` — expected right after `dodot down`. |
+        | stale shell      | Shell hookup: this shell predates your last \`dodot up\`.               | Open a new shell.                              |
+        | this shell only  | Shell hookup: this shell did not load dodot.                            | What the hint names: the hook is missing from your rc (wire it), or it's there and this is likely an old shell (open a new one). |
+        | never activated  | Shell hookup: no shell has loaded dodot yet.                            | `dodot install --write`.                       |
+        | verified broken  | Shell hookup: a new shell did not load dodot.                           | Fix what the diagnosis names — see below.      |
 
     :: table align=lll ::
 

--- a/docs/user/shell-integration.lex
+++ b/docs/user/shell-integration.lex
@@ -44,7 +44,8 @@ Shell integration
         Notes
           created ~/.zshrc
 
-        ✓ Shell hookup verified: a new shell loads dodot.
+        ✓ Shell hookup: dodot is sourced in new shells.
+        Last loaded just now by dodot 5.6.0.
 
     :: shell ::
 
@@ -63,6 +64,8 @@ Shell integration
 3. What the init script contains
 
     A flat shell script: one `source <path>` line per shell-handler source, one `export PATH="<dir>:$PATH"` line per path-handler source, with a `# [<pack>]` comment above each so you can tell what came from where.
+
+    On a macOS host with Homebrew installed, the script *opens* with Homebrew's environment — `brew shellenv` output captured verbatim at the last `dodot up` and cached in the datastore — so brew's `$PATH` entries exist before any pack script runs and your rc needs no bootstrap line of its own. It is emitted first so that dodot's own PATH additions below it win. This block is the one command dodot puts on the shell startup path; [./configuration.lex] §10 documents what it costs, how the capture is cached, and the `[shell] homebrew = "auto" | "off"` key that controls it.
 
     No logic at runtime, no datastore re-discovery. Every line is computed at `dodot up` time, when the script is regenerated. Sourcing the script is just running those plain shell commands — same as if you'd written them by hand.
 
@@ -92,63 +95,104 @@ Shell integration
 
 5. Activation states
 
-    Because the init script leaves evidence, `dodot up` and `dodot status` can tell you whether shells are actually loading dodot instead of assuming it. Five states, five different things to do:
+    Because the init script leaves evidence, every `dodot up`, `dodot down`, and `dodot status` ends with a *footer* about activation instead of assuming shells load dodot. Line one says whether dodot is sourced in new shell sessions, colour-coded by severity; when something needs doing, a hint follows. The last line, dimmed, is the evidence:
+
+        Last loaded 4 minutes ago by dodot 5.6.0.
+
+    :: text ::
+
+    "Last loaded" is the heartbeat file's modification time — when a shell last actually sourced the init script, which is not the same as when `dodot up` generated it. The version is the dodot that generated the script that shell loaded. Evidence left by a dodot old enough to carry no version renders as `≤5.5.1` — the last release before the evidence learned to identify itself. When no shell has ever loaded dodot, the line reads `Never loaded.`; when the heartbeat's timestamp is unreadable, `Last loaded at an unknown time by dodot <version>.`
+
+    This section is where every state and its exact message live; other pages link here rather than repeating them. Seven states, seven different things to do:
 
     Activation states:
-        | State            | What it means                                                    | What to do                                     |
-        | healthy          | A shell has loaded the current init script.                      | Nothing. `status` shows a quiet `shell hookup: ok`. |
-        | stale shell      | *This* shell loaded dodot, but before your last `dodot up`.      | Open a new shell.                              |
-        | shell not loaded | You ran `dodot status` from a terminal, and that shell did not load dodot — whatever some earlier shell once did. | What the hint names: the hook is missing from your rc (wire it), or it's there and this is likely an old shell (open a new one). |
-        | never activated  | No shell has ever loaded dodot's init script.                    | `dodot install --write`.                       |
-        | verified broken  | dodot started a shell and measured that it did not load dodot.   | Fix what the diagnosis names — see below.      |
+        | State            | Line one                                                          | What to do                                     |
+        | healthy          | `Shell hookup: dodot is sourced in new shells.`                   | Nothing.                                       |
+        | version skew     | `Shell hookup: your shells load a different dodot.`               | Find which install your PATH resolves first — see below. |
+        | empty script     | `Shell hookup: wired, but the init script is empty — nothing is deployed.` | `dodot up` — expected right after `dodot down`. |
+        | stale shell      | `Shell hookup: this shell predates your last \`dodot up\`.`       | Open a new shell.                              |
+        | this shell only  | `Shell hookup: this shell did not load dodot.`                    | What the hint names: the hook is missing from your rc (wire it), or it's there and this is likely an old shell (open a new one). |
+        | never activated  | `Shell hookup: no shell has loaded dodot yet.`                    | `dodot install --write`.                       |
+        | verified broken  | `Shell hookup: a new shell did not load dodot.`                   | Fix what the diagnosis names — see below.      |
 
     :: table align=lll ::
 
-    _Never activated_, from `dodot status` — evidence only, no shell is started:
+    _Healthy_ — a shell has loaded the current init script, generated by the dodot you are running:
 
-        ⚠ Deployed, but no shell has loaded dodot yet.
-        Run `dodot install --write` to wire it up, or add this to your shell rc file yourself: [ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ] && . "$HOME/.local/share/dodot/shell/dodot-init.sh"
+        ✓ Shell hookup: dodot is sourced in new shells.
+        Last loaded 4 minutes ago by dodot 5.6.0.
 
     :: shell ::
 
-    _Stale shell_:
+    _Version skew_ — the evidence was left by a *different* dodot than the one you are running. This is the wired-but-dead hookup's most likely cause: an old install earlier on `$PATH` is what your shells actually execute, and no amount of opening new shells will change it. It is a warning, not an error — mid-upgrade it appears transiently and the next shell clears it:
 
-        This shell started before your last `dodot up`.
+        ⚠ Shell hookup: your shells load a different dodot.
+        Open a new shell. If that changes nothing, the `dodot` your shells run is a different install than the one you just ran — check which one your PATH finds first.
+        Last loaded 4 minutes ago by dodot 5.0.0 — you are running 5.6.0.
+
+    :: shell ::
+
+    For the measured answer — which binary `dodot` resolves to at the hook line, and why — run `dodot probe shell-init` ([./commands/probe.lex] §4).
+
+    _Empty script_ — the hookup is wired and firing, but the generated script carries no pack contributions, so a healthy-sounding line would be misleading. This is what `dodot down` leaves behind, and also a first `up` that deployed nothing:
+
+        Shell hookup: wired, but the init script is empty — nothing is deployed.
+        Run `dodot up` to deploy your packs.
+        Last loaded just now by dodot 5.6.0.
+
+    :: shell ::
+
+    _Stale shell_ — *this* shell loaded dodot, but before your last `dodot up`:
+
+        Shell hookup: this shell predates your last `dodot up`.
         Open a new shell to pick up the current deployment.
+        Last loaded 4 minutes ago by dodot 5.6.0.
 
     :: shell ::
 
-    _Shell not loaded_ comes only from `dodot status`, and only when it runs attached to a terminal: no matter what the heartbeat says some past shell did, the shell you are typing in exported no generation stamp, so it demonstrably did not load dodot. This is how `status` catches a hookup that *used to* work and then broke — an rc rewrite, a commented-out hook, a moved dotfiles repo — without starting a shell. A scan of your rc file picks the message. Hook missing:
+    _This shell only_ comes from `dodot status`, and only when it runs attached to a terminal: no matter what the heartbeat says some past shell did, the shell you are typing in exported no generation stamp, so it demonstrably did not load dodot. This is how `status` catches a hookup that *used to* work and then broke — an rc rewrite, a commented-out hook, a moved dotfiles repo — without starting a shell. A scan of your rc file picks the hint. Hook missing:
 
-        This shell hasn't loaded dodot.
+        ⚠ Shell hookup: this shell did not load dodot.
         ~/.zshrc doesn't have the dodot hook. Run `dodot install --write` to wire it up, or add this line yourself: [ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ] && . "$HOME/.local/share/dodot/shell/dodot-init.sh"
+        Last loaded 2 days ago by dodot 5.6.0.
 
     :: shell ::
 
     …or hook present, in which case this is most likely a shell opened before the hook landed:
 
-        This shell hasn't loaded dodot.
+        Shell hookup: this shell did not load dodot.
         The hook is in ~/.zshrc, so this shell probably predates it — open a new shell. If that changes nothing, run `dodot up` to diagnose.
+        Last loaded 2 days ago by dodot 5.6.0.
 
     :: shell ::
 
     The wording stays "this shell", not "your hookup is broken", on purpose: an editor's task shell legitimately reads no rc file, and dodot can't tell that apart from a broken hookup without measuring. When dodot runs with no terminal at all (cron, scripts), this state never fires — a fresh heartbeat still reads as healthy there.
 
-    _Verified broken_ comes only from `dodot up` or `dodot install --write`, which are the two commands allowed to start a shell to find out. The diagnosis splits two ways, because they need different fixes — the hook is missing from the file:
+    _Never activated_ — no shell has ever loaded dodot's init script; there is no heartbeat at all:
 
-        Deployed, but a new shell did not load dodot.
+        ⚠ Shell hookup: no shell has loaded dodot yet.
+        Run `dodot install --write` to wire it up, or add this to your shell rc file yourself: [ -f "$HOME/.local/share/dodot/shell/dodot-init.sh" ] && . "$HOME/.local/share/dodot/shell/dodot-init.sh"
+        Never loaded.
+
+    :: shell ::
+
+    _Verified broken_ comes only from `dodot up` or `dodot install --write`, which are the two commands allowed to start a shell to find out. The diagnosis splits, because the cases need different fixes — the hook is missing from the file:
+
+        ✗ Shell hookup: a new shell did not load dodot.
         The dodot hook is missing from ~/.zshrc — run `dodot install --write` to add it.
+        Never loaded.
 
     :: shell ::
 
     …or the hook is there but nothing reaches it:
 
-        Deployed, but a new shell did not load dodot.
+        ✗ Shell hookup: a new shell did not load dodot.
         The dodot hook is in ~/.zshrc but was never reached — something earlier in that file is failing before it.
+        Last loaded 9 days ago by dodot ≤5.5.1.
 
     :: shell ::
 
-    That second one is the case a static scan of your rc would report as fine. It is why dodot measures.
+    That second one is the case a static scan of your rc would report as fine. It is why dodot measures. (Two rarer diagnoses exist: the shell sourced an *older* init script — check for a second dodot hook or a stale copy — and the shell whose rc file dodot cannot name, where the hint carries the line to paste.)
 
     Who starts a shell, and when:
 
@@ -160,18 +204,11 @@ Shell integration
 
 6. What goes above and below the dodot line
 
-    Two narrow categories belong *above* the dodot block (or your manual eval):
-
-    - *Homebrew shellenv.* Homebrew is what puts `dodot` itself on `$PATH`:
-
-            eval "$(/opt/homebrew/bin/brew shellenv)"   # Apple Silicon
-            eval "$(/usr/local/bin/brew shellenv)"      # Intel macOS
-
-        :: shell ::
-
-        The marked block needs this less than the manual eval does — it sources a file by absolute path rather than invoking dodot — but anything else in your rc that calls `dodot` still needs Homebrew first.
+    One narrow category belongs *above* the dodot block (or your manual eval):
 
     - *OS-level prereqs that block any pack from succeeding.* xcode-select install prompts, license acceptance — anything that has to be in place before any handler can run.
+
+    Homebrew used to be the other one, and no longer is: the init script itself now opens with brew's environment ([#3]), so nothing brew-related needs to sit in your rc. One exception survives, and only for the hand-wired form: `eval "$(dodot init-sh)"` has to *find* `dodot` before the init script can run, so if Homebrew is what installed dodot, `eval "$(/opt/homebrew/bin/brew shellenv)"` still has to come before your eval line. The managed block sources a file by absolute path and has no such need — that bootstrap cycle is one of the reasons it is the recommended form ([#7]).
 
     *Below*, ideally nothing. If you have shell logic that depends on something dodot stages (an alias, a helper function, an environment variable), put it in the same pack so the ordering is internal to the generated script rather than scattered across your rc.
 
@@ -220,11 +257,13 @@ Shell integration
 
     :: shell ::
 
-    Per-source timings and errors from your last shell start:
+    What does `dodot` resolve to at the hook line — plus per-source timings and errors from your last shell start:
 
         dodot probe shell-init
 
     :: shell ::
+
+    That is the deep diagnosis for a hookup the footer flags as skewed or dead: it runs your rc under tracing and names the rc file, the hook's line, and which binary `dodot` resolves to *at that line* — including stale installs it passed over on the way. See [./commands/probe.lex] §4.
 
     The probe surfaces stale data with a flag if the report predates the most recent `dodot up` — staleness is detected via `$XDG_DATA_HOME/dodot/last-up-at` (typically `~/.local/share/dodot/last-up-at`), written on every successful `up`.
 

--- a/docs/user/troubleshooting.lex
+++ b/docs/user/troubleshooting.lex
@@ -89,7 +89,7 @@ Troubleshooting
         | Subcommand          | Answers                                                                |
         | `deployment-map`    | Every dodot-owned symlink, source -> target.                          |
         | `show-data-dir`     | Tree view of `$XDG_DATA_HOME/dodot/` (sentinels, staged init scripts). |
-        | `shell-init`        | Per-source timings + exit codes from your most recent shell startup.   |
+        | `shell-init`        | Startup timings + what `dodot` resolves to at the hook line.           |
         | `app` (macOS)       | App-support routing for a pack: folders, casks, bundles.               |
     :: table align=ll ::
 
@@ -112,14 +112,15 @@ Troubleshooting
 
         :: shell ::
 
-        The line below the pack rows tells you which of these you're looking at:
+        The footer below the pack rows tells you which of these you're looking at (every state and its exact message: [./shell-integration.lex] §5):
 
-        - `shell hookup: ok` — the hookup is fine, so the problem is elsewhere. Skip to the checks below.
-        - `Deployed, but no shell has loaded dodot yet.` — nothing in your shell startup loads dodot. Run `dodot install --write`; it wires the hook and then verifies it by starting a shell.
-        - `This shell started before your last dodot up.` — open a new shell.
-        - `This shell hasn't loaded dodot.` — the terminal you're typing in sourced nothing, even if some earlier shell did. The hint that follows says which case you're in: the hook is missing from your rc file (wire it with `dodot install --write`) or it's present and this is probably a shell opened before it landed (open a new one).
+        - `Shell hookup: dodot is sourced in new shells.` — the hookup is fine, so the problem is elsewhere. Skip to the checks below.
+        - `Shell hookup: no shell has loaded dodot yet.` — nothing in your shell startup loads dodot. Run `dodot install --write`; it wires the hook and then verifies it by starting a shell.
+        - `Shell hookup: this shell predates your last dodot up.` — open a new shell.
+        - `Shell hookup: this shell did not load dodot.` — the terminal you're typing in sourced nothing, even if some earlier shell did. The hint that follows says which case you're in: the hook is missing from your rc file (wire it with `dodot install --write`) or it's present and this is probably a shell opened before it landed (open a new one).
+        - `Shell hookup: your shells load a different dodot.` — the evidence line names both versions. Your shells resolve `dodot` to a different install than the one you just ran — typically a stale binary earlier on `$PATH`. `dodot probe shell-init` names the rc file, the hook line, and the exact binary your shell finds there, plus every candidate it passed over (dangling symlinks included).
 
-        For a measured answer rather than an inferred one — including the case where the hook is in your rc but something earlier in the file fails before reaching it — run `dodot install --write` (safe to re-run; an existing block is replaced, never duplicated) or a plain `dodot up`. Those are the two commands that start a shell to find out. The five states and every message are in [./shell-integration.lex] §5.
+        For a measured answer rather than an inferred one — including the case where the hook is in your rc but something earlier in the file fails before reaching it — run `dodot install --write` (safe to re-run; an existing block is replaced, never duplicated) or a plain `dodot up`. Those are the two commands that start a shell to check activation; `dodot probe shell-init` is the one that traces your rc to diagnose resolution ([./commands/probe.lex] §4).
 
         If the hookup is healthy and a specific pack still isn't landing:
 

--- a/docs/user/troubleshooting.lex
+++ b/docs/user/troubleshooting.lex
@@ -112,13 +112,13 @@ Troubleshooting
 
         :: shell ::
 
-        The footer below the pack rows tells you which of these you're looking at (every state and its exact message: [./shell-integration.lex] §5):
+        The footer below the pack rows tells you which of these you're looking at. Line one, quoted verbatim (every state and its exact message: [./shell-integration.lex] §5):
 
-        - `Shell hookup: dodot is sourced in new shells.` — the hookup is fine, so the problem is elsewhere. Skip to the checks below.
-        - `Shell hookup: no shell has loaded dodot yet.` — nothing in your shell startup loads dodot. Run `dodot install --write`; it wires the hook and then verifies it by starting a shell.
-        - `Shell hookup: this shell predates your last dodot up.` — open a new shell.
-        - `Shell hookup: this shell did not load dodot.` — the terminal you're typing in sourced nothing, even if some earlier shell did. The hint that follows says which case you're in: the hook is missing from your rc file (wire it with `dodot install --write`) or it's present and this is probably a shell opened before it landed (open a new one).
-        - `Shell hookup: your shells load a different dodot.` — the evidence line names both versions. Your shells resolve `dodot` to a different install than the one you just ran — typically a stale binary earlier on `$PATH`. `dodot probe shell-init` names the rc file, the hook line, and the exact binary your shell finds there, plus every candidate it passed over (dangling symlinks included).
+        - Shell hookup: dodot is sourced in new shells. — the hookup is fine, so the problem is elsewhere. Skip to the checks below.
+        - Shell hookup: no shell has loaded dodot yet. — nothing in your shell startup loads dodot. Run `dodot install --write`; it wires the hook and then verifies it by starting a shell.
+        - Shell hookup: this shell predates your last \`dodot up\`. — open a new shell.
+        - Shell hookup: this shell did not load dodot. — the terminal you're typing in sourced nothing, even if some earlier shell did. The hint that follows says which case you're in: the hook is missing from your rc file (wire it with `dodot install --write`) or it's present and this is probably a shell opened before it landed (open a new one).
+        - Shell hookup: your shells load a different dodot. — the evidence line names both versions. Your shells resolve `dodot` to a different install than the one you just ran — typically a stale binary earlier on `$PATH`. `dodot probe shell-init` names the rc file, the hook line, and the exact binary your shell finds there, plus every candidate it passed over (dangling symlinks included).
 
         For a measured answer rather than an inferred one — including the case where the hook is in your rc but something earlier in the file fails before reaching it — run `dodot install --write` (safe to re-run; an existing block is replaced, never duplicated) or a plain `dodot up`. Those are the two commands that start a shell to check activation; `dodot probe shell-init` is the one that traces your rc to diagnose resolution ([./commands/probe.lex] §4).
 

--- a/tests/e2e/bats/test_shell_hookup.bats
+++ b/tests/e2e/bats/test_shell_hookup.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
-# E2E acceptance for the shell hookup (`dodot install`), spec §7.
+# E2E acceptance for the shell hookup: INS01 (`dodot install`, spec §7)
+# and RCS01 (the version-stamped footer and the hook-line trace).
 #
 # The story this file exists to prove, end to end in a clean
 # environment: install dodot, `up` (the never-activated warning
@@ -166,6 +167,60 @@ echo tool output'
     run dodot up
     assert_output_contains "Shell hookup: a new shell did not load dodot."
     assert_output_contains "never reached"
+}
+
+# ── The version-stamped footer (RCS01 WS01) ─────────────────────
+
+@test "the footer catches a heartbeat left by a different dodot version" {
+    dodot up
+    dodot install --write
+    bash -ic true   # a real shell activates, writing the heartbeat
+
+    # A shell whose rc resolves an older dodot would leave this exact
+    # heartbeat: same generation (the script is current), another
+    # version. Keep the real generation so only the version disagrees —
+    # the epic's motivating failure, invisible before RCS01.
+    local hb="$XDG_DATA_HOME/dodot/probes/hookup/heartbeat"
+    read -r gen _ < "$hb"
+    echo "$gen 5.0.0" > "$hb"
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "Shell hookup: your shells load a different dodot."
+    assert_output_contains "by dodot 5.0.0 — you are running"
+}
+
+@test "a version-less heartbeat renders as at most the pre-RCS01 release" {
+    dodot up
+    dodot install --write
+    bash -ic true   # a real shell activates, writing the heartbeat
+
+    # A pre-RCS01 init script wrote only the generation. One rule
+    # covers it: the version renders as a bound, never as a guess.
+    local hb="$XDG_DATA_HOME/dodot/probes/hookup/heartbeat"
+    read -r gen _ < "$hb"
+    echo "$gen" > "$hb"
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "by dodot ≤5.5.1"
+}
+
+@test "after down, a shell that loads the empty script reads as wired-but-empty" {
+    create_pack_file "shell" "aliases.sh" 'alias dodot_hookup_alias="echo activated"'
+    dodot up
+    dodot install --write
+    dodot down
+
+    # The hookup is still wired and firing — a real shell sources the
+    # regenerated, contribution-less script — so a healthy line would
+    # be technically true and practically misleading.
+    bash -ic true
+
+    run dodot status
+    [ "$status" -eq 0 ]
+    assert_output_contains "Shell hookup: wired, but the init script is empty — nothing is deployed."
+    assert_output_contains "Run \`dodot up\` to deploy your packs."
 }
 
 # ── The hook-line trace (`probe shell-init`, RCS01 WS02) ────────


### PR DESCRIPTION
for #292

## Context

The user-facing half of RCS01, following the INS01 pattern: the activation states are documented **once**, with their shipped strings, and every other page links there.

**Why this approach.** Every string quoted was extracted from the shipped code and its pinned string-assertion tests (`activation.rs`, `probe/shell_init.rs`, `trace.rs`), never from the spec's proposed table — per the issue's rule that the code is the authority. Self-checked against the epic's governing docs before opening: the Spec (`docs/proposals/shell-hookup-ergonomics.lex`), its INS01 predecessor (`docs/proposals/shipped/shell-hookup.lex`, for the deviation-note style), and `docs/proposals/shipped/pack-ordering.lex` (whose numeric-prefix contract is deliberately left intact).

- **States documented once** — `shell-integration.lex` §5 now carries all seven states (version skew and empty-script included) with the shipped two-line footer strings and hints; `status.lex`, `up.lex`, `install.lex`, and `troubleshooting.lex` quote only line-one identifiers or link outright. Stale INS01-era strings (`shell hookup: ok`, `Deployed, but…`, `✓ Shell hookup verified…`) are gone everywhere.
- **Probe** — the family intro now says precisely in what sense probe is read-only (dodot state and your files) and that `shell-init` *executes* the rc by default: announced, 5s timeout with process-group kill, never writes the rc, copy-based fallback; four eval-hook verdicts + the file-source pair, skipped-candidate reporting, `--no-trace` and view/filter opt-outs.
- **Homebrew** — `configuration.lex` §10 stays the single home (WS05's unified cost language confirmed present; no interim per-hook language found anywhere). Two accuracy sharpenings there: the two-spawn cause of the 2-3 ms, and the cold-cache live-capture exception `init-sh` actually carries. Retired: the brew-shellenv-above-the-hook guidance (kept only as the manual-eval bootstrap caveat, which remains structurally true) and the `001-homebrew` occasion in `execution-order.lex`.
- **Spec reconciled** — top note + §3.1 note record the two shipped deviations: the diagnosis folded into `probe shell-init` (epic decision 6; no `probe shell-hookup` exists), and the skew hint pointing at PATH generically instead of naming both binary paths.
- **Acceptance** — `test_shell_hookup.bats` gains three WS01 footer tests: version skew via a heartbeat rewritten to another version, `≤5.5.1` rendering of version-less evidence (state-agnostic on purpose — on the current 5.5.1 binary the bound release cannot read as skew, and the assertion survives the version bump), and the wired-but-empty state after `down` proved through a real shell.
- **#260** — commented (not closed): availability-during-init closed for Homebrew by construction, final precedence fully open, `path_helper` demotion parenthetical corrected with #291's measurement.

**Out of scope / do not "fix" here:**

- Moving the Spec to `docs/proposals/shipped/` or flipping its `Status:` — that is the umbrella's close-out call, not this workstream's.
- The version-skew hint not naming both binary paths (spec §2.3's promise) — recorded as a deviation; changing the string is code work outside WS04.
- PATH tiering, hook migration, non-brew package managers — spec §1.4/§9, tracked in #260.
- The pre-existing `[shell_init].profiling.enabled` key spelling in `probe.lex` §6 — untouched, predates this epic.
- A homebrew-block e2e test: emission is `cfg!(target_os = "macos")`-gated and the `ci / e2e` leg runs on Linux with brew deliberately muzzled by the sandbox; the fake-runner unit tests in `homebrew.rs` are the coverage the spec (§7) prescribes.

**Brief-slot note:** the coordinator brief is the issue body itself (per this repo's convention); it named the verify commands (`lexd check`, `pixi run test`) and the governing docs, both honored above. No decision-boundary slot was listed beyond the epic's settled decisions, which were not re-litigated.

## Verification

- `lexd check` clean over every touched `.lex` file
- `pixi run test` green (1505/1505)
- commit/push hooks ran the full lint suite (13 checks OK)
- new bats tests follow the file's existing helper contract; the `ci / e2e` leg validates them on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)