### PR TITLE
ACC01-WS04: Epic: Safety Lock - Workstream: Trusted-root registry lifecycle

### DIFF
--- a/crates/dodot-lib/src/safety_lock.rs
+++ b/crates/dodot-lib/src/safety_lock.rs
@@ -58,11 +58,17 @@
 //!
 //! ACC01-WS01 establishes this vocabulary and the persisted schema; ACC01-WS02
 //! fills in [`environment`], the authoritative `DOTFILES_ROOT` path; ACC01-WS03
-//! fills in [`files`] and composes both into [`selection`]. The remaining
-//! trust-lifecycle, decision, inventory, and scoping entry points carry
+//! fills in [`files`] and composes both into [`selection`]; ACC01-WS04 fills in
+//! the trust lifecycle over the loaded collection — [`check`], [`list`], and
+//! [`forget`]. The remaining inventory and scoping entry points carry
 //! documented signatures with `todo!()` bodies; each names the Work Stream
-//! that fills it in. The data model, the schema, and root selection are
-//! complete and tested.
+//! that fills it in. The data model, the schema, root selection, and the
+//! registry lifecycle are complete and tested.
+//!
+//! What WS05 adds on top of [`check`] is the operation policy — which commands
+//! are root-sensitive, and how a read-only or dry-run invocation passes without
+//! establishing trust; [`decide`] answers only the part the collection can
+//! answer.
 //!
 //! Dodot's pre-Safety-Lock root resolution still runs in
 //! [`crate::paths`](crate::paths) and in the CLI: replacing those callers with

