### PR TITLE
ACC01-WS05: Epic: Safety Lock - Workstream: Safety decisions and orientation inventory

### DIFF
--- a/crates/dodot-lib/src/gates/mod.rs
+++ b/crates/dodot-lib/src/gates/mod.rs
@@ -299,8 +299,18 @@ impl GateTable {
     /// User entries are accepted as `HashMap<String, HashMap<String, String>>`
     /// — the natural confique/serde shape for `[gates]` in TOML where
     /// each value is an inline table of `dimension = value` pairs.
+    ///
+    /// Entries are validated in label order, for the same reason the
+    /// dimensions inside one entry are: which defect a user is shown first
+    /// must not depend on hash iteration. A caller reasoning about *which*
+    /// entry failed — the Safety Lock inventory attributes the failure to the
+    /// `.dodot.toml` that declared it — can then replay the same order and
+    /// reach the same entry.
     pub fn merge_user(&mut self, user: &HashMap<String, HashMap<String, String>>) -> Result<()> {
-        for (label, dims) in user {
+        let mut entries: Vec<(&String, &HashMap<String, String>)> = user.iter().collect();
+        entries.sort_by_key(|(label, _)| *label);
+
+        for (label, dims) in entries {
             // Reject labels whose name can't be matched at runtime —
             // either bad characters (no `[A-Za-z0-9_-]+` shape) or a
             // reserved routing-prefix token (`home`/`xdg`/`app`/`lib`).
@@ -397,7 +407,10 @@ pub fn rel_path_for_glob(rel_path: &std::path::Path) -> String {
 /// - Invalid glob syntax — `glob::Pattern::new` failures bubble up as
 ///   `DodotError::Config`. Silent dropping turns a typo into "no gate
 ///   configured" with no diagnostic, which is exactly the trap the
-///   typo-guard pattern exists to prevent.
+///   typo-guard pattern exists to prevent. Patterns are *validated* in the
+///   same lexicographic order they are returned in, so which of several bad
+///   globs is reported does not depend on hash iteration, and a caller
+///   replaying the check reaches the same entry.
 ///
 /// Both `Scanner::match_entries` (for the status path and any
 /// post-preprocessing matching) and `filter_pre_preprocess_gates` (for
@@ -410,7 +423,11 @@ pub fn compile_mapping_gates<'a>(
 ) -> Result<Vec<(glob::Pattern, &'a str)>> {
     let mut compiled: Vec<(glob::Pattern, &'a str, &'a str)> =
         Vec::with_capacity(mappings_gates.len());
-    for (pat, label) in mappings_gates {
+
+    let mut entries: Vec<(&'a String, &'a String)> = mappings_gates.iter().collect();
+    entries.sort_by_key(|(pat, _)| *pat);
+
+    for (pat, label) in entries {
         let pattern = glob::Pattern::new(pat).map_err(|e| {
             DodotError::Config(format!(
                 "invalid `[mappings.gates]` glob `{pat}` in pack `{pack_name}`: {e}"

--- a/crates/dodot-lib/src/safety_lock.rs
+++ b/crates/dodot-lib/src/safety_lock.rs
@@ -21,10 +21,12 @@
 //! DOTFILES_ROOT ──► environment ─┐
 //!                                ├─► selection ─► ResolvedRoot ─► check ─► TrustDecision
 //! git top-level / cwd ──► files ─┘                     │                        │
-//!                                                      │                        ├─ ExplicitlySelected
-//!                            schema (approved roots, one file)                  ├─ AlreadyApproved
-//!                                                      │                        └─ ApprovalRequired ─► inventory
-//!                                                 list / forget                                          (prompt)
+//!                                                      │           operation ─► authorize ─► GateOutcome
+//!                            schema (approved roots, one file)                       │
+//!                                                      │                             ├─ NotRootSensitive
+//!                                                 list / forget                      ├─ Permitted
+//!                                                                                    └─ ConfirmationRequired
+//!                                                                                         └─ inventory (prompt)
 //! ```
 //!
 //! [`resolve_root`] is the invocation's one act of selection: `DOTFILES_ROOT`,
@@ -44,15 +46,32 @@
 //! Dodot's data directory ([`schema`]), never in the dotfiles repository.
 //! Environment roots are never written there.
 //!
+//! [`authorize`] is the seam a command crosses. [`decide`] answers only what
+//! the trust collection can answer — what standing a root has — and a root's
+//! standing only matters once you know what the command is about to do:
+//! `status` and `up --dry-run` read the same untrusted root that `up` may not
+//! write to. [`RootOperation`] carries that half, declared per command rather
+//! than inferred from which context builder it used (ADR-0002), and the two
+//! compose into one [`GateOutcome`]. An unapproved implicit root gets the
+//! orientation [`inventory`] built and carried out with the answer, so no
+//! approvable outcome can exist for a root Dodot could not describe.
+//!
 //! # Boundaries
 //!
 //! This module is CLI-free by construction: no Clap and no Standout types
 //! appear in any signature, and nothing here reads the process environment,
 //! the current directory, or Git. Those are captured at the process boundary
-//! and injected ([`RootSelectionInput`], [`PathProbe`]). Likewise, persistence
-//! is the caller's: the checking, listing, and forgetting APIs take an
-//! already-loaded [`SafetyLockConfig`] and return typed state changes to
-//! write.
+//! and injected ([`RootSelectionInput`], [`PathProbe`],
+//! [`HostFacts`](crate::gates::HostFacts), [`Fs`](crate::fs::Fs)). Likewise,
+//! persistence is the caller's: the checking, listing, and forgetting APIs
+//! take an already-loaded [`SafetyLockConfig`] and return typed state changes
+//! to write.
+//!
+//! Reading the *root* is different from reading process state, and the
+//! inventory does it: pack discovery and rule matching need the directory. It
+//! stops at routing metadata — configuration and which handler claims which
+//! entry — and never renders, resolves, or reads a candidate file's contents
+//! (Spec, "Non-Goals").
 //!
 //! # Work Stream status
 //!
@@ -60,15 +79,9 @@
 //! fills in [`environment`], the authoritative `DOTFILES_ROOT` path; ACC01-WS03
 //! fills in [`files`] and composes both into [`selection`]; ACC01-WS04 fills in
 //! the trust lifecycle over the loaded collection — [`check`], [`list`], and
-//! [`forget`]. The remaining inventory and scoping entry points carry
-//! documented signatures with `todo!()` bodies; each names the Work Stream
-//! that fills it in. The data model, the schema, root selection, and the
-//! registry lifecycle are complete and tested.
-//!
-//! What WS05 adds on top of [`check`] is the operation policy — which commands
-//! are root-sensitive, and how a read-only or dry-run invocation passes without
-//! establishing trust; [`decide`] answers only the part the collection can
-//! answer.
+//! [`forget`]; ACC01-WS05 adds the [`operation`] policy and the bounded
+//! [`inventory`]. Only [`scope_to_root`] still carries a documented signature
+//! with a `todo!()` body, for WS06.
 //!
 //! Dodot's pre-Safety-Lock root resolution still runs in
 //! [`crate::paths`](crate::paths) and in the CLI: replacing those callers with
@@ -86,6 +99,7 @@ pub mod files;
 pub mod forget;
 pub mod inventory;
 pub mod list;
+pub mod operation;
 pub mod roots;
 pub mod schema;
 pub mod scope;
@@ -104,6 +118,7 @@ pub use inventory::{
     MAX_INVENTORY_PATHS,
 };
 pub use list::{list_roots, TrustedRootEntry, TrustedRootListing};
+pub use operation::{authorize, GateOutcome, RootOperation};
 pub use roots::{ResolvedRoot, RootIdentity, RootSource};
 pub use schema::{
     SafetyLockConfig, TrustedRootsSection, SAFETY_LOCK_FILE_NAME, SAFETY_LOCK_PERSIST_SCOPE,

--- a/crates/dodot-lib/src/safety_lock.rs
+++ b/crates/dodot-lib/src/safety_lock.rs
@@ -71,7 +71,10 @@
 //! inventory does it: pack discovery and rule matching need the directory. It
 //! stops at routing metadata — configuration and which handler claims which
 //! entry — and never renders, resolves, or reads a candidate file's contents
-//! (Spec, "Non-Goals").
+//! (Spec, "Non-Goals"). The injected [`Fs`](crate::fs::Fs) is not a full
+//! virtualization of that read: configuration goes through
+//! [`ConfigManager`](crate::config::ConfigManager), which uses `std::fs`. See
+//! [`build_inventory`](inventory::build_inventory).
 //!
 //! # Work Stream status
 //!

--- a/crates/dodot-lib/src/safety_lock/check.rs
+++ b/crates/dodot-lib/src/safety_lock/check.rs
@@ -13,9 +13,10 @@
 //! deliberate selection, so it neither reads an approval nor writes one
 //! (ADR-0003).
 //!
-//! WS05 layers the operation policy — read-only, dry run, root-sensitive
-//! mutation — on top of what is decided here; this module answers only the
-//! question the trust collection can answer.
+//! This module answers only the question the trust collection can answer.
+//! Whether that answer *matters* to the command at hand is the operation
+//! policy's, and [`authorize`](super::operation::authorize) is the two
+//! composed: a read-only command and a dry run never reach [`decide`] at all.
 
 use super::error::{Result, SafetyLockError};
 use super::roots::{ResolvedRoot, RootIdentity};

--- a/crates/dodot-lib/src/safety_lock/error.rs
+++ b/crates/dodot-lib/src/safety_lock/error.rs
@@ -109,6 +109,40 @@ pub enum SafetyLockError {
          selection — environment roots are never added to the approved roots"
     )]
     EnvironmentRootNotApprovable { spelling: String },
+
+    /// A `.dodot.toml` under the root could not be loaded or is not valid.
+    ///
+    /// Raised while building the orientation inventory, which is the only
+    /// thing standing between an untrusted root and the confirmation prompt.
+    /// Failing here is therefore what keeps Dodot from asking a user to
+    /// approve a root it cannot describe, and from operating on configuration
+    /// it could not load (Spec, story 14). The offending file is named
+    /// because it is the only thing the user can act on.
+    #[error("cannot load the dotfiles configuration at {}: {reason}", config_file.display())]
+    DotfilesConfigUnusable {
+        /// The `.dodot.toml` that failed — the root's or a pack's.
+        config_file: PathBuf,
+        /// What was wrong with it.
+        reason: String,
+    },
+
+    /// The pack layout under the root could not be read, or its files could
+    /// not be routed to handlers.
+    ///
+    /// Distinct from [`DotfilesConfigUnusable`](Self::DotfilesConfigUnusable):
+    /// the configuration loaded, but the directory it describes cannot be
+    /// walked or classified — an unreadable root, a pack name Dodot refuses,
+    /// two packs colliding on one display name. Fails the same way and for the
+    /// same reason: an inventory that silently omitted what it could not read
+    /// would understate what approving the root allows.
+    #[error("cannot inspect the packs under {}: {reason}", directory.display())]
+    PackRoutingUnusable {
+        /// The directory whose contents could not be read or routed — the
+        /// root itself, or one pack under it.
+        directory: PathBuf,
+        /// What went wrong.
+        reason: String,
+    },
 }
 
 /// Result alias for Safety Lock APIs.

--- a/crates/dodot-lib/src/safety_lock/error.rs
+++ b/crates/dodot-lib/src/safety_lock/error.rs
@@ -110,7 +110,12 @@ pub enum SafetyLockError {
     )]
     EnvironmentRootNotApprovable { spelling: String },
 
-    /// A `.dodot.toml` under the root could not be loaded or is not valid.
+    /// A `.dodot.toml` under the root could not be loaded, parsed, or applied.
+    ///
+    /// "Applied" covers configuration that reads fine and then fails in use —
+    /// an unresolvable gate label, an invalid `[mappings.gates]` glob, a file
+    /// gated two ways at once. Those are the user's configuration just as much
+    /// as a syntax error is, and they name the same file.
     ///
     /// Raised while building the orientation inventory, which is the only
     /// thing standing between an untrusted root and the confirmation prompt.

--- a/crates/dodot-lib/src/safety_lock/inventory.rs
+++ b/crates/dodot-lib/src/safety_lock/inventory.rs
@@ -18,7 +18,7 @@
 //! directory?", and a source name answers that better than a rendered one
 //! would.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use crate::config::{mappings_to_rules, ConfigManager};
@@ -208,12 +208,6 @@ pub fn build_inventory(
     let registry = create_registry(fs, &runner);
     let scanner = Scanner::new(fs);
 
-    // Computed once, before any pack: whether the root's own gate
-    // configuration is broken on its own terms. Read only to attribute a
-    // failure the merged pass raises, never to raise one — see
-    // `gate_configuration_owner`.
-    let root_gates_broken = root_gate_configuration_is_broken(&root_config);
-
     let mut counts: BTreeMap<InventoryCategory, usize> = BTreeMap::new();
     let mut entries: Vec<InventoryEntry> = Vec::new();
 
@@ -228,19 +222,23 @@ pub fn build_inventory(
             continue;
         }
 
-        let gate_config_file = gate_configuration_owner(
-            root_path,
-            pack,
-            &pack_config,
-            &root_config,
-            root_gates_broken,
-        );
+        let owner = |declared| {
+            gate_configuration_owner(root_path, pack, &pack_config, &root_config, declared)
+        };
 
+        // Each failure domain is attributed from its own evidence: a
+        // `merge_user` failure is always a `[gates]` entry, and a `scan_pack`
+        // failure never is, because the gate table it uses was already merged
+        // above. Reading one domain's verdict for the other's failure would
+        // send the user to a file that is not the one that failed.
         let mut gates = GateTable::with_builtins();
         if !pack_config.gates.is_empty() {
-            gates
-                .merge_user(&pack_config.gates)
-                .map_err(|error| unusable_config(gate_config_file.clone(), error))?;
+            gates.merge_user(&pack_config.gates).map_err(|error| {
+                unusable_config(
+                    owner(broken_gate_entry_owner(&root_config, &pack_config)),
+                    error,
+                )
+            })?;
         }
 
         let rules = mappings_to_rules(&pack_config.mappings);
@@ -253,7 +251,10 @@ pub fn build_inventory(
                 host,
                 &pack_config.mappings.gates,
             )
-            .map_err(|error| unusable_scan(&pack.path, &gate_config_file, error))?;
+            .map_err(|error| {
+                let declared = broken_mapping_entry_owner(&root_config, &pack_config, &gates);
+                unusable_scan(&pack.path, &owner(declared), error)
+            })?;
 
         for matched in matches {
             let Some(category) = category_of(&matched.handler, &registry) else {
@@ -345,75 +346,137 @@ fn unusable_routing(
     }
 }
 
-/// Whether the root's `[gates]` and `[mappings.gates]` are broken on their own
-/// terms, ignoring anything a pack adds.
-///
-/// Nothing else validates them: `[gates]` and `[mappings.gates]` are checked
-/// only when the scanner interprets a pack's *merged* configuration, which is
-/// why a failure arrives with no idea which layer wrote it. Replaying the
-/// checks against the root layer alone recovers exactly that.
-///
-/// This is an attribution signal, never an acceptance one. `[mappings.gates]`
-/// and `[gates]` are separate tables, so a root mapping may name a label only a
-/// pack defines: this reads `true` while the merged configuration is perfectly
-/// valid. The answer is therefore consulted only once the merged pass has
-/// already failed, and never used to reject a root that works.
-fn root_gate_configuration_is_broken(root_config: &crate::config::DodotConfig) -> bool {
-    let mut table = GateTable::with_builtins();
-    if table.merge_user(&root_config.gates).is_err() {
-        return true;
-    }
+/// Which `.dodot.toml` declared the entry a gate failure is about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GateLayer {
+    Root,
+    Pack,
+}
 
-    let Ok(compiled) = crate::gates::compile_mapping_gates(&root_config.mappings.gates, "<root>")
-    else {
-        return true;
-    };
+/// Whether one `[gates]` entry stands up on its own.
+///
+/// Validated through [`GateTable::merge_user`] rather than a reimplementation
+/// of it, so the question asked here cannot drift from the question the walk
+/// asks.
+fn gate_entry_is_valid(label: &str, dimensions: &HashMap<String, String>) -> bool {
+    let one = HashMap::from([(label.to_string(), dimensions.clone())]);
+    GateTable::with_builtins().merge_user(&one).is_ok()
+}
 
-    compiled
-        .iter()
-        .any(|(_, label)| table.lookup(label).is_none())
+/// The layer that declared the first invalid `[gates]` entry, if any.
+///
+/// Per-entry, because per-entry is where the provenance survives: labels merge
+/// key by key, so the pack's resolved table holds every label either file
+/// declared. For each broken one, the root owns it exactly when the root's own
+/// version of that same label is broken too — which is also what makes the
+/// deep merge safe to reason about. A pack that adds `os` to a root label
+/// already carrying a bad dimension inherits the bad dimension, and the root's
+/// version fails on its own, so the root is named; a pack that breaks a label
+/// the root had valid is named itself.
+///
+/// Entries are visited in label order so a configuration with several broken
+/// entries always reports the same one.
+fn broken_gate_entry_owner(
+    root_config: &crate::config::DodotConfig,
+    pack_config: &crate::config::DodotConfig,
+) -> Option<GateLayer> {
+    let mut labels: Vec<&String> = pack_config.gates.keys().collect();
+    labels.sort();
+
+    labels.into_iter().find_map(|label| {
+        let dimensions = pack_config.gates.get(label)?;
+        if gate_entry_is_valid(label, dimensions) {
+            return None;
+        }
+
+        let root_owns = root_config
+            .gates
+            .get(label)
+            .is_some_and(|root_dimensions| !gate_entry_is_valid(label, root_dimensions));
+
+        Some(if root_owns {
+            GateLayer::Root
+        } else {
+            GateLayer::Pack
+        })
+    })
+}
+
+/// The layer that declared the first unusable `[mappings.gates]` entry, if any.
+///
+/// Exact, unlike the `[gates]` case needing a per-entry replay: this table is a
+/// flat glob-to-label map, so a resolved entry belongs to the pack precisely
+/// when the pack's value for that glob differs from the root's. An entry is
+/// unusable when its glob will not compile or when its label resolves nowhere
+/// in `gates` — the same merged table the walk uses, so a root entry whose
+/// label only a pack defines is correctly not a defect at all.
+///
+/// Entries are visited in glob order for the same reason as above.
+fn broken_mapping_entry_owner(
+    root_config: &crate::config::DodotConfig,
+    pack_config: &crate::config::DodotConfig,
+    gates: &GateTable,
+) -> Option<GateLayer> {
+    let mut globs: Vec<&String> = pack_config.mappings.gates.keys().collect();
+    globs.sort();
+
+    globs.into_iter().find_map(|glob| {
+        let label = pack_config.mappings.gates.get(glob)?;
+        let one = HashMap::from([(glob.clone(), label.clone())]);
+        let compiles = crate::gates::compile_mapping_gates(&one, "<attribution>").is_ok();
+
+        if compiles && gates.lookup(label).is_some() {
+            return None;
+        }
+
+        Some(if root_config.mappings.gates.get(glob) == Some(label) {
+            GateLayer::Root
+        } else {
+            GateLayer::Pack
+        })
+    })
 }
 
 /// The `.dodot.toml` to blame for gate configuration that fails during a walk.
 ///
 /// A pack's configuration is the root's with the pack's merged over it, and the
 /// merge keeps no per-key provenance, so a rejected gate setting does not say
-/// which file wrote it. Two things narrow it down, in order:
+/// which file wrote it. `declared` is that provenance recovered from the entry
+/// that actually fails — [`broken_gate_entry_owner`] for a `[gates]` failure,
+/// [`broken_mapping_entry_owner`] for a `[mappings.gates]` one. Deriving it
+/// from the failing entry rather than from a summary of the root's health is
+/// what keeps an unrelated defect in one file from pulling the blame off the
+/// other: the two are independent, and either may be broken while the other
+/// causes the failure at hand.
 ///
-/// 1. **The root's layer is independently broken** (`root_gates_broken`) — an
-///    invalid `[gates]` entry, an uncompilable glob, a `[mappings.gates]` entry
-///    naming a label the root never defines. Then the root's file is the
-///    answer even when the pack also contributed, which is the case a
-///    contributed-or-not test alone gets wrong: an unrelated valid pack entry
-///    must not move the blame off a broken root.
-/// 2. **The pack contributed no gate configuration** — its `[gates]` and
-///    `[mappings.gates]` are the ones it inherited, so every value the scan
-///    used came from the root. Naming the pack would name a `.dodot.toml` the
-///    user never wrote, and for a pack that carries no configuration, one that
-///    is not on disk to open (story 14: the file named has to be the file the
-///    user can act on).
+/// Some failures name no entry: a filename gate token referring to a label
+/// nothing defines, and a gate-routing conflict, are both about a *file* the
+/// walk met rather than a line either config wrote. `declared` is `None` there
+/// and the fallback is scope — the pack when it contributed gate configuration
+/// of its own, the root when it inherited all of it. That case matters most
+/// for a pack with no `.dodot.toml`, where naming the pack would name a file
+/// that is not on disk to open (story 14: the file named has to be the file
+/// the user can act on).
 ///
-/// Otherwise the pack's file is named: the nearest layer that demonstrably
-/// participated, and one that exists.
-///
-/// One case stays genuinely ambiguous and is not resolved here: a gate-routing
-/// conflict pits a `[mappings.gates]` entry against a filename gate token, and
-/// either the entry or the file can be changed to settle it. Both remedies are
-/// spelled out in the error's own message, which is where that choice belongs.
+/// The conflict stays genuinely ambiguous even so — a `[mappings.gates]` entry
+/// against a filename token, either of which can be changed to settle it. Both
+/// remedies are spelled out in the error's own message, which is where that
+/// choice belongs.
 fn gate_configuration_owner(
     root_path: &Path,
     pack: &crate::packs::Pack,
     pack_config: &crate::config::DodotConfig,
     root_config: &crate::config::DodotConfig,
-    root_gates_broken: bool,
+    declared: Option<GateLayer>,
 ) -> PathBuf {
     let inherited = pack_config.gates == root_config.gates
         && pack_config.mappings.gates == root_config.mappings.gates;
 
-    if root_gates_broken || inherited {
-        root_path.join(DOTFILES_CONFIG_FILE)
-    } else {
-        pack.path.join(DOTFILES_CONFIG_FILE)
+    match declared {
+        Some(GateLayer::Root) => root_path.join(DOTFILES_CONFIG_FILE),
+        Some(GateLayer::Pack) => pack.path.join(DOTFILES_CONFIG_FILE),
+        None if inherited => root_path.join(DOTFILES_CONFIG_FILE),
+        None => pack.path.join(DOTFILES_CONFIG_FILE),
     }
 }
 
@@ -993,6 +1056,102 @@ mod tests {
                 "unexpected error for root {root_config:?} + pack {pack_config:?}: {error}"
             );
         }
+    }
+
+    /// The mirror of the case above, and the reason blame is read off the
+    /// failing entry rather than off either file's overall health: the two
+    /// tables fail independently, so a defect in one file must not pull the
+    /// blame away from the other file's defect that actually stopped the walk.
+    ///
+    /// Both directions of the interaction, in both tables.
+    #[test]
+    fn the_layer_that_declared_the_failing_entry_is_the_one_named() {
+        struct Case {
+            root: &'static str,
+            pack: &'static str,
+            owner: &'static str,
+        }
+
+        for case in [
+            // A root mapping completed by a pack-defined label — unresolvable
+            // read alone, fine merged — beside a pack glob that will not
+            // compile. The walk stops on the pack's glob.
+            Case {
+                root: "[mappings.gates]\n\"aliases.sh\" = \"laptop\"\n",
+                pack: "[gates]\nlaptop = { os = \"darwin\" }\n\
+                       [mappings.gates]\n\"[unclosed\" = \"darwin\"\n",
+                owner: "vim/.dodot.toml",
+            },
+            // A broken root `[mappings.gates]` glob beside a broken pack
+            // `[gates]` entry. `merge_user` fails first, on the pack's entry,
+            // and the root's unrelated mapping defect must not claim it.
+            Case {
+                root: "[mappings.gates]\n\"[unclosed\" = \"darwin\"\n",
+                pack: "[gates]\nbroken = { nonsense = \"x\" }\n",
+                owner: "vim/.dodot.toml",
+            },
+            // The same shape reversed: a broken root `[gates]` entry beside a
+            // pack mapping that is merely unresolvable on its own. The
+            // `[gates]` failure comes first and belongs to the root.
+            Case {
+                root: "[gates]\nbroken = { nonsense = \"x\" }\n",
+                pack: "[mappings.gates]\n\"aliases.sh\" = \"darwin\"\n",
+                owner: ".dodot.toml",
+            },
+        ] {
+            let env = TempEnvironment::builder()
+                .pack("vim")
+                .config(case.pack)
+                .file("aliases.sh", "")
+                .file("vimrc", "")
+                .done()
+                .build();
+            std::fs::write(env.dotfiles_root.join(".dodot.toml"), case.root).unwrap();
+
+            let error =
+                build_inventory(&resolved(&env), env.fs.as_ref(), &host()).expect_err("accepted");
+
+            assert!(
+                matches!(
+                    &error,
+                    SafetyLockError::DotfilesConfigUnusable { config_file, .. }
+                        if config_file == &canonical_root(&env).join(case.owner)
+                ),
+                "root {:?} + pack {:?} should have named {}: {error}",
+                case.root,
+                case.pack,
+                case.owner
+            );
+        }
+    }
+
+    /// A pack that breaks a label the root had valid owns it, even though the
+    /// deep merge means the resolved entry carries both files' dimensions.
+    #[test]
+    fn a_pack_that_breaks_an_inherited_label_is_named_for_it() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .config("[gates]\nlaptop = { nonsense = \"x\" }\n")
+            .file("vimrc", "")
+            .done()
+            .build();
+        std::fs::write(
+            env.dotfiles_root.join(".dodot.toml"),
+            "[gates]\nlaptop = { os = \"darwin\" }\n",
+        )
+        .unwrap();
+
+        let error =
+            build_inventory(&resolved(&env), env.fs.as_ref(), &host()).expect_err("accepted");
+
+        assert!(
+            matches!(
+                &error,
+                SafetyLockError::DotfilesConfigUnusable { config_file, .. }
+                    if config_file == &canonical_root(&env).join("vim/.dodot.toml")
+            ),
+            "unexpected error: {error}"
+        );
     }
 
     /// The attribution replay is read only to place blame, never to assign it.

--- a/crates/dodot-lib/src/safety_lock/inventory.rs
+++ b/crates/dodot-lib/src/safety_lock/inventory.rs
@@ -208,6 +208,12 @@ pub fn build_inventory(
     let registry = create_registry(fs, &runner);
     let scanner = Scanner::new(fs);
 
+    // Computed once, before any pack: whether the root's own gate
+    // configuration is broken on its own terms. Read only to attribute a
+    // failure the merged pass raises, never to raise one — see
+    // `gate_configuration_owner`.
+    let root_gates_broken = root_gate_configuration_is_broken(&root_config);
+
     let mut counts: BTreeMap<InventoryCategory, usize> = BTreeMap::new();
     let mut entries: Vec<InventoryEntry> = Vec::new();
 
@@ -222,8 +228,13 @@ pub fn build_inventory(
             continue;
         }
 
-        let gate_config_file =
-            gate_configuration_owner(root_path, pack, &pack_config, &root_config);
+        let gate_config_file = gate_configuration_owner(
+            root_path,
+            pack,
+            &pack_config,
+            &root_config,
+            root_gates_broken,
+        );
 
         let mut gates = GateTable::with_builtins();
         if !pack_config.gates.is_empty() {
@@ -334,31 +345,72 @@ fn unusable_routing(
     }
 }
 
+/// Whether the root's `[gates]` and `[mappings.gates]` are broken on their own
+/// terms, ignoring anything a pack adds.
+///
+/// Nothing else validates them: `[gates]` and `[mappings.gates]` are checked
+/// only when the scanner interprets a pack's *merged* configuration, which is
+/// why a failure arrives with no idea which layer wrote it. Replaying the
+/// checks against the root layer alone recovers exactly that.
+///
+/// This is an attribution signal, never an acceptance one. `[mappings.gates]`
+/// and `[gates]` are separate tables, so a root mapping may name a label only a
+/// pack defines: this reads `true` while the merged configuration is perfectly
+/// valid. The answer is therefore consulted only once the merged pass has
+/// already failed, and never used to reject a root that works.
+fn root_gate_configuration_is_broken(root_config: &crate::config::DodotConfig) -> bool {
+    let mut table = GateTable::with_builtins();
+    if table.merge_user(&root_config.gates).is_err() {
+        return true;
+    }
+
+    let Ok(compiled) = crate::gates::compile_mapping_gates(&root_config.mappings.gates, "<root>")
+    else {
+        return true;
+    };
+
+    compiled
+        .iter()
+        .any(|(_, label)| table.lookup(label).is_none())
+}
+
 /// The `.dodot.toml` to blame for gate configuration that fails during a walk.
 ///
-/// A pack's configuration is the root's with the pack's merged over it, so a
-/// gate setting the scanner rejects may have been written in either file, and
-/// the module cannot see per-key provenance through the merge. What it can see
-/// is whether the pack contributed to gate configuration *at all*: if the
-/// pack's `[gates]` and `[mappings.gates]` are the ones it inherited, every
-/// value the scan used came from the root, and the root's file is the answer —
-/// not by preference but by elimination. Blaming the pack there would name a
-/// `.dodot.toml` the user never wrote, and for a pack that carries no
-/// configuration, one that is not on disk to open (story 14: the file named
-/// has to be the file the user can act on).
+/// A pack's configuration is the root's with the pack's merged over it, and the
+/// merge keeps no per-key provenance, so a rejected gate setting does not say
+/// which file wrote it. Two things narrow it down, in order:
 ///
-/// When the pack did contribute, its file is named: it is the nearest layer
-/// that demonstrably participated, and it exists.
+/// 1. **The root's layer is independently broken** (`root_gates_broken`) — an
+///    invalid `[gates]` entry, an uncompilable glob, a `[mappings.gates]` entry
+///    naming a label the root never defines. Then the root's file is the
+///    answer even when the pack also contributed, which is the case a
+///    contributed-or-not test alone gets wrong: an unrelated valid pack entry
+///    must not move the blame off a broken root.
+/// 2. **The pack contributed no gate configuration** — its `[gates]` and
+///    `[mappings.gates]` are the ones it inherited, so every value the scan
+///    used came from the root. Naming the pack would name a `.dodot.toml` the
+///    user never wrote, and for a pack that carries no configuration, one that
+///    is not on disk to open (story 14: the file named has to be the file the
+///    user can act on).
+///
+/// Otherwise the pack's file is named: the nearest layer that demonstrably
+/// participated, and one that exists.
+///
+/// One case stays genuinely ambiguous and is not resolved here: a gate-routing
+/// conflict pits a `[mappings.gates]` entry against a filename gate token, and
+/// either the entry or the file can be changed to settle it. Both remedies are
+/// spelled out in the error's own message, which is where that choice belongs.
 fn gate_configuration_owner(
     root_path: &Path,
     pack: &crate::packs::Pack,
     pack_config: &crate::config::DodotConfig,
     root_config: &crate::config::DodotConfig,
+    root_gates_broken: bool,
 ) -> PathBuf {
     let inherited = pack_config.gates == root_config.gates
         && pack_config.mappings.gates == root_config.mappings.gates;
 
-    if inherited {
+    if root_gates_broken || inherited {
         root_path.join(DOTFILES_CONFIG_FILE)
     } else {
         pack.path.join(DOTFILES_CONFIG_FILE)
@@ -890,6 +942,89 @@ mod tests {
                 "unexpected error for root config {root_config:?}: {error}"
             );
         }
+    }
+
+    /// Both layers contributing is where "did the pack write any gate
+    /// configuration?" stops being enough: a valid pack entry that has nothing
+    /// to do with the failure would otherwise pull the blame onto the pack,
+    /// where changing or deleting that entry cannot fix anything. A root whose
+    /// own layer does not stand up is named even when the pack also wrote gate
+    /// configuration.
+    #[test]
+    fn a_broken_root_is_named_even_when_the_pack_also_configures_gates() {
+        for (root_config, pack_config) in [
+            // Invalid `[gates]` entry in the root, unrelated valid one in the
+            // pack — codex's counterexample: deleting `laptop` fixes nothing.
+            (
+                "[gates]\nbroken = { nonsense = \"x\" }\n",
+                "[gates]\nlaptop = { os = \"darwin\" }\n",
+            ),
+            // Invalid root glob, unrelated valid pack mapping.
+            (
+                "[mappings.gates]\n\"[unclosed\" = \"darwin\"\n",
+                "[mappings.gates]\n\"vimrc\" = \"darwin\"\n",
+            ),
+            // Root mapping naming a label nothing defines, beside a pack that
+            // defines a different one.
+            (
+                "[mappings.gates]\n\"aliases.sh\" = \"no-such-label\"\n",
+                "[gates]\nlaptop = { os = \"darwin\" }\n",
+            ),
+        ] {
+            let env = TempEnvironment::builder()
+                .pack("vim")
+                .config(pack_config)
+                .file("aliases.sh", "")
+                .file("vimrc", "")
+                .done()
+                .build();
+            std::fs::write(env.dotfiles_root.join(".dodot.toml"), root_config).unwrap();
+
+            let error =
+                build_inventory(&resolved(&env), env.fs.as_ref(), &host()).expect_err("accepted");
+
+            assert!(
+                matches!(
+                    &error,
+                    SafetyLockError::DotfilesConfigUnusable { config_file, reason }
+                        if config_file == &canonical_root(&env).join(DOTFILES_CONFIG_FILE)
+                            && !reason.is_empty()
+                ),
+                "unexpected error for root {root_config:?} + pack {pack_config:?}: {error}"
+            );
+        }
+    }
+
+    /// The attribution replay is read only to place blame, never to assign it.
+    ///
+    /// `[mappings.gates]` and `[gates]` are separate tables, so the root can
+    /// legitimately map a label that only a pack defines — valid merged, and
+    /// unresolvable read on its own. The inventory must still be built. (The
+    /// mirror case does not exist: gate labels deep-merge key by key, so a
+    /// pack adding `os` to a root label that already carries a bad dimension
+    /// inherits the bad dimension too. A pack cannot repair a broken root
+    /// `[gates]` entry, only a dangling root reference to one.)
+    #[test]
+    fn a_root_layer_a_pack_completes_is_not_an_error() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .config("[gates]\nlaptop = { os = \"darwin\" }\n")
+            .file("aliases.sh", "")
+            .done()
+            .build();
+        std::fs::write(
+            env.dotfiles_root.join(".dodot.toml"),
+            "[mappings.gates]\n\"aliases.sh\" = \"laptop\"\n",
+        )
+        .unwrap();
+
+        let inventory = build_inventory(&resolved(&env), env.fs.as_ref(), &host())
+            .expect("a root mapping a pack-defined label was refused");
+
+        assert_eq!(
+            sample_of(&inventory),
+            [(InventoryCategory::Shell, "vim/aliases.sh".into())]
+        );
     }
 
     /// A root that cannot be walked fails the inventory rather than reporting

--- a/crates/dodot-lib/src/safety_lock/inventory.rs
+++ b/crates/dodot-lib/src/safety_lock/inventory.rs
@@ -222,11 +222,14 @@ pub fn build_inventory(
             continue;
         }
 
+        let gate_config_file =
+            gate_configuration_owner(root_path, pack, &pack_config, &root_config);
+
         let mut gates = GateTable::with_builtins();
         if !pack_config.gates.is_empty() {
             gates
                 .merge_user(&pack_config.gates)
-                .map_err(|error| unusable_config(pack.path.join(DOTFILES_CONFIG_FILE), error))?;
+                .map_err(|error| unusable_config(gate_config_file.clone(), error))?;
         }
 
         let rules = mappings_to_rules(&pack_config.mappings);
@@ -239,7 +242,7 @@ pub fn build_inventory(
                 host,
                 &pack_config.mappings.gates,
             )
-            .map_err(|error| unusable_scan(&pack.path, error))?;
+            .map_err(|error| unusable_scan(&pack.path, &gate_config_file, error))?;
 
         for matched in matches {
             let Some(category) = category_of(&matched.handler, &registry) else {
@@ -331,20 +334,56 @@ fn unusable_routing(
     }
 }
 
+/// The `.dodot.toml` to blame for gate configuration that fails during a walk.
+///
+/// A pack's configuration is the root's with the pack's merged over it, so a
+/// gate setting the scanner rejects may have been written in either file, and
+/// the module cannot see per-key provenance through the merge. What it can see
+/// is whether the pack contributed to gate configuration *at all*: if the
+/// pack's `[gates]` and `[mappings.gates]` are the ones it inherited, every
+/// value the scan used came from the root, and the root's file is the answer —
+/// not by preference but by elimination. Blaming the pack there would name a
+/// `.dodot.toml` the user never wrote, and for a pack that carries no
+/// configuration, one that is not on disk to open (story 14: the file named
+/// has to be the file the user can act on).
+///
+/// When the pack did contribute, its file is named: it is the nearest layer
+/// that demonstrably participated, and it exists.
+fn gate_configuration_owner(
+    root_path: &Path,
+    pack: &crate::packs::Pack,
+    pack_config: &crate::config::DodotConfig,
+    root_config: &crate::config::DodotConfig,
+) -> PathBuf {
+    let inherited = pack_config.gates == root_config.gates
+        && pack_config.mappings.gates == root_config.mappings.gates;
+
+    if inherited {
+        root_path.join(DOTFILES_CONFIG_FILE)
+    } else {
+        pack.path.join(DOTFILES_CONFIG_FILE)
+    }
+}
+
 /// A scan failure, classified by what the user can act on.
 ///
 /// The scanner does two jobs at once: it walks the pack, and it interprets the
 /// pack's configuration — `[mappings.gates]` globs, the gate labels those
 /// entries and filename tokens name, and the conflict between the two all come
 /// back as [`DodotError::Config`](crate::error::DodotError::Config). Reporting
-/// those as a routing failure would name the pack *directory* when the thing
-/// the user has to open is the pack's `.dodot.toml` (story 14: name the bad
-/// file, not the neighbourhood it is in). Everything else the walk can fail on
-/// — an unreadable directory, a layout Dodot refuses — is a routing failure and
+/// those as a routing failure would name a *directory* when the thing the user
+/// has to open is a `.dodot.toml` (story 14: name the bad file, not the
+/// neighbourhood it is in); `gate_config_file` is which one, resolved by
+/// [`gate_configuration_owner`]. Everything else the walk can fail on — an
+/// unreadable directory, a layout Dodot refuses — is a routing failure and
 /// names the directory.
-fn unusable_scan(pack_path: &Path, error: crate::error::DodotError) -> SafetyLockError {
+fn unusable_scan(
+    pack_path: &Path,
+    gate_config_file: &Path,
+    error: crate::error::DodotError,
+) -> SafetyLockError {
     if matches!(error, crate::error::DodotError::Config(_)) {
-        unusable_config(pack_path.join(DOTFILES_CONFIG_FILE), error)
+        unusable_config(gate_config_file.to_path_buf(), error)
     } else {
         unusable_routing(pack_path, error)
     }
@@ -777,6 +816,10 @@ mod tests {
     /// gated two ways at once all surface from the walk — and naming the pack
     /// directory for them would point the user at a place instead of at the
     /// file they have to edit.
+    ///
+    /// Every case here declares gate configuration in the pack, which is what
+    /// makes the pack's file the one to name; the root-owned half is
+    /// `configuration_inherited_from_the_root_names_the_root_config_file`.
     #[test]
     fn configuration_the_walk_rejects_names_the_pack_config_file() {
         for pack_config in [
@@ -784,8 +827,9 @@ mod tests {
             "[mappings.gates]\n\"[unclosed\" = \"darwin\"\n",
             // A label nothing defines, reached through `[mappings.gates]`.
             "[mappings.gates]\n\"aliases.sh\" = \"no-such-label\"\n",
-            // A label nothing defines, reached through the filename grammar.
-            "",
+            // A label nothing defines, reached through the filename grammar,
+            // in a pack whose own `[gates]` could have defined it.
+            "[gates]\nsomething-else = { os = \"darwin\" }\n",
             // One file gated two ways at once.
             "[mappings.gates]\n\"*.sh\" = \"darwin\"\n",
         ] {
@@ -808,6 +852,42 @@ mod tests {
                             && !reason.is_empty()
                 ),
                 "unexpected error for config {pack_config:?}: {error}"
+            );
+        }
+    }
+
+    /// The same walk-time failures, declared one layer up. Pack configuration
+    /// is the root's merged with the pack's, so gate settings the root owns
+    /// reach every pack's scan — and blaming the pack for them would name a
+    /// `.dodot.toml` the user never wrote and, for a pack with no
+    /// configuration of its own, one that is not on disk to open.
+    #[test]
+    fn configuration_inherited_from_the_root_names_the_root_config_file() {
+        for root_config in [
+            "[mappings.gates]\n\"[unclosed\" = \"darwin\"\n",
+            "[mappings.gates]\n\"aliases.sh\" = \"no-such-label\"\n",
+            "",
+            "[mappings.gates]\n\"*.sh\" = \"darwin\"\n",
+        ] {
+            let env = TempEnvironment::builder()
+                .pack("vim")
+                .file("aliases.sh", "")
+                .file("profile._no-such-label.sh", "")
+                .done()
+                .build();
+            std::fs::write(env.dotfiles_root.join(".dodot.toml"), root_config).unwrap();
+
+            let error =
+                build_inventory(&resolved(&env), env.fs.as_ref(), &host()).expect_err("accepted");
+
+            assert!(
+                matches!(
+                    &error,
+                    SafetyLockError::DotfilesConfigUnusable { config_file, reason }
+                        if config_file == &canonical_root(&env).join(DOTFILES_CONFIG_FILE)
+                            && !reason.is_empty()
+                ),
+                "unexpected error for root config {root_config:?}: {error}"
             );
         }
     }

--- a/crates/dodot-lib/src/safety_lock/inventory.rs
+++ b/crates/dodot-lib/src/safety_lock/inventory.rs
@@ -252,7 +252,7 @@ pub fn build_inventory(
                 &pack_config.mappings.gates,
             )
             .map_err(|error| {
-                let declared = broken_mapping_entry_owner(&root_config, &pack_config, &gates);
+                let declared = broken_mapping_entry_owner(&root_config, &pack_config);
                 unusable_scan(&pack.path, &owner(declared), error)
             })?;
 
@@ -402,20 +402,34 @@ fn broken_gate_entry_owner(
     })
 }
 
-/// The layer that declared the first unusable `[mappings.gates]` entry, if any.
+/// The layer that declared the `[mappings.gates]` glob the walk could not
+/// compile, if that is why it stopped.
 ///
-/// Exact, unlike the `[gates]` case needing a per-entry replay: this table is a
-/// flat glob-to-label map, so a resolved entry belongs to the pack precisely
-/// when the pack's value for that glob differs from the root's. An entry is
-/// unusable when its glob will not compile or when its label resolves nowhere
-/// in `gates` — the same merged table the walk uses, so a root entry whose
-/// label only a pack defines is correctly not a defect at all.
+/// Deliberately narrower than "any entry that looks unusable". Glob
+/// compilation is the one mapping check the walk runs *eagerly*, over the
+/// whole table, before it looks at a single file — so if a glob does not
+/// compile, that is necessarily what stopped the walk, and the entry naming it
+/// is exact: this table is a flat glob-to-label map, so an entry belongs to
+/// the pack precisely when the pack's value for that glob differs from the
+/// root's.
 ///
-/// Entries are visited in glob order for the same reason as above.
+/// Label resolution deliberately does *not* appear here, though an unresolved
+/// label reads like a defect. The walk resolves a mapping's label only when
+/// that mapping's glob matches an entry it actually met, so a mapping matching
+/// nothing is accepted with a label nothing defines. Treating one as a defect
+/// let it answer for a failure it had no part in — a filename gate token, say
+/// — and point at the file that declared the dormant mapping instead of the
+/// one the error is about. Which mapping, if any, participated in a given
+/// failure is knowable only from the failure itself, which arrives as prose;
+/// until it carries the entry, those failures take the scope fallback in
+/// [`gate_configuration_owner`] rather than a guess.
+///
+/// Entries are visited in glob order, matching the order
+/// [`compile_mapping_gates`](crate::gates::compile_mapping_gates) validates
+/// them in, so the entry chosen here is the entry that actually failed.
 fn broken_mapping_entry_owner(
     root_config: &crate::config::DodotConfig,
     pack_config: &crate::config::DodotConfig,
-    gates: &GateTable,
 ) -> Option<GateLayer> {
     let mut globs: Vec<&String> = pack_config.mappings.gates.keys().collect();
     globs.sort();
@@ -423,9 +437,7 @@ fn broken_mapping_entry_owner(
     globs.into_iter().find_map(|glob| {
         let label = pack_config.mappings.gates.get(glob)?;
         let one = HashMap::from([(glob.clone(), label.clone())]);
-        let compiles = crate::gates::compile_mapping_gates(&one, "<attribution>").is_ok();
-
-        if compiles && gates.lookup(label).is_some() {
+        if crate::gates::compile_mapping_gates(&one, "<attribution>").is_ok() {
             return None;
         }
 
@@ -1027,12 +1039,6 @@ mod tests {
                 "[mappings.gates]\n\"[unclosed\" = \"darwin\"\n",
                 "[mappings.gates]\n\"vimrc\" = \"darwin\"\n",
             ),
-            // Root mapping naming a label nothing defines, beside a pack that
-            // defines a different one.
-            (
-                "[mappings.gates]\n\"aliases.sh\" = \"no-such-label\"\n",
-                "[gates]\nlaptop = { os = \"darwin\" }\n",
-            ),
         ] {
             let env = TempEnvironment::builder()
                 .pack("vim")
@@ -1056,6 +1062,56 @@ mod tests {
                 "unexpected error for root {root_config:?} + pack {pack_config:?}: {error}"
             );
         }
+    }
+
+    /// A `[mappings.gates]` entry the walk never consults cannot answer for a
+    /// failure it had no part in.
+    ///
+    /// The walk resolves a mapping's label only when that mapping's glob
+    /// matches an entry it met, so `"*.txt" = "no-such-label"` beside no `.txt`
+    /// file is accepted — the first case here proves the inventory is built.
+    /// The second puts that same dormant mapping in the root and lets the walk
+    /// fail on a filename gate token instead: the diagnostic is about
+    /// `a._foo.sh`, so it must name the file that has something to say about
+    /// `foo` — the pack — not the one that happens to hold an unrelated
+    /// unresolved mapping.
+    #[test]
+    fn a_mapping_the_walk_never_consults_does_not_claim_another_failure() {
+        let dormant = "[mappings.gates]\n\"*.txt\" = \"no-such-label\"\n";
+
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .config(dormant)
+            .file("vimrc", "")
+            .done()
+            .build();
+
+        assert_eq!(
+            sample_of(&inventory_of(&env)),
+            [(InventoryCategory::Link, "vim/vimrc".into())],
+            "a mapping matching nothing was treated as a defect"
+        );
+
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .config("[gates]\nlaptop = { os = \"darwin\" }\n")
+            .file("a._foo.sh", "")
+            .done()
+            .build();
+        std::fs::write(env.dotfiles_root.join(DOTFILES_CONFIG_FILE), dormant).unwrap();
+
+        let error =
+            build_inventory(&resolved(&env), env.fs.as_ref(), &host()).expect_err("accepted");
+
+        assert!(
+            matches!(
+                &error,
+                SafetyLockError::DotfilesConfigUnusable { config_file, reason }
+                    if config_file == &canonical_root(&env).join("vim/.dodot.toml")
+                        && reason.contains("foo")
+            ),
+            "a dormant root mapping claimed a filename-gate failure: {error}"
+        );
     }
 
     /// The mirror of the case above, and the reason blame is read off the
@@ -1121,6 +1177,68 @@ mod tests {
                 case.root,
                 case.pack,
                 case.owner
+            );
+        }
+    }
+
+    /// Two broken entries owned by different files, and the one the user is
+    /// told about has to be the one the named file declares.
+    ///
+    /// The walk and the attribution replay both visit entries in key order —
+    /// `merge_user` and `compile_mapping_gates` sort, rather than taking
+    /// whatever order the hash gives — so the entry that fails is the entry
+    /// blame is read from. Without that, the message could quote one label
+    /// while the path pointed at the file holding the other.
+    #[test]
+    fn the_reported_defect_and_the_named_file_are_the_same_entry() {
+        for (root, pack, owner, quoted) in [
+            // Root owns the lexically first broken label, pack the later one.
+            (
+                "[gates]\naaa = { nonsense = \"x\" }\n",
+                "[gates]\nzzz = { nonsense = \"x\" }\n",
+                ".dodot.toml",
+                "aaa",
+            ),
+            // Reversed: the pack owns the lexically first one.
+            (
+                "[gates]\nzzz = { nonsense = \"x\" }\n",
+                "[gates]\naaa = { nonsense = \"x\" }\n",
+                "vim/.dodot.toml",
+                "aaa",
+            ),
+            // The same, for globs that will not compile.
+            (
+                "[mappings.gates]\n\"[a\" = \"darwin\"\n",
+                "[mappings.gates]\n\"[z\" = \"darwin\"\n",
+                ".dodot.toml",
+                "[a",
+            ),
+            (
+                "[mappings.gates]\n\"[z\" = \"darwin\"\n",
+                "[mappings.gates]\n\"[a\" = \"darwin\"\n",
+                "vim/.dodot.toml",
+                "[a",
+            ),
+        ] {
+            let env = TempEnvironment::builder()
+                .pack("vim")
+                .config(pack)
+                .file("vimrc", "")
+                .done()
+                .build();
+            std::fs::write(env.dotfiles_root.join(DOTFILES_CONFIG_FILE), root).unwrap();
+
+            let error =
+                build_inventory(&resolved(&env), env.fs.as_ref(), &host()).expect_err("accepted");
+
+            assert!(
+                matches!(
+                    &error,
+                    SafetyLockError::DotfilesConfigUnusable { config_file, reason }
+                        if config_file == &canonical_root(&env).join(owner)
+                            && reason.contains(quoted)
+                ),
+                "root {root:?} + pack {pack:?} should report {quoted:?} against {owner}: {error}"
             );
         }
     }

--- a/crates/dodot-lib/src/safety_lock/inventory.rs
+++ b/crates/dodot-lib/src/safety_lock/inventory.rs
@@ -436,6 +436,15 @@ fn broken_mapping_entry_owner(
 
     globs.into_iter().find_map(|glob| {
         let label = pack_config.mappings.gates.get(glob)?;
+
+        // One entry at a time through the shared compiler rather than
+        // `glob::Pattern::new` directly. `compile_mapping_gates` exists so
+        // that no two callers "disagree about which globs compile, in what
+        // order, or with what failure mode" (its words), and this is a third
+        // caller: the whole point of asking is to reach the same verdict the
+        // walk reached. Calling the pattern API directly would be the cheaper
+        // spelling of a check that is only useful while it stays identical.
+        // Same reason `gate_entry_is_valid` goes through `merge_user`.
         let one = HashMap::from([(glob.clone(), label.clone())]);
         if crate::gates::compile_mapping_gates(&one, "<attribution>").is_ok() {
             return None;

--- a/crates/dodot-lib/src/safety_lock/inventory.rs
+++ b/crates/dodot-lib/src/safety_lock/inventory.rs
@@ -11,12 +11,28 @@
 //! candidate pack-entry contents (Spec, "Non-Goals"), which is also why a
 //! first-ever run needs no rendered baseline.
 //!
-//! Behaviour arrives in WS05; this Work Stream fixes the shape.
+//! What that costs in precision is deliberate. A file is classified by the
+//! handler the rules route it to, under the name it carries on disk: a
+//! template appears as its source name because rendering it is exactly the
+//! work this refuses to do. The prompt is asking "is this the right
+//! directory?", and a source name answers that better than a rendered one
+//! would.
 
-use std::path::PathBuf;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
-use super::error::Result;
+use crate::config::{mappings_to_rules, ConfigManager};
+use crate::fs::Fs;
+use crate::gates::{pack_os_active, GateTable, HostFacts};
+use crate::handlers::{create_registry, ExecutionPhase};
+use crate::packs::scan_packs;
+use crate::rules::Scanner;
+
+use super::error::{Result, SafetyLockError};
 use super::roots::ResolvedRoot;
+
+/// The per-directory configuration file both the root and each pack may carry.
+const DOTFILES_CONFIG_FILE: &str = ".dodot.toml";
 
 /// The most paths the prompt may show, across all categories combined.
 ///
@@ -57,6 +73,30 @@ impl InventoryCategory {
         InventoryCategory::Other,
     ];
 
+    /// The category a handler in `phase` contributes to, or `None` when it
+    /// contributes nothing.
+    ///
+    /// Derived from the handler's declared phase rather than a table of
+    /// handler names, so a handler added later is classified by what it does
+    /// instead of by whether someone remembered to extend this module.
+    ///
+    /// [`Filter`](ExecutionPhase::Filter) is the `None`: `ignore`, `skip`, and
+    /// `gate` claim a file precisely so that nothing is deployed from it, and
+    /// counting those files would inflate every number the prompt shows with
+    /// entries approving the root cannot act on.
+    pub fn for_phase(phase: ExecutionPhase) -> Option<Self> {
+        match phase {
+            ExecutionPhase::Filter => None,
+            ExecutionPhase::ShellInit => Some(InventoryCategory::Shell),
+            ExecutionPhase::Provision | ExecutionPhase::Setup => {
+                Some(InventoryCategory::CodeExecution)
+            }
+            ExecutionPhase::PathExport => Some(InventoryCategory::Path),
+            ExecutionPhase::External => Some(InventoryCategory::External),
+            ExecutionPhase::Link => Some(InventoryCategory::Link),
+        }
+    }
+
     /// Stable, user-facing name of the category.
     pub fn label(self) -> &'static str {
         match self {
@@ -95,6 +135,10 @@ pub struct CategoryCount {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RootInventory {
     /// Root-wide counts per category, in [`InventoryCategory::PROMPT_ORDER`].
+    ///
+    /// Categories that recognized nothing are absent rather than present with
+    /// a zero: the prompt is a recognition aid, and a column of zeroes is
+    /// noise between the user and the question being asked.
     pub counts: Vec<CategoryCount>,
     /// At most [`MAX_INVENTORY_PATHS`] example paths, category-priority first.
     pub sample: Vec<InventoryEntry>,
@@ -110,14 +154,645 @@ impl RootInventory {
 }
 
 /// Build the orientation inventory for the root about to be approved.
-pub fn build_inventory(root: &ResolvedRoot) -> Result<RootInventory> {
-    let _ = root;
-    todo!("WS05: safety decisions and orientation inventory")
+///
+/// Root-wide by construction: there is no pack filter to pass. A command that
+/// operates on one pack still approves the whole path, so an inventory scoped
+/// to the filter would describe less than the answer authorizes (Spec,
+/// "Risks"). Every active pack under the root is walked.
+///
+/// The walk is the ordinary routing pipeline and nothing more: discover packs,
+/// load each pack's merged configuration, generate its rules, and ask the
+/// scanner which handler claims each top-level entry. No handler is
+/// constructed to produce intents, no template is rendered, no secret is
+/// resolved, and no candidate file's contents are read — the registry is
+/// consulted only for each handler's declared phase. A directory entry counts
+/// once, as the one thing routing recognized; the scanner does not descend
+/// into it and neither does this.
+///
+/// `fs` and `host` are injected for the same reason every other Safety Lock
+/// entry point takes its collaborators: this module captures no process state
+/// of its own, so gating decisions stay stateable in a test rather than
+/// depending on the machine the suite runs on.
+///
+/// Fails when a `.dodot.toml` cannot be loaded
+/// ([`DotfilesConfigUnusable`](SafetyLockError::DotfilesConfigUnusable)) or a
+/// pack cannot be walked or routed
+/// ([`PackRoutingUnusable`](SafetyLockError::PackRoutingUnusable)), each
+/// naming the file or directory at fault. Both fail the inventory rather than
+/// omitting the unreadable part, because the prompt's counts are the user's
+/// only evidence about the root: an inventory that quietly skipped what it
+/// could not read would understate what approval permits.
+pub fn build_inventory(
+    root: &ResolvedRoot,
+    fs: &dyn Fs,
+    host: &HostFacts,
+) -> Result<RootInventory> {
+    let root_path = root.as_path();
+    let config = ConfigManager::new(root_path)
+        .and_then(|manager| manager.root_config().map(|config| (manager, config)));
+    let (manager, root_config) =
+        config.map_err(|error| unusable_config(root_path.join(DOTFILES_CONFIG_FILE), error))?;
+
+    let discovered = scan_packs(fs, root_path, &root_config.pack.ignore)
+        .map_err(|error| unusable_routing(root_path, error))?;
+
+    // Only `Handler::phase` is read, so the run-once handlers never reach a
+    // subprocess — the same posture `handlers::configuration_handler_names`
+    // takes when it inspects the registry without exercising it.
+    let runner = crate::datastore::NoopCommandRunner;
+    let registry = create_registry(fs, &runner);
+    let scanner = Scanner::new(fs);
+
+    let mut counts: BTreeMap<InventoryCategory, usize> = BTreeMap::new();
+    let mut entries: Vec<InventoryEntry> = Vec::new();
+
+    for pack in &discovered.packs {
+        let pack_config = manager
+            .config_for_pack(&pack.path)
+            .map_err(|error| unusable_config(pack.path.join(DOTFILES_CONFIG_FILE), error))?;
+
+        // A pack gated off this host deploys nothing here, so counting it
+        // would describe a machine the user is not on.
+        if !pack_os_active(&pack_config.pack.os, host) {
+            continue;
+        }
+
+        let mut gates = GateTable::with_builtins();
+        if !pack_config.gates.is_empty() {
+            gates
+                .merge_user(&pack_config.gates)
+                .map_err(|error| unusable_config(pack.path.join(DOTFILES_CONFIG_FILE), error))?;
+        }
+
+        let rules = mappings_to_rules(&pack_config.mappings);
+        let matches = scanner
+            .scan_pack(
+                pack,
+                &rules,
+                &pack_config.pack.ignore,
+                &gates,
+                host,
+                &pack_config.mappings.gates,
+            )
+            .map_err(|error| unusable_routing(&pack.path, error))?;
+
+        for matched in matches {
+            let Some(category) = category_of(&matched.handler, &registry) else {
+                continue;
+            };
+
+            *counts.entry(category).or_default() += 1;
+            entries.push(InventoryEntry {
+                category,
+                // Pack-relative becomes root-relative: the prompt names the
+                // root once, and the pack directory is part of what the user
+                // is being asked to recognize.
+                relative_path: Path::new(&pack.name).join(&matched.relative_path),
+            });
+        }
+    }
+
+    // `(category, relative_path)`, which is the prompt's order — see
+    // `InventoryCategory`. Sorting before the cap is what makes the cap
+    // keep the highest-impact entries rather than the first ones walked.
+    entries.sort();
+    let recognized = entries.len();
+    entries.truncate(MAX_INVENTORY_PATHS);
+
+    Ok(RootInventory {
+        counts: InventoryCategory::PROMPT_ORDER
+            .iter()
+            .filter_map(|category| {
+                counts.get(category).map(|&files| CategoryCount {
+                    category: *category,
+                    files,
+                })
+            })
+            .collect(),
+        omitted: recognized - entries.len(),
+        sample: entries,
+    })
+}
+
+/// The inventory category a routed file contributes to, or `None` when it
+/// contributes nothing.
+///
+/// A handler the registry does not know is [`Other`](InventoryCategory::Other)
+/// rather than skipped: it was routed by the loaded configuration, so it is a
+/// file approval would act on, and dropping it would undercount the root.
+fn category_of(
+    handler: &str,
+    registry: &std::collections::HashMap<String, Box<dyn crate::handlers::Handler + '_>>,
+) -> Option<InventoryCategory> {
+    match registry.get(handler) {
+        Some(handler) => InventoryCategory::for_phase(handler.phase()),
+        None => Some(InventoryCategory::Other),
+    }
+}
+
+fn unusable_config(config_file: PathBuf, error: crate::error::DodotError) -> SafetyLockError {
+    SafetyLockError::DotfilesConfigUnusable {
+        config_file,
+        reason: error.to_string(),
+    }
+}
+
+fn unusable_routing(
+    directory: impl Into<PathBuf>,
+    error: crate::error::DodotError,
+) -> SafetyLockError {
+    SafetyLockError::PackRoutingUnusable {
+        directory: directory.into(),
+        reason: error.to_string(),
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::fs::OsFs;
+    use crate::testing::{TempEnvironment, TempEnvironmentBuilder};
+
+    use super::super::roots::{RootIdentity, RootSource};
     use super::*;
+
+    fn host() -> HostFacts {
+        HostFacts::for_tests("darwin", "arm64")
+    }
+
+    /// The inventory of `env`'s dotfiles root, as an unapproved implicit root
+    /// reaching the prompt.
+    fn inventory_of(env: &TempEnvironment) -> RootInventory {
+        build_inventory(&resolved(env), env.fs.as_ref(), &host()).unwrap()
+    }
+
+    fn resolved(env: &TempEnvironment) -> ResolvedRoot {
+        ResolvedRoot::new(
+            RootIdentity::new(canonical_root(env)).unwrap(),
+            RootSource::Git,
+        )
+    }
+
+    /// The root as selection would have canonicalized it — the spelling every
+    /// diagnostic below names, since that is the path the inventory walks.
+    fn canonical_root(env: &TempEnvironment) -> PathBuf {
+        std::fs::canonicalize(&env.dotfiles_root).unwrap()
+    }
+
+    /// `(category, path)` pairs, which is what the prompt renders.
+    fn sample_of(inventory: &RootInventory) -> Vec<(InventoryCategory, String)> {
+        inventory
+            .sample
+            .iter()
+            .map(|entry| {
+                (
+                    entry.category,
+                    entry.relative_path.to_string_lossy().into_owned(),
+                )
+            })
+            .collect()
+    }
+
+    fn counts_of(inventory: &RootInventory) -> Vec<(InventoryCategory, usize)> {
+        inventory
+            .counts
+            .iter()
+            .map(|count| (count.category, count.files))
+            .collect()
+    }
+
+    /// One pack exercising every default handler mapping at once.
+    fn representative_pack(builder: TempEnvironmentBuilder, name: &str) -> TempEnvironmentBuilder {
+        builder
+            .pack(name)
+            .file("aliases.sh", "alias g=git")
+            .file("install.sh", "#!/bin/sh")
+            .file("Brewfile", "brew \"jq\"")
+            .file("externals.toml", "")
+            .file("bin/tool", "#!/bin/sh")
+            .file("config", "x")
+            .done()
+    }
+
+    /// Story 3, and the point of the whole module: what the user is shown is
+    /// every recognized file, classified once, by the handler the loaded
+    /// configuration routes it to.
+    ///
+    /// Once, including where two rules could claim a file: `install.sh` is
+    /// matched by both the install rule and the `*.sh` shell glob, and the
+    /// inventory counts whichever one routing gives it — not both, and not the
+    /// lower-priority one.
+    #[test]
+    fn every_recognized_file_lands_in_exactly_one_category() {
+        let env = representative_pack(TempEnvironment::builder(), "tools").build();
+
+        let inventory = inventory_of(&env);
+
+        assert_eq!(
+            counts_of(&inventory),
+            [
+                (InventoryCategory::Shell, 1),
+                // `install.sh` and `Brewfile` are both code execution: the
+                // category is the handler's phase, not its name.
+                (InventoryCategory::CodeExecution, 2),
+                (InventoryCategory::Path, 1),
+                (InventoryCategory::External, 1),
+                (InventoryCategory::Link, 1),
+            ]
+        );
+        assert_eq!(inventory.total_files(), 6);
+        assert_eq!(inventory.omitted, 0);
+        assert_eq!(
+            sample_of(&inventory),
+            [
+                (InventoryCategory::Shell, "tools/aliases.sh".into()),
+                (InventoryCategory::CodeExecution, "tools/Brewfile".into()),
+                (InventoryCategory::CodeExecution, "tools/install.sh".into()),
+                (InventoryCategory::Path, "tools/bin".into()),
+                (InventoryCategory::External, "tools/externals.toml".into()),
+                (InventoryCategory::Link, "tools/config".into()),
+            ]
+        );
+    }
+
+    /// Detail order is category priority first, then pack-relative path — so
+    /// the entries that can change every future shell survive the cap, and two
+    /// runs over an unchanged root show the same list.
+    #[test]
+    fn detail_is_ordered_by_category_then_path() {
+        let env = TempEnvironment::builder()
+            .pack("zsh")
+            .file("zshrc.sh", "")
+            .done()
+            .pack("apps")
+            .file("gitconfig", "")
+            .file("install.sh", "")
+            .done()
+            .pack("alacritty")
+            .file("alacritty.toml", "")
+            .done()
+            .build();
+
+        let inventory = inventory_of(&env);
+
+        assert_eq!(
+            sample_of(&inventory),
+            [
+                (InventoryCategory::Shell, "zsh/zshrc.sh".into()),
+                (InventoryCategory::CodeExecution, "apps/install.sh".into()),
+                (InventoryCategory::Link, "alacritty/alacritty.toml".into()),
+                (InventoryCategory::Link, "apps/gitconfig".into()),
+            ]
+        );
+        assert_eq!(sample_of(&inventory_of(&env)), sample_of(&inventory));
+    }
+
+    /// Story 3 again, from the other side: the cap keeps the confirmation
+    /// question on screen. What it must not do is quietly shrink the root —
+    /// the counts stay whole and the dropped paths are counted.
+    #[test]
+    fn detail_stops_at_ten_paths_and_counts_what_it_dropped() {
+        let mut builder = TempEnvironment::builder().pack("links");
+        for index in 0..20 {
+            builder = builder.file(&format!("config{index:02}"), "");
+        }
+        let env = representative_pack(builder.done(), "tools").build();
+
+        let inventory = inventory_of(&env);
+
+        assert_eq!(inventory.sample.len(), MAX_INVENTORY_PATHS);
+        assert_eq!(inventory.total_files(), 26);
+        assert_eq!(inventory.omitted, 16);
+        assert_eq!(
+            inventory.omitted + inventory.sample.len(),
+            inventory.total_files(),
+            "the cap lost paths instead of counting them"
+        );
+
+        // Counts are unaffected by the cap: `link` shows 21 while only four
+        // of its paths are detailed.
+        assert_eq!(
+            counts_of(&inventory),
+            [
+                (InventoryCategory::Shell, 1),
+                (InventoryCategory::CodeExecution, 2),
+                (InventoryCategory::Path, 1),
+                (InventoryCategory::External, 1),
+                (InventoryCategory::Link, 21),
+            ]
+        );
+
+        // And what survives is the high-impact end of the order.
+        assert_eq!(
+            sample_of(&inventory)[..6],
+            [
+                (InventoryCategory::Shell, "tools/aliases.sh".into()),
+                (InventoryCategory::CodeExecution, "tools/Brewfile".into()),
+                (InventoryCategory::CodeExecution, "tools/install.sh".into()),
+                (InventoryCategory::Path, "tools/bin".into()),
+                (InventoryCategory::External, "tools/externals.toml".into()),
+                (InventoryCategory::Link, "links/config00".into()),
+            ]
+        );
+    }
+
+    /// Custom mappings are configuration, and configuration is what the
+    /// inventory reads: routing the user changed must be the routing the
+    /// prompt describes, or it would orient them against a deployment that
+    /// never happens.
+    #[test]
+    fn custom_handler_mappings_are_honoured() {
+        let env = TempEnvironment::builder()
+            .pack("nvim")
+            .config(
+                "[mappings]\n\
+                 path = \"scripts\"\n\
+                 shell = [\"*.zsh\"]\n",
+            )
+            .file("scripts/tool", "")
+            .file("profile.zsh", "")
+            .file("aliases.sh", "")
+            .done()
+            .build();
+
+        let inventory = inventory_of(&env);
+
+        assert_eq!(
+            sample_of(&inventory),
+            [
+                (InventoryCategory::Shell, "nvim/profile.zsh".into()),
+                (InventoryCategory::Path, "nvim/scripts".into()),
+                // `bin` is no longer the PATH directory and `*.sh` no longer
+                // shell, so both fall through to the catchall.
+                (InventoryCategory::Link, "nvim/aliases.sh".into()),
+            ]
+        );
+    }
+
+    /// Files that are claimed in order to *not* be deployed — ignored packs,
+    /// ignored and skipped entries, and entries gated off this host — are not
+    /// recognized files. Counting them would inflate every number the user
+    /// reads with things approval cannot act on.
+    #[test]
+    fn what_deploys_nothing_is_not_counted() {
+        let env = TempEnvironment::builder()
+            .pack("archive")
+            .file("vimrc", "")
+            .ignored()
+            .done()
+            .pack("vim")
+            .config("[mappings]\nignore = [\"notes.md\"]\n")
+            .file("vimrc", "")
+            .file("notes.md", "")
+            .file("README.md", "")
+            .file("linux-only.sh._linux", "")
+            .done()
+            .build();
+
+        let inventory = inventory_of(&env);
+
+        assert_eq!(counts_of(&inventory), [(InventoryCategory::Link, 1)]);
+        assert_eq!(
+            sample_of(&inventory),
+            [(InventoryCategory::Link, "vim/vimrc".into())],
+            "a filtered, gated, or ignored-pack file reached the prompt"
+        );
+    }
+
+    /// A pack gated off this host deploys nothing here, so it describes a
+    /// machine the user is not on.
+    #[test]
+    fn packs_gated_off_this_host_are_not_counted() {
+        let env = TempEnvironment::builder()
+            .pack("linux-tools")
+            .config("[pack]\nos = [\"linux\"]\n")
+            .file("aliases.sh", "")
+            .done()
+            .pack("vim")
+            .file("vimrc", "")
+            .done()
+            .build();
+
+        assert_eq!(
+            sample_of(&inventory_of(&env)),
+            [(InventoryCategory::Link, "vim/vimrc".into())]
+        );
+    }
+
+    /// The scanner stops at a pack's top level and so does the inventory: a
+    /// directory is one entry, because one entry is what routing recognized
+    /// and what a handler acts on. Recursing to make the count "more accurate"
+    /// would be inventing detail the deployment does not have.
+    #[test]
+    fn a_directory_entry_counts_once_and_is_not_descended_into() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("colors/one.vim", "")
+            .file("colors/two.vim", "")
+            .file("after/ftplugin/rust.vim", "")
+            .done()
+            .build();
+
+        let inventory = inventory_of(&env);
+
+        assert_eq!(counts_of(&inventory), [(InventoryCategory::Link, 2)]);
+        assert_eq!(
+            sample_of(&inventory),
+            [
+                (InventoryCategory::Link, "vim/after".into()),
+                (InventoryCategory::Link, "vim/colors".into()),
+            ]
+        );
+    }
+
+    /// Spec, "Non-Goals": this is a recognition aid, not a dry run. A template
+    /// is listed under its source name because rendering it — and resolving
+    /// what it would render *from* — is exactly the work refused here, which
+    /// is also why a first-ever run needs no rendered baseline.
+    #[test]
+    fn a_template_is_listed_by_its_source_name_without_being_rendered() {
+        let env = TempEnvironment::builder()
+            .pack("git")
+            .file("gitconfig.tmpl", "[user]\n  name = {{ env.USER }}\n")
+            .done()
+            .build();
+
+        let before = env.list_dir_names(&env.data_dir);
+
+        assert_eq!(
+            sample_of(&inventory_of(&env)),
+            [(InventoryCategory::Link, "git/gitconfig.tmpl".into())]
+        );
+        assert_eq!(
+            env.list_dir_names(&env.data_dir),
+            before,
+            "building the inventory wrote Dodot state"
+        );
+    }
+
+    /// The same claim as the test above, made structurally: the implementation
+    /// cannot render, preprocess, or read a candidate file because it never
+    /// names the machinery that would.
+    #[test]
+    fn the_implementation_reads_no_candidate_contents() {
+        let implementation = include_str!("inventory.rs")
+            .split_once("#[cfg(test)]")
+            .expect("this file carries a test module")
+            .0;
+        let code = implementation
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        for forbidden in [
+            "preprocess",
+            "render",
+            "secret",
+            "read_to_string",
+            "read_file",
+            "to_intents",
+            "DataStore",
+            "walk_pack_recursive",
+        ] {
+            assert!(
+                !code.contains(forbidden),
+                "the inventory reaches past routing metadata through `{forbidden}`"
+            );
+        }
+    }
+
+    /// Story 14: configuration Dodot cannot load is named, with its problem,
+    /// and stops the inventory — an approvable decision is never produced from
+    /// a root Dodot could not describe.
+    #[test]
+    fn invalid_configuration_names_the_offending_file() {
+        for (pack_config, root_config, offender) in [
+            (Some("not valid toml"), None, "vim/.dodot.toml"),
+            (None, Some("[pack]\nos = [\"linux\"]\n"), ".dodot.toml"),
+        ] {
+            let mut builder = TempEnvironment::builder().pack("vim").file("vimrc", "");
+            if let Some(contents) = pack_config {
+                builder = builder.config(contents);
+            }
+            let env = builder.done().build();
+            if let Some(contents) = root_config {
+                std::fs::write(env.dotfiles_root.join(".dodot.toml"), contents).unwrap();
+            }
+
+            let error =
+                build_inventory(&resolved(&env), env.fs.as_ref(), &host()).expect_err("accepted");
+
+            assert!(
+                matches!(
+                    &error,
+                    SafetyLockError::DotfilesConfigUnusable { config_file, reason }
+                        if config_file == &canonical_root(&env).join(offender) && !reason.is_empty()
+                ),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    /// A root that cannot be walked fails the inventory rather than reporting
+    /// an empty one: "nothing here" and "I could not look" must not read the
+    /// same to a user deciding whether to authorize the path.
+    #[test]
+    fn a_root_that_cannot_be_routed_fails_rather_than_reporting_nothing() {
+        let env = TempEnvironment::builder().build();
+        // Two packs that collide on one display name — a layout dodot
+        // refuses to route.
+        for name in ["010-vim", "020-vim"] {
+            std::fs::create_dir(env.dotfiles_root.join(name)).unwrap();
+        }
+
+        let error = build_inventory(&resolved(&env), env.fs.as_ref(), &host()).expect_err("routed");
+
+        assert!(
+            matches!(
+                &error,
+                SafetyLockError::PackRoutingUnusable { directory, .. }
+                    if directory == &canonical_root(&env)
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// An empty root is a real, describable state — the first thing a user
+    /// pointed at the wrong directory should see is that Dodot recognized
+    /// nothing in it.
+    #[test]
+    fn an_empty_root_inventories_to_nothing() {
+        let env = TempEnvironment::builder().build();
+
+        let inventory = build_inventory(&resolved(&env), &OsFs::new(), &host()).unwrap();
+
+        assert!(inventory.counts.is_empty());
+        assert!(inventory.sample.is_empty());
+        assert_eq!(inventory.omitted, 0);
+        assert_eq!(inventory.total_files(), 0);
+    }
+
+    /// Categories follow the handler's declared phase, so a handler added
+    /// later is classified by what it does rather than by whether this module
+    /// was updated. The match is exhaustive: a new phase will not compile
+    /// until it is placed.
+    #[test]
+    fn categories_follow_handler_phases() {
+        use ExecutionPhase::*;
+
+        assert_eq!(
+            InventoryCategory::for_phase(ShellInit),
+            Some(InventoryCategory::Shell)
+        );
+        assert_eq!(
+            InventoryCategory::for_phase(Setup),
+            Some(InventoryCategory::CodeExecution)
+        );
+        assert_eq!(
+            InventoryCategory::for_phase(Provision),
+            Some(InventoryCategory::CodeExecution)
+        );
+        assert_eq!(
+            InventoryCategory::for_phase(PathExport),
+            Some(InventoryCategory::Path)
+        );
+        assert_eq!(
+            InventoryCategory::for_phase(External),
+            Some(InventoryCategory::External)
+        );
+        assert_eq!(
+            InventoryCategory::for_phase(Link),
+            Some(InventoryCategory::Link)
+        );
+        assert_eq!(
+            InventoryCategory::for_phase(Filter),
+            None,
+            "a handler that deploys nothing was counted"
+        );
+    }
+
+    /// A handler the registry does not know is still a file the configuration
+    /// routes, so it counts — as `other`, the category that exists for
+    /// exactly this.
+    #[test]
+    fn an_unknown_handler_counts_as_other() {
+        let fs = OsFs::new();
+        let runner = crate::datastore::NoopCommandRunner;
+        let registry = create_registry(&fs, &runner);
+
+        assert_eq!(
+            category_of("a-handler-from-the-future", &registry),
+            Some(InventoryCategory::Other)
+        );
+        assert_eq!(
+            category_of(crate::handlers::HANDLER_SHELL, &registry),
+            Some(InventoryCategory::Shell)
+        );
+        assert_eq!(
+            category_of(crate::handlers::HANDLER_IGNORE, &registry),
+            None
+        );
+    }
 
     /// The prompt's priority is encoded in the type's ordering rather than a
     /// separate table, so a sort on `(category, path)` cannot drift from the

--- a/crates/dodot-lib/src/safety_lock/inventory.rs
+++ b/crates/dodot-lib/src/safety_lock/inventory.rs
@@ -26,7 +26,7 @@ use crate::fs::Fs;
 use crate::gates::{pack_os_active, GateTable, HostFacts};
 use crate::handlers::{create_registry, ExecutionPhase};
 use crate::packs::scan_packs;
-use crate::rules::Scanner;
+use crate::rules::{RuleMatch, Scanner};
 
 use super::error::{Result, SafetyLockError};
 use super::roots::ResolvedRoot;
@@ -172,7 +172,12 @@ impl RootInventory {
 /// `fs` and `host` are injected for the same reason every other Safety Lock
 /// entry point takes its collaborators: this module captures no process state
 /// of its own, so gating decisions stay stateable in a test rather than
-/// depending on the machine the suite runs on.
+/// depending on the machine the suite runs on. The injection is not total, and
+/// callers should not read it as a virtualized filesystem: the pack walk,
+/// routing, and registry go through `fs`, but configuration is loaded by
+/// [`ConfigManager`], which reads `.dodot.toml` through `std::fs` and searches
+/// ancestors for a `.git` marker. A test that varies configuration therefore
+/// has to write real files, as this module's own tests do.
 ///
 /// Fails when a `.dodot.toml` cannot be loaded
 /// ([`DotfilesConfigUnusable`](SafetyLockError::DotfilesConfigUnusable)) or a
@@ -234,7 +239,7 @@ pub fn build_inventory(
                 host,
                 &pack_config.mappings.gates,
             )
-            .map_err(|error| unusable_routing(&pack.path, error))?;
+            .map_err(|error| unusable_scan(&pack.path, error))?;
 
         for matched in matches {
             let Some(category) = category_of(&matched.handler, &registry) else {
@@ -247,7 +252,8 @@ pub fn build_inventory(
                 // Pack-relative becomes root-relative: the prompt names the
                 // root once, and the pack directory is part of what the user
                 // is being asked to recognize.
-                relative_path: Path::new(&pack.name).join(&matched.relative_path),
+                relative_path: Path::new(&pack.name)
+                    .join(source_relative_path(&pack.path, &matched)),
             });
         }
     }
@@ -272,6 +278,24 @@ pub fn build_inventory(
         omitted: recognized - entries.len(),
         sample: entries,
     })
+}
+
+/// The entry's path as the root actually spells it, relative to its pack.
+///
+/// [`RuleMatch::relative_path`] is the *effective* path routing works from,
+/// not the one on disk: a passing basename gate presents
+/// `aliases._darwin.sh` under its stripped name `aliases.sh`, and a passing
+/// directory gate lifts `_darwin/aliases.sh` to `aliases.sh` at the pack root.
+/// That rewrite is right for handlers and wrong for this prompt, which asks
+/// the user to recognize their own root by the names it carries — a path that
+/// is not in the directory is evidence about a directory that does not exist.
+/// The absolute path is never rewritten, so the displayed path is derived from
+/// it; classification still uses the effective match.
+fn source_relative_path<'a>(pack_path: &Path, matched: &'a RuleMatch) -> &'a Path {
+    matched
+        .absolute_path
+        .strip_prefix(pack_path)
+        .unwrap_or(matched.relative_path.as_path())
 }
 
 /// The inventory category a routed file contributes to, or `None` when it
@@ -304,6 +328,25 @@ fn unusable_routing(
     SafetyLockError::PackRoutingUnusable {
         directory: directory.into(),
         reason: error.to_string(),
+    }
+}
+
+/// A scan failure, classified by what the user can act on.
+///
+/// The scanner does two jobs at once: it walks the pack, and it interprets the
+/// pack's configuration — `[mappings.gates]` globs, the gate labels those
+/// entries and filename tokens name, and the conflict between the two all come
+/// back as [`DodotError::Config`](crate::error::DodotError::Config). Reporting
+/// those as a routing failure would name the pack *directory* when the thing
+/// the user has to open is the pack's `.dodot.toml` (story 14: name the bad
+/// file, not the neighbourhood it is in). Everything else the walk can fail on
+/// — an unreadable directory, a layout Dodot refuses — is a routing failure and
+/// names the directory.
+fn unusable_scan(pack_path: &Path, error: crate::error::DodotError) -> SafetyLockError {
+    if matches!(error, crate::error::DodotError::Config(_)) {
+        unusable_config(pack_path.join(DOTFILES_CONFIG_FILE), error)
+    } else {
+        unusable_routing(pack_path, error)
     }
 }
 
@@ -578,6 +621,41 @@ mod tests {
         );
     }
 
+    /// A gate that *passes* is invisible to routing by design — the scanner
+    /// presents `aliases._darwin.sh` as `aliases.sh` and lifts `_darwin/vimrc`
+    /// to the pack root — but it must stay visible to the prompt. The user is
+    /// being asked to recognize their own root, and a path that is not in the
+    /// directory is evidence about a directory that does not exist. The
+    /// classification still follows the effective name: `aliases._darwin.sh`
+    /// is a shell file because `aliases.sh` is what the rules match.
+    #[test]
+    fn a_passing_gate_is_listed_under_the_name_the_root_carries() {
+        let env = TempEnvironment::builder()
+            .pack("zsh")
+            .file("aliases._darwin.sh", "alias g=git")
+            .done()
+            .pack("vim")
+            .file("_darwin/vimrc", "")
+            .done()
+            .build();
+
+        let inventory = inventory_of(&env);
+
+        assert_eq!(
+            counts_of(&inventory),
+            [(InventoryCategory::Shell, 1), (InventoryCategory::Link, 1)],
+            "the passing gates changed what the entries were classified as"
+        );
+        assert_eq!(
+            sample_of(&inventory),
+            [
+                (InventoryCategory::Shell, "zsh/aliases._darwin.sh".into()),
+                (InventoryCategory::Link, "vim/_darwin/vimrc".into()),
+            ],
+            "the prompt showed a path that does not exist under the root"
+        );
+    }
+
     /// The scanner stops at a pack's top level and so does the inventory: a
     /// directory is one entry, because one entry is what routing recognized
     /// and what a handler acts on. Recursing to make the count "more accurate"
@@ -689,6 +767,47 @@ mod tests {
                         if config_file == &canonical_root(&env).join(offender) && !reason.is_empty()
                 ),
                 "unexpected error: {error}"
+            );
+        }
+    }
+
+    /// Story 14 again, for the configuration that fails in *use* rather than
+    /// in parsing. The scanner interprets gate configuration as it walks, so
+    /// an invalid `[mappings.gates]` glob, an unresolvable label, and a file
+    /// gated two ways at once all surface from the walk — and naming the pack
+    /// directory for them would point the user at a place instead of at the
+    /// file they have to edit.
+    #[test]
+    fn configuration_the_walk_rejects_names_the_pack_config_file() {
+        for pack_config in [
+            // An invalid glob: rejected when the mapping gates compile.
+            "[mappings.gates]\n\"[unclosed\" = \"darwin\"\n",
+            // A label nothing defines, reached through `[mappings.gates]`.
+            "[mappings.gates]\n\"aliases.sh\" = \"no-such-label\"\n",
+            // A label nothing defines, reached through the filename grammar.
+            "",
+            // One file gated two ways at once.
+            "[mappings.gates]\n\"*.sh\" = \"darwin\"\n",
+        ] {
+            let env = TempEnvironment::builder()
+                .pack("vim")
+                .config(pack_config)
+                .file("aliases.sh", "")
+                .file("profile._no-such-label.sh", "")
+                .done()
+                .build();
+
+            let error =
+                build_inventory(&resolved(&env), env.fs.as_ref(), &host()).expect_err("accepted");
+
+            assert!(
+                matches!(
+                    &error,
+                    SafetyLockError::DotfilesConfigUnusable { config_file, reason }
+                        if config_file == &canonical_root(&env).join("vim/.dodot.toml")
+                            && !reason.is_empty()
+                ),
+                "unexpected error for config {pack_config:?}: {error}"
             );
         }
     }

--- a/crates/dodot-lib/src/safety_lock/operation.rs
+++ b/crates/dodot-lib/src/safety_lock/operation.rs
@@ -1,0 +1,539 @@
+//! The one seam every command crosses: what kind of operation is this, and
+//! may it run against this root?
+//!
+//! [`check`](super::check) answers what standing a root has. It cannot answer
+//! whether that standing matters, because that depends on what the command is
+//! about to do — `status` and `up --dry-run` read the same untrusted root
+//! `up` may not write to. [`RootOperation`] is that missing half, and
+//! [`authorize`] is the two composed.
+//!
+//! Root sensitivity is *declared*, never inferred. A command does not become
+//! gated because it built a root-aware context, and does not escape the gate
+//! because its context builder is spelled "read-only" — several commands that
+//! mutate pack source do exactly that today (Spec, "Risks"). ADR-0002 puts the
+//! declaration at one seam so a new mutating command has to state which kind
+//! it is, and so the taxonomy can be reviewed as a list rather than
+//! reconstructed by reading every handler.
+//!
+//! No Clap type appears here, and no command name either. The taxonomy is a
+//! property of what an operation does to the root, which is why it can be
+//! tested exhaustively without a CLI: WS07 maps commands onto these variants
+//! at the process boundary.
+
+use crate::fs::Fs;
+use crate::gates::HostFacts;
+
+use super::check::{decide, TrustDecision};
+use super::error::Result;
+use super::inventory::{build_inventory, RootInventory};
+use super::roots::ResolvedRoot;
+use super::schema::SafetyLockConfig;
+
+/// What an operation does with respect to the resolved dotfiles root.
+///
+/// The variants are about the *target* of the work, not its risk: what makes
+/// an operation root-sensitive is that the root selected what it writes to, so
+/// a wrong root writes to the wrong place (ADR-0002).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RootOperation {
+    /// A mutation of repository, deployment, or user-visible state whose
+    /// target is selected from the resolved root: `up`, `down`, `adopt`,
+    /// `fill`, `init`, `addignore`, and configuration actions persisted into
+    /// the root. The only kind the gate stops.
+    RootSensitiveMutation,
+
+    /// Inspection: reads the root, writes nothing derived from it. `status`,
+    /// `list`, and probes stay available on an unapproved root so a user or
+    /// agent can find out what Dodot sees *before* deciding to authorize it
+    /// (Spec, story 10).
+    ReadOnly,
+
+    /// A mutation the user asked to preview rather than perform. Distinct
+    /// from [`ReadOnly`](Self::ReadOnly) because the command is otherwise
+    /// root-sensitive — the preview is what makes this invocation safe — and
+    /// keeping it distinct is what stops "we already classified `up`" from
+    /// quietly gating its dry run.
+    DryRun,
+
+    /// A mutation whose target is chosen independently of the root: `install
+    /// --write`, `git-install-alias`, dismissed-prompt management, factory
+    /// `reset`, stdin/stdout filters. These keep their own safeguards; root
+    /// trust has nothing to say about a write the root did not select
+    /// (ADR-0002).
+    RootIndependentMutation,
+}
+
+impl RootOperation {
+    /// Whether reaching this operation requires the root to be trusted.
+    ///
+    /// True for exactly one variant. That asymmetry is the policy: the gate
+    /// protects root-derived mutation, not mutation in general, and widening
+    /// it would turn Safety Lock into a general confirmation framework
+    /// (ADR-0002).
+    pub fn requires_trusted_root(self) -> bool {
+        matches!(self, RootOperation::RootSensitiveMutation)
+    }
+
+    /// Stable, user-facing name of the operation kind, for diagnostics and
+    /// debug logging (Spec, "Observability").
+    pub fn label(self) -> &'static str {
+        match self {
+            RootOperation::RootSensitiveMutation => "root-sensitive mutation",
+            RootOperation::ReadOnly => "read-only",
+            RootOperation::DryRun => "dry run",
+            RootOperation::RootIndependentMutation => "root-independent mutation",
+        }
+    }
+}
+
+/// What the safety gate concluded about one operation on one root.
+///
+/// Refusal is not here. Declining at the prompt is the user's answer to
+/// [`ConfirmationRequired`](Self::ConfirmationRequired), not something the
+/// gate decides, and a gate that could not answer at all returns an error
+/// instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GateOutcome {
+    /// The operation is not root-sensitive, so it proceeds without the root's
+    /// standing being consulted at all. No approval is read, and none is
+    /// established — a read-only command on an untrusted root leaves it
+    /// untrusted (Spec, story 10).
+    NotRootSensitive,
+
+    /// Root-sensitive, and the root's standing already permits it: a valid
+    /// `DOTFILES_ROOT`, or an implicit root the user approved before.
+    Permitted(TrustDecision),
+
+    /// Root-sensitive, implicitly selected, and not approved. The mutation
+    /// may not proceed until the user approves this exact path.
+    ///
+    /// The inventory the prompt needs is carried rather than fetched
+    /// afterwards, which is what makes "invalid configuration prevents an
+    /// approvable decision" structural instead of a rule callers must
+    /// remember: an inventory that cannot be built is an error, and no value
+    /// of this variant exists for a caller to answer (Spec, story 14).
+    ConfirmationRequired {
+        /// Root-wide orientation for the path being approved — not scoped to
+        /// whatever packs the current command filtered to.
+        inventory: RootInventory,
+    },
+}
+
+impl GateOutcome {
+    /// Whether the operation may proceed into mutation as-is.
+    pub fn permits_operation(&self) -> bool {
+        !matches!(self, GateOutcome::ConfirmationRequired { .. })
+    }
+
+    /// The orientation inventory, when the user has to be asked.
+    pub fn inventory(&self) -> Option<&RootInventory> {
+        match self {
+            GateOutcome::ConfirmationRequired { inventory } => Some(inventory),
+            _ => None,
+        }
+    }
+}
+
+/// Decide whether `operation` may run against `root`.
+///
+/// The whole policy, in order:
+///
+/// 1. An operation that is not root-sensitive proceeds immediately. Nothing
+///    is read — not the trust state, not the root's contents — so a corrupt
+///    trust file cannot take `status` down with it, and a diagnostic run on an
+///    unfamiliar repository costs nothing.
+/// 2. Otherwise the root's standing decides ([`decide`]): explicit selection
+///    and prior approval both permit the mutation, and neither pays for an
+///    inventory it will not show.
+/// 3. An unapproved implicit root needs the user, so the orientation
+///    inventory is built and carried out with the answer.
+///
+/// Nothing here writes. Approval is [`approve`](super::check::approve)'s job
+/// and persistence is the caller's, which is what lets the CLI record the
+/// user's answer before starting the mutation it authorizes (Spec, "Risks").
+///
+/// Fails when the trust state is unusable, or — for the confirmation case
+/// only — when the root's configuration or pack layout cannot be read. Both
+/// leave the caller with no approvable outcome to act on.
+pub fn authorize(
+    operation: RootOperation,
+    root: &ResolvedRoot,
+    config: &SafetyLockConfig,
+    fs: &dyn Fs,
+    host: &HostFacts,
+) -> Result<GateOutcome> {
+    if !operation.requires_trusted_root() {
+        return Ok(GateOutcome::NotRootSensitive);
+    }
+
+    match decide(root, config)? {
+        TrustDecision::ApprovalRequired => Ok(GateOutcome::ConfirmationRequired {
+            inventory: build_inventory(root, fs, host)?,
+        }),
+        permitted => Ok(GateOutcome::Permitted(permitted)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::fs::OsFs;
+    use crate::testing::TempEnvironment;
+
+    use super::super::error::SafetyLockError;
+    use super::super::inventory::InventoryCategory;
+    use super::super::roots::{RootIdentity, RootSource};
+    use super::super::schema::TrustedRootsSection;
+    use super::*;
+
+    const IMPLICIT: [RootSource; 2] = [RootSource::Git, RootSource::CurrentDirectory];
+
+    fn host() -> HostFacts {
+        HostFacts::for_tests("darwin", "arm64")
+    }
+
+    fn root(path: &Path, source: RootSource) -> ResolvedRoot {
+        ResolvedRoot::new(
+            RootIdentity::new(std::fs::canonicalize(path).unwrap()).unwrap(),
+            source,
+        )
+    }
+
+    fn approved(paths: impl IntoIterator<Item = PathBuf>) -> SafetyLockConfig {
+        SafetyLockConfig {
+            roots: TrustedRootsSection {
+                approved: paths
+                    .into_iter()
+                    .map(|path| RootIdentity::new(std::fs::canonicalize(path).unwrap()).unwrap())
+                    .collect(),
+            },
+        }
+    }
+
+    /// A root that cannot be inventoried at all, used to prove an outcome was
+    /// reached without one being built.
+    fn absent_root(source: RootSource) -> ResolvedRoot {
+        ResolvedRoot::new(
+            RootIdentity::new("/nonexistent/dotfiles-root").unwrap(),
+            source,
+        )
+    }
+
+    fn environment() -> TempEnvironment {
+        TempEnvironment::builder()
+            .pack("zsh")
+            .file("aliases.sh", "alias g=git")
+            .done()
+            .pack("vim")
+            .file("vimrc", "set nocompatible")
+            .done()
+            .build()
+    }
+
+    /// The decision matrix, whole: four operation kinds against explicit,
+    /// approved-implicit, and unapproved-implicit roots.
+    #[test]
+    fn the_gate_stops_exactly_unapproved_implicit_root_sensitive_mutation() {
+        let env = environment();
+        let empty = SafetyLockConfig::default();
+        let trusted = approved([env.dotfiles_root.clone()]);
+
+        for source in IMPLICIT {
+            let implicit = root(&env.dotfiles_root, source);
+
+            assert!(
+                matches!(
+                    authorize(
+                        RootOperation::RootSensitiveMutation,
+                        &implicit,
+                        &empty,
+                        env.fs.as_ref(),
+                        &host()
+                    )
+                    .unwrap(),
+                    GateOutcome::ConfirmationRequired { .. }
+                ),
+                "an unapproved {source} root reached mutation unasked"
+            );
+
+            assert_eq!(
+                authorize(
+                    RootOperation::RootSensitiveMutation,
+                    &implicit,
+                    &trusted,
+                    env.fs.as_ref(),
+                    &host()
+                )
+                .unwrap(),
+                GateOutcome::Permitted(TrustDecision::AlreadyApproved),
+                "an approved {source} root was asked about again"
+            );
+        }
+
+        assert_eq!(
+            authorize(
+                RootOperation::RootSensitiveMutation,
+                &root(&env.dotfiles_root, RootSource::Environment),
+                &empty,
+                env.fs.as_ref(),
+                &host()
+            )
+            .unwrap(),
+            GateOutcome::Permitted(TrustDecision::ExplicitlySelected),
+        );
+
+        // Every other operation kind passes on every root, approved or not.
+        for operation in [
+            RootOperation::ReadOnly,
+            RootOperation::DryRun,
+            RootOperation::RootIndependentMutation,
+        ] {
+            for source in [
+                RootSource::Environment,
+                RootSource::Git,
+                RootSource::CurrentDirectory,
+            ] {
+                assert_eq!(
+                    authorize(
+                        operation,
+                        &root(&env.dotfiles_root, source),
+                        &empty,
+                        env.fs.as_ref(),
+                        &host()
+                    )
+                    .unwrap(),
+                    GateOutcome::NotRootSensitive,
+                    "{} on a {source} root crossed the gate",
+                    operation.label()
+                );
+            }
+        }
+    }
+
+    /// Story 10: a read-only command or a dry run must stay usable on a root
+    /// nothing is known about — including one whose trust state is broken.
+    /// Answering these from the collection at all would let a corrupt file
+    /// take diagnosis down with the mutation it legitimately stops.
+    #[test]
+    fn a_non_root_sensitive_operation_consults_no_trust_state() {
+        let env = environment();
+        let identity =
+            RootIdentity::new(std::fs::canonicalize(&env.dotfiles_root).unwrap()).unwrap();
+        let duplicated = SafetyLockConfig {
+            roots: TrustedRootsSection {
+                approved: vec![identity.clone(), identity],
+            },
+        };
+
+        for operation in [
+            RootOperation::ReadOnly,
+            RootOperation::DryRun,
+            RootOperation::RootIndependentMutation,
+        ] {
+            let outcome = authorize(
+                operation,
+                &root(&env.dotfiles_root, RootSource::Git),
+                &duplicated,
+                env.fs.as_ref(),
+                &host(),
+            )
+            .unwrap();
+
+            assert_eq!(outcome, GateOutcome::NotRootSensitive);
+            assert!(
+                outcome.inventory().is_none(),
+                "{} built a prompt inventory",
+                operation.label()
+            );
+        }
+
+        // The same state does stop the mutation it is about.
+        assert!(matches!(
+            authorize(
+                RootOperation::RootSensitiveMutation,
+                &root(&env.dotfiles_root, RootSource::Git),
+                &duplicated,
+                env.fs.as_ref(),
+                &host(),
+            )
+            .unwrap_err(),
+            SafetyLockError::DuplicateApprovedRoot { .. }
+        ));
+    }
+
+    /// Neither a bypass nor an approval: passing the gate without trust must
+    /// not leave trust behind, or a dry run would silently authorize the real
+    /// run that follows it.
+    #[test]
+    fn passing_the_gate_never_establishes_trust() {
+        let env = environment();
+        let config = SafetyLockConfig::default();
+
+        for operation in [
+            RootOperation::ReadOnly,
+            RootOperation::DryRun,
+            RootOperation::RootIndependentMutation,
+            RootOperation::RootSensitiveMutation,
+        ] {
+            let _ = authorize(
+                operation,
+                &root(&env.dotfiles_root, RootSource::Git),
+                &config,
+                env.fs.as_ref(),
+                &host(),
+            );
+        }
+
+        assert!(
+            config.roots.approved.is_empty(),
+            "the gate wrote an approval"
+        );
+        assert!(
+            !authorize(
+                RootOperation::RootSensitiveMutation,
+                &root(&env.dotfiles_root, RootSource::Git),
+                &config,
+                env.fs.as_ref(),
+                &host(),
+            )
+            .unwrap()
+            .permits_operation(),
+            "an earlier pass through the gate trusted the root"
+        );
+    }
+
+    /// Performance posture (Spec, "Performance"): an already-permitted root
+    /// pays a trust check and nothing else. Proven by permitting a root that
+    /// does not exist — building its inventory would have to fail.
+    #[test]
+    fn a_permitted_root_is_never_inventoried() {
+        let fs = OsFs::new();
+
+        for (root, config) in [
+            (
+                absent_root(RootSource::Environment),
+                SafetyLockConfig::default(),
+            ),
+            (
+                absent_root(RootSource::Git),
+                SafetyLockConfig {
+                    roots: TrustedRootsSection {
+                        approved: vec![RootIdentity::new("/nonexistent/dotfiles-root").unwrap()],
+                    },
+                },
+            ),
+        ] {
+            let outcome = authorize(
+                RootOperation::RootSensitiveMutation,
+                &root,
+                &config,
+                &fs,
+                &host(),
+            )
+            .unwrap();
+
+            assert!(outcome.permits_operation());
+            assert!(outcome.inventory().is_none());
+        }
+    }
+
+    /// Spec, "Risks": the path is approved, not the current command's filter.
+    /// The gate takes no pack filter, so the inventory a filtered `up` shows
+    /// is the same root-wide one an unfiltered `up` shows.
+    #[test]
+    fn the_confirmation_inventory_is_root_wide_not_command_scoped() {
+        let env = environment();
+
+        let outcome = authorize(
+            RootOperation::RootSensitiveMutation,
+            &root(&env.dotfiles_root, RootSource::Git),
+            &SafetyLockConfig::default(),
+            env.fs.as_ref(),
+            &host(),
+        )
+        .unwrap();
+
+        let inventory = outcome.inventory().expect("no inventory to show the user");
+        assert_eq!(inventory.total_files(), 2);
+        assert_eq!(
+            inventory
+                .sample
+                .iter()
+                .map(|entry| (entry.category, entry.relative_path.to_str().unwrap()))
+                .collect::<Vec<_>>(),
+            [
+                (InventoryCategory::Shell, "zsh/aliases.sh"),
+                (InventoryCategory::Link, "vim/vimrc"),
+            ],
+            "the inventory did not cover every pack under the root"
+        );
+    }
+
+    /// Story 14: configuration Dodot cannot load must stop the command, and
+    /// must stop it *before* an approvable outcome exists. There is no
+    /// `ConfirmationRequired` to answer here, so no answer can mint approval.
+    #[test]
+    fn invalid_configuration_yields_no_approvable_outcome() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .config("this is not valid toml")
+            .file("vimrc", "set nocompatible")
+            .done()
+            .build();
+
+        let error = authorize(
+            RootOperation::RootSensitiveMutation,
+            &root(&env.dotfiles_root, RootSource::Git),
+            &SafetyLockConfig::default(),
+            env.fs.as_ref(),
+            &host(),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(
+                &error,
+                SafetyLockError::DotfilesConfigUnusable { config_file, .. }
+                    if config_file == &std::fs::canonicalize(&env.dotfiles_root).unwrap().join("vim").join(".dodot.toml")
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn only_root_sensitive_mutation_requires_trust() {
+        assert!(RootOperation::RootSensitiveMutation.requires_trusted_root());
+
+        for operation in [
+            RootOperation::ReadOnly,
+            RootOperation::DryRun,
+            RootOperation::RootIndependentMutation,
+        ] {
+            assert!(
+                !operation.requires_trusted_root(),
+                "{} requires trust",
+                operation.label()
+            );
+        }
+    }
+
+    #[test]
+    fn operation_labels_name_the_kind() {
+        assert_eq!(
+            [
+                RootOperation::RootSensitiveMutation,
+                RootOperation::ReadOnly,
+                RootOperation::DryRun,
+                RootOperation::RootIndependentMutation,
+            ]
+            .map(RootOperation::label),
+            [
+                "root-sensitive mutation",
+                "read-only",
+                "dry run",
+                "root-independent mutation",
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Implements the pure Safety Lock decision engine and its bounded root-orientation
inventory: the operation policy (`operation.rs`), the composed gate
(`authorize`), and the real `build_inventory` behind the WS01 shape.

for #310

## Context

**Why this shape.**

- *The operation policy is a value, not a flag on a context builder.* `decide`
  answers what standing a root has; it cannot answer whether that standing
  matters, because `status` and `up --dry-run` read the same untrusted root
  `up` may not write to. `RootOperation` has four variants —
  root-sensitive mutation, read-only, dry run, root-independent mutation — and
  exactly one crosses the gate. Dry run is kept distinct from read-only so
  "we already classified `up`" cannot quietly gate its preview (ADR-0002; Spec
  "Risks" on context-builder naming being insufficient evidence).
- *Non-gated operations return before the trust collection is consulted.* A
  corrupt trust file stops the mutation it is about and leaves `status`
  working (story 10). Tested directly.
- *`ConfirmationRequired` carries the inventory* rather than leaving the caller
  to fetch one afterwards. That makes story 14 structural instead of a rule
  callers must remember: an inventory that cannot be built is an error, so no
  approvable outcome exists for a user's "yes" to answer when configuration is
  unreadable. Both failure variants (`DotfilesConfigUnusable`,
  `PackRoutingUnusable`) name the file or directory at fault, and neither
  degrades to a partial inventory — "nothing here" and "I could not look" must
  not read the same to someone deciding whether to authorize a path.
- *Categories come from the handler's declared `ExecutionPhase`*, not a table of
  handler names, so a handler added later is classified by what it does. The
  registry is consulted for `phase()` only (`NoopCommandRunner`, the posture
  `configuration_handler_names` already takes) — no `to_intents`, no datastore.
- *`build_inventory` takes no pack filter and never will.* A filtered command
  still approves the whole path, so a filtered inventory would describe less
  than the answer authorizes (Spec, "Risks").
- *`fs` and `host` are injected*, matching the module's posture: what the walk
  sees is stateable in a test rather than a property of the machine the suite
  runs on. Note this widens the WS01 stub signature from `build_inventory(root)`.

**Self-check against the governing docs.** Diff checked against
`docs/spec/safety-lock.md` (Goals; Proposed Shape "CLI safety gate"; Non-Goals;
stories 3, 10, 13, 14; "Risks" on prompt size and filtered-command scope;
"Performance"; "Testing / Verification" prompt-inventory lane) and
`docs/adr/0002-guard-root-derived-mutations.md`. ADR-0001 and ADR-0003 are
untouched by this WS (`decide`/`approve` unchanged). The Spec's prompt-inventory
test list is covered: default and custom mappings, handler precedence
(`install.sh` claimed by install, not the `*.sh` shell glob), pack and entry
ignores, host gates, pack-level OS gates, template source names, nested files,
PATH entries, provisioning handlers, externals, links, deterministic counts,
the ten-path cap with omitted counts, and the root-wide-vs-filtered distinction.

**Out of scope / what not to "fix".**

- Nothing here is wired into a command. Process-environment capture, the prompt
  itself, TTY handling, exit codes, and Standout bindings are WS07 — this WS is
  library-only Rust with no Clap or Standout types.
- `scope_to_root` remains `todo!()` for WS06.
- Filter-phase files (`ignore`/`skip`/`gate`), `.dodotignore` packs, and packs
  gated off this host deliberately count for nothing: they deploy nothing, and
  counting them would inflate every number the prompt shows.
- A directory entry counts once. The scanner stops at a pack's top level, so
  `vim/colors` is one link entry regardless of what is inside it; recursing to
  make the number "more accurate" would invent detail the deployment does not
  have.
- Zero-count categories are omitted from `counts` (prompt readability), not
  reported as `files: 0`.
- `ConfigManager`'s ancestor search reads config through `std::fs` rather than
  the injected `Fs`, and falls back to the filesystem root when no `.git`
  marker is found. Both are pre-existing (`config/mod.rs`), shared with every
  other config consumer, and out of scope here.

**Brief gap flagged:** the spawn brief carried the issue ref and the branch/PR
mechanics but not the implementer BRIEF TEMPLATE's verify-command, governing-doc,
and decision-boundary slots. Verify commands (`pixi run test`, `pixi run lint`)
and governing docs (Spec + ADR-0002) were taken from `AGENTS.md` and issue #310's
parent epic #305 instead of from the brief.

## Verification

- `pixi run test` — 1688 tests, all green (144 in `safety_lock`, ~30 new).
- `pixi run lint` — clean (enforced by the commit and push hooks).