### PR TITLE
ACC01-WS01: Epic: Safety Lock - Workstream: Contracts and persisted schema

### DIFF
--- a/crates/dodot-lib/src/lib.rs
+++ b/crates/dodot-lib/src/lib.rs
@@ -18,6 +18,7 @@ pub mod probe;
 pub mod prompts;
 pub mod render;
 pub mod rules;
+pub mod safety_lock;
 pub mod secret;
 pub mod shell;
 

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -192,6 +192,21 @@ pub trait Pather: Send + Sync {
         self.data_dir().join("prompts.json")
     }
 
+    /// The Safety Lock trust file: the single clapfig-managed document
+    /// holding every dotfiles root the user has approved for root-sensitive
+    /// mutation (`crate::safety_lock::schema`).
+    ///
+    /// Lives under `data_dir`, deliberately outside the dotfiles root: a
+    /// repository-local marker would dirty the user's source tree, could
+    /// travel in Git, and would break the storage contract. Under `data_dir`
+    /// rather than `cache_dir` because losing it silently un-approves every
+    /// root — preference state, not cache — and because `dodot reset` wiping
+    /// the data dir is the documented recovery route for unusable trust
+    /// state. See `docs/spec/safety-lock.md`.
+    fn safety_lock_path(&self) -> PathBuf {
+        crate::safety_lock::schema::SafetyLockConfig::path_in(self.data_dir())
+    }
+
     /// Per-file baseline cache used by the preprocessing pipeline to
     /// detect divergence and drive cache-backed reverse-merge.
     ///
@@ -581,6 +596,27 @@ mod tests {
             pather.homebrew_cache_path(),
             PathBuf::from("/h/data/dodot/shell/brew-shellenv.json")
         );
+    }
+
+    /// Trust state belongs to dodot, not to the dotfiles repository: an
+    /// approval marker inside the root would travel in the user's Git
+    /// history and could approve a root by being cloned.
+    #[test]
+    fn safety_lock_state_lives_under_the_data_dir_not_the_dotfiles_root() {
+        let pather = XdgPather::builder()
+            .home("/h")
+            .dotfiles_root("/h/dotfiles")
+            .data_dir("/h/data/dodot")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            pather.safety_lock_path(),
+            PathBuf::from("/h/data/dodot/safety-lock.toml")
+        );
+        assert!(!pather
+            .safety_lock_path()
+            .starts_with(pather.dotfiles_root()));
     }
 
     #[test]

--- a/crates/dodot-lib/src/safety_lock.rs
+++ b/crates/dodot-lib/src/safety_lock.rs
@@ -1,0 +1,86 @@
+//! Safety Lock: an implicitly discovered dotfiles root must be approved
+//! before it can drive a root-sensitive mutation.
+//!
+//! Dodot infers a dotfiles root from the enclosing Git repository, then from
+//! the current directory. That convenience is also a hazard: an unrelated
+//! repository looks enough like a dotfiles repository to deploy from, and a
+//! wrong-root `up` can add shell files to every future session while a
+//! wrong-root `down` can remove legitimate state. Safety Lock makes root
+//! intent explicit without removing the convenience — read-only commands and
+//! dry runs stay available on any root, and a valid `DOTFILES_ROOT` remains
+//! the deliberate, noninteractive selection path.
+//!
+//! Governing documents: `docs/spec/safety-lock.md`,
+//! `docs/adr/0001-trust-dotfiles-roots-by-canonical-path.md`,
+//! `docs/adr/0002-guard-root-derived-mutations.md`, and
+//! `docs/adr/0003-inspect-and-revoke-roots-without-a-trust-command.md`.
+//!
+//! # The shape
+//!
+//! ```text
+//! DOTFILES_ROOT ──► environment ─┐
+//!                                ├─► ResolvedRoot ──► check ──► TrustDecision
+//! git top-level / cwd ──► files ─┘        │                          │
+//!                                         │                          ├─ ExplicitlySelected
+//!                       schema (approved roots, one file)            ├─ AlreadyApproved
+//!                                         │                          └─ ApprovalRequired ──► inventory
+//!                                    list / forget                                              (prompt)
+//! ```
+//!
+//! Both selection paths return the same [`ResolvedRoot`]: one canonical
+//! [`RootIdentity`] plus the [`RootSource`] that chose it. Provenance changes
+//! authorization policy — an environment root is already deliberate, an
+//! implicit one needs approval — never the path's representation. No
+//! source-specific type exists past [`roots`]; checking, listing, inventory,
+//! and mutation scoping all take a `ResolvedRoot` or a `RootIdentity`.
+//!
+//! Approved implicit roots live together in one clapfig-managed file under
+//! Dodot's data directory ([`schema`]), never in the dotfiles repository.
+//! Environment roots are never written there.
+//!
+//! # Boundaries
+//!
+//! This module is CLI-free by construction: no Clap and no Standout types
+//! appear in any signature, and nothing here reads the process environment,
+//! the current directory, or Git. Those are captured at the process boundary
+//! and injected ([`EnvironmentRootInput`], [`FileRootInput`],
+//! [`PathProbe`]). Likewise, persistence is the caller's: the checking,
+//! listing, and forgetting APIs take an already-loaded [`SafetyLockConfig`]
+//! and return typed state changes to write.
+//!
+//! # Work Stream status
+//!
+//! ACC01-WS01 establishes this vocabulary and the persisted schema. The
+//! selection, trust-lifecycle, decision, inventory, and scoping entry points
+//! carry documented signatures with `todo!()` bodies; each names the Work
+//! Stream that fills it in. The data model and the schema are complete and
+//! tested.
+
+pub mod check;
+pub mod environment;
+pub mod error;
+pub mod files;
+pub mod forget;
+pub mod inventory;
+pub mod list;
+pub mod roots;
+pub mod schema;
+pub mod scope;
+pub mod util;
+
+pub use check::{approve, decide, ApprovalChange, TrustDecision};
+pub use environment::{resolve_environment_root, EnvironmentRootInput};
+pub use error::{Result as SafetyLockResult, SafetyLockError};
+pub use files::{resolve_file_root, FileRootInput};
+pub use forget::{forget_root, ForgetChange, ForgetRequest};
+pub use inventory::{
+    build_inventory, CategoryCount, InventoryCategory, InventoryEntry, RootInventory,
+    MAX_INVENTORY_PATHS,
+};
+pub use list::{list_roots, TrustedRootEntry, TrustedRootListing};
+pub use roots::{ResolvedRoot, RootIdentity, RootSource};
+pub use schema::{
+    SafetyLockConfig, TrustedRootsSection, SAFETY_LOCK_FILE_NAME, SAFETY_LOCK_PERSIST_SCOPE,
+};
+pub use scope::{scope_to_root, MutationScope, OutOfRootReason, OutOfRootTarget};
+pub use util::{decode_native_path, encode_native_path, OsPathProbe, PathProbe, NATIVE_BYTES_TAG};