--- a/crates/dodot-lib/src/safety_lock/check.rs
+++ b/crates/dodot-lib/src/safety_lock/check.rs
@@ -82,11 +82,15 @@ pub struct ApprovalChange {
 /// than inheriting another root's approval (Spec, story 6).
 ///
 /// Fails when the collection itself is unusable — the same invariants
-/// [`SafetyLockConfig::validate`] enforces at load. Trust state Dodot does not
-/// fully understand must be reported, never read as "nothing approved", which
-/// would silently downgrade a decision to `ApprovalRequired` and, once the user
-/// confirmed, write approvals back over a file whose contents were never
-/// understood (ADR-0001).
+/// [`SafetyLockConfig::validate`] enforces at load. Only an implicit root
+/// reaches that check: an environment root returns on provenance before the
+/// collection is consulted at all, so it is decided whatever state the trust
+/// file is in, the mirror of [`approve`]'s refusal preceding every other
+/// check. For an implicit root — the only case the collection can answer —
+/// trust state Dodot does not fully understand must be reported, never read as
+/// "nothing approved", which would silently downgrade a decision to
+/// `ApprovalRequired` and, once the user confirmed, write approvals back over a
+/// file whose contents were never understood (ADR-0001).
 pub fn decide(root: &ResolvedRoot, config: &SafetyLockConfig) -> Result<TrustDecision> {
     if !root.requires_approval() {
         return Ok(TrustDecision::ExplicitlySelected);
@@ -361,6 +365,12 @@ mod tests {
     /// empty registry: reading it as empty would downgrade the decision to
     /// "ask the user" and then write approvals back over a file whose contents
     /// were never understood.
+    ///
+    /// Only an implicit root reaches that check, because it is the only case
+    /// that consults the collection. An environment root is answered from
+    /// provenance first and is decided whatever state the file is in — the
+    /// mirror of the refusal `approve` gives it, which likewise precedes every
+    /// other check.
     #[test]
     fn unusable_trust_state_is_reported_rather_than_read_as_empty() {
         let root = identity("/home/alice/dotfiles");
@@ -368,7 +378,7 @@ mod tests {
 
         for error in [
             decide(&implicit(root.clone()), &duplicated).unwrap_err(),
-            approve(&duplicated, &implicit(root)).unwrap_err(),
+            approve(&duplicated, &implicit(root.clone())).unwrap_err(),
         ] {
             assert!(
                 matches!(error, SafetyLockError::DuplicateApprovedRoot { ref spelling }
@@ -376,6 +386,19 @@ mod tests {
                 "unexpected error: {error}"
             );
         }
+
+        assert_eq!(
+            decide(&explicit(root.clone()), &duplicated).unwrap(),
+            TrustDecision::ExplicitlySelected,
+            "an environment root's standing was made to depend on the collection"
+        );
+        assert!(
+            matches!(
+                approve(&duplicated, &explicit(root)).unwrap_err(),
+                SafetyLockError::EnvironmentRootNotApprovable { .. }
+            ),
+            "the collection was consulted before refusing an environment root"
+        );
     }
 
     /// The whole lifecycle against the one thing it is for: state the caller

--- a/crates/dodot-lib/src/safety_lock/check.rs
+++ b/crates/dodot-lib/src/safety_lock/check.rs
@@ -8,9 +8,16 @@
 //! (WS07) order the write before the mutation it authorizes — approval records
 //! the user's path decision, not the mutation's outcome (Spec, "Risks").
 //!
-//! Behaviour arrives in WS05; this Work Stream fixes the signatures.
+//! Both operations consult the collection only for an *implicit* root.
+//! Provenance is what decides that: a valid `DOTFILES_ROOT` is already the
+//! deliberate selection, so it neither reads an approval nor writes one
+//! (ADR-0003).
+//!
+//! WS05 layers the operation policy — read-only, dry run, root-sensitive
+//! mutation — on top of what is decided here; this module answers only the
+//! question the trust collection can answer.
 
-use super::error::Result;
+use super::error::{Result, SafetyLockError};
 use super::roots::{ResolvedRoot, RootIdentity};
 use super::schema::SafetyLockConfig;
 
@@ -65,26 +72,375 @@ pub struct ApprovalChange {
 /// Reads nothing from disk: both the root and the trust state are resolved
 /// once per invocation and passed in, so the path checked here is the path
 /// that will be mutated (ADR-0001).
+///
+/// An environment root is answered from its provenance alone — the collection
+/// is not consulted, because nothing in it could authorize or refuse a
+/// selection `DOTFILES_ROOT` already made. For an implicit root the lookup is
+/// exact on the canonical identity, so a moved root, an alias that normalized
+/// elsewhere, and a root whose lossy rendering collides with an approved one
+/// all land on [`ApprovalRequired`](TrustDecision::ApprovalRequired) rather
+/// than inheriting another root's approval (Spec, story 6).
+///
+/// Fails when the collection itself is unusable — the same invariants
+/// [`SafetyLockConfig::validate`] enforces at load. Trust state Dodot does not
+/// fully understand must be reported, never read as "nothing approved", which
+/// would silently downgrade a decision to `ApprovalRequired` and, once the user
+/// confirmed, write approvals back over a file whose contents were never
+/// understood (ADR-0001).
 pub fn decide(root: &ResolvedRoot, config: &SafetyLockConfig) -> Result<TrustDecision> {
-    let _ = (root, config);
-    todo!("WS05: safety decisions over the loaded trust state")
+    if !root.requires_approval() {
+        return Ok(TrustDecision::ExplicitlySelected);
+    }
+
+    config.validate()?;
+
+    Ok(if config.is_approved(root.identity()) {
+        TrustDecision::AlreadyApproved
+    } else {
+        TrustDecision::ApprovalRequired
+    })
 }
 
 /// Produce the trust state that records approval of `root`.
+///
+/// Idempotent: approving a root the collection already holds returns it
+/// unchanged with [`added`](ApprovalChange::added) `false`, so a caller can
+/// skip the write and a repeated confirmation cannot mint a duplicate the next
+/// load would refuse.
+///
+/// Approval is an append. Roots stay independent and unordered — nothing here
+/// promotes, replaces, or arbitrates between the roots already held, because
+/// the collection has no preferred entry to be (Spec, story 5).
 ///
 /// Fails with
 /// [`EnvironmentRootNotApprovable`](super::error::SafetyLockError::EnvironmentRootNotApprovable)
 /// for an environment-selected root: `DOTFILES_ROOT` is already the deliberate
 /// selection, and adding it to the collection would trust a path the user was
-/// never shown (ADR-0003).
+/// never shown (ADR-0003). That refusal precedes every other check, so an
+/// environment root cannot be recorded whatever state the collection is in.
 pub fn approve(config: &SafetyLockConfig, root: &ResolvedRoot) -> Result<ApprovalChange> {
-    let _ = (config, root);
-    todo!("WS04: trusted-root registry lifecycle")
+    if !root.requires_approval() {
+        return Err(SafetyLockError::EnvironmentRootNotApprovable {
+            spelling: root.identity().spelling(),
+        });
+    }
+
+    config.validate()?;
+
+    let identity = root.identity().clone();
+    let mut config = config.clone();
+    let added = !config.is_approved(&identity);
+    if added {
+        config.roots.approved.push(identity.clone());
+    }
+
+    Ok(ApprovalChange {
+        config,
+        identity,
+        added,
+    })
 }
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+    use std::path::PathBuf;
+
+    use super::super::roots::RootSource;
+    use super::super::schema::TrustedRootsSection;
     use super::*;
+
+    fn identity(path: &str) -> RootIdentity {
+        RootIdentity::new(path).unwrap()
+    }
+
+    /// A root whose native path is not valid UTF-8. `0x80` is a continuation
+    /// byte with no lead byte, so std will never hand these bytes back as a
+    /// string.
+    fn non_unicode_identity(suffix: &[u8]) -> RootIdentity {
+        let mut bytes = b"/tmp/".to_vec();
+        bytes.extend_from_slice(suffix);
+        RootIdentity::new(PathBuf::from(OsString::from_vec(bytes))).unwrap()
+    }
+
+    fn approved(roots: impl IntoIterator<Item = RootIdentity>) -> SafetyLockConfig {
+        SafetyLockConfig {
+            roots: TrustedRootsSection {
+                approved: roots.into_iter().collect(),
+            },
+        }
+    }
+
+    fn implicit(identity: RootIdentity) -> ResolvedRoot {
+        ResolvedRoot::new(identity, RootSource::Git)
+    }
+
+    fn explicit(identity: RootIdentity) -> ResolvedRoot {
+        ResolvedRoot::new(identity, RootSource::Environment)
+    }
+
+    #[test]
+    fn an_implicit_root_is_approved_only_when_the_collection_holds_it() {
+        let root = identity("/home/alice/dotfiles");
+
+        assert_eq!(
+            decide(&implicit(root.clone()), &SafetyLockConfig::default()).unwrap(),
+            TrustDecision::ApprovalRequired
+        );
+        assert_eq!(
+            decide(&implicit(root.clone()), &approved([root.clone()])).unwrap(),
+            TrustDecision::AlreadyApproved
+        );
+
+        // Both implicit mechanisms are one case: the collection records a
+        // path, not the mechanism that found it.
+        let from_cwd = ResolvedRoot::new(root.clone(), RootSource::CurrentDirectory);
+        assert_eq!(
+            decide(&from_cwd, &approved([root])).unwrap(),
+            TrustDecision::AlreadyApproved
+        );
+    }
+
+    /// Deliberate selection is answered from provenance alone: an environment
+    /// root neither reads an approval nor needs one (ADR-0003).
+    #[test]
+    fn an_environment_root_is_deliberate_without_a_trust_record() {
+        let root = identity("/home/alice/dotfiles");
+        let config = SafetyLockConfig::default();
+
+        assert_eq!(
+            decide(&explicit(root.clone()), &config).unwrap(),
+            TrustDecision::ExplicitlySelected
+        );
+
+        let refusal = approve(&config, &explicit(root.clone())).unwrap_err();
+        assert!(
+            matches!(
+                refusal,
+                SafetyLockError::EnvironmentRootNotApprovable { ref spelling }
+                    if spelling == "/home/alice/dotfiles"
+            ),
+            "unexpected error: {refusal}"
+        );
+        assert!(
+            config.roots.approved.is_empty(),
+            "the environment root reached the collection"
+        );
+
+        // Its standing does not depend on the collection either way: an
+        // already-listed path is still explicitly selected, and still not
+        // approvable.
+        let listed = approved([root.clone()]);
+        assert_eq!(
+            decide(&explicit(root.clone()), &listed).unwrap(),
+            TrustDecision::ExplicitlySelected
+        );
+        assert!(approve(&listed, &explicit(root)).is_err());
+    }
+
+    /// Story 5: roots are independent. Approving a second one neither replaces
+    /// the first nor marks either preferred.
+    #[test]
+    fn independent_roots_are_approved_without_arbitration() {
+        let personal = identity("/home/alice/dotfiles");
+        let work = identity("/home/alice/work-dotfiles");
+
+        let change = approve(&SafetyLockConfig::default(), &implicit(personal.clone())).unwrap();
+        assert!(change.added);
+        let change = approve(&change.config, &implicit(work.clone())).unwrap();
+        assert!(change.added);
+
+        assert_eq!(
+            change.config.roots.approved,
+            vec![personal.clone(), work.clone()]
+        );
+        assert_eq!(
+            decide(&implicit(personal), &change.config).unwrap(),
+            TrustDecision::AlreadyApproved
+        );
+        assert_eq!(
+            decide(&implicit(work), &change.config).unwrap(),
+            TrustDecision::AlreadyApproved
+        );
+        assert!(change.config.validate().is_ok());
+    }
+
+    /// Re-confirming a root must not mint a second record: the duplicate a
+    /// non-idempotent append leaves behind is exactly what the next load
+    /// refuses to read.
+    #[test]
+    fn approving_an_approved_root_changes_nothing() {
+        let root = identity("/home/alice/dotfiles");
+        let first = approve(&SafetyLockConfig::default(), &implicit(root.clone())).unwrap();
+
+        let second = approve(&first.config, &implicit(root.clone())).unwrap();
+
+        assert!(!second.added, "a repeated approval reported a change");
+        assert_eq!(second.identity, root);
+        assert_eq!(second.config.roots.approved, vec![root]);
+        assert!(second.config.validate().is_ok());
+    }
+
+    /// Approval is spelling-insensitive in exactly the way identity is: an
+    /// alias of an approved root is the same record, not a second one.
+    #[test]
+    fn an_alias_of_an_approved_root_is_already_approved() {
+        let config = approved([identity("/home/alice/dotfiles")]);
+
+        for alias in [
+            "/home/alice//dotfiles",
+            "/home/alice/dotfiles/",
+            "/home/alice/./dotfiles",
+        ] {
+            let root = implicit(identity(alias));
+            assert_eq!(
+                decide(&root, &config).unwrap(),
+                TrustDecision::AlreadyApproved,
+                "`{alias}` was not recognized as the approved root"
+            );
+            assert!(
+                !approve(&config, &root).unwrap().added,
+                "`{alias}` was recorded as a second approval"
+            );
+        }
+    }
+
+    /// Story 6: approval belongs to a path, so a root that moved arrives at
+    /// the gate unapproved rather than inheriting its old location's standing.
+    #[test]
+    fn a_moved_root_does_not_inherit_the_old_locations_approval() {
+        let config = approved([identity("/home/alice/dotfiles")]);
+        let moved = implicit(identity("/home/alice/archive/dotfiles"));
+
+        assert_eq!(
+            decide(&moved, &config).unwrap(),
+            TrustDecision::ApprovalRequired
+        );
+
+        // Nor does a parent or child of the approved root.
+        for neighbour in ["/home/alice", "/home/alice/dotfiles/vim"] {
+            assert_eq!(
+                decide(&implicit(identity(neighbour)), &config).unwrap(),
+                TrustDecision::ApprovalRequired,
+                "`{neighbour}` inherited the approved root's standing"
+            );
+        }
+    }
+
+    /// Two roots whose lossy renderings collide are two records: approving one
+    /// must not authorize the other, which a rendering-based lookup would.
+    #[test]
+    fn lossy_colliding_roots_are_approved_independently() {
+        let one = non_unicode_identity(b"\x80");
+        let other = non_unicode_identity(b"\x81");
+        assert_eq!(
+            one.as_path().to_string_lossy(),
+            other.as_path().to_string_lossy(),
+            "test premise: these two roots render identically when lossy"
+        );
+
+        let change = approve(&SafetyLockConfig::default(), &implicit(one.clone())).unwrap();
+
+        assert_eq!(
+            decide(&implicit(one), &change.config).unwrap(),
+            TrustDecision::AlreadyApproved
+        );
+        assert_eq!(
+            decide(&implicit(other.clone()), &change.config).unwrap(),
+            TrustDecision::ApprovalRequired
+        );
+
+        let change = approve(&change.config, &implicit(other)).unwrap();
+        assert!(change.added);
+        assert_eq!(change.config.roots.approved.len(), 2);
+        assert!(change.config.validate().is_ok());
+    }
+
+    /// Trust state Dodot cannot fully read is reported, never treated as an
+    /// empty registry: reading it as empty would downgrade the decision to
+    /// "ask the user" and then write approvals back over a file whose contents
+    /// were never understood.
+    #[test]
+    fn unusable_trust_state_is_reported_rather_than_read_as_empty() {
+        let root = identity("/home/alice/dotfiles");
+        let duplicated = approved([root.clone(), root.clone()]);
+
+        for error in [
+            decide(&implicit(root.clone()), &duplicated).unwrap_err(),
+            approve(&duplicated, &implicit(root)).unwrap_err(),
+        ] {
+            assert!(
+                matches!(error, SafetyLockError::DuplicateApprovedRoot { ref spelling }
+                    if spelling == "/home/alice/dotfiles"),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    /// The whole lifecycle against the one thing it is for: state the caller
+    /// writes and loads back. Approving, listing, and forgetting each hand
+    /// back a collection the validated load accepts — which is what keeps a
+    /// non-Unicode root and a repeated confirmation from producing a file
+    /// Dodot then refuses to read.
+    #[test]
+    fn the_lifecycle_produces_collections_that_load_back_unchanged() {
+        use super::super::forget::{forget_root, ForgetRequest};
+        use super::super::list::list_roots;
+        use super::super::test_probe::FakeProbe;
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let persist = |config: &SafetyLockConfig| {
+            std::fs::write(
+                SafetyLockConfig::path_in(data_dir.path()),
+                toml::to_string(config).unwrap(),
+            )
+            .unwrap();
+            SafetyLockConfig::load_from(data_dir.path()).unwrap()
+        };
+
+        let personal = identity("/home/alice/dotfiles");
+        let native = non_unicode_identity(b"\x80dots");
+
+        let mut config = SafetyLockConfig::default();
+        for root in [&personal, &native] {
+            config = persist(&approve(&config, &implicit(root.clone())).unwrap().config);
+        }
+        // The repeated confirmation a user gives on a second run.
+        config = persist(
+            &approve(&config, &implicit(personal.clone()))
+                .unwrap()
+                .config,
+        );
+
+        assert_eq!(
+            config.roots.approved,
+            vec![personal.clone(), native.clone()]
+        );
+
+        let listing = list_roots(&config, &FakeProbe::default()).unwrap();
+        let spelling = listing.entries[1].spelling();
+        let config = persist(
+            &forget_root(
+                &config,
+                &ForgetRequest::new(spelling),
+                &FakeProbe::default(),
+            )
+            .unwrap()
+            .config,
+        );
+
+        assert_eq!(config.roots.approved, vec![personal.clone()]);
+        assert_eq!(
+            decide(&implicit(native), &config).unwrap(),
+            TrustDecision::ApprovalRequired,
+            "the forgotten root survived the round trip as approved"
+        );
+        assert_eq!(
+            decide(&implicit(personal), &config).unwrap(),
+            TrustDecision::AlreadyApproved
+        );
+    }
 
     #[test]
     fn only_an_unapproved_implicit_root_needs_confirmation() {

--- a/crates/dodot-lib/src/safety_lock/check.rs
+++ b/crates/dodot-lib/src/safety_lock/check.rs
@@ -371,6 +371,13 @@ mod tests {
     /// provenance first and is decided whatever state the file is in — the
     /// mirror of the refusal `approve` gives it, which likewise precedes every
     /// other check.
+    ///
+    /// Not a hypothetical value either: since
+    /// [`SafetyLockConfig::load_for_revocation`] exists so `roots forget` can
+    /// reach a duplicated file, a caller that routed *this* decision through
+    /// it would arrive here with exactly this collection. Validating what it
+    /// is given is what makes that a reported error rather than an
+    /// authorization answered off unusable state.
     #[test]
     fn unusable_trust_state_is_reported_rather_than_read_as_empty() {
         let root = identity("/home/alice/dotfiles");

--- a/crates/dodot-lib/src/safety_lock/forget.rs
+++ b/crates/dodot-lib/src/safety_lock/forget.rs
@@ -6,20 +6,28 @@
 //!
 //! 1. an argument that still exists is canonicalized first, so any alias of
 //!    the root selects the same approval;
-//! 2. an argument that does not exist is matched against the exact stored
-//!    spelling — the one `roots list` printed.
+//! 2. otherwise the argument names the approval by its own spelling — the one
+//!    `roots list` printed.
+//!
+//! Rule 2 is the fallback for *every* way rule 1 can come up empty, not only
+//! for a deleted path. A root that was replaced at the same spelling — the
+//! directory removed and a symlink to somewhere else put in its place —
+//! canonicalizes to a path the collection never held, and if that were the
+//! whole rule its record would be unreachable by any argument the user could
+//! type. Falling back cannot over-authorize either: revocation only ever
+//! removes trust, so the worst a match too many costs is one more
+//! confirmation.
 //!
 //! Like approval, revocation returns the trust state to persist rather than
 //! writing it.
-//!
-//! Behaviour arrives in WS04; this Work Stream fixes the signature.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
 
-use super::error::Result;
+use super::error::{Result, SafetyLockError};
 use super::roots::RootIdentity;
 use super::schema::SafetyLockConfig;
-use super::util::PathProbe;
+use super::util::{decode_native_path, encode_native_path, PathProbe};
 
 /// What the user asked to forget, exactly as they spelled it.
 ///
@@ -58,23 +66,357 @@ impl ForgetChange {
 }
 
 /// Remove the approval `request` names, if the trust state holds it.
+///
+/// The argument is read as either spelling [`roots list`](super::list) prints
+/// — a plain path, or a tagged `os-bytes:` one — and then matched by the two
+/// rules this module documents: the canonical identity when the path resolves,
+/// the argument's own identity otherwise.
+///
+/// An argument that matches nothing is not a failure: `removed` is `None` and
+/// the returned state is the one passed in, so a caller can tell "no such
+/// approval" from "the trust file is broken" and say so.
+///
+/// Fails when the collection is unusable, and when the argument cannot name a
+/// root at all: a malformed `os-bytes:` spelling, a relative path, or one
+/// carrying `..`. A relative argument is refused rather than resolved, because
+/// resolving it would mean reading the process working directory — the ambient
+/// state Safety Lock captures once at the boundary and never re-reads
+/// (ADR-0001). Callers anchor a relative argument to their captured invocation
+/// directory before asking.
 pub fn forget_root(
     config: &SafetyLockConfig,
     request: &ForgetRequest,
     probe: &dyn PathProbe,
 ) -> Result<ForgetChange> {
-    let _ = (config, request, probe);
-    todo!("WS04: trusted-root registry lifecycle")
+    config.validate()?;
+
+    let candidate = requested_path(&request.argument)?;
+    if !candidate.is_absolute() {
+        return Err(SafetyLockError::RelativeRootIdentity {
+            spelling: encode_native_path(&candidate),
+        });
+    }
+
+    // Rule 1: an argument the filesystem can resolve names the root it
+    // resolves to, so any alias of a live root selects its approval.
+    let resolved = match probe.canonicalize(&candidate) {
+        Ok(canonical) => Some(RootIdentity::new(canonical)?),
+        Err(_) => None,
+    };
+
+    // Rule 2: otherwise — the path is gone, or resolves somewhere the
+    // collection never held — the argument names the approval by its own
+    // spelling.
+    let target = match resolved {
+        Some(identity) if config.is_approved(&identity) => identity,
+        _ => RootIdentity::new(candidate)?,
+    };
+
+    let mut config = config.clone();
+    let removed = if config.is_approved(&target) {
+        config.roots.approved.retain(|held| *held != target);
+        Some(target)
+    } else {
+        None
+    };
+
+    Ok(ForgetChange { config, removed })
+}
+
+/// Read the argument as the path it names: a tagged spelling decodes back to
+/// its native bytes, anything else is the path itself.
+///
+/// A non-Unicode argument cannot carry the tag — the tag is ASCII — so it is
+/// taken verbatim, which is how a root typed at the shell and the same root
+/// copied out of `roots list` reach the matching rules as one path.
+fn requested_path(argument: &OsStr) -> Result<PathBuf> {
+    match argument.to_str() {
+        Some(text) => decode_native_path(text),
+        None => Ok(PathBuf::from(argument)),
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::ffi::OsStringExt;
+
+    use super::super::schema::TrustedRootsSection;
+    use super::super::test_probe::{Entry, FakeProbe};
+    use super::super::util::OsPathProbe;
     use super::*;
+
+    fn identity(path: &str) -> RootIdentity {
+        RootIdentity::new(path).unwrap()
+    }
+
+    fn non_unicode_path(suffix: &[u8]) -> PathBuf {
+        let mut bytes = b"/tmp/".to_vec();
+        bytes.extend_from_slice(suffix);
+        PathBuf::from(OsString::from_vec(bytes))
+    }
+
+    fn non_unicode_identity(suffix: &[u8]) -> RootIdentity {
+        RootIdentity::new(non_unicode_path(suffix)).unwrap()
+    }
+
+    fn approved(roots: impl IntoIterator<Item = RootIdentity>) -> SafetyLockConfig {
+        SafetyLockConfig {
+            roots: TrustedRootsSection {
+                approved: roots.into_iter().collect(),
+            },
+        }
+    }
+
+    fn forget(
+        config: &SafetyLockConfig,
+        argument: impl Into<OsString>,
+        probe: &dyn PathProbe,
+    ) -> Result<ForgetChange> {
+        forget_root(config, &ForgetRequest::new(argument), probe)
+    }
+
+    /// Rule 1: a live root is canonicalized first, so every alias of it — a
+    /// spelling variant or a symlink — selects the one approval it has.
+    #[test]
+    fn an_alias_of_a_live_root_selects_its_approval() {
+        let config = approved([identity("/srv/dots"), identity("/srv/other")]);
+
+        for (argument, probe) in [
+            ("/srv/dots", FakeProbe::dir("/srv/dots")),
+            ("/srv/dots/", FakeProbe::dir("/srv/dots")),
+            ("/srv//dots", FakeProbe::dir("/srv/dots")),
+            ("/srv/./dots", FakeProbe::dir("/srv/dots")),
+            (
+                "/srv/link",
+                FakeProbe::default().link("/srv/link", "/srv/dots"),
+            ),
+        ] {
+            let change = forget(&config, argument, &probe).unwrap();
+
+            assert!(change.changed(), "`{argument}` matched no approval");
+            assert_eq!(change.removed.unwrap(), identity("/srv/dots"));
+            assert_eq!(
+                change.config.roots.approved,
+                vec![identity("/srv/other")],
+                "`{argument}` disturbed an unrelated approval"
+            );
+            assert!(change.config.validate().is_ok());
+        }
+    }
+
+    /// Rule 2, the deleted case: what `roots list` printed is what revocation
+    /// accepts back, for a plain path and for a tagged non-Unicode one alike
+    /// (ADR-0003).
+    #[test]
+    fn a_deleted_root_is_forgotten_by_its_exact_stored_spelling() {
+        let gone = identity("/srv/deleted");
+        let gone_non_unicode = non_unicode_identity(b"\x80dots");
+        let config = approved([gone.clone(), gone_non_unicode.clone()]);
+        let probe = FakeProbe::default();
+
+        for expected in [gone, gone_non_unicode.clone()] {
+            let change = forget(&config, expected.spelling(), &probe).unwrap();
+
+            assert_eq!(change.removed.as_ref(), Some(&expected));
+            assert_eq!(change.config.roots.approved.len(), 1);
+        }
+
+        // The same root typed as its native bytes rather than as the tagged
+        // spelling: one path, one approval, either way in.
+        let change = forget(&config, non_unicode_path(b"\x80dots"), &probe).unwrap();
+        assert_eq!(change.removed, Some(gone_non_unicode));
+    }
+
+    /// Story 6 from the revocation side: a moved root leaves a record at the
+    /// old path, and that record is exactly what the old spelling removes —
+    /// the new location's approval is untouched.
+    #[test]
+    fn moving_a_root_leaves_the_old_approval_revocable() {
+        let old = identity("/srv/dots");
+        let new = identity("/srv/moved/dots");
+        let config = approved([old.clone(), new.clone()]);
+        let probe = FakeProbe::dir("/srv/moved/dots");
+
+        let change = forget(&config, old.spelling(), &probe).unwrap();
+
+        assert_eq!(change.removed, Some(old));
+        assert_eq!(change.config.roots.approved, vec![new]);
+    }
+
+    /// The case rule 2 exists for beyond deletion: the approved directory was
+    /// replaced at the same spelling, so canonicalization now lands on a path
+    /// the collection never held. Without the fallback that record would be
+    /// unreachable by any argument the user could type.
+    #[test]
+    fn a_root_replaced_at_its_own_spelling_is_still_revocable() {
+        let replaced = identity("/srv/dots");
+        let config = approved([replaced.clone()]);
+        let probe = FakeProbe::default().link("/srv/dots", "/srv/elsewhere");
+
+        let change = forget(&config, "/srv/dots", &probe).unwrap();
+
+        assert_eq!(change.removed, Some(replaced));
+        assert!(change.config.roots.approved.is_empty());
+    }
+
+    /// Rule 1 wins while it matches: when the replacement's own target is
+    /// approved too, the live root the argument resolves to is the one
+    /// revoked, because that is the root the argument names *now*.
+    #[test]
+    fn the_canonical_rule_is_tried_before_the_stored_spelling() {
+        let config = approved([identity("/srv/dots"), identity("/srv/elsewhere")]);
+        let probe = FakeProbe::default().link("/srv/dots", "/srv/elsewhere");
+
+        let change = forget(&config, "/srv/dots", &probe).unwrap();
+
+        assert_eq!(change.removed, Some(identity("/srv/elsewhere")));
+        assert_eq!(change.config.roots.approved, vec![identity("/srv/dots")]);
+    }
+
+    /// Two roots whose lossy renderings collide are revoked one at a time: a
+    /// match key built from a rendering would remove whichever came first.
+    #[test]
+    fn forgetting_one_lossy_colliding_root_leaves_the_other() {
+        let one = non_unicode_identity(b"\x80");
+        let other = non_unicode_identity(b"\x81");
+        assert_eq!(
+            one.as_path().to_string_lossy(),
+            other.as_path().to_string_lossy(),
+            "test premise: these two roots render identically when lossy"
+        );
+
+        let change = forget(
+            &approved([one.clone(), other.clone()]),
+            one.spelling(),
+            &FakeProbe::default(),
+        )
+        .unwrap();
+
+        assert_eq!(change.removed, Some(one));
+        assert_eq!(change.config.roots.approved, vec![other]);
+    }
+
+    /// Revocation is idempotent in the only way it can be: forgetting an
+    /// approval that is not held is reported, not an error, and forgetting the
+    /// same root twice reports the second attempt as a no-op.
+    #[test]
+    fn an_argument_that_matches_nothing_is_reported_not_failed() {
+        let config = approved([identity("/srv/dots")]);
+        let probe = FakeProbe::dir("/srv/unapproved");
+
+        let change = forget(&config, "/srv/unapproved", &probe).unwrap();
+
+        assert!(!change.changed());
+        assert_eq!(change.config.roots.approved, config.roots.approved);
+
+        let removed = forget(&config, "/srv/dots", &FakeProbe::default()).unwrap();
+        let again = forget(&removed.config, "/srv/dots", &FakeProbe::default()).unwrap();
+        assert!(!again.changed());
+    }
+
+    /// An argument that cannot name a root is a mistake worth naming: a
+    /// relative path has no fixed meaning, a `..` spelling is an alias the
+    /// collection never stores, and a truncated tagged spelling is not a path
+    /// at all. None of them may silently read as "no such approval".
+    #[test]
+    fn an_argument_that_cannot_name_a_root_says_so() {
+        let config = approved([identity("/srv/dots")]);
+        let probe = FakeProbe::dir("/srv/dots");
+
+        let error = forget(&config, "dots", &probe).unwrap_err();
+        assert!(
+            matches!(error, SafetyLockError::RelativeRootIdentity { ref spelling } if spelling == "dots"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            probe.canonicalized().is_empty(),
+            "a relative argument reached the filesystem probe"
+        );
+
+        let error = forget(&config, "/srv/dots/../other", &probe).unwrap_err();
+        assert!(
+            matches!(error, SafetyLockError::NonCanonicalRootIdentity { .. }),
+            "unexpected error: {error}"
+        );
+
+        let error = forget(&config, "os-bytes:2f7", &probe).unwrap_err();
+        assert!(
+            matches!(error, SafetyLockError::UnreadableSpelling { .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// Revocation rewrites the collection, so it must refuse to start from one
+    /// it does not understand: writing back a state derived from a file Dodot
+    /// could not read would drop approvals it never saw.
+    #[test]
+    fn an_unusable_collection_is_reported_rather_than_rewritten() {
+        let root = identity("/srv/dots");
+
+        let error = forget(
+            &approved([root.clone(), root]),
+            "/srv/dots",
+            &FakeProbe::default(),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(error, SafetyLockError::DuplicateApprovedRoot { .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// A directory that exists but cannot be read is still a live root: rule 1
+    /// only needs the path to resolve, so an unreadable root is revocable
+    /// through its aliases like any other.
+    #[test]
+    fn an_unreadable_but_present_root_still_canonicalizes() {
+        let config = approved([identity("/srv/dots")]);
+        let probe = FakeProbe::default()
+            .link("/srv/link", "/srv/dots")
+            .add("/srv/dots", Entry::UnreadableDir);
+
+        let change = forget(&config, "/srv/link", &probe).unwrap();
+
+        assert_eq!(change.removed, Some(identity("/srv/dots")));
+    }
+
+    /// The alias rule against a real filesystem: a symlink and a `..`-free
+    /// spelling variant both revoke the approval recorded at the canonical
+    /// path.
+    #[test]
+    fn aliases_resolve_against_a_real_filesystem() {
+        let home = tempfile::tempdir().unwrap();
+        let home = std::fs::canonicalize(home.path()).unwrap();
+        let root = home.join("dotfiles");
+        std::fs::create_dir(&root).unwrap();
+        let link = home.join("link-to-dotfiles");
+        std::os::unix::fs::symlink(&root, &link).unwrap();
+
+        let config = approved([RootIdentity::new(&root).unwrap()]);
+
+        for argument in [link.clone(), root.join("")] {
+            let change = forget(&config, argument.clone(), &OsPathProbe).unwrap();
+            assert_eq!(
+                change.removed.as_ref().map(RootIdentity::as_path),
+                Some(root.as_path()),
+                "`{}` did not select the approval at the canonical path",
+                argument.display()
+            );
+        }
+
+        // And the deleted case, on the same filesystem: once the directory is
+        // gone, the stored spelling is what removes the record.
+        std::fs::remove_dir(&root).unwrap();
+        let change = forget(&config, root.as_os_str(), &OsPathProbe).unwrap();
+        assert_eq!(
+            change.removed.map(|identity| identity.as_path().to_owned()),
+            Some(root)
+        );
+    }
 
     #[test]
     fn a_request_keeps_the_argument_bytes_it_was_given() {
-        use std::os::unix::ffi::OsStringExt;
-
         let raw = OsString::from_vec(b"/tmp/\x80dots".to_vec());
         assert_eq!(ForgetRequest::new(raw.clone()).argument, raw);
         assert_eq!(

--- a/crates/dodot-lib/src/safety_lock/forget.rs
+++ b/crates/dodot-lib/src/safety_lock/forget.rs
@@ -22,8 +22,11 @@
 //! writing it. It is also the one operation here that may *start* from
 //! unusable state: the collection it produces is validated, the one it was
 //! given is not, so revoking a duplicated approval is the narrow recovery the
-//! Spec asks for rather than another way to be locked out (see
-//! [`forget_root`]).
+//! Spec asks for rather than another way to be locked out. That takes both
+//! ends of the path — a caller that loads through
+//! [`SafetyLockConfig::load_for_revocation`](super::schema::SafetyLockConfig::load_for_revocation)
+//! so the duplicated file reaches [`forget_root`] at all, and the outgoing
+//! validation here so the repair is checked before it is written back.
 
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
@@ -106,6 +109,15 @@ impl ForgetChange {
 /// locked out of it. An argument that leaves the duplicate standing still
 /// fails, so state derived from contents Dodot never understood is never
 /// handed back to be written.
+///
+/// **Load through
+/// [`SafetyLockConfig::load_for_revocation`](super::schema::SafetyLockConfig::load_for_revocation),
+/// not [`load_from`](super::schema::SafetyLockConfig::load_from).** That is
+/// what makes the paragraph above reachable from a real trust file rather than
+/// only from a constructed value: `load_from` post-validates, so it refuses a
+/// duplicated file before revocation ever sees it, and the user's only exit
+/// would be factory `reset`. Every *other* consumer keeps `load_from` — `roots
+/// list` surfacing the problem is the Spec's other half of this same sentence.
 pub fn forget_root(
     config: &SafetyLockConfig,
     request: &ForgetRequest,
@@ -399,6 +411,54 @@ mod tests {
             "every copy of the duplicated approval must go, not just the first"
         );
         assert!(change.config.validate().is_ok());
+    }
+
+    /// The recovery the Spec describes, end to end through the production
+    /// routes rather than a constructed value: a duplicated trust file on
+    /// disk, loaded through the revocation route, repaired by forgetting the
+    /// affected root, written back, and read again through the validated load
+    /// every other consumer uses.
+    ///
+    /// The load step is the half a constructed collection cannot prove:
+    /// `load_from` post-validates, so without a revocation-specific route the
+    /// duplicated file never reaches `forget_root` and the user's only exit is
+    /// factory `reset`.
+    #[test]
+    fn a_duplicated_trust_file_is_repaired_through_the_production_routes() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let path = SafetyLockConfig::path_in(data_dir.path());
+        let duplicated = identity("/srv/dots");
+        let intact = identity("/srv/other");
+        std::fs::write(
+            &path,
+            "[roots]\napproved = [\"/srv/dots\", \"/srv/other\", \"/srv/dots\"]\n",
+        )
+        .unwrap();
+
+        // The validated route refuses it — which is the whole problem.
+        assert!(
+            SafetyLockConfig::load_from(data_dir.path()).is_err(),
+            "the validated load accepted a duplicated trust file"
+        );
+
+        let config = SafetyLockConfig::load_for_revocation(data_dir.path()).unwrap();
+        assert_eq!(
+            config.roots.approved,
+            vec![duplicated.clone(), intact.clone(), duplicated.clone()],
+            "the revocation route did not read the file as written"
+        );
+
+        let change = forget(&config, duplicated.spelling(), &FakeProbe::default()).unwrap();
+        assert_eq!(change.removed, Some(duplicated));
+
+        std::fs::write(&path, toml::to_string(&change.config).unwrap()).unwrap();
+
+        let reloaded = SafetyLockConfig::load_from(data_dir.path()).unwrap();
+        assert_eq!(
+            reloaded.roots.approved,
+            vec![intact],
+            "the repaired file did not keep the untouched approval"
+        );
     }
 
     /// The other half of that: revocation rewrites the collection, so an

--- a/crates/dodot-lib/src/safety_lock/forget.rs
+++ b/crates/dodot-lib/src/safety_lock/forget.rs
@@ -19,7 +19,11 @@
 //! confirmation.
 //!
 //! Like approval, revocation returns the trust state to persist rather than
-//! writing it.
+//! writing it. It is also the one operation here that may *start* from
+//! unusable state: the collection it produces is validated, the one it was
+//! given is not, so revoking a duplicated approval is the narrow recovery the
+//! Spec asks for rather than another way to be locked out (see
+//! [`forget_root`]).
 
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
@@ -76,20 +80,37 @@ impl ForgetChange {
 /// the returned state is the one passed in, so a caller can tell "no such
 /// approval" from "the trust file is broken" and say so.
 ///
-/// Fails when the collection is unusable, and when the argument cannot name a
-/// root at all: a malformed `os-bytes:` spelling, a relative path, or one
-/// carrying `..`. A relative argument is refused rather than resolved, because
-/// resolving it would mean reading the process working directory — the ambient
-/// state Safety Lock captures once at the boundary and never re-reads
-/// (ADR-0001). Callers anchor a relative argument to their captured invocation
-/// directory before asking.
+/// Fails when the argument cannot name a root at all: a malformed `os-bytes:`
+/// spelling, a relative path, or a `..` spelling that rule 2 has to read. A
+/// relative argument is refused rather than resolved, because resolving it
+/// would mean reading the process working directory — the ambient state Safety
+/// Lock captures once at the boundary and never re-reads (ADR-0001). Callers
+/// anchor a relative argument to their captured invocation directory before
+/// asking.
+///
+/// `..` is not refused up front, because rule 1 consults the filesystem first
+/// and the Spec has an existing path canonicalized before matching: a live
+/// `/srv/dots/../other` resolves like any other alias and revokes whatever
+/// approval it lands on. It is refused exactly where rule 1 comes up empty —
+/// the path does not resolve, or resolves to an identity the collection never
+/// held — because rule 2 would then have to read the unresolved spelling, and
+/// `..` cannot be folded away without knowing whether a component is a symlink
+/// ([`RootIdentity::new`]).
+///
+/// Fails, too, when the collection this *leaves behind* is unusable.
+/// Validation runs on the way out rather than the way in so that revocation
+/// stays the narrow recovery route for a broken trust file (Spec, "Proposed
+/// Shape"): the only state `validate` refuses in an already-parsed collection
+/// is a duplicated approval, and forgetting that root drops every copy of it,
+/// so the one operation that can repair the collection must not be the one
+/// locked out of it. An argument that leaves the duplicate standing still
+/// fails, so state derived from contents Dodot never understood is never
+/// handed back to be written.
 pub fn forget_root(
     config: &SafetyLockConfig,
     request: &ForgetRequest,
     probe: &dyn PathProbe,
 ) -> Result<ForgetChange> {
-    config.validate()?;
-
     let candidate = requested_path(&request.argument)?;
     if !candidate.is_absolute() {
         return Err(SafetyLockError::RelativeRootIdentity {
@@ -119,6 +140,14 @@ pub fn forget_root(
     } else {
         None
     };
+
+    // The outgoing state, not the incoming one: a duplicated approval is
+    // removable by forgetting its root — every copy goes — and refusing to
+    // start would leave factory reset as the only exit from a collection this
+    // very call repairs. Whatever the argument did not repair still fails
+    // here, so a caller is never handed state to write over contents Dodot
+    // could not read.
+    config.validate()?;
 
     Ok(ForgetChange { config, removed })
 }
@@ -315,9 +344,10 @@ mod tests {
     }
 
     /// An argument that cannot name a root is a mistake worth naming: a
-    /// relative path has no fixed meaning, a `..` spelling is an alias the
-    /// collection never stores, and a truncated tagged spelling is not a path
-    /// at all. None of them may silently read as "no such approval".
+    /// relative path has no fixed meaning, a `..` spelling the filesystem
+    /// cannot resolve is an alias the collection never stores, and a truncated
+    /// tagged spelling is not a path at all. None of them may silently read as
+    /// "no such approval".
     #[test]
     fn an_argument_that_cannot_name_a_root_says_so() {
         let config = approved([identity("/srv/dots")]);
@@ -346,24 +376,48 @@ mod tests {
         );
     }
 
-    /// Revocation rewrites the collection, so it must refuse to start from one
-    /// it does not understand: writing back a state derived from a file Dodot
-    /// could not read would drop approvals it never saw.
+    /// The narrow recovery the Spec asks of revocation: a duplicated approval
+    /// is unusable state, and forgetting that root is what repairs it —
+    /// validating the incoming collection instead would leave factory reset as
+    /// the only way out of a file this very call fixes.
     #[test]
-    fn an_unusable_collection_is_reported_rather_than_rewritten() {
-        let root = identity("/srv/dots");
-
-        let error = forget(
-            &approved([root.clone(), root]),
-            "/srv/dots",
-            &FakeProbe::default(),
-        )
-        .unwrap_err();
-
+    fn a_duplicated_approval_is_repairable_by_forgetting_its_root() {
+        let duplicated = identity("/srv/dots");
+        let intact = identity("/srv/other");
+        let config = approved([duplicated.clone(), intact.clone(), duplicated.clone()]);
         assert!(
-            matches!(error, SafetyLockError::DuplicateApprovedRoot { .. }),
-            "unexpected error: {error}"
+            config.validate().is_err(),
+            "test premise: this collection is unusable as given"
         );
+
+        let change = forget(&config, "/srv/dots", &FakeProbe::default()).unwrap();
+
+        assert_eq!(change.removed, Some(duplicated));
+        assert_eq!(
+            change.config.roots.approved,
+            vec![intact],
+            "every copy of the duplicated approval must go, not just the first"
+        );
+        assert!(change.config.validate().is_ok());
+    }
+
+    /// The other half of that: revocation rewrites the collection, so an
+    /// argument that leaves the unusable part standing is still refused.
+    /// Handing back state derived from contents Dodot could not read would
+    /// drop approvals it never saw.
+    #[test]
+    fn an_unusable_collection_the_argument_does_not_repair_is_reported() {
+        let duplicated = identity("/srv/dots");
+        let config = approved([duplicated.clone(), duplicated]);
+
+        for argument in ["/srv/unapproved", "/srv/other"] {
+            let error = forget(&config, argument, &FakeProbe::default()).unwrap_err();
+
+            assert!(
+                matches!(error, SafetyLockError::DuplicateApprovedRoot { .. }),
+                "`{argument}`: unexpected error: {error}"
+            );
+        }
     }
 
     /// A directory that exists but cannot be read is still a live root: rule 1
@@ -412,6 +466,45 @@ mod tests {
         assert_eq!(
             change.removed.map(|identity| identity.as_path().to_owned()),
             Some(root)
+        );
+    }
+
+    /// The `..` boundary as a real filesystem draws it, which no fake probe
+    /// can: rule 1 resolves the alias, so a `..` spelling of an approved root
+    /// revokes it — that is the Spec's "an existing path is canonicalized
+    /// before matching". Refusal is rule 2's, and fires only where rule 1 came
+    /// up empty: the same directory reached by a `..` spelling that resolves
+    /// somewhere the collection never held is not a record to match but an
+    /// alias to name, because folding `..` away needs to know whether a
+    /// component is a symlink.
+    #[test]
+    fn a_resolvable_parent_alias_revokes_what_it_resolves_to() {
+        let home = tempfile::tempdir().unwrap();
+        let home = std::fs::canonicalize(home.path()).unwrap();
+        let root = home.join("dotfiles");
+        let sibling = home.join("elsewhere");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&sibling).unwrap();
+
+        let config = approved([RootIdentity::new(&root).unwrap()]);
+
+        // Rule 1: the alias resolves onto the approved identity.
+        let alias = sibling.join("..").join("dotfiles");
+        let change = forget(&config, alias.clone(), &OsPathProbe).unwrap();
+        assert_eq!(
+            change.removed.as_ref().map(RootIdentity::as_path),
+            Some(root.as_path()),
+            "`{}` did not select the approval it resolves to",
+            alias.display()
+        );
+
+        // Rule 2: the same shape resolving onto an identity the collection
+        // never held is refused rather than read as an unresolved spelling.
+        let unapproved = root.join("..").join("elsewhere");
+        let error = forget(&config, unapproved, &OsPathProbe).unwrap_err();
+        assert!(
+            matches!(error, SafetyLockError::NonCanonicalRootIdentity { .. }),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/dodot-lib/src/safety_lock/list.rs
+++ b/crates/dodot-lib/src/safety_lock/list.rs
@@ -5,8 +5,6 @@
 //! [`forget_root`](super::forget::forget_root) accepts back. That round trip
 //! is the contract: an approval a user can see is an approval they can revoke,
 //! including for a root that has since been moved or deleted (ADR-0003).
-//!
-//! Behaviour arrives in WS05; this Work Stream fixes the signature.
 
 use super::error::Result;
 use super::roots::RootIdentity;
@@ -18,10 +16,11 @@ use super::util::PathProbe;
 pub struct TrustedRootEntry {
     /// The approved canonical root.
     pub identity: RootIdentity,
-    /// Whether that path is still a readable directory.
+    /// Whether that path is still a directory Dodot could use as a root.
     ///
-    /// Purely informational: a missing root keeps its approval — and stays
-    /// revocable by its exact spelling — until the user forgets it.
+    /// Purely informational: a root that has been moved, deleted, or made
+    /// unreadable keeps its approval — and stays revocable by its exact
+    /// spelling — until the user forgets it.
     pub exists: bool,
 }
 
@@ -51,14 +50,186 @@ impl TrustedRootListing {
 }
 
 /// List the approved roots in the loaded trust state.
+///
+/// Deterministic in both order and spelling: entries come back in stored
+/// order, each named by its own reversible spelling. Nothing is sorted by a
+/// rendering, de-duplicated, or folded — two roots whose lossy renderings
+/// collide list as two entries a user can tell apart and revoke separately
+/// (Spec, "Proposed Shape").
+///
+/// The probe answers only [`exists`](TrustedRootEntry::exists), which no other
+/// field depends on: listing an approval never re-canonicalizes it, so a root
+/// that has been moved or replaced is still shown at the spelling it was
+/// approved at — the one `roots forget` needs back.
+///
+/// Fails when the collection is unusable, so `roots list` surfaces a broken
+/// trust file rather than showing it as empty (Spec, "Proposed Shape").
 pub fn list_roots(config: &SafetyLockConfig, probe: &dyn PathProbe) -> Result<TrustedRootListing> {
-    let _ = (config, probe);
-    todo!("WS05: orientation and root listing")
+    config.validate()?;
+
+    Ok(TrustedRootListing {
+        entries: config
+            .roots
+            .approved
+            .iter()
+            .map(|identity| TrustedRootEntry {
+                identity: identity.clone(),
+                exists: probe.is_readable_dir(identity.as_path()),
+            })
+            .collect(),
+    })
 }
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+    use std::path::PathBuf;
+
+    use super::super::error::SafetyLockError;
+    use super::super::schema::TrustedRootsSection;
+    use super::super::test_probe::{Entry, FakeProbe};
+    use super::super::util::OsPathProbe;
     use super::*;
+
+    fn identity(path: &str) -> RootIdentity {
+        RootIdentity::new(path).unwrap()
+    }
+
+    fn non_unicode_identity(suffix: &[u8]) -> RootIdentity {
+        let mut bytes = b"/tmp/".to_vec();
+        bytes.extend_from_slice(suffix);
+        RootIdentity::new(PathBuf::from(OsString::from_vec(bytes))).unwrap()
+    }
+
+    fn approved(roots: impl IntoIterator<Item = RootIdentity>) -> SafetyLockConfig {
+        SafetyLockConfig {
+            roots: TrustedRootsSection {
+                approved: roots.into_iter().collect(),
+            },
+        }
+    }
+
+    /// Order is the stored order, unchanged: the collection has no preferred
+    /// root, so re-ordering the listing would invent a precedence the model
+    /// does not have.
+    #[test]
+    fn every_approved_root_lists_once_in_stored_order() {
+        let config = approved([
+            identity("/home/alice/work-dotfiles"),
+            identity("/home/alice/dotfiles"),
+            identity("/home/alice/archive/dotfiles"),
+        ]);
+        let probe = FakeProbe::dir("/home/alice/dotfiles")
+            .add("/home/alice/work-dotfiles", Entry::UnreadableDir);
+
+        let listing = list_roots(&config, &probe).unwrap();
+
+        assert!(!listing.is_empty());
+        assert_eq!(
+            listing
+                .entries
+                .iter()
+                .map(|entry| (entry.spelling(), entry.exists))
+                .collect::<Vec<_>>(),
+            vec![
+                ("/home/alice/work-dotfiles".to_owned(), false),
+                ("/home/alice/dotfiles".to_owned(), true),
+                ("/home/alice/archive/dotfiles".to_owned(), false),
+            ]
+        );
+    }
+
+    /// A user who has approved nothing is in a state, not in trouble.
+    #[test]
+    fn nothing_approved_lists_nothing() {
+        let listing = list_roots(&SafetyLockConfig::default(), &FakeProbe::default()).unwrap();
+        assert!(listing.is_empty());
+    }
+
+    /// The round trip the management surface is built on: what listing prints
+    /// is what revocation accepts back, for every entry — including one whose
+    /// path is gone and one whose path is not valid UTF-8 (ADR-0003).
+    #[test]
+    fn every_listed_spelling_reads_back_as_the_root_it_names() {
+        let config = approved([
+            identity("/home/alice/dotfiles"),
+            non_unicode_identity(b"\x80dots"),
+        ]);
+
+        let listing = list_roots(&config, &FakeProbe::default()).unwrap();
+
+        for entry in &listing.entries {
+            assert_eq!(
+                RootIdentity::parse(&entry.spelling()).unwrap(),
+                entry.identity,
+                "`{}` did not read back as the root it names",
+                entry.spelling()
+            );
+        }
+    }
+
+    /// Two roots that render identically must stay two lines a user can tell
+    /// apart, or revoking one of them is guesswork.
+    #[test]
+    fn lossy_colliding_roots_list_as_two_distinguishable_entries() {
+        let one = non_unicode_identity(b"\x80");
+        let other = non_unicode_identity(b"\x81");
+        assert_eq!(
+            one.as_path().to_string_lossy(),
+            other.as_path().to_string_lossy(),
+            "test premise: these two roots render identically when lossy"
+        );
+
+        let listing = list_roots(&approved([one, other]), &FakeProbe::default()).unwrap();
+
+        let spellings: Vec<String> = listing
+            .entries
+            .iter()
+            .map(TrustedRootEntry::spelling)
+            .collect();
+        assert_eq!(
+            spellings,
+            vec!["os-bytes:2f746d702f80", "os-bytes:2f746d702f81"]
+        );
+    }
+
+    /// `roots list` is the surface that has to *report* a broken trust file:
+    /// showing it as "nothing approved" would tell a user their roots were
+    /// forgotten when they were merely unreadable.
+    #[test]
+    fn an_unusable_collection_is_reported_rather_than_listed_empty() {
+        let root = identity("/home/alice/dotfiles");
+
+        let error = list_roots(&approved([root.clone(), root]), &FakeProbe::default()).unwrap_err();
+
+        assert!(
+            matches!(error, SafetyLockError::DuplicateApprovedRoot { .. }),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// Existence against the real filesystem, which is where the flag is
+    /// actually read: an approved root that is still there, and one whose
+    /// directory has since been removed.
+    #[test]
+    fn existence_reflects_the_real_filesystem() {
+        let home = tempfile::tempdir().unwrap();
+        let present = std::fs::canonicalize(home.path()).unwrap().join("dotfiles");
+        std::fs::create_dir(&present).unwrap();
+        let removed = present.parent().unwrap().join("gone");
+
+        let config = approved([
+            RootIdentity::new(&present).unwrap(),
+            RootIdentity::new(&removed).unwrap(),
+        ]);
+
+        let listing = list_roots(&config, &OsPathProbe).unwrap();
+
+        assert!(listing.entries[0].exists);
+        assert!(!listing.entries[1].exists);
+        assert_eq!(listing.entries[1].identity.as_path(), removed);
+    }
 
     #[test]
     fn an_entry_prints_the_spelling_forget_accepts() {

--- a/crates/dodot-lib/src/safety_lock/schema.rs
+++ b/crates/dodot-lib/src/safety_lock/schema.rs
@@ -28,10 +28,14 @@
 //! Environment-selected roots never appear here: `DOTFILES_ROOT` *is* the
 //! deliberate selection, so it is authorized without a record (ADR-0003).
 //!
-//! This module owns the schema, the store's coordinates, and the one
-//! validated way to load it ([`SafetyLockConfig::load_from`]). *Writing*
-//! belongs to the caller: the checking, listing, and forgetting APIs take an
-//! already-loaded [`SafetyLockConfig`] and return typed state changes.
+//! This module owns the schema, the store's coordinates, and the two ways to
+//! load it: [`SafetyLockConfig::load_from`], which every consumer uses and
+//! which fails closed, and
+//! [`SafetyLockConfig::load_for_revocation`], which drops the duplicate check
+//! alone so `roots forget` can repair the one violation a readable file can
+//! carry. *Writing* belongs to the caller: the checking, listing, and
+//! forgetting APIs take an already-loaded [`SafetyLockConfig`] and return
+//! typed state changes.
 
 use std::path::{Path, PathBuf};
 
@@ -91,7 +95,24 @@ impl SafetyLockConfig {
     /// Validation is not a step a caller can forget: an invariant checked
     /// only by convention is one [`is_approved`](Self::is_approved) would
     /// eventually answer from unvalidated state.
+    ///
+    /// The one route that deliberately does not come through here is
+    /// [`load_for_revocation`](Self::load_for_revocation), which has to read
+    /// the state this hook refuses in order to repair it.
     pub fn store_in(data_dir: &Path) -> ClapfigBuilder<Self> {
+        Self::coordinates(data_dir)
+            .post_validate(|config: &Self| config.validate().map_err(|err| err.to_string()))
+    }
+
+    /// Where the trust file is and how it is layered — the store without the
+    /// invariant hook.
+    ///
+    /// Private, and the only statement of the file's coordinates:
+    /// [`store_in`](Self::store_in) is this plus post-validation, and
+    /// [`load_for_revocation`](Self::load_for_revocation) is this alone.
+    /// Saying it once is what keeps the validated and recovery routes reading
+    /// the same file.
+    fn coordinates(data_dir: &Path) -> ClapfigBuilder<Self> {
         Clapfig::builder::<Self>()
             .app_name("dodot")
             .file_name(SAFETY_LOCK_FILE_NAME)
@@ -101,7 +122,6 @@ impl SafetyLockConfig {
                 SearchPath::Path(data_dir.to_path_buf()),
             )
             .no_env()
-            .post_validate(|config: &Self| config.validate().map_err(|err| err.to_string()))
     }
 
     /// Load the trust file from `data_dir`, or the empty default when it is
@@ -112,7 +132,43 @@ impl SafetyLockConfig {
     /// trust file Dodot cannot fully read never resolves to a smaller, or
     /// empty, set of approvals (ADR-0001).
     pub fn load_from(data_dir: &Path) -> Result<Self> {
-        Self::store_in(data_dir)
+        Self::load_through(Self::store_in(data_dir), data_dir)
+    }
+
+    /// Load the trust file for **revocation only**, without the duplicate
+    /// check.
+    ///
+    /// `roots forget` is the Spec's narrow recovery from a trust file Dodot
+    /// refuses: "`roots list` surfaces the problem, `roots forget` removes an
+    /// identifiable affected record, and factory `reset` remains the recovery
+    /// route when narrower revocation is not possible." A duplicated approval
+    /// is the only invariant a syntactically valid file can violate, so
+    /// loading through [`load_from`](Self::load_from) would refuse the very
+    /// state revocation exists to repair, and the user's only exit from one
+    /// bad record would be the factory reset that drops every *other* approval
+    /// with it.
+    ///
+    /// Relaxed by that one invariant and nothing else. An unreadable file, a
+    /// malformed document, and an entry that is not a representable
+    /// [`RootIdentity`] all still fail, because those are refused while
+    /// deserializing rather than by the hook this route drops.
+    ///
+    /// What comes back belongs to
+    /// [`forget_root`](super::forget::forget_root) and to nothing else — it
+    /// validates the collection it *leaves*, so the repair is checked before
+    /// the caller writes it. Routing [`decide`](super::check::decide),
+    /// [`approve`](super::check::approve), or
+    /// [`list_roots`](super::list::list_roots) through here would change
+    /// nothing but which call reports the problem: each validates what it is
+    /// given.
+    pub fn load_for_revocation(data_dir: &Path) -> Result<Self> {
+        Self::load_through(Self::coordinates(data_dir), data_dir)
+    }
+
+    /// Run a load and name the trust file in whatever goes wrong, so both
+    /// routes report a failure the same way.
+    fn load_through(store: ClapfigBuilder<Self>, data_dir: &Path) -> Result<Self> {
+        store
             .load()
             .map_err(|err| SafetyLockError::TrustStateUnusable {
                 path: Self::path_in(data_dir),
@@ -347,6 +403,59 @@ mod tests {
 
         // Not merely the wrapper's doing: the builder itself refuses.
         assert!(SafetyLockConfig::store_in(data_dir.path()).load().is_err());
+    }
+
+    /// The revocation route relaxes the duplicate invariant and *only* that
+    /// one, so `roots forget` can reach the state it exists to repair without
+    /// becoming a way to read any other broken file as approval.
+    #[test]
+    fn the_revocation_route_relaxes_the_duplicate_invariant_and_nothing_else() {
+        let data_dir = tempfile::tempdir().unwrap();
+        write_trust_file(
+            data_dir.path(),
+            "[roots]\napproved = [\"/home/alice/dotfiles\", \"/home/alice//dotfiles/\"]\n",
+        );
+
+        // The duplicate — including one reached through a spelling variant —
+        // loads, byte-exact and un-de-duplicated, so revocation can see which
+        // record to remove.
+        let recoverable = SafetyLockConfig::load_for_revocation(data_dir.path()).unwrap();
+        assert_eq!(
+            recoverable.roots.approved,
+            vec![
+                identity("/home/alice/dotfiles"),
+                identity("/home/alice/dotfiles")
+            ]
+        );
+        assert!(
+            recoverable.validate().is_err(),
+            "the route must hand back the unusable state, not quietly repair it"
+        );
+
+        // Everything else still fails: a malformed document, and an entry
+        // that is not a representable identity.
+        for content in [
+            "[roots]\napproved = [\"/home/alice/dotfiles\"",
+            "[roots]\napproved = [\"relative/dotfiles\"]\n",
+            "[roots]\napproved = [\"/home/alice/dotfiles/../other\"]\n",
+            "[roots]\napproved = \"not-a-list\"\n",
+        ] {
+            let data_dir = tempfile::tempdir().unwrap();
+            write_trust_file(data_dir.path(), content);
+
+            assert!(
+                SafetyLockConfig::load_for_revocation(data_dir.path()).is_err(),
+                "the revocation route accepted `{content}`"
+            );
+        }
+
+        // And an absent file is still the empty default, not an error.
+        let empty = tempfile::tempdir().unwrap();
+        assert!(SafetyLockConfig::load_for_revocation(empty.path())
+            .unwrap()
+            .roots
+            .approved
+            .is_empty());
     }
 
     /// Two spellings of one root are a duplicate too — identity


### PR DESCRIPTION
Implements the trusted-root lifecycle over the typed WS01 collection: `decide`,
`approve`, `list_roots`, and `forget_root` now operate on one already-loaded
`SafetyLockConfig` and return a typed decision or the state to persist.

for #309 (epic #305)

## What changed

- `check::decide` — an environment root is `ExplicitlySelected` from provenance
  alone; an implicit root is looked up exactly on its canonical identity, so a
  moved root, a normalized-elsewhere alias, and a lossy-rendering twin all land
  on `ApprovalRequired`.
- `check::approve` — idempotent append. Refuses an environment root before
  consulting the collection at all (ADR-0003), never arbitrates between roots.
- `list::list_roots` — stored order, each entry named by its own reversible
  spelling, `exists` probed but nothing re-canonicalized.
- `forget::forget_root` — canonicalize a live argument, else match the
  argument's own spelling; a no-match is reported, not failed.
- Unusable state is reported, never read as an empty registry. `decide`,
  `approve`, and `list_roots` validate before they read the collection;
  `forget_root` validates the collection it *leaves* instead, so revoking a
  duplicated approval is the narrow recovery the Spec asks of it rather than
  one more thing locked out by the state it repairs.
- `schema::SafetyLockConfig::load_for_revocation` — the store's coordinates
  without the post-validation hook, so that recovery is reachable from a real
  trust file and not only from a constructed value. Relaxes the duplicate
  invariant and nothing else; every other consumer keeps `load_from`.

Tests cover multiple independent roots, repeated approval, aliases (spelling
variants and symlinks), moved and deleted roots, same-spelling replacements,
exact-spelling forget for a plain and a non-Unicode root, lossy-rendering
collisions, unusable model state at every entry point (reported by three of
them, repaired by `forget_root` — including the whole production path: a
duplicated file on disk, refused by `load_from`, loaded through the revocation
route, repaired, written back, reloaded), resolvable and unresolvable `..`
arguments against a real filesystem, and a full
approve → persist → load → list → forget → load round trip. The real filesystem
is exercised alongside the stated-filesystem probe, as the neighbouring
selection modules do.

## Context

**Why this approach.** The trust file already fails closed at load
(`load_from` runs `validate`), but these APIs take a config *value*, so a caller
can hand them one that never went through that seam. Validating in each entry
point that reads the collection is what makes "invalid state is reported, never
treated as an empty registry" a property of the API rather than of caller
discipline — reading a broken file as empty would downgrade a decision to
`ApprovalRequired` and then write approvals back over contents Dodot never
understood (ADR-0001).

Revocation is the deliberate exception (round 2, on review). The Spec pairs
that fail-closed rule with a recovery route — "`roots list` surfaces the
problem, `roots forget` removes an identifiable affected record, and factory
`reset` remains the recovery route when narrower revocation is not possible" —
and validating `forget_root`'s *input* made the narrow route unreachable, so
the only exit from a broken file was the wide one. In an already-parsed
collection the sole state `validate` refuses is a duplicated approval, and
forgetting that root drops every copy of it; validating the outgoing collection
instead keeps the guarantee where it does work (an argument that leaves the
duplicate standing still fails, so nothing unread is ever handed back to be
written) while letting the operation that repairs the file run.

That took both ends of the path, not just the API end (round 3, on review).
`load_from` attaches `validate` as clapfig's post-validation hook, so a
duplicated *file* was still refused before revocation could see it — the API
was capable and the user was still stuck. `load_for_revocation` is the same
store coordinates without that hook: the one invariant a readable file can
violate is relaxed, and nothing else is (unreadable, malformed, and
unrepresentable entries fail while deserializing, not at the hook). `store_in`
and the recovery route now share one private `coordinates` builder so the
file's location is stated once and the two cannot drift apart.

**One deliberate extension of ADR-0003, worth a reviewer's eye.** The ADR
states two forget rules: canonicalize a path that exists, else match the exact
stored spelling. Taken literally, a root *replaced at its own spelling* —
directory removed, symlink to somewhere else put in its place — is unreachable:
rule 1 applies (the path resolves) but resolves to an identity the collection
never held, and rule 2 never runs. That strands an approval record, which is the
outcome the ADR exists to prevent, and the issue's own test list names
same-spelling replacements. So rule 2 is the fallback for every way rule 1 comes
up empty, not for deletion only. It cannot over-authorize: revocation only ever
removes trust, so a match too many costs one extra confirmation, never an
unapproved mutation. Rule 1 still wins wherever it matches — a live alias whose
target is approved revokes the target.

**Why `decide` lands here and not in WS05.** #309's acceptance criteria put
check alongside approve/list/forget, and comparing an implicit root's identity
against the stored collection *is* the registry question. What WS05 adds on top
is the operation policy — which commands are root-sensitive, and how read-only
and dry-run invocations pass without establishing trust. The stub's
"behaviour arrives in WS05" notes are updated accordingly.

**Smaller decisions.** A relative `forget` argument is refused with
`RelativeRootIdentity` rather than silently matching nothing: anchoring it would
mean reading the process working directory, which this module never does, and a
stored spelling is always absolute so it could never match. `TrustedRootEntry`'s
`exists` is answered by `is_readable_dir` (the probe's walkability question),
and its doc now says "a directory Dodot could use as a root" instead of the
looser WS01 wording.

**Out of scope — please do not "fix".** No persistence *writes*, no store-path
selection, no concurrent-writer coordination: the caller owns the write.
(`load_for_revocation` is a read, added on review so the Spec's recovery route
is reachable; the repaired state is still returned, not written.) No
Clap and no Standout (WS07). `inventory` and `scope` keep their `todo!()`
bodies — WS05 and WS06. Nothing is wired into a command yet, and
`crate::paths`' pre-Safety-Lock resolution is untouched (WS07).

**Self-check.** Diff checked against `docs/spec/safety-lock.md` (stories 5–7,
"Proposed Shape", "State ownership"), ADR-0001, and ADR-0003; the one place it
goes beyond the ADR's letter is the forget fallback described above, taken in
service of the ADR's stated guarantee. `pixi run test` passes (1666 tests);
`pixi run lint` clean.

**Brief gap.** This Run was spawned with an issue reference only — no filled
implementer brief naming verify commands, governing docs, or decision
boundaries. Those were taken from `AGENTS.md`, the epic (#305), and the Spec/ADR
list it names.


