### PR TITLE
ACC01-WS02: Epic: Safety Lock - Workstream: Authoritative environment-root resolution

### DIFF
--- a/crates/dodot-lib/src/safety_lock.rs
+++ b/crates/dodot-lib/src/safety_lock.rs
@@ -50,11 +50,16 @@
 //!
 //! # Work Stream status
 //!
-//! ACC01-WS01 establishes this vocabulary and the persisted schema. The
-//! selection, trust-lifecycle, decision, inventory, and scoping entry points
+//! ACC01-WS01 establishes this vocabulary and the persisted schema; ACC01-WS02
+//! fills in [`environment`], the authoritative `DOTFILES_ROOT` path. The
+//! remaining trust-lifecycle, decision, inventory, and scoping entry points
 //! carry documented signatures with `todo!()` bodies; each names the Work
-//! Stream that fills it in. The data model and the schema are complete and
-//! tested.
+//! Stream that fills it in. The data model, the schema, and environment
+//! selection are complete and tested.
+//!
+//! Nothing in this module is wired into a command yet: the process boundary
+//! that captures the environment, the current directory, and Git — and the
+//! gate that consults all of this — arrives with WS07.
 
 pub mod check;
 pub mod environment;

--- a/crates/dodot-lib/src/safety_lock/environment.rs
+++ b/crates/dodot-lib/src/safety_lock/environment.rs
@@ -5,20 +5,30 @@
 //! directory, so an explicit configuration mistake cannot quietly become a
 //! different root (ADR-0002, Spec story 9).
 //!
+//! That guarantee is carried by the return type rather than by caller
+//! discipline: implicit discovery is what a caller does with `Ok(None)`, and
+//! no failing value can produce `Ok(None)`. Every present value is either a
+//! root or an error.
+//!
 //! The variable is *injected*, not read here. The capture belongs to the
 //! process boundary (WS07); this module is a pure function of its input so
 //! every explicit-value case — empty, relative, non-Unicode, missing,
 //! non-directory, unreadable — is testable without mutating a shared
-//! environment.
+//! environment. The invocation directory is injected for the same reason: a
+//! relative value is anchored to *that* directory, never to whatever
+//! directory the process happens to be in when the probe runs.
 //!
-//! Behaviour arrives in WS02; this Work Stream fixes the signature.
+//! Nothing here writes trust state. An environment root is invocation-local:
+//! it authorizes this invocation because the user spelled it out, and is
+//! never added to the approved-roots collection (ADR-0003).
 
-use std::ffi::OsString;
-use std::path::PathBuf;
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
 
-use super::error::Result;
-use super::roots::ResolvedRoot;
-use super::util::PathProbe;
+use super::error::{Result, SafetyLockError};
+use super::roots::{ResolvedRoot, RootIdentity, RootSource};
+use super::util::{encode_native_path, PathProbe};
 
 /// The environment inputs root selection depends on, captured once per
 /// invocation.