--- a/crates/dodot-lib/src/safety_lock/check.rs
+++ b/crates/dodot-lib/src/safety_lock/check.rs
@@ -1,0 +1,99 @@
+//! The trust decision: may this resolved root drive a root-sensitive
+//! mutation?
+//!
+//! Deciding and *recording* are separate. [`decide`] is a pure question over
+//! the resolved root and the loaded trust state; [`approve`] returns the trust
+//! state as it would be after approval, leaving the write to the caller. That
+//! split is what keeps this API free of persistence I/O and lets the CLI gate
+//! (WS07) order the write before the mutation it authorizes — approval records
+//! the user's path decision, not the mutation's outcome (Spec, "Risks").
+//!
+//! Behaviour arrives in WS05; this Work Stream fixes the signatures.
+
+use super::error::Result;
+use super::roots::{ResolvedRoot, RootIdentity};
+use super::schema::SafetyLockConfig;
+
+/// Whether a resolved root may proceed into root-sensitive mutation.
+///
+/// The variants are outcomes, not policy: nothing here says how a caller
+/// obtains approval, only what standing the root currently has.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustDecision {
+    /// Selected by a valid `DOTFILES_ROOT`. Deliberate selection needs no
+    /// stored approval and records none.
+    ExplicitlySelected,
+    /// An implicit root already present in the approved collection.
+    AlreadyApproved,
+    /// An implicit root with no approval. The command may not mutate until
+    /// the user approves this exact canonical path.
+    ApprovalRequired,
+}
+
+impl TrustDecision {
+    /// Whether the root-sensitive mutation may proceed as-is.
+    pub fn permits_mutation(self) -> bool {
+        matches!(
+            self,
+            TrustDecision::ExplicitlySelected | TrustDecision::AlreadyApproved
+        )
+    }
+
+    /// Whether the caller must obtain the user's confirmation first.
+    pub fn needs_confirmation(self) -> bool {
+        matches!(self, TrustDecision::ApprovalRequired)
+    }
+}
+
+/// The trust state as it would be after approving a root, plus whether that
+/// changed anything.
+///
+/// Returned rather than written: the caller owns persistence.
+#[derive(Debug, Clone)]
+pub struct ApprovalChange {
+    /// The trust state to persist.
+    pub config: SafetyLockConfig,
+    /// The root that was approved.
+    pub identity: RootIdentity,
+    /// `false` when the root was already approved, so the caller can skip a
+    /// pointless write.
+    pub added: bool,
+}
+
+/// Decide what standing `root` has under the loaded trust state.
+///
+/// Reads nothing from disk: both the root and the trust state are resolved
+/// once per invocation and passed in, so the path checked here is the path
+/// that will be mutated (ADR-0001).
+pub fn decide(root: &ResolvedRoot, config: &SafetyLockConfig) -> Result<TrustDecision> {
+    let _ = (root, config);
+    todo!("WS05: safety decisions over the loaded trust state")
+}
+
+/// Produce the trust state that records approval of `root`.
+///
+/// Fails with
+/// [`EnvironmentRootNotApprovable`](super::error::SafetyLockError::EnvironmentRootNotApprovable)
+/// for an environment-selected root: `DOTFILES_ROOT` is already the deliberate
+/// selection, and adding it to the collection would trust a path the user was
+/// never shown (ADR-0003).
+pub fn approve(config: &SafetyLockConfig, root: &ResolvedRoot) -> Result<ApprovalChange> {
+    let _ = (config, root);
+    todo!("WS04: trusted-root registry lifecycle")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_an_unapproved_implicit_root_needs_confirmation() {
+        assert!(TrustDecision::ExplicitlySelected.permits_mutation());
+        assert!(TrustDecision::AlreadyApproved.permits_mutation());
+        assert!(!TrustDecision::ApprovalRequired.permits_mutation());
+
+        assert!(TrustDecision::ApprovalRequired.needs_confirmation());
+        assert!(!TrustDecision::AlreadyApproved.needs_confirmation());
+        assert!(!TrustDecision::ExplicitlySelected.needs_confirmation());
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/environment.rs
+++ b/crates/dodot-lib/src/safety_lock/environment.rs
@@ -1,0 +1,107 @@
+//! Authoritative environment-root selection (`DOTFILES_ROOT`).
+//!
+//! A present `DOTFILES_ROOT` is deliberate selection and is authoritative: an
+//! unusable value is a hard error, never a fall-through to Git or the current
+//! directory, so an explicit configuration mistake cannot quietly become a
+//! different root (ADR-0002, Spec story 9).
+//!
+//! The variable is *injected*, not read here. The capture belongs to the
+//! process boundary (WS07); this module is a pure function of its input so
+//! every explicit-value case — empty, relative, non-Unicode, missing,
+//! non-directory, unreadable — is testable without mutating a shared
+//! environment.
+//!
+//! Behaviour arrives in WS02; this Work Stream fixes the signature.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use super::error::Result;
+use super::roots::ResolvedRoot;
+use super::util::PathProbe;
+
+/// The environment inputs root selection depends on, captured once per
+/// invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvironmentRootInput {
+    /// `DOTFILES_ROOT` exactly as the process environment carried it, or
+    /// `None` when it is unset.
+    ///
+    /// An [`OsString`] rather than a `String`: a non-Unicode value is
+    /// accepted when it resolves to a readable directory, so the raw bytes
+    /// must survive capture.
+    pub raw_value: Option<OsString>,
+
+    /// The home directory used to expand a leading `~`.
+    pub home_dir: PathBuf,
+}
+
+impl EnvironmentRootInput {
+    /// An input with `DOTFILES_ROOT` unset.
+    pub fn unset(home_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            raw_value: None,
+            home_dir: home_dir.into(),
+        }
+    }
+
+    /// An input carrying a captured `DOTFILES_ROOT` value.
+    pub fn set(home_dir: impl Into<PathBuf>, raw_value: impl Into<OsString>) -> Self {
+        Self {
+            raw_value: Some(raw_value.into()),
+            home_dir: home_dir.into(),
+        }
+    }
+
+    /// Whether `DOTFILES_ROOT` was present at all — the question that decides
+    /// whether implicit selection runs, independent of whether the value is
+    /// usable.
+    pub fn is_set(&self) -> bool {
+        self.raw_value.is_some()
+    }
+}
+
+/// Resolve the environment root, if `DOTFILES_ROOT` selected one.
+///
+/// Returns:
+///
+/// - `Ok(Some(root))` — a valid value, canonicalized, with source
+///   [`RootSource::Environment`](super::roots::RootSource::Environment).
+///   Selection produces at most this one invocation-local root; it is never
+///   written to the approved-roots collection.
+/// - `Ok(None)` — `DOTFILES_ROOT` is unset, so implicit selection applies.
+/// - `Err(..)` — the value is present but unusable
+///   ([`SafetyLockError::EnvironmentRootEmpty`](super::error::SafetyLockError::EnvironmentRootEmpty)
+///   or
+///   [`EnvironmentRootUnusable`](super::error::SafetyLockError::EnvironmentRootUnusable)).
+///   The caller must fail rather than resolve another root.
+pub fn resolve_environment_root(
+    input: &EnvironmentRootInput,
+    probe: &dyn PathProbe,
+) -> Result<Option<ResolvedRoot>> {
+    let _ = (input, probe);
+    todo!("WS02: authoritative environment-root resolution")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presence_is_independent_of_usability() {
+        assert!(!EnvironmentRootInput::unset("/home/alice").is_set());
+        assert!(EnvironmentRootInput::set("/home/alice", "").is_set());
+        assert!(EnvironmentRootInput::set("/home/alice", "/srv/dots").is_set());
+    }
+
+    #[test]
+    fn a_captured_value_keeps_its_native_bytes() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let raw = OsString::from_vec(b"/tmp/\x80dots".to_vec());
+        let input = EnvironmentRootInput::set("/home/alice", raw.clone());
+
+        assert_eq!(input.raw_value.as_deref(), Some(raw.as_os_str()));
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/error.rs
+++ b/crates/dodot-lib/src/safety_lock/error.rs
@@ -48,12 +48,27 @@ pub enum SafetyLockError {
     #[error("could not determine a dotfiles root from `{}`", current_dir.display())]
     NoImplicitRoot { current_dir: PathBuf },
 
-    /// A path that must be canonical and absolute was neither.
+    /// A path that must be canonical and absolute was not absolute.
     ///
     /// Root identity is the canonical absolute path (ADR-0001); a relative
     /// spelling has no stable identity to approve or revoke.
     #[error("`{spelling}` is not an absolute path, so it cannot identify a dotfiles root")]
     RelativeRootIdentity { spelling: String },
+
+    /// An absolute path carried a `..` component, so it is an *alias* of a
+    /// root rather than the root itself.
+    ///
+    /// `..` cannot be resolved without consulting the filesystem — under a
+    /// symlink `/a/b/..` is not `/a` — so an identity is refused rather than
+    /// lexically rewritten. Two spellings of one directory would otherwise
+    /// become two identities and slip past duplicate detection and approval
+    /// lookup alike (ADR-0001). Resolve the path first: selection
+    /// canonicalizes through [`PathProbe`](super::util::PathProbe).
+    #[error(
+        "`{spelling}` contains `..`, so it names an alias rather than a \
+         dotfiles root — pass the resolved path instead"
+    )]
+    NonCanonicalRootIdentity { spelling: String },
 
     /// A stored spelling could not be read back into a native path — the
     /// tagged encoding was truncated or contained non-hex characters.

--- a/crates/dodot-lib/src/safety_lock/error.rs
+++ b/crates/dodot-lib/src/safety_lock/error.rs
@@ -1,0 +1,88 @@
+//! Errors raised by Safety Lock.
+//!
+//! The variants are deliberately narrow: each one names the coordinate the
+//! user has to act on (the offending path, the trust file, the spelling that
+//! could not be read back) because Safety Lock's diagnostics are the only
+//! thing a refused user has to work from. See `docs/spec/safety-lock.md`
+//! ("Observability").
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Every way Safety Lock can refuse to produce a root, a trust decision, or a
+/// scoped mutation set.
+///
+/// Nothing here describes *user refusal* at the confirmation prompt: declining
+/// an implicit root is a [`TrustDecision`](super::check::TrustDecision), not an
+/// error. These variants are the cases where Dodot cannot answer the question
+/// at all and must fail closed.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SafetyLockError {
+    /// `DOTFILES_ROOT` was set to an empty value. Per ADR-0002 a present
+    /// explicit value is authoritative, so this fails instead of falling
+    /// through to Git or the current directory.
+    #[error(
+        "DOTFILES_ROOT is set but empty — unset it to let dodot discover the \
+         root, or point it at your dotfiles directory"
+    )]
+    EnvironmentRootEmpty,
+
+    /// `DOTFILES_ROOT` was set to a value that is not a usable directory
+    /// (missing, not a directory, unreadable, or uncanonicalizable). Never
+    /// falls back to implicit selection.
+    #[error("DOTFILES_ROOT is set to `{spelling}` but {reason}")]
+    EnvironmentRootUnusable {
+        /// The value in the reversible spelling of
+        /// [`super::util::encode_native_path`], so a non-Unicode value is
+        /// named the same way trust state and `roots list` name it.
+        spelling: String,
+        /// What made the value unusable, phrased to complete the sentence
+        /// "DOTFILES_ROOT is set to `…` but …".
+        reason: String,
+    },
+
+    /// Implicit selection found neither a Git top-level nor a usable current
+    /// directory.
+    #[error("could not determine a dotfiles root from `{}`", current_dir.display())]
+    NoImplicitRoot { current_dir: PathBuf },
+
+    /// A path that must be canonical and absolute was neither.
+    ///
+    /// Root identity is the canonical absolute path (ADR-0001); a relative
+    /// spelling has no stable identity to approve or revoke.
+    #[error("`{spelling}` is not an absolute path, so it cannot identify a dotfiles root")]
+    RelativeRootIdentity { spelling: String },
+
+    /// A stored spelling could not be read back into a native path — the
+    /// tagged encoding was truncated or contained non-hex characters.
+    #[error("`{spelling}` is not a valid dotfiles-root spelling: {reason}")]
+    UnreadableSpelling { spelling: String, reason: String },
+
+    /// The trust file exists but cannot be used. Fails closed: an unreadable
+    /// or invalid trust file never reads as "no roots approved".
+    #[error("cannot read the trusted-roots file at {}: {reason}", path.display())]
+    TrustStateUnusable { path: PathBuf, reason: String },
+
+    /// The trust file listed the same canonical root twice, or listed an
+    /// entry that is not a usable root identity.
+    #[error("the trusted-roots file lists `{spelling}` more than once")]
+    DuplicateApprovedRoot { spelling: String },
+
+    /// An environment-selected root was passed to approval. `DOTFILES_ROOT`
+    /// *is* the deliberate selection (ADR-0003); writing it into the approved
+    /// collection would silently trust a path the user never confirmed.
+    #[error(
+        "`{spelling}` was selected by DOTFILES_ROOT, which is already deliberate \
+         selection — environment roots are never added to the approved roots"
+    )]
+    EnvironmentRootNotApprovable { spelling: String },
+}
+
+/// Result alias for Safety Lock APIs.
+///
+/// Distinct from [`crate::Result`]: Safety Lock is a self-contained boundary
+/// whose callers (the CLI gate, later Work Streams) decide how a refusal maps
+/// onto Dodot's command-level error type.
+pub type Result<T> = std::result::Result<T, SafetyLockError>;

