### PR TITLE
ACC01-WS03: Epic: Safety Lock - Workstream: Implicit file-root resolution and path identity

### DIFF
--- a/crates/dodot-lib/src/safety_lock.rs
+++ b/crates/dodot-lib/src/safety_lock.rs
@@ -19,13 +19,19 @@
 //!
 //! ```text
 //! DOTFILES_ROOT ──► environment ─┐
-//!                                ├─► ResolvedRoot ──► check ──► TrustDecision
-//! git top-level / cwd ──► files ─┘        │                          │
-//!                                         │                          ├─ ExplicitlySelected
-//!                       schema (approved roots, one file)            ├─ AlreadyApproved
-//!                                         │                          └─ ApprovalRequired ──► inventory
-//!                                    list / forget                                              (prompt)
+//!                                ├─► selection ─► ResolvedRoot ─► check ─► TrustDecision
+//! git top-level / cwd ──► files ─┘                     │                        │
+//!                                                      │                        ├─ ExplicitlySelected
+//!                            schema (approved roots, one file)                  ├─ AlreadyApproved
+//!                                                      │                        └─ ApprovalRequired ─► inventory
+//!                                                 list / forget                                          (prompt)
 //! ```
+//!
+//! [`resolve_root`] is the invocation's one act of selection: `DOTFILES_ROOT`,
+//! then the Git top-level, then the current directory — and nothing after
+//! that. Every consumer carries the [`ResolvedRoot`] it returns rather than
+//! resolving again, which is what keeps the root the user approved and the
+//! root Dodot mutates the same one (ADR-0001).
 //!
 //! Both selection paths return the same [`ResolvedRoot`]: one canonical
 //! [`RootIdentity`] plus the [`RootSource`] that chose it. Provenance changes
@@ -43,19 +49,25 @@
 //! This module is CLI-free by construction: no Clap and no Standout types
 //! appear in any signature, and nothing here reads the process environment,
 //! the current directory, or Git. Those are captured at the process boundary
-//! and injected ([`EnvironmentRootInput`], [`FileRootInput`],
-//! [`PathProbe`]). Likewise, persistence is the caller's: the checking,
-//! listing, and forgetting APIs take an already-loaded [`SafetyLockConfig`]
-//! and return typed state changes to write.
+//! and injected ([`RootSelectionInput`], [`PathProbe`]). Likewise, persistence
+//! is the caller's: the checking, listing, and forgetting APIs take an
+//! already-loaded [`SafetyLockConfig`] and return typed state changes to
+//! write.
 //!
 //! # Work Stream status
 //!
 //! ACC01-WS01 establishes this vocabulary and the persisted schema; ACC01-WS02
-//! fills in [`environment`], the authoritative `DOTFILES_ROOT` path. The
-//! remaining trust-lifecycle, decision, inventory, and scoping entry points
-//! carry documented signatures with `todo!()` bodies; each names the Work
-//! Stream that fills it in. The data model, the schema, and environment
-//! selection are complete and tested.
+//! fills in [`environment`], the authoritative `DOTFILES_ROOT` path; ACC01-WS03
+//! fills in [`files`] and composes both into [`selection`]. The remaining
+//! trust-lifecycle, decision, inventory, and scoping entry points carry
+//! documented signatures with `todo!()` bodies; each names the Work Stream
+//! that fills it in. The data model, the schema, and root selection are
+//! complete and tested.
+//!
+//! Dodot's pre-Safety-Lock root resolution still runs in
+//! [`crate::paths`](crate::paths) and in the CLI: replacing those callers with
+//! [`resolve_root`] is the process-boundary work of WS07, which is where the
+//! environment, cwd, and Git capture this module refuses to perform lands.
 //!
 //! Nothing in this module is wired into a command yet: the process boundary
 //! that captures the environment, the current directory, and Git — and the
@@ -71,6 +83,9 @@ pub mod list;
 pub mod roots;
 pub mod schema;
 pub mod scope;
+pub mod selection;
+#[cfg(test)]
+mod test_probe;
 pub mod util;
 
 pub use check::{approve, decide, ApprovalChange, TrustDecision};
@@ -88,4 +103,5 @@ pub use schema::{
     SafetyLockConfig, TrustedRootsSection, SAFETY_LOCK_FILE_NAME, SAFETY_LOCK_PERSIST_SCOPE,
 };
 pub use scope::{scope_to_root, MutationScope, OutOfRootReason, OutOfRootTarget};
+pub use selection::{resolve_root, RootSelectionInput};
 pub use util::{decode_native_path, encode_native_path, OsPathProbe, PathProbe, NATIVE_BYTES_TAG};

--- a/crates/dodot-lib/src/safety_lock/environment.rs
+++ b/crates/dodot-lib/src/safety_lock/environment.rs
@@ -27,8 +27,8 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
 use super::error::{Result, SafetyLockError};
-use super::roots::{ResolvedRoot, RootIdentity, RootSource};
-use super::util::{encode_native_path, PathProbe};
+use super::roots::{ResolvedRoot, RootSource};
+use super::util::{canonical_root_identity, encode_native_path, PathProbe, UnusableRoot};
 
 /// The environment inputs root selection depends on, captured once per
 /// invocation.
@@ -147,30 +147,26 @@ pub fn resolve_environment_root(
         )));
     }
 
-    let canonical = probe.canonicalize(&candidate).map_err(|err| {
-        if err.kind() == std::io::ErrorKind::NotFound {
-            unusable(format!("{named} does not exist"))
-        } else {
+    // The usability requirements themselves are shared with implicit
+    // selection; only the phrasing is the variable's own, because a refused
+    // user is reading about `DOTFILES_ROOT` rather than about a path Dodot
+    // picked. The last case is defensive: a canonical path from the filesystem
+    // is absolute and free of `..`, so it only fires for a probe that says
+    // otherwise, and it stays an environment diagnostic so the message still
+    // names the variable.
+    let identity = canonical_root_identity(&candidate, probe).map_err(|failure| match failure {
+        UnusableRoot::Missing => unusable(format!("{named} does not exist")),
+        UnusableRoot::Unresolvable(err) => {
             unusable(format!("{named} could not be resolved: {err}"))
         }
-    })?;
-
-    if !probe.is_directory(&canonical) {
-        return Err(unusable(format!("{named} is not a directory")));
-    }
-
-    if !probe.is_readable_dir(&canonical) {
-        return Err(unusable(format!(
+        UnusableRoot::NotADirectory => unusable(format!("{named} is not a directory")),
+        UnusableRoot::Unreadable => unusable(format!(
             "{named} is a directory whose contents cannot be read"
-        )));
-    }
-
-    // Defensive: a canonical path from the filesystem is absolute and free of
-    // `..`, so this only fires for a probe that says otherwise. It stays an
-    // environment diagnostic rather than a bare identity error so the message
-    // still names `DOTFILES_ROOT`.
-    let identity = RootIdentity::new(canonical)
-        .map_err(|err| unusable(format!("{named} did not resolve to a usable root: {err}")))?;
+        )),
+        UnusableRoot::NotAnIdentity(err) => {
+            unusable(format!("{named} did not resolve to a usable root: {err}"))
+        }
+    })?;
 
     Ok(Some(ResolvedRoot::new(identity, RootSource::Environment)))
 }