@@ -32,23 +42,39 @@ pub struct EnvironmentRootInput {
     /// must survive capture.
     pub raw_value: Option<OsString>,
 
+    /// The directory Dodot was invoked from, which a relative value is
+    /// resolved against.
+    ///
+    /// Expected to be absolute — the caller captures it from the process. A
+    /// relative value anchored to a relative invocation directory is refused
+    /// rather than handed to the probe, because resolving it would silently
+    /// depend on the process working directory this module deliberately does
+    /// not read.
+    pub current_dir: PathBuf,
+
     /// The home directory used to expand a leading `~`.
     pub home_dir: PathBuf,
 }
 
 impl EnvironmentRootInput {
     /// An input with `DOTFILES_ROOT` unset.
-    pub fn unset(home_dir: impl Into<PathBuf>) -> Self {
+    pub fn unset(current_dir: impl Into<PathBuf>, home_dir: impl Into<PathBuf>) -> Self {
         Self {
             raw_value: None,
+            current_dir: current_dir.into(),
             home_dir: home_dir.into(),
         }
     }
 
     /// An input carrying a captured `DOTFILES_ROOT` value.
-    pub fn set(home_dir: impl Into<PathBuf>, raw_value: impl Into<OsString>) -> Self {
+    pub fn set(
+        current_dir: impl Into<PathBuf>,
+        home_dir: impl Into<PathBuf>,
+        raw_value: impl Into<OsString>,
+    ) -> Self {
         Self {
             raw_value: Some(raw_value.into()),
+            current_dir: current_dir.into(),
             home_dir: home_dir.into(),
         }
     }
@@ -62,6 +88,12 @@ impl EnvironmentRootInput {
 }
 
 /// Resolve the environment root, if `DOTFILES_ROOT` selected one.
+///
+/// A present value is expanded (a leading `~` against the injected home
+/// directory, a relative path against the injected invocation directory),
+/// validated as a readable directory, and canonicalized once. The native form
+/// is preserved throughout, so a non-Unicode value keeps its bytes into the
+/// resulting [`RootIdentity`] and into any diagnostic naming it.
 ///
 /// Returns:
 ///
@@ -79,29 +111,541 @@ pub fn resolve_environment_root(
     input: &EnvironmentRootInput,
     probe: &dyn PathProbe,
 ) -> Result<Option<ResolvedRoot>> {
-    let _ = (input, probe);
-    todo!("WS02: authoritative environment-root resolution")
+    let Some(raw_value) = input.raw_value.as_deref() else {
+        return Ok(None);
+    };
+
+    if raw_value.is_empty() {
+        return Err(SafetyLockError::EnvironmentRootEmpty);
+    }
+
+    let expanded = expand_leading_tilde(raw_value, &input.home_dir);
+    let candidate = if expanded.is_absolute() {
+        expanded
+    } else {
+        input.current_dir.join(expanded)
+    };
+
+    // Naming the value the user set, plus the path it expanded to when the
+    // two differ: `~/dots` and `dots` are only actionable once the reader
+    // knows which directory they landed in.
+    let unusable = |reason: String| SafetyLockError::EnvironmentRootUnusable {
+        spelling: encode_native_path(Path::new(raw_value)),
+        reason,
+    };
+    let named = if candidate.as_os_str() == raw_value {
+        "it".to_owned()
+    } else {
+        format!("`{}`", encode_native_path(&candidate))
+    };
+
+    if !candidate.is_absolute() {
+        return Err(unusable(format!(
+            "{named} is relative and the invocation directory `{}` is not \
+             absolute, so it cannot be anchored",
+            encode_native_path(&input.current_dir)
+        )));
+    }
+
+    let canonical = probe.canonicalize(&candidate).map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            unusable(format!("{named} does not exist"))
+        } else {
+            unusable(format!("{named} could not be resolved: {err}"))
+        }
+    })?;
+
+    if !probe.is_directory(&canonical) {
+        return Err(unusable(format!("{named} is not a directory")));
+    }
+
+    if !probe.is_readable_dir(&canonical) {
+        return Err(unusable(format!(
+            "{named} is a directory whose contents cannot be listed"
+        )));
+    }
+
+    // Defensive: a canonical path from the filesystem is absolute and free of
+    // `..`, so this only fires for a probe that says otherwise. It stays an
+    // environment diagnostic rather than a bare identity error so the message
+    // still names `DOTFILES_ROOT`.
+    let identity = RootIdentity::new(canonical)
+        .map_err(|err| unusable(format!("{named} did not resolve to a usable root: {err}")))?;
+
+    Ok(Some(ResolvedRoot::new(identity, RootSource::Environment)))
+}
+
+/// Expand a leading `~` against `home_dir`, byte-wise so a non-Unicode value
+/// survives.
+///
+/// Only a bare `~` and a `~/`-prefixed path expand; `~user` is left alone,
+/// matching the rest of Dodot's tilde handling (`crate::paths`).
+fn expand_leading_tilde(raw_value: &OsStr, home_dir: &Path) -> PathBuf {
+    let bytes = raw_value.as_bytes();
+
+    if bytes == b"~" {
+        return home_dir.to_path_buf();
+    }
+
+    let Some(rest) = bytes.strip_prefix(b"~/") else {
+        return PathBuf::from(raw_value);
+    };
+
+    // `~//dots` must stay under home: joining a `/`-prefixed remainder would
+    // discard the home directory entirely.
+    let rest = match rest.iter().position(|byte| *byte != b'/') {
+        Some(start) => &rest[start..],
+        None => return home_dir.to_path_buf(),
+    };
+
+    home_dir.join(Path::new(OsStr::from_bytes(rest)))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+    use std::io;
+    use std::os::unix::ffi::OsStringExt;
+    use std::sync::Mutex;
+
     use super::*;
+
+    const CWD: &str = "/home/alice/work";
+    const HOME: &str = "/home/alice";
+
+    /// What a path is, as far as the probe is concerned.
+    #[derive(Debug, Clone)]
+    enum Entry {
+        ReadableDir,
+        UnreadableDir,
+        NotADirectory,
+        Unresolvable(io::ErrorKind),
+    }
+
+    /// A filesystem stated as data: what each path canonicalizes to, and what
+    /// it is once canonical. Anything unregistered is missing.
+    #[derive(Debug, Default)]
+    struct FakeProbe {
+        links: Vec<(PathBuf, PathBuf)>,
+        entries: Vec<(PathBuf, Entry)>,
+        canonicalized: Mutex<Vec<PathBuf>>,
+    }
+
+    impl FakeProbe {
+        fn with(path: &str, entry: Entry) -> Self {
+            let probe = Self::default();
+            probe.add(PathBuf::from(path), entry)
+        }
+
+        fn dir(path: &str) -> Self {
+            Self::with(path, Entry::ReadableDir)
+        }
+
+        fn add(mut self, path: PathBuf, entry: Entry) -> Self {
+            self.entries.push((path, entry));
+            self
+        }
+
+        /// `path` canonicalizes to `target`, which is a readable directory.
+        fn link(mut self, path: &str, target: &str) -> Self {
+            self.links
+                .push((PathBuf::from(path), PathBuf::from(target)));
+            self.add(PathBuf::from(target), Entry::ReadableDir)
+        }
+
+        fn entry(&self, path: &Path) -> Option<&Entry> {
+            self.entries
+                .iter()
+                .find(|(known, _)| known == path)
+                .map(|(_, entry)| entry)
+        }
+
+        /// Every path `canonicalize` was asked about — the proof that a
+        /// relative value was anchored to the injected directory.
+        fn canonicalized(&self) -> Vec<PathBuf> {
+            self.canonicalized.lock().unwrap().clone()
+        }
+    }
+
+    impl PathProbe for FakeProbe {
+        fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+            self.canonicalized.lock().unwrap().push(path.to_path_buf());
+
+            if let Some((_, target)) = self.links.iter().find(|(known, _)| known == path) {
+                return Ok(target.clone());
+            }
+
+            match self.entry(path) {
+                Some(Entry::Unresolvable(kind)) => Err(io::Error::from(*kind)),
+                Some(_) => Ok(path.to_path_buf()),
+                None => Err(io::Error::from(io::ErrorKind::NotFound)),
+            }
+        }
+
+        fn is_directory(&self, path: &Path) -> bool {
+            matches!(
+                self.entry(path),
+                Some(Entry::ReadableDir | Entry::UnreadableDir)
+            )
+        }
+
+        fn is_readable_dir(&self, path: &Path) -> bool {
+            matches!(self.entry(path), Some(Entry::ReadableDir))
+        }
+    }
+
+    fn resolve(raw_value: impl Into<OsString>, probe: &FakeProbe) -> Result<Option<ResolvedRoot>> {
+        resolve_environment_root(&EnvironmentRootInput::set(CWD, HOME, raw_value), probe)
+    }
+
+    fn unusable_reason(error: SafetyLockError) -> String {
+        match error {
+            SafetyLockError::EnvironmentRootUnusable { reason, .. } => reason,
+            other => panic!("expected an unusable-value error, got: {other}"),
+        }
+    }
 
     #[test]
     fn presence_is_independent_of_usability() {
-        assert!(!EnvironmentRootInput::unset("/home/alice").is_set());
-        assert!(EnvironmentRootInput::set("/home/alice", "").is_set());
-        assert!(EnvironmentRootInput::set("/home/alice", "/srv/dots").is_set());
+        assert!(!EnvironmentRootInput::unset(CWD, HOME).is_set());
+        assert!(EnvironmentRootInput::set(CWD, HOME, "").is_set());
+        assert!(EnvironmentRootInput::set(CWD, HOME, "/srv/dots").is_set());
     }
 
     #[test]
     fn a_captured_value_keeps_its_native_bytes() {
-        use std::ffi::OsString;
-        use std::os::unix::ffi::OsStringExt;
-
         let raw = OsString::from_vec(b"/tmp/\x80dots".to_vec());
-        let input = EnvironmentRootInput::set("/home/alice", raw.clone());
+        let input = EnvironmentRootInput::set(CWD, HOME, raw.clone());
 
         assert_eq!(input.raw_value.as_deref(), Some(raw.as_os_str()));
+    }
+
+    #[test]
+    fn an_unset_variable_leaves_selection_to_implicit_discovery() {
+        let probe = FakeProbe::default();
+        let resolved =
+            resolve_environment_root(&EnvironmentRootInput::unset(CWD, HOME), &probe).unwrap();
+
+        assert_eq!(resolved, None);
+        assert!(
+            probe.canonicalized().is_empty(),
+            "an unset variable touched the filesystem"
+        );
+    }
+
+    #[test]
+    fn an_absolute_value_selects_that_root_with_environment_provenance() {
+        let root = resolve("/srv/dots", &FakeProbe::dir("/srv/dots"))
+            .unwrap()
+            .expect("a valid value selects a root");
+
+        assert_eq!(root.as_path(), Path::new("/srv/dots"));
+        assert_eq!(root.source(), RootSource::Environment);
+    }
+
+    /// Selection canonicalizes once, so downstream trust lookup and mutation
+    /// see the symlink's target rather than the spelling that reached them
+    /// (ADR-0001).
+    #[test]
+    fn a_value_is_canonicalized_once_into_the_identity() {
+        let probe = FakeProbe::default().link("/srv/link", "/srv/dots");
+        let root = resolve("/srv/link", &probe).unwrap().unwrap();
+
+        assert_eq!(root.identity(), &RootIdentity::new("/srv/dots").unwrap());
+        assert_eq!(probe.canonicalized(), vec![PathBuf::from("/srv/link")]);
+    }
+
+    /// The value is anchored to the *injected* invocation directory: this
+    /// module reads no process state, so the same input resolves the same way
+    /// wherever the test binary happens to run.
+    #[test]
+    fn a_relative_value_resolves_against_the_injected_invocation_directory() {
+        let probe = FakeProbe::dir("/home/alice/work/dots");
+        let root = resolve("dots", &probe).unwrap().unwrap();
+
+        assert_eq!(root.as_path(), Path::new("/home/alice/work/dots"));
+        assert_eq!(
+            probe.canonicalized(),
+            vec![PathBuf::from("/home/alice/work/dots")],
+            "the probe saw a path anchored somewhere other than the injected cwd"
+        );
+    }
+
+    #[test]
+    fn a_leading_tilde_expands_against_the_injected_home_directory() {
+        for (value, expected) in [
+            ("~", "/home/alice"),
+            ("~/", "/home/alice"),
+            ("~/dots", "/home/alice/dots"),
+            // A doubled separator must not discard home.
+            ("~//dots", "/home/alice/dots"),
+        ] {
+            let root = resolve(value, &FakeProbe::dir(expected)).unwrap().unwrap();
+            assert_eq!(
+                root.as_path(),
+                Path::new(expected),
+                "`{value}` expanded wrong"
+            );
+        }
+    }
+
+    /// `~user` is not tilde expansion Dodot performs, so it stays a literal
+    /// relative path rather than becoming some other user's home.
+    #[test]
+    fn a_tilde_user_value_is_not_expanded() {
+        let probe = FakeProbe::dir("/home/alice/work/~bob/dots");
+        let root = resolve("~bob/dots", &probe).unwrap().unwrap();
+
+        assert_eq!(root.as_path(), Path::new("/home/alice/work/~bob/dots"));
+    }
+
+    /// A non-Unicode value keeps its native bytes all the way into the
+    /// identity, and is spelled the same reversible way trust state spells it
+    /// (ADR-0001).
+    #[test]
+    fn a_non_unicode_value_keeps_its_native_form() {
+        let raw = OsString::from_vec(b"/srv/\x80dots".to_vec());
+        let probe = FakeProbe::default().add(PathBuf::from(raw.clone()), Entry::ReadableDir);
+
+        let root = resolve(raw.clone(), &probe).unwrap().unwrap();
+
+        assert_eq!(root.as_path(), Path::new(&raw));
+        assert_eq!(root.identity().spelling(), "os-bytes:2f7372762f80646f7473");
+        assert_eq!(root.source(), RootSource::Environment);
+    }
+
+    /// A non-Unicode value that fails validation is named in the same
+    /// reversible spelling, so the diagnostic points at a path the user can
+    /// act on (Spec, "Proposed Shape").
+    #[test]
+    fn a_non_unicode_failure_is_named_reversibly() {
+        let raw = OsString::from_vec(b"/srv/\x80dots".to_vec());
+        let error = resolve(raw, &FakeProbe::default()).unwrap_err();
+
+        let SafetyLockError::EnvironmentRootUnusable { spelling, .. } = error else {
+            panic!("expected an unusable-value error");
+        };
+        assert_eq!(spelling, "os-bytes:2f7372762f80646f7473");
+    }
+
+    #[test]
+    fn an_empty_value_is_a_hard_error() {
+        let error = resolve("", &FakeProbe::default()).unwrap_err();
+        assert!(
+            matches!(error, SafetyLockError::EnvironmentRootEmpty),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// Each unusable class names what is actually wrong: the user's next
+    /// action differs between a typo, a file, and a permission problem.
+    #[test]
+    fn each_unusable_class_produces_its_own_diagnostic() {
+        let missing = unusable_reason(resolve("/srv/dots", &FakeProbe::default()).unwrap_err());
+        let not_a_dir = unusable_reason(
+            resolve(
+                "/srv/dots",
+                &FakeProbe::with("/srv/dots", Entry::NotADirectory),
+            )
+            .unwrap_err(),
+        );
+        let unreadable = unusable_reason(
+            resolve(
+                "/srv/dots",
+                &FakeProbe::with("/srv/dots", Entry::UnreadableDir),
+            )
+            .unwrap_err(),
+        );
+        let uncanonicalizable = unusable_reason(
+            resolve(
+                "/srv/dots",
+                &FakeProbe::with(
+                    "/srv/dots",
+                    Entry::Unresolvable(io::ErrorKind::PermissionDenied),
+                ),
+            )
+            .unwrap_err(),
+        );
+
+        assert!(missing.contains("does not exist"), "{missing}");
+        assert!(not_a_dir.contains("is not a directory"), "{not_a_dir}");
+        assert!(unreadable.contains("cannot be listed"), "{unreadable}");
+        assert!(
+            uncanonicalizable.contains("could not be resolved"),
+            "{uncanonicalizable}"
+        );
+
+        let distinct: HashSet<String> = [missing, not_a_dir, unreadable, uncanonicalizable]
+            .into_iter()
+            .collect();
+        assert_eq!(distinct.len(), 4, "two classes share one diagnostic");
+    }
+
+    /// A value that had to be expanded is reported with the path it expanded
+    /// to: `~/dots` alone does not tell the reader where Dodot looked.
+    #[test]
+    fn a_failing_expanded_value_names_the_path_it_expanded_to() {
+        let error = resolve("~/dots", &FakeProbe::default()).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "DOTFILES_ROOT is set to `~/dots` but `/home/alice/dots` does not exist"
+        );
+    }
+
+    /// Anchoring a relative value to a relative invocation directory would
+    /// hand the probe a relative path, which the operating system resolves
+    /// against the process working directory — the one piece of state this
+    /// module refuses to depend on.
+    #[test]
+    fn a_relative_value_is_refused_when_the_invocation_directory_is_relative() {
+        let probe = FakeProbe::dir("work/dots");
+        let input = EnvironmentRootInput::set("work", HOME, "dots");
+
+        let reason = unusable_reason(resolve_environment_root(&input, &probe).unwrap_err());
+
+        assert!(reason.contains("cannot be anchored"), "{reason}");
+        assert!(
+            probe.canonicalized().is_empty(),
+            "a relative path reached the filesystem probe"
+        );
+    }
+
+    /// The Spec's central environment rule (story 9, ADR-0002): no present
+    /// value, however broken, may reach Git or current-directory discovery.
+    /// This is the composition a caller performs, with discovery instrumented.
+    #[test]
+    fn no_failing_value_ever_reaches_implicit_discovery() {
+        struct Selection {
+            implicit_calls: Mutex<usize>,
+        }
+
+        impl Selection {
+            /// Environment first, implicit discovery only when the variable
+            /// selected nothing — the shape every caller of
+            /// [`resolve_environment_root`] has.
+            fn select(&self, input: &EnvironmentRootInput, probe: &dyn PathProbe) -> Result<()> {
+                if resolve_environment_root(input, probe)?.is_some() {
+                    return Ok(());
+                }
+                *self.implicit_calls.lock().unwrap() += 1;
+                Ok(())
+            }
+        }
+
+        let failing: Vec<(&str, FakeProbe)> = vec![
+            ("", FakeProbe::default()),
+            ("/srv/missing", FakeProbe::default()),
+            (
+                "/srv/dots",
+                FakeProbe::with("/srv/dots", Entry::NotADirectory),
+            ),
+            (
+                "/srv/dots",
+                FakeProbe::with("/srv/dots", Entry::UnreadableDir),
+            ),
+            (
+                "/srv/dots",
+                FakeProbe::with(
+                    "/srv/dots",
+                    Entry::Unresolvable(io::ErrorKind::PermissionDenied),
+                ),
+            ),
+            ("~/dots", FakeProbe::default()),
+            ("dots", FakeProbe::default()),
+        ];
+
+        let selection = Selection {
+            implicit_calls: Mutex::new(0),
+        };
+
+        for (value, probe) in &failing {
+            let input = EnvironmentRootInput::set(CWD, HOME, *value);
+            assert!(
+                selection.select(&input, probe).is_err(),
+                "`{value}` did not fail"
+            );
+        }
+        assert_eq!(
+            *selection.implicit_calls.lock().unwrap(),
+            0,
+            "a failing DOTFILES_ROOT fell through to implicit discovery"
+        );
+
+        // The one input that *does* hand over: no variable at all.
+        selection
+            .select(
+                &EnvironmentRootInput::unset(CWD, HOME),
+                &FakeProbe::default(),
+            )
+            .unwrap();
+        assert_eq!(*selection.implicit_calls.lock().unwrap(), 1);
+    }
+
+    /// An environment root is deliberate selection, so it needs no approval —
+    /// and resolution produces nothing to persist, which is what keeps it
+    /// invocation-local (ADR-0003).
+    #[test]
+    fn an_environment_root_is_invocation_local_and_needs_no_approval() {
+        let root = resolve("/srv/dots", &FakeProbe::dir("/srv/dots"))
+            .unwrap()
+            .unwrap();
+
+        assert!(!root.requires_approval());
+        assert!(!root.source().is_implicit());
+    }
+
+    /// The module boundary the Spec draws: the environment is captured at the
+    /// process edge and injected. A direct lookup here would make selection
+    /// untestable and would re-read state that must be resolved once per
+    /// invocation (ADR-0001).
+    #[test]
+    fn resolution_never_reads_the_process_environment() {
+        let source = include_str!("environment.rs");
+        // The implementation only: this test names the forbidden calls, so
+        // scanning itself would always find them.
+        let implementation = source
+            .split_once("#[cfg(test)]")
+            .expect("this file carries a test module")
+            .0;
+        let code = implementation
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        for forbidden in ["std::env", "env::var", "current_dir()"] {
+            assert!(
+                !code.contains(forbidden),
+                "environment.rs reads process state through `{forbidden}`"
+            );
+        }
+    }
+
+    /// The whole path against a real filesystem, so the injected probe is not
+    /// the only thing the behaviour has ever been proven against.
+    #[test]
+    fn a_real_directory_resolves_through_the_os_probe() {
+        use super::super::util::OsPathProbe;
+
+        let home = tempfile::tempdir().unwrap();
+        let root = home.path().join("dotfiles");
+        std::fs::create_dir(&root).unwrap();
+        let canonical_root = std::fs::canonicalize(&root).unwrap();
+
+        let input = EnvironmentRootInput::set(home.path(), home.path(), "~/dotfiles");
+        let resolved = resolve_environment_root(&input, &OsPathProbe)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.as_path(), canonical_root);
+        assert_eq!(resolved.source(), RootSource::Environment);
+
+        // A file at the same coordinate is refused rather than selected.
+        let file = home.path().join("not-a-root");
+        std::fs::write(&file, b"").unwrap();
+        let input = EnvironmentRootInput::set(home.path(), home.path(), file);
+        let reason = unusable_reason(resolve_environment_root(&input, &OsPathProbe).unwrap_err());
+        assert!(reason.contains("is not a directory"), "{reason}");
     }
 }