--- a/crates/dodot-lib/src/safety_lock/files.rs
+++ b/crates/dodot-lib/src/safety_lock/files.rs
@@ -1,0 +1,89 @@
+//! Implicit file-root selection: the Git top-level, then the current
+//! directory.
+//!
+//! This is the convenient discovery path Safety Lock keeps rather than
+//! removes (Spec, "Goals") — and precisely the path whose result needs
+//! approval before it can drive a root-sensitive mutation, because filesystem
+//! shape is not user intent.
+//!
+//! Like environment selection, the inputs are injected: the current directory
+//! and the enclosing Git top-level are captured by the caller, so discovery
+//! and provenance are testable without a real repository or a process-wide
+//! working directory. The result is the same [`ResolvedRoot`] the environment
+//! path produces — only its [`RootSource`](super::roots::RootSource) differs.
+//!
+//! Behaviour arrives in WS03; this Work Stream fixes the signature.
+
+use std::path::PathBuf;
+
+use super::error::Result;
+use super::roots::ResolvedRoot;
+use super::util::PathProbe;
+
+/// The filesystem inputs implicit selection depends on, captured once per
+/// invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileRootInput {
+    /// The directory Dodot was invoked from.
+    pub current_dir: PathBuf,
+
+    /// The Git top-level enclosing `current_dir`, or `None` when it is not
+    /// inside a repository.
+    ///
+    /// Discovered by the caller, which is what keeps `git` out of this
+    /// module and lets tests state "inside a repo" as data.
+    pub git_top_level: Option<PathBuf>,
+}
+
+impl FileRootInput {
+    /// An input for a current directory outside any Git repository.
+    pub fn outside_repository(current_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            current_dir: current_dir.into(),
+            git_top_level: None,
+        }
+    }
+
+    /// An input for a current directory inside a Git repository.
+    pub fn inside_repository(
+        current_dir: impl Into<PathBuf>,
+        git_top_level: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            current_dir: current_dir.into(),
+            git_top_level: Some(git_top_level.into()),
+        }
+    }
+}
+
+/// Resolve the implicit root: the Git top-level when there is one, otherwise
+/// the current directory, canonicalized once.
+///
+/// The returned root always carries an implicit
+/// [`RootSource`](super::roots::RootSource) — `Git` or `CurrentDirectory` —
+/// so the safety gate can tell the user which mechanism selected the path it
+/// is asking them to approve (Spec, story 2).
+pub fn resolve_file_root(input: &FileRootInput, probe: &dyn PathProbe) -> Result<ResolvedRoot> {
+    let _ = (input, probe);
+    todo!("WS03: implicit file-root resolution and path identity")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repository_membership_is_stated_as_data() {
+        assert_eq!(
+            FileRootInput::outside_repository("/tmp/scratch").git_top_level,
+            None
+        );
+        assert_eq!(
+            FileRootInput::inside_repository("/srv/dots/vim", "/srv/dots"),
+            FileRootInput {
+                current_dir: PathBuf::from("/srv/dots/vim"),
+                git_top_level: Some(PathBuf::from("/srv/dots")),
+            }
+        );
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/forget.rs
+++ b/crates/dodot-lib/src/safety_lock/forget.rs
@@ -1,0 +1,100 @@
+//! Revoking an approval — the reversing half of root management
+//! (`dodot roots forget <path>`).
+//!
+//! Two matching rules, in order, so moving or deleting a root cannot strand
+//! its record (ADR-0003):
+//!
+//! 1. an argument that still exists is canonicalized first, so any alias of
+//!    the root selects the same approval;
+//! 2. an argument that does not exist is matched against the exact stored
+//!    spelling — the one `roots list` printed.
+//!
+//! Like approval, revocation returns the trust state to persist rather than
+//! writing it.
+//!
+//! Behaviour arrives in WS04; this Work Stream fixes the signature.
+
+use std::ffi::OsString;
+
+use super::error::Result;
+use super::roots::RootIdentity;
+use super::schema::SafetyLockConfig;
+use super::util::PathProbe;
+
+/// What the user asked to forget, exactly as they spelled it.
+///
+/// An [`OsString`] because the argument may be a non-Unicode path or the
+/// `os-bytes:` spelling of one; both must survive to the matching rules
+/// untouched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgetRequest {
+    pub argument: OsString,
+}
+
+impl ForgetRequest {
+    pub fn new(argument: impl Into<OsString>) -> Self {
+        Self {
+            argument: argument.into(),
+        }
+    }
+}
+
+/// The trust state as it would be after revocation, plus what was removed.
+#[derive(Debug, Clone)]
+pub struct ForgetChange {
+    /// The trust state to persist.
+    pub config: SafetyLockConfig,
+    /// The approval that was removed, or `None` when the argument matched no
+    /// approved root — a distinction the caller reports rather than treating
+    /// as failure.
+    pub removed: Option<RootIdentity>,
+}
+
+impl ForgetChange {
+    /// Whether anything was actually removed.
+    pub fn changed(&self) -> bool {
+        self.removed.is_some()
+    }
+}
+
+/// Remove the approval `request` names, if the trust state holds it.
+pub fn forget_root(
+    config: &SafetyLockConfig,
+    request: &ForgetRequest,
+    probe: &dyn PathProbe,
+) -> Result<ForgetChange> {
+    let _ = (config, request, probe);
+    todo!("WS04: trusted-root registry lifecycle")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_request_keeps_the_argument_bytes_it_was_given() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let raw = OsString::from_vec(b"/tmp/\x80dots".to_vec());
+        assert_eq!(ForgetRequest::new(raw.clone()).argument, raw);
+        assert_eq!(
+            ForgetRequest::new("os-bytes:2f746d702f80646f7473").argument,
+            OsString::from("os-bytes:2f746d702f80646f7473")
+        );
+    }
+
+    #[test]
+    fn a_change_reports_whether_it_removed_anything() {
+        let unchanged = ForgetChange {
+            config: SafetyLockConfig::default(),
+            removed: None,
+        };
+        let removed = ForgetChange {
+            config: SafetyLockConfig::default(),
+            removed: Some(RootIdentity::new("/home/alice/dotfiles").unwrap()),
+        };
+
+        assert!(!unchanged.changed());
+        assert!(removed.changed());
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/inventory.rs
+++ b/crates/dodot-lib/src/safety_lock/inventory.rs
@@ -1,0 +1,205 @@
+//! The orientation inventory shown before a user approves an implicit root.
+//!
+//! Its job is recognition, not prediction: root-wide counts per configured
+//! handler category plus at most [`MAX_INVENTORY_PATHS`] example paths across
+//! the whole prompt, prioritized so shell and code-execution entries — the
+//! ones that can change every future shell — are the ones the user actually
+//! sees. Omitted paths are counted, never silently dropped.
+//!
+//! Explicitly *not* a dry run: building this reads configuration and routing
+//! metadata only. It never renders templates, resolves secrets, or inspects
+//! candidate pack-entry contents (Spec, "Non-Goals"), which is also why a
+//! first-ever run needs no rendered baseline.
+//!
+//! Behaviour arrives in WS05; this Work Stream fixes the shape.
+
+use std::path::PathBuf;
+
+use super::error::Result;
+use super::roots::ResolvedRoot;
+
+/// The most paths the prompt may show, across all categories combined.
+///
+/// A cap, not a per-category quota: the point is that the confirmation
+/// question stays on screen (Spec, story 3).
+pub const MAX_INVENTORY_PATHS: usize = 10;
+
+/// A configured-handler category, in prompt priority order.
+///
+/// The derived [`Ord`] *is* the priority: shell and code execution first
+/// because they run or alter program state, then the categories that alter
+/// path resolution and user-visible files. Sorting entries by
+/// `(category, path)` therefore produces the prompt's order directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum InventoryCategory {
+    /// Shell startup files added to every future shell session.
+    Shell,
+    /// Install scripts, package manifests, and other provisioning inputs.
+    CodeExecution,
+    /// Directories added to `PATH`.
+    Path,
+    /// External handlers.
+    External,
+    /// Symlinked files.
+    Link,
+    /// Everything else the configured handlers recognize.
+    Other,
+}
+
+impl InventoryCategory {
+    /// The categories in the order the prompt lists them.
+    pub const PROMPT_ORDER: [InventoryCategory; 6] = [
+        InventoryCategory::Shell,
+        InventoryCategory::CodeExecution,
+        InventoryCategory::Path,
+        InventoryCategory::External,
+        InventoryCategory::Link,
+        InventoryCategory::Other,
+    ];
+
+    /// Stable, user-facing name of the category.
+    pub fn label(self) -> &'static str {
+        match self {
+            InventoryCategory::Shell => "shell",
+            InventoryCategory::CodeExecution => "code execution",
+            InventoryCategory::Path => "path",
+            InventoryCategory::External => "external",
+            InventoryCategory::Link => "link",
+            InventoryCategory::Other => "other",
+        }
+    }
+}
+
+/// One example path shown in the prompt.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InventoryEntry {
+    /// The category this file was recognized as. First sort key, so
+    /// high-impact entries survive the path cap.
+    pub category: InventoryCategory,
+    /// The file's path relative to the root being approved — the prompt names
+    /// the root once and stays readable.
+    pub relative_path: PathBuf,
+}
+
+/// How many files a category recognized, root-wide.
+///
+/// Counts are unaffected by the path cap: they stay visible even when their
+/// example paths were omitted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CategoryCount {
+    pub category: InventoryCategory,
+    pub files: usize,
+}
+
+/// The bounded orientation inventory for one root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RootInventory {
+    /// Root-wide counts per category, in [`InventoryCategory::PROMPT_ORDER`].
+    pub counts: Vec<CategoryCount>,
+    /// At most [`MAX_INVENTORY_PATHS`] example paths, category-priority first.
+    pub sample: Vec<InventoryEntry>,
+    /// How many recognized files are not in `sample`.
+    pub omitted: usize,
+}
+
+impl RootInventory {
+    /// Total recognized files across all categories.
+    pub fn total_files(&self) -> usize {
+        self.counts.iter().map(|count| count.files).sum()
+    }
+}
+
+/// Build the orientation inventory for the root about to be approved.
+pub fn build_inventory(root: &ResolvedRoot) -> Result<RootInventory> {
+    let _ = root;
+    todo!("WS05: safety decisions and orientation inventory")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The prompt's priority is encoded in the type's ordering rather than a
+    /// separate table, so a sort on `(category, path)` cannot drift from the
+    /// documented order.
+    #[test]
+    fn category_ordering_is_the_prompt_priority() {
+        let mut shuffled = vec![
+            InventoryCategory::Other,
+            InventoryCategory::Link,
+            InventoryCategory::CodeExecution,
+            InventoryCategory::External,
+            InventoryCategory::Shell,
+            InventoryCategory::Path,
+        ];
+        shuffled.sort();
+
+        assert_eq!(shuffled, InventoryCategory::PROMPT_ORDER);
+    }
+
+    #[test]
+    fn entries_sort_by_category_then_relative_path() {
+        let mut entries = [
+            InventoryEntry {
+                category: InventoryCategory::Link,
+                relative_path: PathBuf::from("vim/vimrc"),
+            },
+            InventoryEntry {
+                category: InventoryCategory::Shell,
+                relative_path: PathBuf::from("zsh/zshrc"),
+            },
+            InventoryEntry {
+                category: InventoryCategory::Shell,
+                relative_path: PathBuf::from("bash/bashrc"),
+            },
+        ];
+        entries.sort();
+
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.relative_path.to_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["bash/bashrc", "zsh/zshrc", "vim/vimrc"]
+        );
+    }
+
+    #[test]
+    fn counts_stay_whole_when_paths_are_capped() {
+        let inventory = RootInventory {
+            counts: vec![
+                CategoryCount {
+                    category: InventoryCategory::Shell,
+                    files: 12,
+                },
+                CategoryCount {
+                    category: InventoryCategory::Link,
+                    files: 30,
+                },
+            ],
+            sample: Vec::new(),
+            omitted: 42,
+        };
+
+        assert_eq!(inventory.total_files(), 42);
+        assert!(MAX_INVENTORY_PATHS < inventory.total_files());
+    }
+
+    #[test]
+    fn category_labels_are_stable() {
+        assert_eq!(
+            InventoryCategory::PROMPT_ORDER
+                .iter()
+                .map(|category| category.label())
+                .collect::<Vec<_>>(),
+            [
+                "shell",
+                "code execution",
+                "path",
+                "external",
+                "link",
+                "other"
+            ]
+        );
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/list.rs
+++ b/crates/dodot-lib/src/safety_lock/list.rs
@@ -1,0 +1,81 @@
+//! Listing approved roots — the inspection half of root management
+//! (`dodot roots list`).
+//!
+//! Every listed entry prints its reversible spelling, which is exactly what
+//! [`forget_root`](super::forget::forget_root) accepts back. That round trip
+//! is the contract: an approval a user can see is an approval they can revoke,
+//! including for a root that has since been moved or deleted (ADR-0003).
+//!
+//! Behaviour arrives in WS05; this Work Stream fixes the signature.
+
+use super::error::Result;
+use super::roots::RootIdentity;
+use super::schema::SafetyLockConfig;
+use super::util::PathProbe;
+
+/// One approved root as presented to the user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedRootEntry {
+    /// The approved canonical root.
+    pub identity: RootIdentity,
+    /// Whether that path is still a readable directory.
+    ///
+    /// Purely informational: a missing root keeps its approval — and stays
+    /// revocable by its exact spelling — until the user forgets it.
+    pub exists: bool,
+}
+
+impl TrustedRootEntry {
+    /// The spelling to print, and the one `roots forget` accepts back.
+    pub fn spelling(&self) -> String {
+        self.identity.spelling()
+    }
+}
+
+/// The full approved-roots listing.
+///
+/// Ordered as stored: the collection has no preferred root, so nothing here
+/// implies precedence between the entries (Spec, story 5).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TrustedRootListing {
+    pub entries: Vec<TrustedRootEntry>,
+}
+
+impl TrustedRootListing {
+    /// Whether no root is approved — the state a user with no trust file is
+    /// in, which the listing must render as "nothing approved" rather than as
+    /// an error.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// List the approved roots in the loaded trust state.
+pub fn list_roots(config: &SafetyLockConfig, probe: &dyn PathProbe) -> Result<TrustedRootListing> {
+    let _ = (config, probe);
+    todo!("WS05: orientation and root listing")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_entry_prints_the_spelling_forget_accepts() {
+        let entry = TrustedRootEntry {
+            identity: RootIdentity::new("/home/alice/dotfiles").unwrap(),
+            exists: false,
+        };
+
+        assert_eq!(entry.spelling(), "/home/alice/dotfiles");
+        assert_eq!(
+            RootIdentity::parse(&entry.spelling()).unwrap(),
+            entry.identity
+        );
+    }
+
+    #[test]
+    fn an_empty_listing_is_a_state_not_an_error() {
+        assert!(TrustedRootListing::default().is_empty());
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/roots.rs
+++ b/crates/dodot-lib/src/safety_lock/roots.rs
@@ -1,0 +1,337 @@
+//! The root vocabulary every Safety Lock consumer shares.
+//!
+//! Both selection paths — `DOTFILES_ROOT` and implicit Git/cwd discovery —
+//! produce one [`ResolvedRoot`]: the same canonical [`RootIdentity`] plus the
+//! [`RootSource`] that selected it. Provenance changes *authorization policy*
+//! (an environment root is deliberate; an implicit root needs approval); it
+//! never changes how the path is represented, compared, or displayed. That is
+//! why no source-specific struct exists past this module: checking, listing,
+//! inventory, and mutation scoping all take a `ResolvedRoot` or a
+//! `RootIdentity`.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::error::{Result, SafetyLockError};
+use super::util::{decode_native_path, encode_native_path};
+
+/// How the dotfiles root for this invocation was selected.
+///
+/// The two implicit variants are kept apart rather than folded into one
+/// "implicit" case because the confirmation prompt has to tell the user
+/// *which* mechanism picked the path — the Git top-level is frequently not the
+/// directory shown in their shell prompt (Spec, story 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RootSource {
+    /// A valid `DOTFILES_ROOT`. Deliberate selection: never requires
+    /// approval, and never enters the approved-roots collection.
+    Environment,
+    /// The Git top-level enclosing the current directory.
+    Git,
+    /// The current directory, when no Git top-level applied.
+    CurrentDirectory,
+}
+
+impl RootSource {
+    /// Whether this source is implicit discovery, i.e. filesystem shape
+    /// rather than an explicit act of selection.
+    ///
+    /// This is the single predicate the safety gate branches on; the
+    /// per-mechanism distinction below it is presentational.
+    pub fn is_implicit(self) -> bool {
+        matches!(self, RootSource::Git | RootSource::CurrentDirectory)
+    }
+
+    /// Stable, user-facing name of the selecting mechanism.
+    pub fn label(self) -> &'static str {
+        match self {
+            RootSource::Environment => "DOTFILES_ROOT",
+            RootSource::Git => "git top-level",
+            RootSource::CurrentDirectory => "current directory",
+        }
+    }
+}
+
+impl fmt::Display for RootSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// A dotfiles root's identity: its canonical absolute path in the operating
+/// system's native form.
+///
+/// Equality, ordering, and hashing compare the native path exactly, so two
+/// roots that merely *render* alike stay two identities (ADR-0001). The path
+/// is held privately because every construction route validates it: an
+/// identity that is relative — and therefore cannot be approved or revoked
+/// unambiguously — is not representable.
+///
+/// Serialization uses the reversible spelling of
+/// [`encode_native_path`](super::util::encode_native_path), which is what
+/// makes the trust file a valid TOML/JSON/YAML document without discarding
+/// bytes.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RootIdentity {
+    path: PathBuf,
+}
+
+impl RootIdentity {
+    /// Build an identity from an already-canonicalized absolute path.
+    ///
+    /// Canonicalization itself belongs to the selection modules — this
+    /// constructor only enforces the invariant every consumer relies on
+    /// (absolute path, native bytes preserved).
+    pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        if !path.is_absolute() {
+            return Err(SafetyLockError::RelativeRootIdentity {
+                spelling: encode_native_path(&path),
+            });
+        }
+        Ok(Self { path })
+    }
+
+    /// Read an identity back from a stored or user-supplied spelling.
+    ///
+    /// Accepts both forms [`spelling`](Self::spelling) produces, so a line
+    /// copied out of `roots list` can be passed straight back to
+    /// `roots forget`.
+    pub fn parse(spelling: &str) -> Result<Self> {
+        Self::new(decode_native_path(spelling)?)
+    }
+
+    /// The canonical native path.
+    pub fn as_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The reversible spelling: plain text for a UTF-8 path, tagged hex
+    /// otherwise. This is what trust state stores and what `roots list`
+    /// prints.
+    pub fn spelling(&self) -> String {
+        encode_native_path(&self.path)
+    }
+
+    /// Whether `candidate` is this root or lies inside it.
+    ///
+    /// Used by mutation scoping to keep an authorized root and the mutated
+    /// root the same one (ADR-0002). Both sides must already be canonical;
+    /// this is a path comparison, not a filesystem check.
+    pub fn contains(&self, candidate: &Path) -> bool {
+        candidate.starts_with(&self.path)
+    }
+}
+
+impl fmt::Display for RootIdentity {
+    /// Displays the reversible spelling — never a lossy rendering, so a
+    /// diagnostic names the root the user can act on.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.spelling())
+    }
+}
+
+impl Serialize for RootIdentity {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.spelling())
+    }
+}
+
+impl<'de> Deserialize<'de> for RootIdentity {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        struct SpellingVisitor;
+
+        impl Visitor<'_> for SpellingVisitor {
+            type Value = RootIdentity;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("an absolute dotfiles-root path, or its `os-bytes:` spelling")
+            }
+
+            fn visit_str<E: de::Error>(self, value: &str) -> std::result::Result<Self::Value, E> {
+                RootIdentity::parse(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(SpellingVisitor)
+    }
+}
+
+/// One invocation's dotfiles root: the canonical identity plus how it was
+/// selected.
+///
+/// Resolution happens once per invocation and this value is then carried
+/// through trust lookup, confirmation, and execution — nothing downstream
+/// consults the environment, Git, or the current directory again (ADR-0001).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ResolvedRoot {
+    identity: RootIdentity,
+    source: RootSource,
+}
+
+impl ResolvedRoot {
+    /// Pair a canonical identity with the source that selected it.
+    pub fn new(identity: RootIdentity, source: RootSource) -> Self {
+        Self { identity, source }
+    }
+
+    /// The canonical identity.
+    pub fn identity(&self) -> &RootIdentity {
+        &self.identity
+    }
+
+    /// The canonical native path — shorthand for `identity().as_path()`.
+    pub fn as_path(&self) -> &Path {
+        self.identity.as_path()
+    }
+
+    /// How this root was selected.
+    pub fn source(&self) -> RootSource {
+        self.source
+    }
+
+    /// Whether reaching a root-sensitive mutation through this root requires
+    /// a recorded approval.
+    ///
+    /// True exactly for implicitly discovered roots: a valid `DOTFILES_ROOT`
+    /// already expresses deliberate selection (Spec, story 8).
+    pub fn requires_approval(&self) -> bool {
+        self.source.is_implicit()
+    }
+
+    /// Consume the resolved root, keeping only its identity.
+    pub fn into_identity(self) -> RootIdentity {
+        self.identity
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    use super::*;
+
+    fn identity(path: &str) -> RootIdentity {
+        RootIdentity::new(path).unwrap()
+    }
+
+    fn non_unicode_identity(suffix: &[u8]) -> RootIdentity {
+        let mut bytes = b"/tmp/".to_vec();
+        bytes.extend_from_slice(suffix);
+        RootIdentity::new(PathBuf::from(OsString::from_vec(bytes))).unwrap()
+    }
+
+    #[test]
+    fn relative_paths_are_not_identities() {
+        let err = RootIdentity::new("dotfiles").unwrap_err();
+        assert!(
+            matches!(err, SafetyLockError::RelativeRootIdentity { .. }),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn identity_displays_its_reversible_spelling() {
+        assert_eq!(
+            identity("/home/alice/dotfiles").to_string(),
+            "/home/alice/dotfiles"
+        );
+        assert!(non_unicode_identity(b"\x80")
+            .to_string()
+            .starts_with("os-bytes:"));
+    }
+
+    #[test]
+    fn identity_parses_back_from_either_spelling() {
+        for original in [
+            identity("/home/alice/dotfiles"),
+            non_unicode_identity(b"\x80dots"),
+        ] {
+            let parsed = RootIdentity::parse(&original.spelling()).unwrap();
+            assert_eq!(parsed, original);
+        }
+    }
+
+    /// Identity is the native path, not a rendering of it: roots that render
+    /// identically must not compare, hash, or de-duplicate as one.
+    #[test]
+    fn identities_never_collapse_on_a_lossy_rendering() {
+        let one = non_unicode_identity(b"\x80");
+        let other = non_unicode_identity(b"\x81");
+
+        assert_eq!(
+            one.as_path().to_string_lossy(),
+            other.as_path().to_string_lossy(),
+            "test premise: these two roots render identically when lossy"
+        );
+        assert_ne!(one, other);
+
+        let set: HashSet<RootIdentity> = [one, other].into_iter().collect();
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn identity_containment_covers_the_root_itself_and_its_children() {
+        let root = identity("/home/alice/dotfiles");
+
+        assert!(root.contains(Path::new("/home/alice/dotfiles")));
+        assert!(root.contains(Path::new("/home/alice/dotfiles/vim/vimrc")));
+        assert!(!root.contains(Path::new("/home/alice/other/vimrc")));
+        // Prefix-of-a-component, not a real descendant.
+        assert!(!root.contains(Path::new("/home/alice/dotfiles-backup/vimrc")));
+    }
+
+    #[test]
+    fn only_implicit_sources_require_approval() {
+        let id = identity("/home/alice/dotfiles");
+
+        assert!(!ResolvedRoot::new(id.clone(), RootSource::Environment).requires_approval());
+        assert!(ResolvedRoot::new(id.clone(), RootSource::Git).requires_approval());
+        assert!(ResolvedRoot::new(id, RootSource::CurrentDirectory).requires_approval());
+    }
+
+    #[test]
+    fn source_labels_name_the_selecting_mechanism() {
+        assert_eq!(RootSource::Environment.to_string(), "DOTFILES_ROOT");
+        assert_eq!(RootSource::Git.to_string(), "git top-level");
+        assert_eq!(
+            RootSource::CurrentDirectory.to_string(),
+            "current directory"
+        );
+    }
+
+    /// Both selection paths hand downstream code the same type, so a
+    /// consumer cannot accidentally branch on a source-specific struct.
+    #[test]
+    fn both_selection_paths_produce_one_resolved_root_type() {
+        let from_env = ResolvedRoot::new(identity("/srv/dots"), RootSource::Environment);
+        let from_git = ResolvedRoot::new(identity("/srv/dots"), RootSource::Git);
+
+        assert_eq!(from_env.identity(), from_git.identity());
+        assert_eq!(from_env.as_path(), Path::new("/srv/dots"));
+        assert_ne!(from_env, from_git);
+        assert_eq!(from_git.into_identity(), identity("/srv/dots"));
+    }
+
+    #[test]
+    fn identity_serializes_as_its_spelling() {
+        let plain = serde_json::to_string(&identity("/home/alice/dotfiles")).unwrap();
+        assert_eq!(plain, "\"/home/alice/dotfiles\"");
+
+        let tagged = serde_json::to_string(&non_unicode_identity(b"\x80")).unwrap();
+        assert_eq!(tagged, "\"os-bytes:2f746d702f80\"");
+    }
+
+    #[test]
+    fn identity_deserialization_rejects_relative_and_malformed_spellings() {
+        assert!(serde_json::from_str::<RootIdentity>("\"dotfiles\"").is_err());
+        assert!(serde_json::from_str::<RootIdentity>("\"os-bytes:2f7\"").is_err());
+        assert!(serde_json::from_str::<RootIdentity>("42").is_err());
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/roots.rs
+++ b/crates/dodot-lib/src/safety_lock/roots.rs
@@ -10,7 +10,7 @@
 //! `RootIdentity`.
 
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -67,9 +67,19 @@ impl fmt::Display for RootSource {
 ///
 /// Equality, ordering, and hashing compare the native path exactly, so two
 /// roots that merely *render* alike stay two identities (ADR-0001). The path
-/// is held privately because every construction route validates it: an
-/// identity that is relative — and therefore cannot be approved or revoked
-/// unambiguously — is not representable.
+/// is held privately because every construction route enforces the identity
+/// invariant rather than trusting the caller for it: the stored path is
+/// always absolute, always free of `..`, and always spelled with single
+/// separators and no trailing one. A relative path — which cannot be approved
+/// or revoked unambiguously — and a `..` alias — which would be a *second*
+/// identity for a root already approved — are both unrepresentable.
+///
+/// What the type cannot promise is symlink resolution: that needs the
+/// filesystem. Selection canonicalizes once per invocation through
+/// [`PathProbe`](super::util::PathProbe) and builds the identity from that
+/// result (ADR-0001); the invariant here is what holds for *every* identity,
+/// including one read back from trust state long after the path it names
+/// stopped existing.
 ///
 /// Serialization uses the reversible spelling of
 /// [`encode_native_path`](super::util::encode_native_path), which is what
@@ -81,11 +91,25 @@ pub struct RootIdentity {
 }
 
 impl RootIdentity {
-    /// Build an identity from an already-canonicalized absolute path.
+    /// Build an identity from an absolute path, enforcing everything
+    /// canonicality means that can be decided without touching the
+    /// filesystem.
     ///
-    /// Canonicalization itself belongs to the selection modules — this
-    /// constructor only enforces the invariant every consumer relies on
-    /// (absolute path, native bytes preserved).
+    /// Refused: a relative path, and any path carrying a `..` component.
+    /// Accepted and made canonical in place: purely syntactic spelling
+    /// differences that name the same path unconditionally — repeated
+    /// separators, a trailing separator, an interior `.`. `/srv//dots/`,
+    /// `/srv/./dots`, and `/srv/dots` are therefore one identity, not three,
+    /// so no alias can slip past duplicate detection or approval lookup.
+    ///
+    /// `..` is refused rather than folded away because folding it is only
+    /// correct when no component is a symlink, which this constructor cannot
+    /// know. Symlink resolution belongs to selection, which canonicalizes
+    /// through [`PathProbe`](super::util::PathProbe) and passes the result
+    /// here.
+    ///
+    /// Native bytes are preserved: normalization rewrites separators only,
+    /// never a component.
     pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
         if !path.is_absolute() {
@@ -93,19 +117,35 @@ impl RootIdentity {
                 spelling: encode_native_path(&path),
             });
         }
-        Ok(Self { path })
+
+        let mut canonical = PathBuf::new();
+        for component in path.components() {
+            if component == Component::ParentDir {
+                return Err(SafetyLockError::NonCanonicalRootIdentity {
+                    spelling: encode_native_path(&path),
+                });
+            }
+            canonical.push(component.as_os_str());
+        }
+
+        Ok(Self { path: canonical })
     }
 
     /// Read an identity back from a stored or user-supplied spelling.
     ///
     /// Accepts both forms [`spelling`](Self::spelling) produces, so a line
     /// copied out of `roots list` can be passed straight back to
-    /// `roots forget`.
+    /// `roots forget`, and applies the same invariant as
+    /// [`new`](Self::new) — a stored entry that is relative or aliased fails
+    /// the read instead of becoming a second identity.
     pub fn parse(spelling: &str) -> Result<Self> {
         Self::new(decode_native_path(spelling)?)
     }
 
-    /// The canonical native path.
+    /// The canonical native path: absolute, free of `..`, singly separated.
+    ///
+    /// Canonical up to symlinks — see [`RootIdentity`] for what the type does
+    /// and does not decide without the filesystem.
     pub fn as_path(&self) -> &Path {
         &self.path
     }
@@ -120,10 +160,19 @@ impl RootIdentity {
     /// Whether `candidate` is this root or lies inside it.
     ///
     /// Used by mutation scoping to keep an authorized root and the mutated
-    /// root the same one (ADR-0002). Both sides must already be canonical;
-    /// this is a path comparison, not a filesystem check.
+    /// root the same one (ADR-0002). This is a path comparison, not a
+    /// filesystem check: the caller canonicalizes `candidate` first, and a
+    /// candidate that is not canonical is answered `false` rather than
+    /// trusted. `/srv/dots/../../etc/passwd` starts with `/srv/dots`
+    /// component-wise, so a plain prefix test would authorize a write clean
+    /// outside the root; here it lands in the out-of-root report instead,
+    /// which is the direction that fails closed.
     pub fn contains(&self, candidate: &Path) -> bool {
-        candidate.starts_with(&self.path)
+        candidate.is_absolute()
+            && !candidate
+                .components()
+                .any(|component| component == Component::ParentDir)
+            && candidate.starts_with(&self.path)
     }
 }
 
@@ -236,6 +285,65 @@ mod tests {
         );
     }
 
+    /// The alias case the authorization boundary turns on: `..` cannot be
+    /// resolved without the filesystem, so an identity carrying one is
+    /// refused instead of becoming a second record for an already-approved
+    /// root.
+    #[test]
+    fn parent_dir_aliases_are_not_identities() {
+        for alias in ["/srv/dots/../other", "/srv/dots/..", "/../srv/dots"] {
+            let err = RootIdentity::new(alias).unwrap_err();
+            assert!(
+                matches!(err, SafetyLockError::NonCanonicalRootIdentity { .. }),
+                "`{alias}` was accepted as an identity: {err:?}"
+            );
+        }
+
+        // Every construction route, not just the direct one.
+        assert!(RootIdentity::parse("/srv/dots/../other").is_err());
+        assert!(serde_json::from_str::<RootIdentity>("\"/srv/dots/../other\"").is_err());
+    }
+
+    /// A `..` alias must not be able to reach a distinct identity by any
+    /// route — a lexically resolved spelling and the real path are one
+    /// record, and duplicate detection sees them as one.
+    #[test]
+    fn aliases_cannot_produce_a_second_identity_for_one_root() {
+        let root = identity("/srv/dots/other");
+
+        for alias in ["/srv//dots/other", "/srv/dots/other/", "/srv/./dots/other"] {
+            let from_alias = RootIdentity::new(alias).unwrap();
+            assert_eq!(from_alias, root, "`{alias}` became a second identity");
+            assert_eq!(from_alias.spelling(), root.spelling());
+        }
+
+        let set: HashSet<RootIdentity> =
+            ["/srv//dots/other", "/srv/dots/other/", "/srv/dots/other"]
+                .into_iter()
+                .map(identity)
+                .collect();
+        assert_eq!(
+            set.len(),
+            1,
+            "spelling variants de-duplicated into one root"
+        );
+    }
+
+    /// Normalization rewrites separators only: a non-Unicode component keeps
+    /// its bytes, so the identity still round-trips through trust state.
+    #[test]
+    fn normalization_preserves_native_component_bytes() {
+        let original = non_unicode_identity(b"\x80dots");
+        let with_trailing_separator = {
+            let mut bytes = b"/tmp/".to_vec();
+            bytes.extend_from_slice(b"\x80dots/");
+            RootIdentity::new(PathBuf::from(OsString::from_vec(bytes))).unwrap()
+        };
+
+        assert_eq!(with_trailing_separator, original);
+        assert_eq!(original.spelling(), "os-bytes:2f746d702f80646f7473");
+    }
+
     #[test]
     fn identity_displays_its_reversible_spelling() {
         assert_eq!(
@@ -285,6 +393,22 @@ mod tests {
         assert!(!root.contains(Path::new("/home/alice/other/vimrc")));
         // Prefix-of-a-component, not a real descendant.
         assert!(!root.contains(Path::new("/home/alice/dotfiles-backup/vimrc")));
+    }
+
+    /// Containment is the mutation-scoping gate, so a candidate that walks
+    /// back out of the root must not be reported as inside it — a plain
+    /// component-prefix test says it is.
+    #[test]
+    fn containment_refuses_candidates_that_escape_through_parent_dirs() {
+        let root = identity("/home/alice/dotfiles");
+
+        assert!(
+            Path::new("/home/alice/dotfiles/../../../etc/passwd").starts_with(root.as_path()),
+            "test premise: a bare prefix test accepts this escape"
+        );
+        assert!(!root.contains(Path::new("/home/alice/dotfiles/../../../etc/passwd")));
+        assert!(!root.contains(Path::new("/home/alice/dotfiles/vim/../vimrc")));
+        assert!(!root.contains(Path::new("dotfiles/vim/vimrc")));
     }
 
     #[test]

--- a/crates/dodot-lib/src/safety_lock/schema.rs
+++ b/crates/dodot-lib/src/safety_lock/schema.rs
@@ -28,9 +28,10 @@
 //! Environment-selected roots never appear here: `DOTFILES_ROOT` *is* the
 //! deliberate selection, so it is authorized without a record (ADR-0003).
 //!
-//! This module owns the schema and the store's coordinates only. Loading and
-//! writing belong to the caller: the checking, listing, and forgetting APIs
-//! take an already-loaded [`SafetyLockConfig`] and return typed state changes.
+//! This module owns the schema, the store's coordinates, and the one
+//! validated way to load it ([`SafetyLockConfig::load_from`]). *Writing*
+//! belongs to the caller: the checking, listing, and forgetting APIs take an
+//! already-loaded [`SafetyLockConfig`] and return typed state changes.
 
 use std::path::{Path, PathBuf};
 
@@ -83,6 +84,13 @@ impl SafetyLockConfig {
     /// document at a known location, not a merged hierarchy. The environment
     /// layer is off deliberately — an env var that could inject an approved
     /// root would be a bypass around the confirmation gate.
+    ///
+    /// [`validate`](Self::validate) is attached as clapfig's post-validation
+    /// hook, so **every** route through this builder — `load`, and the config
+    /// actions — either yields a config satisfying the invariants or fails.
+    /// Validation is not a step a caller can forget: an invariant checked
+    /// only by convention is one [`is_approved`](Self::is_approved) would
+    /// eventually answer from unvalidated state.
     pub fn store_in(data_dir: &Path) -> ClapfigBuilder<Self> {
         Clapfig::builder::<Self>()
             .app_name("dodot")
@@ -93,6 +101,23 @@ impl SafetyLockConfig {
                 SearchPath::Path(data_dir.to_path_buf()),
             )
             .no_env()
+            .post_validate(|config: &Self| config.validate().map_err(|err| err.to_string()))
+    }
+
+    /// Load the trust file from `data_dir`, or the empty default when it is
+    /// absent.
+    ///
+    /// The loading API Safety Lock consumers use. Fails closed on every other
+    /// outcome — unreadable file, malformed entry, violated invariant — so a
+    /// trust file Dodot cannot fully read never resolves to a smaller, or
+    /// empty, set of approvals (ADR-0001).
+    pub fn load_from(data_dir: &Path) -> Result<Self> {
+        Self::store_in(data_dir)
+            .load()
+            .map_err(|err| SafetyLockError::TrustStateUnusable {
+                path: Self::path_in(data_dir),
+                reason: err.to_string(),
+            })
     }
 
     /// Whether `identity` is approved.
@@ -105,12 +130,17 @@ impl SafetyLockConfig {
 
     /// Check the invariants a loaded trust file must satisfy.
     ///
-    /// Only one can be violated by a syntactically valid file: the same
-    /// canonical root listed twice. (Relative or malformed entries cannot be
-    /// represented — [`RootIdentity`] rejects them while deserializing.) A
-    /// duplicate is a hard error rather than a silent de-duplication because
-    /// trust state Dodot does not fully understand must never be treated as
-    /// approval.
+    /// Runs automatically on every load — [`store_in`](Self::store_in)
+    /// attaches it as clapfig's post-validation hook — and is public for the
+    /// other direction: checking a collection Dodot has just changed, before
+    /// writing it back.
+    ///
+    /// Only one invariant can be violated by a syntactically valid file: the
+    /// same canonical root listed twice. (Relative, aliased, or malformed
+    /// entries cannot be represented — [`RootIdentity`] rejects them while
+    /// deserializing.) A duplicate is a hard error rather than a silent
+    /// de-duplication because trust state Dodot does not fully understand
+    /// must never be treated as approval.
     pub fn validate(&self) -> Result<()> {
         let approved = &self.roots.approved;
         for (index, identity) in approved.iter().enumerate() {
@@ -157,7 +187,11 @@ mod tests {
     }
 
     fn load(data_dir: &Path) -> SafetyLockConfig {
-        SafetyLockConfig::store_in(data_dir).load().unwrap()
+        SafetyLockConfig::load_from(data_dir).unwrap()
+    }
+
+    fn write_trust_file(data_dir: &Path, content: &str) {
+        std::fs::write(SafetyLockConfig::path_in(data_dir), content).unwrap();
     }
 
     #[test]
@@ -202,7 +236,7 @@ mod tests {
             },
         })
         .unwrap();
-        std::fs::write(SafetyLockConfig::path_in(data_dir.path()), &written).unwrap();
+        write_trust_file(data_dir.path(), &written);
 
         // Valid UTF-8 roots are stored plainly; only the non-Unicode one is
         // tagged. The file stays a document a user can read and edit.
@@ -229,11 +263,7 @@ mod tests {
                 approved: vec![one.clone(), other.clone()],
             },
         };
-        std::fs::write(
-            SafetyLockConfig::path_in(data_dir.path()),
-            toml::to_string(&config).unwrap(),
-        )
-        .unwrap();
+        write_trust_file(data_dir.path(), &toml::to_string(&config).unwrap());
 
         let loaded = load(data_dir.path());
         assert_eq!(loaded.roots.approved, vec![one.clone(), other.clone()]);
@@ -279,14 +309,57 @@ mod tests {
     /// a smaller — or empty — set of approvals.
     #[test]
     fn a_malformed_entry_fails_the_load_instead_of_reading_as_empty() {
-        let data_dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            SafetyLockConfig::path_in(data_dir.path()),
-            "[roots]\napproved = [\"relative/dotfiles\"]\n",
-        )
-        .unwrap();
+        for entry in ["relative/dotfiles", "/home/alice/dotfiles/../other"] {
+            let data_dir = tempfile::tempdir().unwrap();
+            write_trust_file(
+                data_dir.path(),
+                &format!("[roots]\napproved = [\"{entry}\"]\n"),
+            );
 
+            assert!(
+                SafetyLockConfig::load_from(data_dir.path()).is_err(),
+                "`{entry}` loaded as a usable approval"
+            );
+        }
+    }
+
+    /// The invariant has to hold at the *loading* seam, not only for a value
+    /// a caller remembered to check: `is_approved` answers authorization
+    /// straight off a loaded config, so an invalid file must never become
+    /// one.
+    #[test]
+    fn duplicate_roots_in_the_file_fail_the_production_load() {
+        let data_dir = tempfile::tempdir().unwrap();
+        write_trust_file(
+            data_dir.path(),
+            "[roots]\napproved = [\"/home/alice/dotfiles\", \"/home/alice/dotfiles\"]\n",
+        );
+
+        let err = SafetyLockConfig::load_from(data_dir.path()).unwrap_err();
+        assert!(
+            matches!(err, SafetyLockError::TrustStateUnusable { .. }),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string().contains("/home/alice/dotfiles"),
+            "the diagnostic must name the offending root: {err}"
+        );
+
+        // Not merely the wrapper's doing: the builder itself refuses.
         assert!(SafetyLockConfig::store_in(data_dir.path()).load().is_err());
+    }
+
+    /// Two spellings of one root are a duplicate too — identity
+    /// normalization is what makes the check see through the alias.
+    #[test]
+    fn spelling_variants_of_one_root_are_caught_as_duplicates() {
+        let data_dir = tempfile::tempdir().unwrap();
+        write_trust_file(
+            data_dir.path(),
+            "[roots]\napproved = [\"/home/alice/dotfiles\", \"/home/alice//dotfiles/\"]\n",
+        );
+
+        assert!(SafetyLockConfig::load_from(data_dir.path()).is_err());
     }
 
     /// The file is self-documenting: clapfig generates its template from the

--- a/crates/dodot-lib/src/safety_lock/schema.rs
+++ b/crates/dodot-lib/src/safety_lock/schema.rs
@@ -1,0 +1,313 @@
+//! The persisted Safety Lock trust schema.
+//!
+//! Approval state is **one** clapfig-managed file, `safety-lock.toml`, living
+//! under Dodot's data directory — never inside the dotfiles root, which holds
+//! user-authored source only (Spec, "State ownership and migration"). Its
+//! whole content is the collection of implicit roots the user approved:
+//!
+//! ```toml
+//! [roots]
+//! approved = [
+//!   "/home/alice/dotfiles",
+//!   "/home/alice/work-dotfiles",
+//!   "os-bytes:2f746d702f80646f7473",  # a non-Unicode root
+//! ]
+//! ```
+//!
+//! Three properties this shape is chosen for:
+//!
+//! - **Multiple roots, no preferred one.** `approved` is a flat collection;
+//!   nothing marks a default (Spec, story 5).
+//! - **Absent file means no approvals, never an error.** The compiled default
+//!   is an empty collection, so a first-ever run just finds nothing approved.
+//!   That is the *only* way an empty registry may arise: an unreadable or
+//!   malformed file fails closed (ADR-0001) rather than reading as empty.
+//! - **Lossless identity.** Entries are [`RootIdentity`] spellings, so a
+//!   non-Unicode root survives a write/read cycle byte for byte.
+//!
+//! Environment-selected roots never appear here: `DOTFILES_ROOT` *is* the
+//! deliberate selection, so it is authorized without a record (ADR-0003).
+//!
+//! This module owns the schema and the store's coordinates only. Loading and
+//! writing belong to the caller: the checking, listing, and forgetting APIs
+//! take an already-loaded [`SafetyLockConfig`] and return typed state changes.
+
+use std::path::{Path, PathBuf};
+
+use clapfig::{Clapfig, ClapfigBuilder, SearchPath};
+use confique::Config;
+use serde::{Deserialize, Serialize};
+
+use super::error::{Result, SafetyLockError};
+use super::roots::RootIdentity;
+
+/// File name of the trust file inside Dodot's data directory.
+pub const SAFETY_LOCK_FILE_NAME: &str = "safety-lock.toml";
+
+/// Name of the clapfig persist scope that writes [`SAFETY_LOCK_FILE_NAME`].
+pub const SAFETY_LOCK_PERSIST_SCOPE: &str = "data";
+
+/// The complete persisted Safety Lock state.
+#[derive(Config, Debug, Clone, Serialize, Deserialize)]
+pub struct SafetyLockConfig {
+    #[config(nested)]
+    pub roots: TrustedRootsSection,
+}
+
+/// The approved-roots collection.
+#[derive(Config, Debug, Clone, Serialize, Deserialize)]
+pub struct TrustedRootsSection {
+    /// Dotfiles roots this user has approved for root-sensitive mutation,
+    /// each as the canonical absolute path it was approved at.
+    ///
+    /// A path that is valid UTF-8 is written plainly; anything else is
+    /// written as `os-bytes:` followed by the hex of its native bytes, which
+    /// is exactly the spelling `dodot roots list` prints and `dodot roots
+    /// forget` accepts back.
+    ///
+    /// Approval does not expire. Entries are removed by `dodot roots forget
+    /// <path>` or by `dodot reset` clearing Dodot-owned state.
+    #[config(default = [])]
+    pub approved: Vec<RootIdentity>,
+}
+
+impl SafetyLockConfig {
+    /// The trust file's path inside `data_dir`.
+    pub fn path_in(data_dir: &Path) -> PathBuf {
+        data_dir.join(SAFETY_LOCK_FILE_NAME)
+    }
+
+    /// The clapfig builder for the trust file in `data_dir`.
+    ///
+    /// One search path and one persist scope: the trust file is a single
+    /// document at a known location, not a merged hierarchy. The environment
+    /// layer is off deliberately — an env var that could inject an approved
+    /// root would be a bypass around the confirmation gate.
+    pub fn store_in(data_dir: &Path) -> ClapfigBuilder<Self> {
+        Clapfig::builder::<Self>()
+            .app_name("dodot")
+            .file_name(SAFETY_LOCK_FILE_NAME)
+            .search_paths(vec![SearchPath::Path(data_dir.to_path_buf())])
+            .persist_scope(
+                SAFETY_LOCK_PERSIST_SCOPE,
+                SearchPath::Path(data_dir.to_path_buf()),
+            )
+            .no_env()
+    }
+
+    /// Whether `identity` is approved.
+    ///
+    /// Matching is exact on the canonical native path, so two roots whose
+    /// lossy renderings collide never satisfy each other's lookup.
+    pub fn is_approved(&self, identity: &RootIdentity) -> bool {
+        self.roots.approved.contains(identity)
+    }
+
+    /// Check the invariants a loaded trust file must satisfy.
+    ///
+    /// Only one can be violated by a syntactically valid file: the same
+    /// canonical root listed twice. (Relative or malformed entries cannot be
+    /// represented — [`RootIdentity`] rejects them while deserializing.) A
+    /// duplicate is a hard error rather than a silent de-duplication because
+    /// trust state Dodot does not fully understand must never be treated as
+    /// approval.
+    pub fn validate(&self) -> Result<()> {
+        let approved = &self.roots.approved;
+        for (index, identity) in approved.iter().enumerate() {
+            if approved[..index].contains(identity) {
+                return Err(SafetyLockError::DuplicateApprovedRoot {
+                    spelling: identity.spelling(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for SafetyLockConfig {
+    /// No approved roots — the state of a user who has never confirmed an
+    /// implicit root, and what an absent trust file resolves to.
+    fn default() -> Self {
+        Self {
+            roots: TrustedRootsSection {
+                approved: Vec::new(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    use clapfig::types::ConfigAction;
+    use clapfig::ConfigResult;
+
+    use super::*;
+
+    fn identity(path: &str) -> RootIdentity {
+        RootIdentity::new(path).unwrap()
+    }
+
+    fn non_unicode_identity(suffix: &[u8]) -> RootIdentity {
+        let mut bytes = b"/tmp/".to_vec();
+        bytes.extend_from_slice(suffix);
+        RootIdentity::new(PathBuf::from(OsString::from_vec(bytes))).unwrap()
+    }
+
+    fn load(data_dir: &Path) -> SafetyLockConfig {
+        SafetyLockConfig::store_in(data_dir).load().unwrap()
+    }
+
+    #[test]
+    fn the_trust_file_is_one_document_under_the_data_dir() {
+        assert_eq!(
+            SafetyLockConfig::path_in(Path::new("/u/.local/share/dodot")),
+            PathBuf::from("/u/.local/share/dodot/safety-lock.toml")
+        );
+    }
+
+    #[test]
+    fn absent_file_loads_an_empty_collection() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let config = load(data_dir.path());
+
+        assert!(config.roots.approved.is_empty());
+        assert!(!SafetyLockConfig::path_in(data_dir.path()).exists());
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn the_default_matches_what_an_absent_file_loads() {
+        let data_dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            load(data_dir.path()).roots.approved,
+            SafetyLockConfig::default().roots.approved
+        );
+    }
+
+    #[test]
+    fn multiple_roots_round_trip_through_the_file() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let approved = vec![
+            identity("/home/alice/dotfiles"),
+            identity("/home/alice/work-dotfiles"),
+            non_unicode_identity(b"\x80dots"),
+        ];
+
+        let written = toml::to_string(&SafetyLockConfig {
+            roots: TrustedRootsSection {
+                approved: approved.clone(),
+            },
+        })
+        .unwrap();
+        std::fs::write(SafetyLockConfig::path_in(data_dir.path()), &written).unwrap();
+
+        // Valid UTF-8 roots are stored plainly; only the non-Unicode one is
+        // tagged. The file stays a document a user can read and edit.
+        assert!(written.contains("\"/home/alice/dotfiles\""));
+        assert!(written.contains("\"os-bytes:2f746d702f80646f7473\""));
+
+        let loaded = load(data_dir.path());
+        assert_eq!(loaded.roots.approved, approved);
+        assert!(loaded.validate().is_ok());
+    }
+
+    /// The reason the byte-exact identity matters at the storage layer: a
+    /// deleted non-Unicode root must remain revocable by passing back what
+    /// `roots list` printed, which requires the stored spelling to survive
+    /// the write/read cycle unchanged.
+    #[test]
+    fn lossy_colliding_roots_persist_as_two_records() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let one = non_unicode_identity(b"\x80");
+        let other = non_unicode_identity(b"\x81");
+
+        let config = SafetyLockConfig {
+            roots: TrustedRootsSection {
+                approved: vec![one.clone(), other.clone()],
+            },
+        };
+        std::fs::write(
+            SafetyLockConfig::path_in(data_dir.path()),
+            toml::to_string(&config).unwrap(),
+        )
+        .unwrap();
+
+        let loaded = load(data_dir.path());
+        assert_eq!(loaded.roots.approved, vec![one.clone(), other.clone()]);
+        assert!(loaded.is_approved(&one));
+        assert!(loaded.is_approved(&other));
+        assert!(loaded.validate().is_ok());
+    }
+
+    #[test]
+    fn approval_lookup_is_exact() {
+        let config = SafetyLockConfig {
+            roots: TrustedRootsSection {
+                approved: vec![identity("/home/alice/dotfiles")],
+            },
+        };
+
+        assert!(config.is_approved(&identity("/home/alice/dotfiles")));
+        assert!(!config.is_approved(&identity("/home/alice/dotfiles/vim")));
+        assert!(!config.is_approved(&identity("/home/alice/other")));
+        assert!(!SafetyLockConfig::default().is_approved(&identity("/home/alice/dotfiles")));
+    }
+
+    #[test]
+    fn a_root_listed_twice_is_rejected() {
+        let config = SafetyLockConfig {
+            roots: TrustedRootsSection {
+                approved: vec![
+                    identity("/home/alice/dotfiles"),
+                    identity("/home/alice/dotfiles"),
+                ],
+            },
+        };
+
+        let err = config.validate().unwrap_err();
+        assert!(
+            matches!(err, SafetyLockError::DuplicateApprovedRoot { ref spelling } if spelling == "/home/alice/dotfiles"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// An entry that is not a usable identity fails the load rather than
+    /// being skipped: a trust file Dodot cannot fully read never resolves to
+    /// a smaller — or empty — set of approvals.
+    #[test]
+    fn a_malformed_entry_fails_the_load_instead_of_reading_as_empty() {
+        let data_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            SafetyLockConfig::path_in(data_dir.path()),
+            "[roots]\napproved = [\"relative/dotfiles\"]\n",
+        )
+        .unwrap();
+
+        assert!(SafetyLockConfig::store_in(data_dir.path()).load().is_err());
+    }
+
+    /// The file is self-documenting: clapfig generates its template from the
+    /// schema's doc comments, so the one documented file stays in step with
+    /// the struct.
+    #[test]
+    fn the_generated_template_documents_the_approved_collection() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let ConfigResult::Template(template) = SafetyLockConfig::store_in(data_dir.path())
+            .handle(&ConfigAction::Gen { output: None })
+            .unwrap()
+        else {
+            panic!("expected a generated template");
+        };
+
+        assert!(template.contains("[roots]"), "template:\n{template}");
+        assert!(template.contains("approved"), "template:\n{template}");
+        assert!(
+            template.contains("dodot roots forget"),
+            "the doc comment explaining how approvals are removed did not \
+             reach the template:\n{template}"
+        );
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/scope.rs
+++ b/crates/dodot-lib/src/safety_lock/scope.rs
@@ -1,0 +1,101 @@
+//! Scoping a cache-derived mutation set to the authorized root.
+//!
+//! `refresh` and `transform check` take their write targets from the shared
+//! preprocessor baseline cache, whose stored `source_path` may name a file
+//! under a *different* root. Per-root cache namespaces are out of scope, so
+//! the gate's "the target is the selected root" invariant is met by scoping
+//! the mutation set instead: only baselines whose canonical source path lies
+//! inside the authorized root are written, and every other baseline is
+//! reported as out-of-root (ADR-0002).
+//!
+//! Trusting one root therefore cannot authorize a write into another root's
+//! user-authored source.
+//!
+//! Behaviour arrives in WS06; this Work Stream fixes the shape.
+
+use std::path::PathBuf;
+
+use super::error::Result;
+use super::roots::RootIdentity;
+use super::util::PathProbe;
+
+/// Why a candidate was excluded from the mutation set.
+///
+/// Every variant is reported, never written: a source path Dodot cannot place
+/// inside the authorized root is not authorized by it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutOfRootReason {
+    /// The canonical source path lies outside the authorized root.
+    OutsideRoot,
+    /// The source path no longer exists.
+    Missing,
+    /// The source path exists but could not be canonicalized, so it cannot be
+    /// placed relative to the root.
+    Uncanonicalizable,
+}
+
+/// A candidate excluded from the mutation set, with the reason to report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutOfRootTarget {
+    /// The candidate's source path as the cache stored it.
+    pub source_path: PathBuf,
+    pub reason: OutOfRootReason,
+}
+
+/// The mutation set split against the authorized root.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MutationScope {
+    /// Canonical source paths inside the authorized root — the only ones that
+    /// may be written.
+    pub in_root: Vec<PathBuf>,
+    /// Everything else, with its reason.
+    pub out_of_root: Vec<OutOfRootTarget>,
+}
+
+impl MutationScope {
+    /// Whether any candidate was excluded, i.e. whether the command has an
+    /// out-of-root report to make.
+    pub fn has_out_of_root(&self) -> bool {
+        !self.out_of_root.is_empty()
+    }
+}
+
+/// Split `candidates` into the paths `root` authorizes and the ones it does
+/// not.
+pub fn scope_to_root(
+    root: &RootIdentity,
+    candidates: &[PathBuf],
+    probe: &dyn PathProbe,
+) -> Result<MutationScope> {
+    let _ = (root, candidates, probe);
+    todo!("WS06: scope shared-cache mutations to one root")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_empty_scope_authorizes_and_reports_nothing() {
+        let scope = MutationScope::default();
+
+        assert!(scope.in_root.is_empty());
+        assert!(!scope.has_out_of_root());
+    }
+
+    #[test]
+    fn excluded_candidates_are_reported_not_written() {
+        let scope = MutationScope {
+            in_root: vec![PathBuf::from("/srv/dots/vim/vimrc")],
+            out_of_root: vec![OutOfRootTarget {
+                source_path: PathBuf::from("/other/dots/vim/vimrc"),
+                reason: OutOfRootReason::OutsideRoot,
+            }],
+        };
+
+        assert!(scope.has_out_of_root());
+        assert!(!scope
+            .in_root
+            .contains(&PathBuf::from("/other/dots/vim/vimrc")));
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/util.rs
+++ b/crates/dodot-lib/src/safety_lock/util.rs
@@ -1,0 +1,230 @@
+//! Shared Safety Lock utilities: the reversible spelling of a native path,
+//! and the filesystem probe the selection paths are injected with.
+//!
+//! ## Reversible spelling
+//!
+//! A root's identity is its canonical path in the operating system's own
+//! form, stored losslessly (ADR-0001). Trust state, `roots list`, prompts,
+//! and diagnostics all name a root through [`encode_native_path`], so the
+//! identity a user approves is exactly the one they can inspect and revoke:
+//!
+//! - a path that is valid UTF-8 is spelled plainly, byte for byte;
+//! - anything else is spelled as [`NATIVE_BYTES_TAG`] followed by the
+//!   lowercase hex of its native bytes.
+//!
+//! A lossy rendering (`Path::display`, `to_string_lossy`) is never the stored
+//! identity nor a match key: two roots whose lossy renderings collide keep
+//! two distinct spellings and stay two records.
+//!
+//! The tag is only ambiguous for a plain path that itself begins with
+//! `os-bytes:`. [`encode_native_path`] resolves that by hex-encoding such a
+//! path too, so decoding a spelling always reproduces the exact input bytes —
+//! no escape grammar, no unrepresentable path.
+
+use std::ffi::OsString;
+use std::fmt::Write as _;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::path::{Path, PathBuf};
+
+use super::error::{Result, SafetyLockError};
+
+/// Prefix marking a spelling that carries hex-encoded native path bytes
+/// rather than the path's plain text.
+pub const NATIVE_BYTES_TAG: &str = "os-bytes:";
+
+/// Spell `path` reversibly: plainly when it is valid UTF-8, tagged hex
+/// otherwise.
+///
+/// [`decode_native_path`] reverses this exactly for every input.
+pub fn encode_native_path(path: &Path) -> String {
+    match path.to_str() {
+        Some(text) if !text.starts_with(NATIVE_BYTES_TAG) => text.to_owned(),
+        _ => {
+            let bytes = path.as_os_str().as_bytes();
+            let mut spelling = String::with_capacity(NATIVE_BYTES_TAG.len() + bytes.len() * 2);
+            spelling.push_str(NATIVE_BYTES_TAG);
+            for byte in bytes {
+                // Writing into a String is infallible.
+                let _ = write!(spelling, "{byte:02x}");
+            }
+            spelling
+        }
+    }
+}
+
+/// Read a spelling produced by [`encode_native_path`] back into the native
+/// path it names.
+///
+/// Untagged input is taken verbatim, so a path the user typed at the command
+/// line round-trips through this function unchanged.
+pub fn decode_native_path(spelling: &str) -> Result<PathBuf> {
+    let Some(hex) = spelling.strip_prefix(NATIVE_BYTES_TAG) else {
+        return Ok(PathBuf::from(spelling));
+    };
+
+    if !hex.len().is_multiple_of(2) {
+        return Err(SafetyLockError::UnreadableSpelling {
+            spelling: spelling.to_owned(),
+            reason: format!(
+                "the tagged encoding has an odd number of hex digits ({})",
+                hex.len()
+            ),
+        });
+    }
+
+    let mut bytes = Vec::with_capacity(hex.len() / 2);
+    for pair in hex.as_bytes().chunks(2) {
+        let digits =
+            std::str::from_utf8(pair).map_err(|_| SafetyLockError::UnreadableSpelling {
+                spelling: spelling.to_owned(),
+                reason: "the tagged encoding contains non-ASCII characters".to_owned(),
+            })?;
+        let byte =
+            u8::from_str_radix(digits, 16).map_err(|_| SafetyLockError::UnreadableSpelling {
+                spelling: spelling.to_owned(),
+                reason: format!("`{digits}` is not a pair of hex digits"),
+            })?;
+        bytes.push(byte);
+    }
+
+    Ok(PathBuf::from(OsString::from_vec(bytes)))
+}
+
+/// The filesystem questions root selection asks, injected so the selection
+/// and trust logic stay testable without a real repository.
+///
+/// Only two questions matter, and both come from the Spec's explicit-value
+/// rules: a candidate must resolve to a readable directory, and it is then
+/// canonicalized once per invocation.
+pub trait PathProbe: Send + Sync {
+    /// Resolve `path` to its canonical absolute form, following symlinks.
+    fn canonicalize(&self, path: &Path) -> std::io::Result<PathBuf>;
+
+    /// Whether `path` is a directory whose entries can be listed.
+    ///
+    /// A directory that exists but cannot be read is not a usable root: the
+    /// pipeline would fail partway through pack discovery instead of at
+    /// selection time.
+    fn is_readable_dir(&self, path: &Path) -> bool;
+}
+
+/// [`PathProbe`] backed by the real filesystem.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OsPathProbe;
+
+impl PathProbe for OsPathProbe {
+    fn canonicalize(&self, path: &Path) -> std::io::Result<PathBuf> {
+        std::fs::canonicalize(path)
+    }
+
+    fn is_readable_dir(&self, path: &Path) -> bool {
+        path.is_dir() && std::fs::read_dir(path).is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A non-Unicode path, built from bytes std will never hand back as
+    /// UTF-8. `0x80` is a continuation byte with no lead byte.
+    fn non_unicode_path(suffix: &[u8]) -> PathBuf {
+        let mut bytes = b"/tmp/".to_vec();
+        bytes.extend_from_slice(suffix);
+        PathBuf::from(OsString::from_vec(bytes))
+    }
+
+    #[test]
+    fn utf8_paths_spell_plainly() {
+        assert_eq!(
+            encode_native_path(Path::new("/home/alice/dotfiles")),
+            "/home/alice/dotfiles"
+        );
+    }
+
+    #[test]
+    fn utf8_paths_round_trip() {
+        let path = Path::new("/home/alice/dot files/über");
+        let spelling = encode_native_path(path);
+        assert_eq!(decode_native_path(&spelling).unwrap(), path);
+    }
+
+    #[test]
+    fn non_unicode_paths_spell_tagged_and_round_trip() {
+        let path = non_unicode_path(b"\x80dots");
+        let spelling = encode_native_path(&path);
+
+        assert!(
+            spelling.starts_with(NATIVE_BYTES_TAG),
+            "non-Unicode path spelled plainly: {spelling}"
+        );
+        assert_eq!(spelling, "os-bytes:2f746d702f80646f7473");
+        assert_eq!(decode_native_path(&spelling).unwrap(), path);
+    }
+
+    /// The reason the identity is bytes and not a lossy rendering: two
+    /// distinct roots can share one `to_string_lossy` rendering. Their
+    /// spellings must stay distinct or the two roots collapse into one
+    /// trust record.
+    #[test]
+    fn lossy_collisions_keep_distinct_spellings() {
+        let one = non_unicode_path(b"\x80");
+        let other = non_unicode_path(b"\x81");
+
+        assert_eq!(
+            one.to_string_lossy(),
+            other.to_string_lossy(),
+            "test premise: these two paths render identically when lossy"
+        );
+        assert_ne!(encode_native_path(&one), encode_native_path(&other));
+        assert_eq!(decode_native_path(&encode_native_path(&one)).unwrap(), one);
+        assert_eq!(
+            decode_native_path(&encode_native_path(&other)).unwrap(),
+            other
+        );
+    }
+
+    /// A plain path that begins with the tag would otherwise decode as
+    /// tagged hex. Encoding hex-encodes it instead, so reversibility holds
+    /// for every input rather than for realistic inputs only.
+    #[test]
+    fn plain_text_starting_with_the_tag_is_encoded_not_confused() {
+        let path = PathBuf::from(format!("{NATIVE_BYTES_TAG}deadbeef"));
+        let spelling = encode_native_path(&path);
+
+        assert_ne!(spelling, path.to_str().unwrap());
+        assert_eq!(decode_native_path(&spelling).unwrap(), path);
+    }
+
+    #[test]
+    fn truncated_tagged_spelling_is_rejected() {
+        let err = decode_native_path("os-bytes:2f7").unwrap_err();
+        assert!(
+            matches!(err, SafetyLockError::UnreadableSpelling { .. }),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn non_hex_tagged_spelling_is_rejected() {
+        let err = decode_native_path("os-bytes:zz").unwrap_err();
+        assert!(
+            matches!(err, SafetyLockError::UnreadableSpelling { .. }),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn os_probe_canonicalizes_and_reports_readable_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let probe = OsPathProbe;
+
+        let canonical = probe.canonicalize(dir.path()).unwrap();
+        assert!(probe.is_readable_dir(&canonical));
+
+        let file = canonical.join("not-a-dir");
+        std::fs::write(&file, b"").unwrap();
+        assert!(!probe.is_readable_dir(&file));
+        assert!(!probe.is_readable_dir(&canonical.join("missing")));
+    }
+}


### PR DESCRIPTION
Establishes the CLI-free Safety Lock facade, data model, and clapfig-backed persisted
trust schema. Behavioral entry points are documented signatures with `todo!()` bodies;
later Work Streams fill them in.

for #306 (epic #305)

## What landed

- `safety_lock.rs` + `safety_lock/` with the modules the ticket names: `roots`,
  `environment`, `files`, `check`, `list`, `forget`, `inventory`, `scope`, `util`, plus
  `schema` and `error`. The facade re-exports the whole vocabulary.
- `RootIdentity` / `RootSource` / `ResolvedRoot`: both selection paths return the *same*
  `ResolvedRoot`, so no source-specific struct reaches checking, inventory, or scoping.
  Identity is the canonical native path held privately (relative paths are not
  representable); equality, ordering, and hashing compare bytes.
- Reversible spelling in `util`: valid UTF-8 serializes plainly, anything else as
  `os-bytes:<hex>`. A lossy rendering is never the identity nor a match key.
- `schema`: one clapfig-managed `safety-lock.toml` under the data dir
  (`Pather::safety_lock_path`), `[roots] approved` defaulting to an empty collection,
  `validate()` for duplicates, and `Default` matching what an absent file loads.
- 42 focused tests + 1 `paths` test. `pixi run test`: 1586 passed. `pixi run lint`: green.

## Context

**Why this shape.**

- *Identity is bytes, not a rendering.* `RootIdentity` holds `PathBuf` privately and
  every construction route validates absoluteness, so an un-approvable identity cannot
  exist. Tests pin the case the Spec cares about: two roots whose `to_string_lossy`
  renderings collide stay two records through serialize → write → load → lookup.
- *Encoding needs no escape grammar.* A plain path that itself begins with `os-bytes:`
  is hex-encoded too, so `decode(encode(p)) == p` holds for **every** input rather than
  for realistic inputs only. That avoids a second, subtler spelling rule later.
- *Failing closed is a type-level property.* `RootIdentity`'s `Deserialize` rejects
  relative and malformed spellings, so a partly-unreadable trust file fails the load
  instead of resolving to a smaller — or empty — set of approvals. An empty collection
  can only come from an absent file.
- *Injected inputs, not ambient state.* `EnvironmentRootInput`, `FileRootInput`, and the
  `PathProbe` trait keep the env var, cwd, Git, and the filesystem at the process
  boundary (WS07), so WS02/WS03 can test every explicit-value case as data.
- *`clapfig` in `schema` is deliberate, and is not a CLI type.* The ticket and Spec
  require a clapfig-managed file; `SafetyLockConfig::store_in` returns a
  `ClapfigBuilder` and performs no I/O. No `clap`, no Standout type appears anywhere in
  the module. The check/list/forget APIs take a loaded `SafetyLockConfig` and return
  typed changes (`ApprovalChange`, `ForgetChange`) for the caller to persist.
- *Trust state lives under `data_dir`.* Added `Pather::safety_lock_path` rather than
  letting WS04 invent a second answer; a test asserts it is not under the dotfiles root.

**Out of scope / please don't "fix".**

- Every `todo!()` body is intentional and names its Work Stream (WS02–WS06). No test
  invokes unfinished behavior.
- `build_inventory` takes only a `ResolvedRoot`: what classification needs (config,
  routing metadata) is WS05's call, not a guess to freeze here. Likewise the *shaping*
  of the inventory (sorting, the 10-path cap, omitted counts) is left to WS05 — this WS
  only fixes the priority ordering in the type and the `MAX_INVENTORY_PATHS` constant.
- `SafetyLockError` is deliberately not wired into `DodotError`. Nothing calls Safety
  Lock yet; the mapping belongs with the CLI seam in WS07.
- Unix-only path handling (`std::os::unix::ffi`) matches the crate, which already uses
  `std::os::unix` unconditionally in `fs/os.rs`.

**Self-check against the governing docs.** Diff checked against `docs/spec/safety-lock.md`
and ADRs 0001–0003: canonical-path identity + lossless native storage + reversible
display (0001); root-derived mutation scoping shape with in-root/out-of-root reporting
(0002); `roots list` / `roots forget` surfaces with no standalone trust verb, and
environment roots never entering the approved collection (0003).

**Brief gap (flagged).** This Run was spawned with a prompt, not a filled implementer
BRIEF TEMPLATE: no verify-command list, no governing-doc list, no decision boundaries
were supplied. I derived them from issue #306 and epic #305 (Spec + the three ADRs named
there) and used `pixi run test` / `pixi run lint` as the gates. Worth fixing upstream for
WS02+ rather than each implementer re-deriving it.