@@ -208,91 +204,12 @@ mod tests {
     use std::os::unix::ffi::OsStringExt;
     use std::sync::Mutex;
 
+    use super::super::roots::RootIdentity;
+    use super::super::test_probe::{Entry, FakeProbe};
     use super::*;
 
     const CWD: &str = "/home/alice/work";
     const HOME: &str = "/home/alice";
-
-    /// What a path is, as far as the probe is concerned.
-    #[derive(Debug, Clone)]
-    enum Entry {
-        ReadableDir,
-        UnreadableDir,
-        NotADirectory,
-        Unresolvable(io::ErrorKind),
-    }
-
-    /// A filesystem stated as data: what each path canonicalizes to, and what
-    /// it is once canonical. Anything unregistered is missing.
-    #[derive(Debug, Default)]
-    struct FakeProbe {
-        links: Vec<(PathBuf, PathBuf)>,
-        entries: Vec<(PathBuf, Entry)>,
-        canonicalized: Mutex<Vec<PathBuf>>,
-    }
-
-    impl FakeProbe {
-        fn with(path: &str, entry: Entry) -> Self {
-            let probe = Self::default();
-            probe.add(PathBuf::from(path), entry)
-        }
-
-        fn dir(path: &str) -> Self {
-            Self::with(path, Entry::ReadableDir)
-        }
-
-        fn add(mut self, path: PathBuf, entry: Entry) -> Self {
-            self.entries.push((path, entry));
-            self
-        }
-
-        /// `path` canonicalizes to `target`, which is a readable directory.
-        fn link(mut self, path: &str, target: &str) -> Self {
-            self.links
-                .push((PathBuf::from(path), PathBuf::from(target)));
-            self.add(PathBuf::from(target), Entry::ReadableDir)
-        }
-
-        fn entry(&self, path: &Path) -> Option<&Entry> {
-            self.entries
-                .iter()
-                .find(|(known, _)| known == path)
-                .map(|(_, entry)| entry)
-        }
-
-        /// Every path `canonicalize` was asked about — the proof that a
-        /// relative value was anchored to the injected directory.
-        fn canonicalized(&self) -> Vec<PathBuf> {
-            self.canonicalized.lock().unwrap().clone()
-        }
-    }
-
-    impl PathProbe for FakeProbe {
-        fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
-            self.canonicalized.lock().unwrap().push(path.to_path_buf());
-
-            if let Some((_, target)) = self.links.iter().find(|(known, _)| known == path) {
-                return Ok(target.clone());
-            }
-
-            match self.entry(path) {
-                Some(Entry::Unresolvable(kind)) => Err(io::Error::from(*kind)),
-                Some(_) => Ok(path.to_path_buf()),
-                None => Err(io::Error::from(io::ErrorKind::NotFound)),
-            }
-        }
-
-        fn is_directory(&self, path: &Path) -> bool {
-            matches!(
-                self.entry(path),
-                Some(Entry::ReadableDir | Entry::UnreadableDir)
-            )
-        }
-
-        fn is_readable_dir(&self, path: &Path) -> bool {
-            matches!(self.entry(path), Some(Entry::ReadableDir))
-        }
-    }
 
     fn resolve(raw_value: impl Into<OsString>, probe: &FakeProbe) -> Result<Option<ResolvedRoot>> {
         resolve_environment_root(&EnvironmentRootInput::set(CWD, HOME, raw_value), probe)
@@ -593,33 +510,6 @@ mod tests {
 
         assert!(!root.requires_approval());
         assert!(!root.source().is_implicit());
-    }
-
-    /// The module boundary the Spec draws: the environment is captured at the
-    /// process edge and injected. A direct lookup here would make selection
-    /// untestable and would re-read state that must be resolved once per
-    /// invocation (ADR-0001).
-    #[test]
-    fn resolution_never_reads_the_process_environment() {
-        let source = include_str!("environment.rs");
-        // The implementation only: this test names the forbidden calls, so
-        // scanning itself would always find them.
-        let implementation = source
-            .split_once("#[cfg(test)]")
-            .expect("this file carries a test module")
-            .0;
-        let code = implementation
-            .lines()
-            .filter(|line| !line.trim_start().starts_with("//"))
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        for forbidden in ["std::env", "env::var", "current_dir()"] {
-            assert!(
-                !code.contains(forbidden),
-                "environment.rs reads process state through `{forbidden}`"
-            );
-        }
     }
 
     /// The whole path against a real filesystem, so the injected probe is not

--- a/crates/dodot-lib/src/safety_lock/environment.rs
+++ b/crates/dodot-lib/src/safety_lock/environment.rs
@@ -139,22 +139,23 @@ pub fn resolve_environment_root(
         format!("`{}`", encode_native_path(&candidate))
     };
 
-    if !candidate.is_absolute() {
-        return Err(unusable(format!(
-            "{named} is relative and the invocation directory `{}` is not \
-             absolute, so it cannot be anchored",
-            encode_native_path(&input.current_dir)
-        )));
-    }
-
     // The usability requirements themselves are shared with implicit
     // selection; only the phrasing is the variable's own, because a refused
     // user is reading about `DOTFILES_ROOT` rather than about a path Dodot
-    // picked. The last case is defensive: a canonical path from the filesystem
-    // is absolute and free of `..`, so it only fires for a probe that says
+    // picked. The first case can only be a relative value joined onto a
+    // relative invocation directory — an absolute value, and a relative one
+    // anchored to an absolute directory, are both absolute by construction —
+    // so the message names that directory rather than repeating the value.
+    // The last case is defensive: a canonical path from the filesystem is
+    // absolute and free of `..`, so it only fires for a probe that says
     // otherwise, and it stays an environment diagnostic so the message still
     // names the variable.
     let identity = canonical_root_identity(&candidate, probe).map_err(|failure| match failure {
+        UnusableRoot::Relative => unusable(format!(
+            "{named} is relative and the invocation directory `{}` is not \
+             absolute, so it cannot be anchored",
+            encode_native_path(&input.current_dir)
+        )),
         UnusableRoot::Missing => unusable(format!("{named} does not exist")),
         UnusableRoot::Unresolvable(err) => {
             unusable(format!("{named} could not be resolved: {err}"))

--- a/crates/dodot-lib/src/safety_lock/error.rs
+++ b/crates/dodot-lib/src/safety_lock/error.rs
@@ -43,10 +43,26 @@ pub enum SafetyLockError {
         reason: String,
     },
 
-    /// Implicit selection found neither a Git top-level nor a usable current
-    /// directory.
-    #[error("could not determine a dotfiles root from `{}`", current_dir.display())]
-    NoImplicitRoot { current_dir: PathBuf },
+    /// Implicit selection chose a candidate — the Git top-level, or the
+    /// current directory — that is not a usable root.
+    ///
+    /// Naming the mechanism matters as much as naming the path: the Git
+    /// top-level is frequently not the directory the user's shell prompt shows
+    /// (Spec, story 2), so "the git top-level `/srv/dots` …" tells them where
+    /// to look while a bare path does not. The selected mechanism is never
+    /// retried against the other one: a Git top-level that cannot be used is
+    /// not evidence that the current directory was meant instead.
+    #[error("the {selected_by} `{spelling}` cannot be used as a dotfiles root: {reason}")]
+    ImplicitRootUnusable {
+        /// The candidate in the reversible spelling of
+        /// [`super::util::encode_native_path`].
+        spelling: String,
+        /// Which implicit mechanism chose it.
+        selected_by: super::roots::RootSource,
+        /// What made it unusable, phrased to complete the sentence "the … `…`
+        /// cannot be used as a dotfiles root: …".
+        reason: String,
+    },
 
     /// A path that must be canonical and absolute was not absolute.
     ///

--- a/crates/dodot-lib/src/safety_lock/files.rs
+++ b/crates/dodot-lib/src/safety_lock/files.rs
@@ -121,15 +121,12 @@ pub fn resolve_file_root(input: &FileRootInput, probe: &dyn PathProbe) -> Result
         reason,
     };
 
-    if !candidate.is_absolute() {
-        return Err(unusable(
+    let identity = canonical_root_identity(candidate, probe).map_err(|failure| match failure {
+        UnusableRoot::Relative => unusable(
             "it is relative, so anchoring it would depend on the process working \
              directory rather than the captured invocation directory"
                 .to_owned(),
-        ));
-    }
-
-    let identity = canonical_root_identity(candidate, probe).map_err(|failure| match failure {
+        ),
         UnusableRoot::Missing => unusable("it does not exist".to_owned()),
         UnusableRoot::Unresolvable(err) => unusable(format!("it could not be resolved: {err}")),
         UnusableRoot::NotADirectory => unusable("it is not a directory".to_owned()),

--- a/crates/dodot-lib/src/safety_lock/files.rs
+++ b/crates/dodot-lib/src/safety_lock/files.rs
@@ -10,28 +10,55 @@
 //! and the enclosing Git top-level are captured by the caller, so discovery
 //! and provenance are testable without a real repository or a process-wide
 //! working directory. The result is the same [`ResolvedRoot`] the environment
-//! path produces — only its [`RootSource`](super::roots::RootSource) differs.
+//! path produces — only its [`RootSource`] differs.
 //!
-//! Behaviour arrives in WS03; this Work Stream fixes the signature.
+//! # Two candidates, in order, and no third
+//!
+//! The Git top-level is preferred because it is the answer that survives
+//! navigation: a user in `dots/vim/colors` means the repository, not the
+//! directory they happen to stand in. The current directory applies when Git
+//! reported no top-level at all.
+//!
+//! There is no `$HOME/dotfiles` fallback. Dodot's pre-Safety-Lock path
+//! resolution ends there when Git finds nothing, which invents a root out of a
+//! naming convention: it names a path the user did not select, from an
+//! invocation that says nothing about it. Git then the current directory are
+//! the two mechanisms the Spec approves, and each produces a path the user was
+//! standing in or inside of — a path the confirmation prompt can meaningfully
+//! ask them to recognize.
+//!
+//! A chosen candidate is also never retried against the other one. When Git
+//! reported a top-level that turns out to be unusable, selection fails naming
+//! it; falling through to the current directory would quietly select a
+//! *different* root — a descendant of the one that failed — which is the
+//! substitution ADR-0002 rules out for explicit values, for the same reason.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use super::error::Result;
-use super::roots::ResolvedRoot;
-use super::util::PathProbe;
+use super::error::{Result, SafetyLockError};
+use super::roots::{ResolvedRoot, RootSource};
+use super::util::{canonical_root_identity, encode_native_path, PathProbe, UnusableRoot};
 
 /// The filesystem inputs implicit selection depends on, captured once per
 /// invocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileRootInput {
     /// The directory Dodot was invoked from.
+    ///
+    /// Expected to be absolute — the caller captures it from the process. A
+    /// relative candidate is refused rather than handed to the probe, which
+    /// would resolve it against the process working directory this module
+    /// deliberately does not read.
     pub current_dir: PathBuf,
 
     /// The Git top-level enclosing `current_dir`, or `None` when it is not
     /// inside a repository.
     ///
     /// Discovered by the caller, which is what keeps `git` out of this
-    /// module and lets tests state "inside a repo" as data.
+    /// module and lets tests state "inside a repo" as data. Taken as given:
+    /// with nested repositories, the top-level Git reports for `current_dir`
+    /// is the innermost one, and selection uses that rather than searching for
+    /// an outer repository of its own.
     pub git_top_level: Option<PathBuf>,
 }
 
@@ -54,23 +81,94 @@ impl FileRootInput {
             git_top_level: Some(git_top_level.into()),
         }
     }
+
+    /// The candidate this input selects, and the mechanism that selected it.
+    fn candidate(&self) -> (&Path, RootSource) {
+        match self.git_top_level.as_deref() {
+            Some(top_level) => (top_level, RootSource::Git),
+            None => (self.current_dir.as_path(), RootSource::CurrentDirectory),
+        }
+    }
 }
 
 /// Resolve the implicit root: the Git top-level when there is one, otherwise
 /// the current directory, canonicalized once.
 ///
-/// The returned root always carries an implicit
-/// [`RootSource`](super::roots::RootSource) — `Git` or `CurrentDirectory` —
-/// so the safety gate can tell the user which mechanism selected the path it
-/// is asking them to approve (Spec, story 2).
+/// The returned root always carries an implicit [`RootSource`] — `Git` or
+/// `CurrentDirectory` — so the safety gate can tell the user which mechanism
+/// selected the path it is asking them to approve (Spec, story 2).
+///
+/// Canonicalization happens here and only here, which is what gives the root
+/// its identity: symlink aliases of one directory resolve to a single
+/// identity, so approving a root through one spelling covers every other
+/// spelling of it. It is also why a *moved* root is reassessed rather than
+/// inheriting the old approval (Spec, story 6) — the path it canonicalizes to
+/// is a different identity — while a directory replaced at the same canonical
+/// path keeps the identity the user approved, which is the path-based trust
+/// model ADR-0001 chose deliberately.
+///
+/// Fails when the selected candidate is not a usable root
+/// ([`SafetyLockError::ImplicitRootUnusable`]). Unlike a failing
+/// `DOTFILES_ROOT`, this is not a configuration mistake to correct — it is
+/// usually a `cd` into a directory that has since gone away — but it fails the
+/// same way, without substituting another root.
 pub fn resolve_file_root(input: &FileRootInput, probe: &dyn PathProbe) -> Result<ResolvedRoot> {
-    let _ = (input, probe);
-    todo!("WS03: implicit file-root resolution and path identity")
+    let (candidate, selected_by) = input.candidate();
+
+    let unusable = |reason: String| SafetyLockError::ImplicitRootUnusable {
+        spelling: encode_native_path(candidate),
+        selected_by,
+        reason,
+    };
+
+    if !candidate.is_absolute() {
+        return Err(unusable(
+            "it is relative, so anchoring it would depend on the process working \
+             directory rather than the captured invocation directory"
+                .to_owned(),
+        ));
+    }
+
+    let identity = canonical_root_identity(candidate, probe).map_err(|failure| match failure {
+        UnusableRoot::Missing => unusable("it does not exist".to_owned()),
+        UnusableRoot::Unresolvable(err) => unusable(format!("it could not be resolved: {err}")),
+        UnusableRoot::NotADirectory => unusable("it is not a directory".to_owned()),
+        UnusableRoot::Unreadable => {
+            unusable("it is a directory whose contents cannot be read".to_owned())
+        }
+        UnusableRoot::NotAnIdentity(err) => {
+            unusable(format!("it did not resolve to a usable root: {err}"))
+        }
+    })?;
+
+    Ok(ResolvedRoot::new(identity, selected_by))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+    use std::ffi::OsString;
+    use std::io;
+    use std::os::unix::ffi::OsStringExt;
+
+    use super::super::roots::RootIdentity;
+    use super::super::test_probe::{Entry, FakeProbe};
+    use super::super::util::OsPathProbe;
     use super::*;
+
+    fn unusable_reason(error: SafetyLockError) -> String {
+        match error {
+            SafetyLockError::ImplicitRootUnusable { reason, .. } => reason,
+            other => panic!("expected an unusable-candidate error, got: {other}"),
+        }
+    }
+
+    fn selecting_mechanism(error: SafetyLockError) -> RootSource {
+        match error {
+            SafetyLockError::ImplicitRootUnusable { selected_by, .. } => selected_by,
+            other => panic!("expected an unusable-candidate error, got: {other}"),
+        }
+    }
 
     #[test]
     fn repository_membership_is_stated_as_data() {
@@ -85,5 +183,373 @@ mod tests {
                 git_top_level: Some(PathBuf::from("/srv/dots")),
             }
         );
+    }
+
+    /// Spec story 2: from a subdirectory, the root is the repository — the
+    /// path the user must be shown, precisely because it is *not* the
+    /// directory their prompt shows.
+    #[test]
+    fn a_git_top_level_wins_over_the_directory_the_user_stands_in() {
+        let probe = FakeProbe::dir("/srv/dots").and_dir("/srv/dots/vim/colors");
+        let input = FileRootInput::inside_repository("/srv/dots/vim/colors", "/srv/dots");
+
+        let root = resolve_file_root(&input, &probe).unwrap();
+
+        assert_eq!(root.as_path(), Path::new("/srv/dots"));
+        assert_eq!(root.source(), RootSource::Git);
+        assert_eq!(
+            probe.canonicalized(),
+            vec![PathBuf::from("/srv/dots")],
+            "the current directory was probed even though Git had an answer"
+        );
+    }
+
+    /// Nested repositories: the top-level belongs to the innermost repository
+    /// containing the current directory, and selection takes what the caller
+    /// captured rather than looking for an outer repository.
+    #[test]
+    fn a_nested_repository_selects_its_own_top_level() {
+        let probe = FakeProbe::dir("/srv/dots").and_dir("/srv/dots/vendor/plugin");
+        let input = FileRootInput::inside_repository(
+            "/srv/dots/vendor/plugin/lua",
+            "/srv/dots/vendor/plugin",
+        );
+
+        let root = resolve_file_root(&input, &probe).unwrap();
+
+        assert_eq!(root.as_path(), Path::new("/srv/dots/vendor/plugin"));
+        assert_eq!(root.source(), RootSource::Git);
+    }
+
+    #[test]
+    fn without_a_git_top_level_the_current_directory_is_the_root() {
+        let probe = FakeProbe::dir("/tmp/scratch");
+        let input = FileRootInput::outside_repository("/tmp/scratch");
+
+        let root = resolve_file_root(&input, &probe).unwrap();
+
+        assert_eq!(root.as_path(), Path::new("/tmp/scratch"));
+        assert_eq!(root.source(), RootSource::CurrentDirectory);
+    }
+
+    /// The fallback Safety Lock removes. `$HOME/dotfiles` is a naming
+    /// convention, not a selection: outside a repository the root is the
+    /// directory the user actually invoked Dodot from, even when the
+    /// conventional path exists and is a perfectly good dotfiles repository.
+    #[test]
+    fn a_conventional_home_dotfiles_directory_is_not_an_implicit_fallback() {
+        let probe = FakeProbe::dir("/home/alice").and_dir("/home/alice/dotfiles");
+        let input = FileRootInput::outside_repository("/home/alice");
+
+        let root = resolve_file_root(&input, &probe).unwrap();
+
+        assert_eq!(root.as_path(), Path::new("/home/alice"));
+        assert_eq!(root.source(), RootSource::CurrentDirectory);
+        assert_eq!(
+            probe.canonicalized(),
+            vec![PathBuf::from("/home/alice")],
+            "a conventional path was probed as a candidate"
+        );
+    }
+
+    /// Selection canonicalizes once, and that result is the identity: every
+    /// alias of one directory therefore approves, lists, and revokes as one
+    /// record (ADR-0001).
+    #[test]
+    fn aliases_of_one_directory_resolve_to_one_identity() {
+        let through_link = resolve_file_root(
+            &FileRootInput::inside_repository("/srv/link/vim", "/srv/link"),
+            &FakeProbe::default().link("/srv/link", "/srv/dots"),
+        )
+        .unwrap();
+        let direct = resolve_file_root(
+            &FileRootInput::inside_repository("/srv/dots/vim", "/srv/dots"),
+            &FakeProbe::dir("/srv/dots"),
+        )
+        .unwrap();
+
+        assert_eq!(through_link.identity(), direct.identity());
+        assert_eq!(through_link, direct);
+        let identities: HashSet<RootIdentity> = [through_link, direct]
+            .into_iter()
+            .map(ResolvedRoot::into_identity)
+            .collect();
+        assert_eq!(identities.len(), 1);
+    }
+
+    /// Spec story 6: approval follows the canonical path, so a root that moved
+    /// resolves to a different identity and is reassessed, while a directory
+    /// replaced at the same canonical path keeps the identity that was
+    /// approved (ADR-0001 — path-based trust, deliberately).
+    #[test]
+    fn moving_a_root_changes_its_identity_and_replacing_it_in_place_does_not() {
+        let before = resolve_file_root(
+            &FileRootInput::outside_repository("/srv/dots"),
+            &FakeProbe::dir("/srv/dots"),
+        )
+        .unwrap();
+
+        let moved = resolve_file_root(
+            &FileRootInput::outside_repository("/srv/moved/dots"),
+            &FakeProbe::dir("/srv/moved/dots"),
+        )
+        .unwrap();
+        assert_ne!(before.identity(), moved.identity());
+
+        // Same path, different directory behind it: one identity, so trust
+        // established before the replacement still matches.
+        let replaced = resolve_file_root(
+            &FileRootInput::outside_repository("/srv/dots"),
+            &FakeProbe::dir("/srv/dots"),
+        )
+        .unwrap();
+        assert_eq!(before.identity(), replaced.identity());
+    }
+
+    /// A symlinked root that is *moved* is reassessed by where it now points,
+    /// not by the unchanged spelling that reaches selection.
+    #[test]
+    fn a_relocated_symlink_target_is_a_new_identity() {
+        let before = resolve_file_root(
+            &FileRootInput::outside_repository("/srv/link"),
+            &FakeProbe::default().link("/srv/link", "/srv/dots"),
+        )
+        .unwrap();
+        let after = resolve_file_root(
+            &FileRootInput::outside_repository("/srv/link"),
+            &FakeProbe::default().link("/srv/link", "/srv/moved/dots"),
+        )
+        .unwrap();
+
+        assert_ne!(before.identity(), after.identity());
+        assert_eq!(after.as_path(), Path::new("/srv/moved/dots"));
+    }
+
+    /// Handing the probe a relative path would resolve it against the process
+    /// working directory — the one piece of state selection refuses to read,
+    /// because it is resolved once per invocation and injected (ADR-0001).
+    #[test]
+    fn a_relative_candidate_is_refused_before_it_reaches_the_filesystem() {
+        for (input, expected) in [
+            (
+                FileRootInput::outside_repository("dots"),
+                RootSource::CurrentDirectory,
+            ),
+            (
+                FileRootInput::inside_repository("/srv/dots/vim", "../dots"),
+                RootSource::Git,
+            ),
+        ] {
+            let probe = FakeProbe::dir("dots").and_dir("../dots");
+
+            let error = resolve_file_root(&input, &probe).unwrap_err();
+
+            let SafetyLockError::ImplicitRootUnusable {
+                selected_by,
+                reason,
+                ..
+            } = error
+            else {
+                panic!("expected an unusable-candidate error");
+            };
+            assert_eq!(selected_by, expected);
+            assert!(reason.contains("it is relative"), "{reason}");
+            assert!(
+                probe.canonicalized().is_empty(),
+                "a relative path reached the filesystem probe"
+            );
+        }
+    }
+
+    /// An absolute current directory still selects normally when the Git
+    /// top-level is absent — the relative refusal is about the candidate
+    /// actually used, not about every captured value.
+    #[test]
+    fn a_relative_current_directory_does_not_spoil_a_usable_git_top_level() {
+        let probe = FakeProbe::dir("/srv/dots");
+        let input = FileRootInput::inside_repository("vim", "/srv/dots");
+
+        let root = resolve_file_root(&input, &probe).unwrap();
+
+        assert_eq!(root.as_path(), Path::new("/srv/dots"));
+    }
+
+    /// Each unusable class names what is wrong: a root that vanished, a file,
+    /// a permission problem, and an unresolvable path are four situations.
+    #[test]
+    fn each_unusable_class_produces_its_own_diagnostic() {
+        let cases = [
+            ("does not exist", FakeProbe::default()),
+            (
+                "is not a directory",
+                FakeProbe::with("/srv/dots", Entry::NotADirectory),
+            ),
+            (
+                "cannot be read",
+                FakeProbe::with("/srv/dots", Entry::UnreadableDir),
+            ),
+            (
+                "could not be resolved",
+                FakeProbe::with(
+                    "/srv/dots",
+                    Entry::Unresolvable(io::ErrorKind::PermissionDenied),
+                ),
+            ),
+        ];
+
+        let mut reasons = HashSet::new();
+        for (expected, probe) in cases {
+            let error = resolve_file_root(&FileRootInput::outside_repository("/srv/dots"), &probe)
+                .unwrap_err();
+            let reason = unusable_reason(error);
+            assert!(reason.contains(expected), "{reason}");
+            reasons.insert(reason);
+        }
+        assert_eq!(reasons.len(), 4, "two classes share one diagnostic");
+    }
+
+    /// A Git top-level Dodot cannot use is a failure, not a hint to try the
+    /// directory below it: selecting the current directory here would deploy
+    /// from a *different* root than the mechanism chose.
+    #[test]
+    fn an_unusable_git_top_level_never_falls_through_to_the_current_directory() {
+        let probe = FakeProbe::dir("/srv/dots/vim");
+        let input = FileRootInput::inside_repository("/srv/dots/vim", "/srv/dots");
+
+        let error = resolve_file_root(&input, &probe).unwrap_err();
+
+        assert_eq!(selecting_mechanism(error), RootSource::Git);
+        assert_eq!(
+            probe.canonicalized(),
+            vec![PathBuf::from("/srv/dots")],
+            "the current directory was probed as a second candidate"
+        );
+    }
+
+    /// The diagnostic names the mechanism as well as the path, because the
+    /// user's next action differs: a stale Git top-level is a repository
+    /// problem, a missing current directory is a shell problem.
+    #[test]
+    fn the_diagnostic_names_the_mechanism_that_chose_the_path() {
+        let git = resolve_file_root(
+            &FileRootInput::inside_repository("/srv/dots/vim", "/srv/dots"),
+            &FakeProbe::default(),
+        )
+        .unwrap_err();
+        let cwd = resolve_file_root(
+            &FileRootInput::outside_repository("/srv/dots"),
+            &FakeProbe::default(),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            git.to_string(),
+            "the git top-level `/srv/dots` cannot be used as a dotfiles root: \
+             it does not exist"
+        );
+        assert_eq!(
+            cwd.to_string(),
+            "the current directory `/srv/dots` cannot be used as a dotfiles root: \
+             it does not exist"
+        );
+    }
+
+    /// A non-Unicode root keeps its native bytes into the identity, and is
+    /// named the same reversible way trust state names it (ADR-0001).
+    #[test]
+    fn a_non_unicode_root_keeps_its_native_form() {
+        let native = PathBuf::from(OsString::from_vec(b"/srv/\x80dots".to_vec()));
+        let probe = FakeProbe::dir(native.clone());
+
+        let root = resolve_file_root(
+            &FileRootInput::inside_repository(native.join("vim"), native.clone()),
+            &probe,
+        )
+        .unwrap();
+
+        assert_eq!(root.as_path(), native);
+        assert_eq!(root.identity().spelling(), "os-bytes:2f7372762f80646f7473");
+        assert_eq!(
+            RootIdentity::parse(&root.identity().spelling()).unwrap(),
+            *root.identity()
+        );
+    }
+
+    /// A non-Unicode candidate that fails is named reversibly too: a lossy
+    /// rendering would print a path the user cannot act on.
+    #[test]
+    fn a_non_unicode_failure_is_named_reversibly() {
+        let native = PathBuf::from(OsString::from_vec(b"/srv/\x80dots".to_vec()));
+
+        let error = resolve_file_root(
+            &FileRootInput::outside_repository(native),
+            &FakeProbe::default(),
+        )
+        .unwrap_err();
+
+        let SafetyLockError::ImplicitRootUnusable { spelling, .. } = error else {
+            panic!("expected an unusable-candidate error");
+        };
+        assert_eq!(spelling, "os-bytes:2f7372762f80646f7473");
+    }
+
+    /// Both implicit mechanisms produce a root that needs approval — that is
+    /// the whole point of separating them from `DOTFILES_ROOT`.
+    #[test]
+    fn every_implicit_root_requires_approval() {
+        for input in [
+            FileRootInput::inside_repository("/srv/dots/vim", "/srv/dots"),
+            FileRootInput::outside_repository("/srv/dots"),
+        ] {
+            let root = resolve_file_root(&input, &FakeProbe::dir("/srv/dots")).unwrap();
+
+            assert!(root.requires_approval());
+            assert!(root.source().is_implicit());
+        }
+    }
+
+    /// The whole path against a real filesystem, so the injected probe is not
+    /// the only thing the behaviour has ever been proven against. A temporary
+    /// directory is itself reached through a symlink on macOS (`/var` →
+    /// `/private/var`), which makes the canonicalization real rather than
+    /// arranged.
+    #[test]
+    fn a_real_repository_resolves_through_the_os_probe() {
+        let home = tempfile::tempdir().unwrap();
+        let repository = home.path().join("dotfiles");
+        std::fs::create_dir_all(repository.join("vim/colors")).unwrap();
+        let canonical = std::fs::canonicalize(&repository).unwrap();
+
+        let from_subdirectory = resolve_file_root(
+            &FileRootInput::inside_repository(repository.join("vim/colors"), &repository),
+            &OsPathProbe,
+        )
+        .unwrap();
+        assert_eq!(from_subdirectory.as_path(), canonical);
+        assert_eq!(from_subdirectory.source(), RootSource::Git);
+
+        // The same repository reached through a symlink is one identity.
+        let alias = home.path().join("dots-link");
+        std::os::unix::fs::symlink(&repository, &alias).unwrap();
+        let through_alias =
+            resolve_file_root(&FileRootInput::outside_repository(&alias), &OsPathProbe).unwrap();
+        assert_eq!(through_alias.identity(), from_subdirectory.identity());
+        assert_eq!(through_alias.source(), RootSource::CurrentDirectory);
+
+        // A file at the same coordinate is refused rather than selected.
+        let file = home.path().join("not-a-root");
+        std::fs::write(&file, b"").unwrap();
+        let reason = unusable_reason(
+            resolve_file_root(&FileRootInput::outside_repository(&file), &OsPathProbe).unwrap_err(),
+        );
+        assert!(reason.contains("is not a directory"), "{reason}");
+
+        // And a root that went away since the shell entered it.
+        let removed = home.path().join("gone");
+        let reason = unusable_reason(
+            resolve_file_root(&FileRootInput::outside_repository(&removed), &OsPathProbe)
+                .unwrap_err(),
+        );
+        assert!(reason.contains("does not exist"), "{reason}");
     }
 }

--- a/crates/dodot-lib/src/safety_lock/selection.rs
+++ b/crates/dodot-lib/src/safety_lock/selection.rs
@@ -1,0 +1,336 @@
+//! One resolution per invocation: the single entry point every root consumer
+//! shares.
+//!
+//! Root selection used to live in more than one place — the library's path
+//! resolution, the CLI's own discovery, the tutorial's — each re-reading
+//! `DOTFILES_ROOT`, re-running `git rev-parse`, and disagreeing about what
+//! happens when none of it works (Spec, "Problem"). [`resolve_root`] is the
+//! one that answers the question: the invocation's process facts go in
+//! ([`RootSelectionInput`]), one immutable [`ResolvedRoot`] comes out, and
+//! every consumer carries that value instead of asking again (ADR-0001).
+//!
+//! The order is the whole policy, and it is short:
+//!
+//! 1. a present `DOTFILES_ROOT` — authoritative, so a broken value fails here
+//!    rather than selecting something else ([`resolve_environment_root`]);
+//! 2. the enclosing Git top-level;
+//! 3. the current directory ([`resolve_file_root`]).
+//!
+//! There is no fourth step. What makes "carried, not rediscovered" real is
+//! that this function is a pure function of injected input: it holds no
+//! process state to re-read, so a second consultation is not merely
+//! discouraged, it is not expressible without capturing the process again —
+//! which happens once, at the boundary (WS07).
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use super::environment::{resolve_environment_root, EnvironmentRootInput};
+use super::error::Result;
+use super::files::{resolve_file_root, FileRootInput};
+use super::roots::ResolvedRoot;
+use super::util::PathProbe;
+
+/// Everything about the invoking process that root selection depends on,
+/// captured once.
+///
+/// The current directory is held once rather than once per selection path, so
+/// a relative `DOTFILES_ROOT` and the implicit candidate can never be anchored
+/// to two different directories.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RootSelectionInput {
+    /// `DOTFILES_ROOT` exactly as the process environment carried it, or
+    /// `None` when it is unset.
+    pub dotfiles_root: Option<OsString>,
+
+    /// The directory Dodot was invoked from. Expected to be absolute.
+    pub current_dir: PathBuf,
+
+    /// The home directory, used to expand a leading `~`.
+    pub home_dir: PathBuf,
+
+    /// The Git top-level enclosing `current_dir`, or `None` when it is not
+    /// inside a repository.
+    pub git_top_level: Option<PathBuf>,
+}
+
+impl RootSelectionInput {
+    /// An invocation with no `DOTFILES_ROOT` and no enclosing repository —
+    /// the case where the current directory is the root.
+    pub fn new(current_dir: impl Into<PathBuf>, home_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            dotfiles_root: None,
+            current_dir: current_dir.into(),
+            home_dir: home_dir.into(),
+            git_top_level: None,
+        }
+    }
+
+    /// The same invocation with `DOTFILES_ROOT` set to `value`.
+    pub fn with_dotfiles_root(mut self, value: impl Into<OsString>) -> Self {
+        self.dotfiles_root = Some(value.into());
+        self
+    }
+
+    /// The same invocation from inside a repository whose top-level is
+    /// `git_top_level`.
+    pub fn with_git_top_level(mut self, git_top_level: impl Into<PathBuf>) -> Self {
+        self.git_top_level = Some(git_top_level.into());
+        self
+    }
+
+    /// The environment-selection view of this invocation.
+    pub fn environment(&self) -> EnvironmentRootInput {
+        EnvironmentRootInput {
+            raw_value: self.dotfiles_root.clone(),
+            current_dir: self.current_dir.clone(),
+            home_dir: self.home_dir.clone(),
+        }
+    }
+
+    /// The implicit-selection view of this invocation.
+    pub fn files(&self) -> FileRootInput {
+        FileRootInput {
+            current_dir: self.current_dir.clone(),
+            git_top_level: self.git_top_level.clone(),
+        }
+    }
+}
+
+/// Resolve this invocation's dotfiles root: `DOTFILES_ROOT`, then the Git
+/// top-level, then the current directory.
+///
+/// The result is immutable and self-contained — a canonical
+/// [`RootIdentity`](super::roots::RootIdentity) plus the
+/// [`RootSource`](super::roots::RootSource) that selected it — so trust
+/// lookup, the confirmation prompt, and execution can all carry the same value
+/// instead of consulting the environment, Git, or the current directory again
+/// (ADR-0001).
+///
+/// Provenance is the only thing that varies with which mechanism won:
+/// `DOTFILES_ROOT` yields a root that needs no approval, while both implicit
+/// mechanisms yield one that does.
+///
+/// Fails when a present `DOTFILES_ROOT` is unusable — which never falls
+/// through to implicit selection — or when the implicit candidate is unusable.
+pub fn resolve_root(input: &RootSelectionInput, probe: &dyn PathProbe) -> Result<ResolvedRoot> {
+    match resolve_environment_root(&input.environment(), probe)? {
+        Some(root) => Ok(root),
+        None => resolve_file_root(&input.files(), probe),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::super::error::SafetyLockError;
+    use super::super::roots::RootSource;
+    use super::super::test_probe::{Entry, FakeProbe};
+    use super::super::util::OsPathProbe;
+    use super::*;
+
+    const CWD: &str = "/srv/dots/vim";
+    const HOME: &str = "/home/alice";
+
+    fn invocation() -> RootSelectionInput {
+        RootSelectionInput::new(CWD, HOME)
+    }
+
+    #[test]
+    fn an_explicit_root_outranks_both_implicit_mechanisms() {
+        let probe = FakeProbe::dir("/srv/explicit").and_dir("/srv/dots");
+        let input = invocation()
+            .with_git_top_level("/srv/dots")
+            .with_dotfiles_root("/srv/explicit");
+
+        let root = resolve_root(&input, &probe).unwrap();
+
+        assert_eq!(root.as_path(), Path::new("/srv/explicit"));
+        assert_eq!(root.source(), RootSource::Environment);
+        assert!(!root.requires_approval());
+    }
+
+    #[test]
+    fn without_an_explicit_root_the_git_top_level_wins() {
+        let probe = FakeProbe::dir("/srv/dots");
+        let root = resolve_root(&invocation().with_git_top_level("/srv/dots"), &probe).unwrap();
+
+        assert_eq!(root.as_path(), Path::new("/srv/dots"));
+        assert_eq!(root.source(), RootSource::Git);
+        assert!(root.requires_approval());
+    }
+
+    #[test]
+    fn without_git_the_current_directory_is_the_root() {
+        let probe = FakeProbe::dir(CWD).and_dir("/home/alice/dotfiles");
+
+        let root = resolve_root(&invocation(), &probe).unwrap();
+
+        assert_eq!(root.as_path(), Path::new(CWD));
+        assert_eq!(root.source(), RootSource::CurrentDirectory);
+        assert_eq!(
+            probe.canonicalized(),
+            vec![PathBuf::from(CWD)],
+            "the conventional home path was probed as a candidate"
+        );
+    }
+
+    /// The rule the ordering exists to enforce (Spec story 9, ADR-0002): a
+    /// present value is authoritative, so nothing about it being broken may
+    /// reach the mechanisms below it.
+    #[test]
+    fn a_broken_explicit_root_never_reaches_implicit_selection() {
+        let probe = FakeProbe::dir("/srv/dots");
+        let input = invocation()
+            .with_git_top_level("/srv/dots")
+            .with_dotfiles_root("/srv/missing");
+
+        let error = resolve_root(&input, &probe).unwrap_err();
+
+        assert!(
+            matches!(error, SafetyLockError::EnvironmentRootUnusable { .. }),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            probe.canonicalized(),
+            vec![PathBuf::from("/srv/missing")],
+            "an implicit candidate was probed after an explicit value failed"
+        );
+    }
+
+    /// One invocation, one canonicalization: the value that comes out is what
+    /// every later consumer uses, so selection must not leave a second
+    /// resolution for anyone to perform (ADR-0001).
+    #[test]
+    fn one_invocation_canonicalizes_exactly_once() {
+        for (input, probe) in [
+            (
+                invocation().with_dotfiles_root("~/dots"),
+                FakeProbe::dir("/home/alice/dots"),
+            ),
+            (
+                invocation().with_git_top_level("/srv/link"),
+                FakeProbe::default().link("/srv/link", "/srv/dots"),
+            ),
+            (invocation(), FakeProbe::dir(CWD)),
+        ] {
+            resolve_root(&input, &probe).unwrap();
+
+            assert_eq!(
+                probe.canonicalized().len(),
+                1,
+                "resolution asked the filesystem more than once: {:?}",
+                probe.canonicalized()
+            );
+        }
+    }
+
+    /// A relative `DOTFILES_ROOT` and an implicit candidate are anchored to
+    /// the same captured directory, because there is only one to anchor to.
+    #[test]
+    fn both_selection_paths_see_one_captured_invocation_directory() {
+        let input = invocation().with_dotfiles_root("dots");
+
+        assert_eq!(input.environment().current_dir, input.files().current_dir);
+
+        let probe = FakeProbe::dir("/srv/dots/vim/dots");
+        let root = resolve_root(&input, &probe).unwrap();
+        assert_eq!(root.as_path(), Path::new("/srv/dots/vim/dots"));
+    }
+
+    /// The resolved root is a value: consumers hold it, clone it, and compare
+    /// it without any of them being able to reach back at the process.
+    #[test]
+    fn the_resolved_root_is_carried_rather_than_rediscovered() {
+        let probe = FakeProbe::dir("/srv/dots");
+        let root = resolve_root(&invocation().with_git_top_level("/srv/dots"), &probe).unwrap();
+
+        let carried: Vec<ResolvedRoot> = (0..3).map(|_| root.clone()).collect();
+
+        assert!(carried.iter().all(|held| *held == root));
+        assert_eq!(
+            probe.canonicalized().len(),
+            1,
+            "carrying the root re-consulted the filesystem"
+        );
+    }
+
+    /// The composition against a real filesystem: an explicit value, a
+    /// repository, and a bare directory, all through the same entry point.
+    #[test]
+    fn the_whole_order_holds_against_a_real_filesystem() {
+        let home = tempfile::tempdir().unwrap();
+        let repository = home.path().join("dotfiles");
+        std::fs::create_dir_all(repository.join("vim")).unwrap();
+        let explicit = home.path().join("explicit");
+        std::fs::create_dir(&explicit).unwrap();
+        let canonical_repository = std::fs::canonicalize(&repository).unwrap();
+        let canonical_explicit = std::fs::canonicalize(&explicit).unwrap();
+
+        let inside = RootSelectionInput::new(repository.join("vim"), home.path())
+            .with_git_top_level(&repository);
+
+        let root = resolve_root(&inside, &OsPathProbe).unwrap();
+        assert_eq!(root.as_path(), canonical_repository);
+        assert_eq!(root.source(), RootSource::Git);
+
+        let root = resolve_root(
+            &inside.clone().with_dotfiles_root("~/explicit"),
+            &OsPathProbe,
+        )
+        .unwrap();
+        assert_eq!(root.as_path(), canonical_explicit);
+        assert_eq!(root.source(), RootSource::Environment);
+
+        let outside = RootSelectionInput::new(repository.join("vim"), home.path());
+        let root = resolve_root(&outside, &OsPathProbe).unwrap();
+        assert_eq!(root.as_path(), canonical_repository.join("vim"));
+        assert_eq!(root.source(), RootSource::CurrentDirectory);
+    }
+
+    /// Selection reads no process state of its own: every fact it needs is a
+    /// field of its input, which is what makes the decision tests above
+    /// independent of where the test binary runs.
+    #[test]
+    fn selection_never_reads_the_process_environment() {
+        for source in [
+            include_str!("selection.rs"),
+            include_str!("files.rs"),
+            include_str!("environment.rs"),
+        ] {
+            // The implementation only: this test names the forbidden calls, so
+            // scanning itself would always find them.
+            let implementation = source
+                .split_once("#[cfg(test)]")
+                .expect("this file carries a test module")
+                .0;
+            let code = implementation
+                .lines()
+                .filter(|line| !line.trim_start().starts_with("//"))
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            for forbidden in ["std::env", "env::var", "current_dir()", "Command::new"] {
+                assert!(
+                    !code.contains(forbidden),
+                    "root selection reads process state through `{forbidden}`"
+                );
+            }
+        }
+    }
+
+    /// `Entry` exists so unusable candidates are stateable; the ordering tests
+    /// above rely on that as much as the failure tests do.
+    #[test]
+    fn an_unusable_implicit_candidate_fails_the_whole_selection() {
+        let probe = FakeProbe::with("/srv/dots", Entry::NotADirectory);
+        let error =
+            resolve_root(&invocation().with_git_top_level("/srv/dots"), &probe).unwrap_err();
+
+        assert!(
+            matches!(error, SafetyLockError::ImplicitRootUnusable { .. }),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/test_probe.rs
+++ b/crates/dodot-lib/src/safety_lock/test_probe.rs
@@ -1,0 +1,112 @@
+//! A filesystem stated as data, for the selection tests.
+//!
+//! Root selection asks the filesystem three questions ([`PathProbe`]), and
+//! every interesting answer — a symlink, a missing path, a file, an unreadable
+//! directory, a path that cannot be resolved at all — is awkward or
+//! unportable to arrange for real. Stating them as data makes each case one
+//! line, and keeps the decision tests free of ambient process state: no
+//! temporary directory, no process working directory, no repository.
+//!
+//! The fake also *records* what it was asked. That is how the tests prove the
+//! invariants that are about restraint rather than results: a failing
+//! `DOTFILES_ROOT` never probes an implicit candidate, and one invocation
+//! canonicalizes exactly once (ADR-0001).
+//!
+//! Selection is still proven against the real filesystem too — each selection
+//! module carries an [`OsPathProbe`](super::util::OsPathProbe) case — so the
+//! fake's answers cannot be the only thing the behaviour holds against.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use super::util::PathProbe;
+
+/// What a path is, as far as the probe is concerned.
+#[derive(Debug, Clone)]
+pub enum Entry {
+    ReadableDir,
+    UnreadableDir,
+    NotADirectory,
+    Unresolvable(io::ErrorKind),
+}
+
+/// What each path canonicalizes to, and what it is once canonical. Anything
+/// unregistered is missing.
+#[derive(Debug, Default)]
+pub struct FakeProbe {
+    links: Vec<(PathBuf, PathBuf)>,
+    entries: Vec<(PathBuf, Entry)>,
+    canonicalized: Mutex<Vec<PathBuf>>,
+}
+
+impl FakeProbe {
+    /// A filesystem holding one path, which is `entry`.
+    pub fn with(path: impl Into<PathBuf>, entry: Entry) -> Self {
+        Self::default().add(path, entry)
+    }
+
+    /// A filesystem holding one readable directory.
+    pub fn dir(path: impl Into<PathBuf>) -> Self {
+        Self::with(path, Entry::ReadableDir)
+    }
+
+    /// Add another path.
+    pub fn add(mut self, path: impl Into<PathBuf>, entry: Entry) -> Self {
+        self.entries.push((path.into(), entry));
+        self
+    }
+
+    /// Add another readable directory.
+    pub fn and_dir(self, path: impl Into<PathBuf>) -> Self {
+        self.add(path, Entry::ReadableDir)
+    }
+
+    /// `path` canonicalizes to `target`, which is a readable directory.
+    pub fn link(mut self, path: impl Into<PathBuf>, target: impl Into<PathBuf>) -> Self {
+        let target = target.into();
+        self.links.push((path.into(), target.clone()));
+        self.and_dir(target)
+    }
+
+    fn entry(&self, path: &Path) -> Option<&Entry> {
+        self.entries
+            .iter()
+            .find(|(known, _)| known == path)
+            .map(|(_, entry)| entry)
+    }
+
+    /// Every path `canonicalize` was asked about, in order — the proof that a
+    /// candidate was anchored where the test says, and that resolution
+    /// happened once.
+    pub fn canonicalized(&self) -> Vec<PathBuf> {
+        self.canonicalized.lock().unwrap().clone()
+    }
+}
+
+impl PathProbe for FakeProbe {
+    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        self.canonicalized.lock().unwrap().push(path.to_path_buf());
+
+        if let Some((_, target)) = self.links.iter().find(|(known, _)| known == path) {
+            return Ok(target.clone());
+        }
+
+        match self.entry(path) {
+            Some(Entry::Unresolvable(kind)) => Err(io::Error::from(*kind)),
+            Some(_) => Ok(path.to_path_buf()),
+            None => Err(io::Error::from(io::ErrorKind::NotFound)),
+        }
+    }
+
+    fn is_directory(&self, path: &Path) -> bool {
+        matches!(
+            self.entry(path),
+            Some(Entry::ReadableDir | Entry::UnreadableDir)
+        )
+    }
+
+    fn is_readable_dir(&self, path: &Path) -> bool {
+        matches!(self.entry(path), Some(Entry::ReadableDir))
+    }
+}

--- a/crates/dodot-lib/src/safety_lock/util.rs
+++ b/crates/dodot-lib/src/safety_lock/util.rs
@@ -25,10 +25,12 @@
 //!
 //! [`canonical_root_identity`] is the one place a candidate path becomes a
 //! root identity, shared by both selection paths so an environment root and an
-//! implicit one are held to the same standard. It reports *which* requirement
-//! failed rather than a bare boolean, because each caller phrases the refusal
-//! in its own vocabulary — `DOTFILES_ROOT` names the variable, implicit
-//! selection names the mechanism that chose the path.
+//! implicit one are held to the same standard — including the requirement that
+//! the candidate be absolute, which it enforces in every build rather than
+//! trusting its callers to have checked. It reports *which* requirement failed
+//! rather than a bare boolean, because each caller phrases the refusal in its
+//! own vocabulary — `DOTFILES_ROOT` names the variable, implicit selection
+//! names the mechanism that chose the path.
 
 use std::ffi::OsString;
 use std::fmt::Write as _;
@@ -143,6 +145,9 @@ pub trait PathProbe: Send + Sync {
 /// meant, and a permission problem have three different next actions.
 #[derive(Debug)]
 pub(super) enum UnusableRoot {
+    /// The candidate is relative, so it has no meaning independent of the
+    /// process working directory.
+    Relative,
     /// Nothing exists at the candidate path.
     Missing,
     /// Something is there, but it could not be resolved.
@@ -160,23 +165,29 @@ pub(super) enum UnusableRoot {
 /// yielding the root identity built from that canonical path.
 ///
 /// This is the whole of what "usable root" means, and both selection paths ask
-/// it here rather than each spelling out the sequence: canonicalize (which is
-/// also what resolves aliases and symlinks into one identity, ADR-0001), then
-/// require a directory, then require one whose entries discovery could
-/// actually walk.
+/// it here rather than each spelling out the sequence: require an absolute
+/// path, canonicalize it (which is also what resolves aliases and symlinks
+/// into one identity, ADR-0001), then require a directory, then require one
+/// whose entries discovery could actually walk.
 ///
-/// `candidate` must already be absolute. A relative path would be resolved by
-/// the operating system against the process working directory — the state
-/// Safety Lock resolves once per invocation and never re-reads — so callers
-/// anchor it to their injected invocation directory, or refuse it, first.
+/// Absoluteness is the first requirement rather than a caller precondition,
+/// and it is checked in every build rather than asserted: a relative path
+/// would be resolved by the operating system against the process working
+/// directory — the state Safety Lock resolves once per invocation and never
+/// re-reads — so a release build that let one through would silently reopen
+/// the very ambiguity this module exists to close. Callers still anchor a
+/// relative value to their injected invocation directory before asking; what
+/// they get back for one that could not be anchored is
+/// [`UnusableRoot::Relative`], phrased in their own vocabulary like every
+/// other failure. The check precedes the probe, so a relative candidate never
+/// reaches the filesystem.
 pub(super) fn canonical_root_identity(
     candidate: &Path,
     probe: &dyn PathProbe,
 ) -> std::result::Result<RootIdentity, UnusableRoot> {
-    debug_assert!(
-        candidate.is_absolute(),
-        "a relative candidate would be resolved against the process working directory"
-    );
+    if !candidate.is_absolute() {
+        return Err(UnusableRoot::Relative);
+    }
 
     let canonical = probe.canonicalize(candidate).map_err(|err| {
         if err.kind() == std::io::ErrorKind::NotFound {
@@ -237,7 +248,30 @@ impl PathProbe for OsPathProbe {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_probe::FakeProbe;
     use super::*;
+
+    /// Absoluteness is a real requirement of the shared helper, not a
+    /// developer-only assumption: an assertion compiled out of release builds
+    /// would leave a relative candidate to be resolved against the process
+    /// working directory — exactly the ambient state this module refuses to
+    /// read — so it is checked in every build, and checked before the probe,
+    /// so the filesystem is never asked about a path with no fixed meaning.
+    #[test]
+    fn a_relative_candidate_is_refused_without_touching_the_filesystem() {
+        let probe = FakeProbe::dir("dots");
+
+        let failure = canonical_root_identity(Path::new("dots"), &probe).unwrap_err();
+
+        assert!(
+            matches!(failure, UnusableRoot::Relative),
+            "unexpected failure: {failure:?}"
+        );
+        assert!(
+            probe.canonicalized().is_empty(),
+            "a relative candidate reached the filesystem probe"
+        );
+    }
 
     /// A non-Unicode path, built from bytes std will never hand back as
     /// UTF-8. `0x80` is a continuation byte with no lead byte.

--- a/crates/dodot-lib/src/safety_lock/util.rs
+++ b/crates/dodot-lib/src/safety_lock/util.rs
@@ -20,6 +20,15 @@
 //! `os-bytes:`. [`encode_native_path`] resolves that by hex-encoding such a
 //! path too, so decoding a spelling always reproduces the exact input bytes —
 //! no escape grammar, no unrepresentable path.
+//!
+//! ## Candidate validation
+//!
+//! [`canonical_root_identity`] is the one place a candidate path becomes a
+//! root identity, shared by both selection paths so an environment root and an
+//! implicit one are held to the same standard. It reports *which* requirement
+//! failed rather than a bare boolean, because each caller phrases the refusal
+//! in its own vocabulary — `DOTFILES_ROOT` names the variable, implicit
+//! selection names the mechanism that chose the path.
 
 use std::ffi::OsString;
 use std::fmt::Write as _;
@@ -27,6 +36,7 @@ use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 
 use super::error::{Result, SafetyLockError};
+use super::roots::RootIdentity;
 
 /// Prefix marking a spelling that carries hex-encoded native path bytes
 /// rather than the path's plain text.
@@ -124,6 +134,67 @@ pub trait PathProbe: Send + Sync {
     /// usable root, and answering "readable" for it would let the pipeline
     /// fail partway through discovery instead of at selection time.
     fn is_readable_dir(&self, path: &Path) -> bool;
+}
+
+/// Why a candidate path cannot become a root identity.
+///
+/// One variant per requirement [`canonical_root_identity`] checks, so a caller
+/// can say what the user has to fix: a typo, a file where a directory was
+/// meant, and a permission problem have three different next actions.
+#[derive(Debug)]
+pub(super) enum UnusableRoot {
+    /// Nothing exists at the candidate path.
+    Missing,
+    /// Something is there, but it could not be resolved.
+    Unresolvable(std::io::Error),
+    /// The canonical path is not a directory.
+    NotADirectory,
+    /// The canonical path is a directory whose contents cannot be read.
+    Unreadable,
+    /// The canonical path is not a usable identity — only reachable through a
+    /// [`PathProbe`] that returns something non-canonical.
+    NotAnIdentity(SafetyLockError),
+}
+
+/// Canonicalize `candidate` once and check it is a directory Dodot can walk,
+/// yielding the root identity built from that canonical path.
+///
+/// This is the whole of what "usable root" means, and both selection paths ask
+/// it here rather than each spelling out the sequence: canonicalize (which is
+/// also what resolves aliases and symlinks into one identity, ADR-0001), then
+/// require a directory, then require one whose entries discovery could
+/// actually walk.
+///
+/// `candidate` must already be absolute. A relative path would be resolved by
+/// the operating system against the process working directory — the state
+/// Safety Lock resolves once per invocation and never re-reads — so callers
+/// anchor it to their injected invocation directory, or refuse it, first.
+pub(super) fn canonical_root_identity(
+    candidate: &Path,
+    probe: &dyn PathProbe,
+) -> std::result::Result<RootIdentity, UnusableRoot> {
+    debug_assert!(
+        candidate.is_absolute(),
+        "a relative candidate would be resolved against the process working directory"
+    );
+
+    let canonical = probe.canonicalize(candidate).map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            UnusableRoot::Missing
+        } else {
+            UnusableRoot::Unresolvable(err)
+        }
+    })?;
+
+    if !probe.is_directory(&canonical) {
+        return Err(UnusableRoot::NotADirectory);
+    }
+
+    if !probe.is_readable_dir(&canonical) {
+        return Err(UnusableRoot::Unreadable);
+    }
+
+    RootIdentity::new(canonical).map_err(UnusableRoot::NotAnIdentity)
 }
 
 /// [`PathProbe`] backed by the real filesystem.


### PR DESCRIPTION
Fills in implicit file-root selection — the Git top-level, then the current directory — and composes it with WS02's `DOTFILES_ROOT` path into `resolve_root`, the invocation's single act of root selection.

`for #308`

## Context

Why this shape: the epic's premise is that a root is *selected once and then carried* (ADR-0001). WS02 landed the authoritative environment path; this WS lands the other two mechanisms and, more importantly, the one function that orders all three. `resolve_root(&RootSelectionInput, &dyn PathProbe)` is a pure function of injected process facts — no `std::env`, no `git`, no process working directory — so "carried, not rediscovered" is not a convention a reviewer has to police: a second consultation is not expressible without capturing the process again, which happens once, at the boundary (WS07).

Three deliberate calls:

- **No `$HOME/dotfiles` fallback.** Dodot's pre-Safety-Lock resolution ends there when Git finds nothing, which invents a root out of a naming convention — a path the user did not select, from an invocation that says nothing about it. Git, then the current directory, are the two mechanisms the Spec approves, and each yields a path the user was standing in or inside of, which is what makes the confirmation prompt answerable.
- **No retry against the other candidate.** A Git top-level that turns out to be unusable fails naming itself; falling through to the current directory would quietly select a *different* root (a descendant of the one that failed) — the substitution ADR-0002 rules out for explicit values, for the same reason. Likewise a broken `DOTFILES_ROOT` never reaches implicit selection.
- **`ImplicitRootUnusable` names the mechanism, not just the path.** `NoImplicitRoot { current_dir }` is replaced by it, because the Git top-level is frequently *not* the directory the user's shell prompt shows (Spec, story 2): "the git top-level `/srv/dots` cannot be used …" tells them where to look, and a bare path does not.

Structure: the usability sequence WS02 spelled out inline (canonicalize → is a directory → is a directory discovery could walk) moves to `util::canonical_root_identity`, so both selection paths are held to one standard and each phrases the refusal in its own vocabulary — `DOTFILES_ROOT` names the variable, implicit selection names the mechanism. It reports *which* requirement failed (`UnusableRoot`) rather than a bare boolean, which is what makes that split possible. The `FakeProbe` WS02 kept private to its test module moves to a shared `test_probe` (test-only) for the same reason.

Out of scope / do not "fix" here: wiring any of this into a command. `crate::paths` and the CLI still run the old resolution; replacing those callers is WS07's process-boundary work, which is where the environment, cwd, and Git capture this module refuses to perform lands. Also out of scope: the trust lifecycle, the decision gate, and the inventory — WS04/WS05, still `todo!()` with documented signatures.

Self-check: checked against ADR-0001 (canonical path is the identity; alias and symlink spellings collapse to one, a *moved* root is a new identity, a directory replaced at the same canonical path keeps the approval) and ADR-0002 (an unusable explicit value fails rather than substituting).

## What is in the diff

| File | |
|---|---|
| `safety_lock/files.rs` | `resolve_file_root` — Git top-level, else current directory, canonicalized once, tagged with the `RootSource` that chose it |
| `safety_lock/selection.rs` | new — `resolve_root` + `RootSelectionInput`: the three-step order and the invocation facts it needs |
| `safety_lock/util.rs` | new — `canonical_root_identity` / `UnusableRoot`: the shared "usable root" sequence |
| `safety_lock/environment.rs` | refactored onto that shared helper; behaviour and messages unchanged |
| `safety_lock/error.rs` | `NoImplicitRoot` → `ImplicitRootUnusable { spelling, selected_by, reason }` |
| `safety_lock/test_probe.rs` | new, test-only — the filesystem-as-data `FakeProbe`, moved out of `environment.rs` |
| `safety_lock.rs` | module docs: the selection box in the diagram, the WS03 status, the WS07 pointer |

## Tests

The behaviours pinned, rather than the code paths covered:

- **Order** — an explicit root outranks both implicit mechanisms; a broken explicit root never *probes* an implicit candidate; without `DOTFILES_ROOT` the Git top-level wins; without Git the current directory is the root.
- **Restraint** — one invocation canonicalizes exactly once (the `FakeProbe` records what it was asked); selection never reads the process environment; both paths see one captured invocation directory, so a relative `DOTFILES_ROOT` and the implicit candidate can never anchor to two different directories.
- **Identity** — aliases of one directory resolve to one identity; *moving* a root changes its identity while replacing the directory in place does not; a relocated symlink target is a new identity; a non-Unicode root keeps its native form and is named reversibly when it fails.
- **Refusal** — relative, missing, not-a-directory, unresolvable, and listable-but-not-walkable candidates each fail with the diagnostic that names what to fix; a relative candidate never reaches the probe at all.
- **Real filesystem** — the whole order holds against `OsPathProbe` too, so the fake's answers are not the only thing the behaviour holds against.

`pixi run test` → **1636 passed, 0 skipped**. Lint suite green via the commit and push hooks.