--- a/crates/dodot-lib/src/safety_lock/environment.rs
+++ b/crates/dodot-lib/src/safety_lock/environment.rs
@@ -161,7 +161,7 @@ pub fn resolve_environment_root(
 
     if !probe.is_readable_dir(&canonical) {
         return Err(unusable(format!(
-            "{named} is a directory whose contents cannot be listed"
+            "{named} is a directory whose contents cannot be read"
         )));
     }
 
@@ -469,7 +469,7 @@ mod tests {
 
         assert!(missing.contains("does not exist"), "{missing}");
         assert!(not_a_dir.contains("is not a directory"), "{not_a_dir}");
-        assert!(unreadable.contains("cannot be listed"), "{unreadable}");
+        assert!(unreadable.contains("cannot be read"), "{unreadable}");
         assert!(
             uncanonicalizable.contains("could not be resolved"),
             "{uncanonicalizable}"

--- a/crates/dodot-lib/src/safety_lock/util.rs
+++ b/crates/dodot-lib/src/safety_lock/util.rs
@@ -114,11 +114,15 @@ pub trait PathProbe: Send + Sync {
     /// symlink's target rather than the link.
     fn is_directory(&self, path: &Path) -> bool;
 
-    /// Whether `path` is a directory whose entries can be listed.
+    /// Whether `path` is a directory pack discovery could actually walk:
+    /// its entries list, every entry in that listing is readable, and its
+    /// children are reachable.
     ///
-    /// A directory that exists but cannot be read is not a usable root: the
-    /// pipeline would fail partway through pack discovery instead of at
-    /// selection time.
+    /// All three are one question because discovery asks all three. A
+    /// directory that opens for listing but hands back unreachable children
+    /// — read permission without search permission, mode `0400` — is not a
+    /// usable root, and answering "readable" for it would let the pipeline
+    /// fail partway through discovery instead of at selection time.
     fn is_readable_dir(&self, path: &Path) -> bool;
 }
 
@@ -136,7 +140,27 @@ impl PathProbe for OsPathProbe {
     }
 
     fn is_readable_dir(&self, path: &Path) -> bool {
-        path.is_dir() && std::fs::read_dir(path).is_ok()
+        if !path.is_dir() {
+            return false;
+        }
+
+        // A successful `read_dir` only proves the iterator opened. Search
+        // ("execute") permission is a separate bit, and without it a
+        // directory still hands back its names while every child is
+        // unreachable — so ask the lookup discovery will ask: resolving `.`
+        // *inside* the directory needs exactly the permission that walking
+        // into its entries needs.
+        if std::fs::metadata(path.join(".")).is_err() {
+            return false;
+        }
+
+        // The listing must also survive being consumed: entries can error
+        // one by one while the iterator itself opened cleanly, and a root
+        // whose listing is incomplete is one discovery cannot walk either.
+        match std::fs::read_dir(path) {
+            Ok(mut entries) => entries.all(|entry| entry.is_ok()),
+            Err(_) => false,
+        }
     }
 }
 
@@ -249,28 +273,79 @@ mod tests {
         assert!(!probe.is_readable_dir(&canonical.join("missing")));
     }
 
-    /// The two directory questions are asked separately so a diagnostic can
-    /// say which one failed: a mode-000 directory *is* a directory, and only
-    /// the listing fails.
-    #[test]
-    fn os_probe_separates_being_a_directory_from_being_readable() {
+    /// Build `name` under `parent` holding one entry, at `mode`, and ask the
+    /// probe both directory questions about it — restoring the permissions
+    /// before returning so a failed assertion in the caller cannot leave the
+    /// directory unremovable for `TempDir`'s cleanup.
+    fn probe_dir_at_mode(parent: &Path, name: &str, mode: u32) -> (bool, bool) {
         use std::os::unix::fs::PermissionsExt;
 
-        // Running as root defeats the permission bits entirely.
-        if unsafe { libc::geteuid() } == 0 {
+        let dir = parent.join(name);
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("pack"), b"").unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(mode)).unwrap();
+
+        let probe = OsPathProbe;
+        let answers = (probe.is_directory(&dir), probe.is_readable_dir(&dir));
+
+        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+        answers
+    }
+
+    /// Whether `chmod` actually blocks this process. Running as root — or
+    /// with `CAP_DAC_OVERRIDE` in a container — bypasses the permission bits
+    /// entirely, which would make the cases below vacuous rather than wrong,
+    /// so those runs skip.
+    fn chmod_blocks_this_process(parent: &Path) -> bool {
+        let (_, readable) = probe_dir_at_mode(parent, "dac-probe", 0o000);
+        !readable
+    }
+
+    /// The two directory questions are asked separately so a diagnostic can
+    /// say which one failed: a mode-000 directory *is* a directory, and only
+    /// the reading fails.
+    #[test]
+    fn os_probe_separates_being_a_directory_from_being_readable() {
+        let parent = tempfile::tempdir().unwrap();
+        if !chmod_blocks_this_process(parent.path()) {
+            eprintln!(
+                "skipping os_probe_separates_being_a_directory_from_being_readable: \
+                 process bypasses DAC permissions (running as root?)"
+            );
             return;
         }
 
+        let (is_dir, readable) = probe_dir_at_mode(parent.path(), "locked", 0o000);
+        assert!(is_dir);
+        assert!(!readable);
+    }
+
+    /// Read permission without search permission is the case a plain
+    /// `read_dir(..).is_ok()` gets wrong: the listing opens and the names
+    /// come back, but every child is unreachable, so discovery would fail
+    /// entry by entry on a root selection had already blessed.
+    #[test]
+    fn os_probe_rejects_a_directory_it_can_list_but_not_walk() {
         let parent = tempfile::tempdir().unwrap();
-        let locked = parent.path().join("locked");
-        std::fs::create_dir(&locked).unwrap();
-        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if !chmod_blocks_this_process(parent.path()) {
+            eprintln!(
+                "skipping os_probe_rejects_a_directory_it_can_list_but_not_walk: \
+                 process bypasses DAC permissions (running as root?)"
+            );
+            return;
+        }
 
-        let probe = OsPathProbe;
-        assert!(probe.is_directory(&locked));
-        assert!(!probe.is_readable_dir(&locked));
+        let (is_dir, readable) = probe_dir_at_mode(parent.path(), "no-search", 0o400);
+        assert!(is_dir, "a mode-0400 directory is still a directory");
+        assert!(
+            !readable,
+            "a directory whose children cannot be reached is not a usable root"
+        );
 
-        // Let the TempDir clean itself up.
-        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700)).unwrap();
+        // The ordinary case still passes: the stricter probe rejects the
+        // unwalkable directory, not every directory.
+        let (is_dir, readable) = probe_dir_at_mode(parent.path(), "ordinary", 0o700);
+        assert!(is_dir);
+        assert!(readable);
     }
 }

--- a/crates/dodot-lib/src/safety_lock/util.rs
+++ b/crates/dodot-lib/src/safety_lock/util.rs
@@ -93,12 +93,26 @@ pub fn decode_native_path(spelling: &str) -> Result<PathBuf> {
 /// The filesystem questions root selection asks, injected so the selection
 /// and trust logic stay testable without a real repository.
 ///
-/// Only two questions matter, and both come from the Spec's explicit-value
-/// rules: a candidate must resolve to a readable directory, and it is then
-/// canonicalized once per invocation.
+/// The questions come from the Spec's explicit-value rules: a candidate is
+/// canonicalized once per invocation and must then be a readable directory.
+/// Being a directory and being readable are asked separately because a
+/// refused user is told *which* one failed — "is not a directory" and
+/// "cannot be read" are different mistakes with different fixes, and one
+/// boolean could not tell them apart.
 pub trait PathProbe: Send + Sync {
     /// Resolve `path` to its canonical absolute form, following symlinks.
+    ///
+    /// This is also what separates "nothing is there" from "something is
+    /// there that cannot be resolved": the two arrive as
+    /// [`ErrorKind::NotFound`](std::io::ErrorKind::NotFound) and any other
+    /// error respectively.
     fn canonicalize(&self, path: &Path) -> std::io::Result<PathBuf>;
+
+    /// Whether `path` is a directory at all.
+    ///
+    /// Asked of an already-canonical path, so the answer is about the
+    /// symlink's target rather than the link.
+    fn is_directory(&self, path: &Path) -> bool;
 
     /// Whether `path` is a directory whose entries can be listed.
     ///
@@ -115,6 +129,10 @@ pub struct OsPathProbe;
 impl PathProbe for OsPathProbe {
     fn canonicalize(&self, path: &Path) -> std::io::Result<PathBuf> {
         std::fs::canonicalize(path)
+    }
+
+    fn is_directory(&self, path: &Path) -> bool {
+        path.is_dir()
     }
 
     fn is_readable_dir(&self, path: &Path) -> bool {
@@ -220,11 +238,39 @@ mod tests {
         let probe = OsPathProbe;
 
         let canonical = probe.canonicalize(dir.path()).unwrap();
+        assert!(probe.is_directory(&canonical));
         assert!(probe.is_readable_dir(&canonical));
 
         let file = canonical.join("not-a-dir");
         std::fs::write(&file, b"").unwrap();
+        assert!(!probe.is_directory(&file));
         assert!(!probe.is_readable_dir(&file));
+        assert!(!probe.is_directory(&canonical.join("missing")));
         assert!(!probe.is_readable_dir(&canonical.join("missing")));
+    }
+
+    /// The two directory questions are asked separately so a diagnostic can
+    /// say which one failed: a mode-000 directory *is* a directory, and only
+    /// the listing fails.
+    #[test]
+    fn os_probe_separates_being_a_directory_from_being_readable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Running as root defeats the permission bits entirely.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+
+        let parent = tempfile::tempdir().unwrap();
+        let locked = parent.path().join("locked");
+        std::fs::create_dir(&locked).unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let probe = OsPathProbe;
+        assert!(probe.is_directory(&locked));
+        assert!(!probe.is_readable_dir(&locked));
+
+        // Let the TempDir clean itself up.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700)).unwrap();
     }
 }


### PR DESCRIPTION
Implements the environment-selection path behind the WS01 facade: a present
`DOTFILES_ROOT` selects the root or hard-fails, and never falls through to Git
or current-directory discovery.

for #307 (epic #305)

## Context

**Why this shape.** The Spec's environment rule (story 9, ADR-0002) is a
*negative* guarantee — no failing value reaches implicit discovery — so it is
carried by the return type rather than by caller discipline: implicit discovery
is what a caller does with `Ok(None)`, and no present value can produce
`Ok(None)`. The acceptance criterion asking for proof is tested by stating the
composition a caller performs (environment first, discovery on `None`) with
discovery instrumented, and asserting the counter stays at zero across every
failing class.

**The invocation directory is now an input.** WS01's `EnvironmentRootInput`
carried `home_dir` only; a relative value needs an anchor, and the issue names
the injected cwd. Anchoring to the *process* working directory instead would
make resolution depend on where the binary runs (untestable) and would be a
second read of state ADR-0001 says is resolved once per invocation. So
`current_dir` joins the struct, and the constructors take it first:
`unset(cwd, home)` / `set(cwd, home, value)`, mirroring `FileRootInput`. A
relative value with a *relative* injected cwd is refused rather than handed to
the probe — that is the one seam where the process-cwd leak would otherwise
reappear.

**`PathProbe` gained `is_directory`.** The criterion asks for distinct,
actionable errors for missing / non-directory / unreadable / uncanonicalizable.
WS01's single `is_readable_dir` cannot separate "you pointed at a file" from
"you cannot read that directory", so the two questions are now asked
separately; `canonicalize`'s `NotFound` vs. any-other-error separates the other
two. `is_readable_dir` also got stricter (review round 1): it used to accept any
directory whose iterator opened, which let a read-without-search directory
(mode `0400`) through — the listing opens, but every child is unreachable, so
discovery would have failed on a root selection had already blessed. It now
also checks that the directory can be walked into and that the listing survives
being consumed. Strictly a narrowing of what counts as usable, so WS03's use of
it is unaffected.

**Diagnostics.** A value that had to be expanded is reported with the path it
expanded to (``DOTFILES_ROOT is set to `~/dots` but `/home/alice/dots` does not exist``),
and a non-Unicode value is named in the same reversible spelling trust state
and `roots list` use (ADR-0001).

## Self-check against the governing docs

- `docs/spec/safety-lock.md` — "Proposed Shape" (a present value is
  authoritative; empty/nonexistent/non-directory/unreadable/uncanonicalizable
  hard-fail; relative and non-Unicode accepted then canonicalized; native form
  preserved through diagnostics) and "Testing / Verification" (every explicit
  value class covered, including no-fallback).
- ADR-0001 — resolved and canonicalized once per invocation; identity is the
  native canonical path, never a lossy rendering.
- ADR-0002 — an unusable explicit value fails instead of selecting a different
  root.
- ADR-0003 — an environment root is invocation-local: resolution writes nothing
  and returns nothing to persist, and the resolved root reports
  `requires_approval() == false`. (`approve` refusing an environment root is
  WS04's `todo!()`, untouched here.)

## Out of scope / what not to "fix"

- **No wiring.** Nothing calls this yet. Capturing `DOTFILES_ROOT`, the cwd,
  and Git at the process boundary — and `crates/dodot-lib/src/paths`' own
  `resolve_dotfiles_root` still reading the env directly — belongs to WS07.
  Duplicate-looking resolution logic is expected until then.
- `files.rs`, `check.rs`, `forget.rs`, `inventory.rs`, `scope.rs` keep their
  WS01 `todo!()` bodies.
- **No changelog fragment**: no user-visible behaviour changes until the gate
  is wired (WS01 landed the same way); the epic's fragment belongs with the
  wiring workstream.
- `~user` is deliberately *not* expanded, matching `crate::paths`' existing
  tilde handling.
- The non-Unicode cases use the injected probe rather than a real directory on
  purpose: APFS rejects non-UTF-8 filenames, so a real-filesystem version would
  fail on macOS. One real-filesystem test (`OsPathProbe`, tempdir, tilde value,
  file-not-a-directory) covers the end-to-end path.

## Verification

- `pixi run test` — 1610 passed, 0 failed.
- `pixi run lint` — OK (13 checks), also enforced by the commit/push hooks.
