### PR TITLE
ACC01-WS06: Epic: Safety Lock - Workstream: Scope shared-cache mutations to one root

### DIFF
--- a/crates/dodot-cli/src/handlers.rs
+++ b/crates/dodot-cli/src/handlers.rs
@@ -11,6 +11,7 @@ use standout::cli::{CommandContext, HandlerResult, Output};
 
 use dodot_lib::commands::{self, GroupMode, ViewMode};
 use dodot_lib::packs::orchestration::ExecutionContext;
+use dodot_lib::safety_lock::{OsPathProbe, PathProbe, RootIdentity};
 
 /// Side-channel exit code set by handlers that succeeded in producing
 /// output but want the process to exit non-zero (e.g.
@@ -56,6 +57,31 @@ fn build_ctx(matches: &clap::ArgMatches) -> Result<ExecutionContext, anyhow::Err
     ctx.group_mode = group_mode_from(matches);
 
     Ok(ctx)
+}
+
+/// The one dotfiles root this invocation may write under.
+///
+/// `refresh` and `transform check` take their write targets from the
+/// shared preprocessor baseline cache, which can name sources under any
+/// root that has ever run `dodot up` on this machine, so they scope
+/// their mutation set to this root and report the rest
+/// (`docs/adr/0002-guard-root-derived-mutations.md`).
+///
+/// The root is canonicalized here the same way Safety Lock's selection
+/// canonicalizes a candidate, so a root reached through a symlink (a
+/// symlinked `$HOME`, macOS's `/var` → `/private/var`) still contains
+/// its own sources. This is interim wiring: ACC01-WS07 replaces it with
+/// the authorized `ResolvedRoot` the gate produces, which is resolved
+/// once at the process boundary instead of per command.
+fn authorized_root(ctx: &ExecutionContext) -> Result<RootIdentity, anyhow::Error> {
+    let root = ctx.paths.dotfiles_root();
+    let canonical = OsPathProbe.canonicalize(root).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot resolve the dotfiles root at {}: {e}",
+            root.display()
+        )
+    })?;
+    Ok(RootIdentity::new(canonical)?)
 }
 
 /// Build a read-only context (no dry-run/provision flags).
@@ -330,7 +356,7 @@ pub fn transform_check_handler(
 ) -> HandlerResult<commands::transform::TransformCheckResult> {
     let ctx = build_ctx(matches)?;
     let strict = flag_or_false(matches, "strict");
-    let result = commands::transform::check(&ctx, strict)?;
+    let result = commands::transform::check(&ctx, strict, &authorized_root(&ctx)?)?;
     PENDING_EXIT_CODE.store(result.exit_code(), Ordering::Relaxed);
     Ok(Output::Render(result))
 }
@@ -501,7 +527,11 @@ pub fn refresh_handler(
     } else {
         commands::refresh::RefreshMode::Report
     };
-    Ok(Output::Render(commands::refresh::refresh(&ctx, mode)?))
+    Ok(Output::Render(commands::refresh::refresh(
+        &ctx,
+        mode,
+        &authorized_root(&ctx)?,
+    )?))
 }
 
 /// `dodot transform install-hook` — write `.git/hooks/pre-commit` with

--- a/crates/dodot-lib/src/commands/refresh.rs
+++ b/crates/dodot-lib/src/commands/refresh.rs
@@ -26,12 +26,24 @@
 //!
 //! Exit code: 0 in all healthy cases. Errors (real I/O failures only)
 //! propagate as `DodotError::Fs`.
+//!
+//! # One cache, one root
+//!
+//! The baseline cache is shared across every dotfiles root that has ever
+//! run `dodot up` on this machine, and each baseline stores the absolute
+//! path of the source it was rendered from. Touching those paths blind
+//! would let a refresh run from one root write mtimes into another
+//! root's user-authored sources, so the mutation set is scoped to the
+//! root the invocation is authorized for: only sources that canonically
+//! lie inside it are touched, and every other baseline is reported
+//! (`docs/adr/0002-guard-root-derived-mutations.md`).
 
 use serde::Serialize;
 
 use crate::packs::orchestration::ExecutionContext;
 use crate::preprocessing::baseline::hex_sha256;
 use crate::preprocessing::divergence::collect_baselines;
+use crate::safety_lock::{scope_to_root, OsPathProbe, OutOfRootReason, RootIdentity, ScopeOutcome};
 use crate::Result;
 
 /// What `refresh` did to a single processed file.
@@ -46,8 +58,35 @@ pub enum RefreshAction {
     /// Deployed file is missing from the datastore (e.g. user removed
     /// it). Reported but not actioned.
     MissingDeployed,
+    /// The cached source belongs to a different dotfiles root. Reported;
+    /// this invocation is not authorized to touch it.
+    OutOfRoot,
     /// Cached source path no longer exists on disk. Reported.
     MissingSource,
+    /// The baseline records no absolute source path at all — an entry
+    /// written before the cache tracked source paths. Reported; the next
+    /// `dodot up` rewrites it.
+    StaleSource,
+    /// The cached source exists but could not be resolved, so it cannot
+    /// be placed inside the root. Reported, never touched.
+    UnresolvableSource,
+}
+
+impl RefreshAction {
+    /// Name the reason a baseline stayed out of the mutation set.
+    ///
+    /// One action per reason rather than a single "not mine" bucket: a
+    /// source under another root, a deleted source, a source path the
+    /// cache never recorded, and one Dodot cannot resolve are four
+    /// different states of the user's machine with four different fixes.
+    fn out_of_root(reason: OutOfRootReason) -> Self {
+        match reason {
+            OutOfRootReason::OutsideRoot => RefreshAction::OutOfRoot,
+            OutOfRootReason::Missing => RefreshAction::MissingSource,
+            OutOfRootReason::Stale => RefreshAction::StaleSource,
+            OutOfRootReason::Uncanonicalizable => RefreshAction::UnresolvableSource,
+        }
+    }
 }
 
 /// One row in the refresh report.
@@ -89,22 +128,50 @@ pub enum RefreshMode {
     ListPaths,
 }
 
-/// Run `dodot refresh` in the given mode.
+/// Run `dodot refresh` in the given mode, touching only sources under
+/// `authorized_root`.
 ///
-/// Walks every cached baseline. For each:
+/// Walks every cached baseline and scopes the walk to the authorized root
+/// first (see the module docs). For each baseline:
+///   - if its source is not inside the root → report why, touch nothing
 ///   - read the deployed bytes from `<data_dir>/packs/<pack>/<handler>/<filename>`
 ///   - hash them; compare to `baseline.rendered_hash`
 ///   - if equal → action `Clean`
 ///   - if differ AND mode != ListPaths → copy deployed mtime onto source, action `Touched`
 ///   - if differ AND mode == ListPaths → action `Touched` (no write; the source path will be printed)
 ///   - if deployed is missing → action `MissingDeployed`
-///   - if source path is empty or missing → action `MissingSource`
-pub fn refresh(ctx: &ExecutionContext, mode: RefreshMode) -> Result<RefreshResult> {
+///
+/// `authorized_root` is the canonical root this invocation may write
+/// under — the root the user selected, and (once WS07 wires the gate)
+/// approved. It is not re-derived here: the root that was authorized and
+/// the root that is mutated must be the same one (ADR-0001).
+///
+/// The mtime is written to the *canonical* source path rather than the
+/// spelling the cache stored, because that is the path containment was
+/// decided on; a source reached through an in-root symlink is touched at
+/// its resolved location. The report still names the stored path, which
+/// is what the user recognizes and what `--list-paths` consumers feed
+/// back to their watchers.
+pub fn refresh(
+    ctx: &ExecutionContext,
+    mode: RefreshMode,
+    authorized_root: &RootIdentity,
+) -> Result<RefreshResult> {
     let baselines = collect_baselines(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+    let sources: Vec<std::path::PathBuf> = baselines
+        .iter()
+        .map(|(_, _, _, baseline)| baseline.source_path.clone())
+        .collect();
+    // The command layer's filesystem is the real one (`OsFs`), so
+    // canonicalization asks the matching OS probe.
+    let scope = scope_to_root(authorized_root, &sources, &OsPathProbe);
+
     let mut entries = Vec::with_capacity(baselines.len());
     let mut touched_any = false;
 
-    for (pack, handler, filename, baseline) in baselines {
+    for ((pack, handler, filename, baseline), outcome) in
+        baselines.into_iter().zip(scope.outcomes())
+    {
         let source_path = baseline.source_path.clone();
         let deployed_path = ctx
             .paths
@@ -114,9 +181,23 @@ pub fn refresh(ctx: &ExecutionContext, mode: RefreshMode) -> Result<RefreshResul
             .join(&handler)
             .join(&filename);
 
-        let action = if source_path.as_os_str().is_empty() || !ctx.fs.exists(&source_path) {
-            RefreshAction::MissingSource
-        } else if !ctx.fs.exists(&deployed_path) {
+        // Only the authorized canonical path is ever written; everything
+        // else is a row in the report.
+        let authorized = match outcome {
+            ScopeOutcome::InRoot(canonical) => canonical,
+            ScopeOutcome::OutOfRoot(target) => {
+                entries.push(RefreshEntry {
+                    pack,
+                    handler,
+                    filename,
+                    source_path: source_path.display().to_string(),
+                    action: RefreshAction::out_of_root(target.reason),
+                });
+                continue;
+            }
+        };
+
+        let action = if !ctx.fs.exists(&deployed_path) {
             RefreshAction::MissingDeployed
         } else {
             // Hash the deployed bytes. A read error here surfaces as a
@@ -129,7 +210,7 @@ pub fn refresh(ctx: &ExecutionContext, mode: RefreshMode) -> Result<RefreshResul
             } else {
                 if mode != RefreshMode::ListPaths {
                     let deployed_mtime = ctx.fs.modified(&deployed_path)?;
-                    let source_mtime = ctx.fs.modified(&source_path)?;
+                    let source_mtime = ctx.fs.modified(authorized)?;
                     // The whole point of refresh is to invalidate
                     // git's stat-cache by changing the source mtime.
                     // If the deployed mtime happens to equal the
@@ -148,7 +229,7 @@ pub fn refresh(ctx: &ExecutionContext, mode: RefreshMode) -> Result<RefreshResul
                     } else {
                         deployed_mtime
                     };
-                    ctx.fs.set_modified(&source_path, target)?;
+                    ctx.fs.set_modified(authorized, target)?;
                 }
                 touched_any = true;
                 RefreshAction::Touched
@@ -230,6 +311,30 @@ mod tests {
         env.fs.write_file(path, body).unwrap();
     }
 
+    /// The root this invocation is authorized to touch: the
+    /// environment's dotfiles root, canonicalized.
+    ///
+    /// Canonicalized because the command canonicalizes every source
+    /// before placing it, and a root that is not itself canonical
+    /// contains none of them — `TempDir` hands back `/var/…` on macOS
+    /// while every resolved source under it comes back as `/private/var/…`.
+    fn root(env: &TempEnvironment) -> RootIdentity {
+        canonical_root(&env.dotfiles_root)
+    }
+
+    fn canonical_root(path: &std::path::Path) -> RootIdentity {
+        RootIdentity::new(std::fs::canonicalize(path).unwrap()).unwrap()
+    }
+
+    /// A second dotfiles root beside the first, sharing this
+    /// environment's one data and cache directory — the arrangement the
+    /// scoping exists for.
+    fn second_root_dir(env: &TempEnvironment) -> std::path::PathBuf {
+        let dir = env.home.join("other-dotfiles");
+        env.fs.mkdir_all(&dir).unwrap();
+        dir
+    }
+
     /// Stage a baseline + matching pack source + matching deployed
     /// file. Returns the absolute source and deployed paths so the
     /// test can edit either side.
@@ -240,7 +345,21 @@ mod tests {
         rendered: &[u8],
         source: &[u8],
     ) -> (std::path::PathBuf, std::path::PathBuf) {
-        let src = env.dotfiles_root.join(pack).join(template_name);
+        let root = env.dotfiles_root.clone();
+        stage_under(env, &root, pack, template_name, rendered, source)
+    }
+
+    /// [`stage_one`] for a source under an arbitrary root, so one cache
+    /// can hold baselines belonging to two different roots.
+    fn stage_under(
+        env: &TempEnvironment,
+        root: &std::path::Path,
+        pack: &str,
+        template_name: &str,
+        rendered: &[u8],
+        source: &[u8],
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
+        let src = root.join(pack).join(template_name);
         write_file(env, &src, source);
         let stripped = template_name.strip_suffix(".tmpl").unwrap_or(template_name);
         let deployed = env
@@ -268,7 +387,7 @@ mod tests {
     fn empty_cache_yields_empty_report() {
         let env = TempEnvironment::builder().build();
         let ctx = make_ctx(&env);
-        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
         assert!(r.entries.is_empty());
         assert!(!r.touched_any);
     }
@@ -282,7 +401,7 @@ mod tests {
         let before = env.fs.modified(&src).unwrap();
 
         let ctx = make_ctx(&env);
-        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
         assert_eq!(r.entries.len(), 1);
         assert!(matches!(r.entries[0].action, RefreshAction::Clean));
         assert!(!r.touched_any);
@@ -300,7 +419,7 @@ mod tests {
         let deployed_mtime = env.fs.modified(&deployed).unwrap();
 
         let ctx = make_ctx(&env);
-        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
         assert_eq!(r.entries.len(), 1);
         assert!(matches!(r.entries[0].action, RefreshAction::Touched));
         assert!(r.touched_any);
@@ -323,7 +442,7 @@ mod tests {
         env.fs.write_file(&deployed, b"rendered EDITED").unwrap();
 
         let ctx = make_ctx(&env);
-        let r = refresh(&ctx, RefreshMode::ListPaths).unwrap();
+        let r = refresh(&ctx, RefreshMode::ListPaths, &root(&env)).unwrap();
         assert_eq!(r.entries.len(), 1);
         assert!(matches!(r.entries[0].action, RefreshAction::Touched));
         assert!(r.touched_any);
@@ -343,7 +462,7 @@ mod tests {
         let deployed_mtime = env.fs.modified(&deployed).unwrap();
 
         let ctx = make_ctx(&env);
-        let r = refresh(&ctx, RefreshMode::Quiet).unwrap();
+        let r = refresh(&ctx, RefreshMode::Quiet, &root(&env)).unwrap();
         assert!(matches!(r.entries[0].action, RefreshAction::Touched));
         assert_eq!(env.fs.modified(&src).unwrap(), deployed_mtime);
     }
@@ -377,7 +496,7 @@ mod tests {
         write_file(&env, &deployed, b"rendered");
 
         let ctx = make_ctx(&env);
-        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
         assert_eq!(r.entries.len(), 1);
         assert!(matches!(r.entries[0].action, RefreshAction::MissingSource));
         assert!(!r.touched_any);
@@ -402,7 +521,7 @@ mod tests {
             .unwrap();
 
         let ctx = make_ctx(&env);
-        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
         assert!(matches!(
             r.entries[0].action,
             RefreshAction::MissingDeployed
@@ -432,7 +551,7 @@ mod tests {
         env.fs.write_file(&deployed, b"hello Bob").unwrap();
 
         let ctx = make_ctx(&env);
-        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
         assert!(matches!(r.entries[0].action, RefreshAction::Touched));
         assert!(r.touched_any);
     }
@@ -453,7 +572,7 @@ mod tests {
         assert_eq!(env.fs.modified(&deployed).unwrap(), pinned);
 
         let ctx = make_ctx(&env);
-        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
         assert!(matches!(r.entries[0].action, RefreshAction::Touched));
 
         let after = env.fs.modified(&src).unwrap();
@@ -477,7 +596,7 @@ mod tests {
             stage_one(&env, pack, name, b"rendered", b"src");
         }
         let ctx = make_ctx(&env);
-        let r = refresh(&ctx, RefreshMode::Report).unwrap();
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
         let order: Vec<_> = r
             .entries
             .iter()
@@ -491,5 +610,202 @@ mod tests {
                 ("zebra".into(), "z".into()),
             ]
         );
+    }
+
+    // ── mutation scoping (ACC01-WS06) ────────────────────────────
+
+    /// Two roots, one shared cache: whichever root the invocation is
+    /// authorized for, the other root's sources keep their mtimes. This
+    /// is the property the scoping exists for — approval for one root
+    /// cannot reach into a second repository's working tree
+    /// (ADR-0002).
+    #[test]
+    fn authorizing_one_root_never_touches_the_other_roots_sources() {
+        let env = TempEnvironment::builder().build();
+        let other_root = second_root_dir(&env);
+
+        let (here, here_deployed) = stage_one(&env, "app", "cfg.toml.tmpl", b"rendered", b"src");
+        let (there, there_deployed) = stage_under(
+            &env,
+            &other_root,
+            "other",
+            "cfg.toml.tmpl",
+            b"rendered",
+            b"src",
+        );
+
+        // Both deployed files diverge, so both baselines *want* a touch.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        env.fs
+            .write_file(&here_deployed, b"rendered EDITED")
+            .unwrap();
+        env.fs
+            .write_file(&there_deployed, b"rendered EDITED")
+            .unwrap();
+        let here_before = env.fs.modified(&here).unwrap();
+        let there_before = env.fs.modified(&there).unwrap();
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
+
+        let actions: Vec<(&str, &RefreshAction)> = r
+            .entries
+            .iter()
+            .map(|e| (e.pack.as_str(), &e.action))
+            .collect();
+        assert!(
+            matches!(
+                actions.as_slice(),
+                [
+                    ("app", RefreshAction::Touched),
+                    ("other", RefreshAction::OutOfRoot)
+                ]
+            ),
+            "unexpected actions: {actions:?}"
+        );
+        assert_ne!(
+            env.fs.modified(&here).unwrap(),
+            here_before,
+            "the authorized root's own source was not touched"
+        );
+        assert_eq!(
+            env.fs.modified(&there).unwrap(),
+            there_before,
+            "another root's source was touched"
+        );
+
+        // Authorize the other root instead: the mirror image, from the
+        // same cache.
+        let r = refresh(&ctx, RefreshMode::Report, &canonical_root(&other_root)).unwrap();
+        let actions: Vec<(&str, &RefreshAction)> = r
+            .entries
+            .iter()
+            .map(|e| (e.pack.as_str(), &e.action))
+            .collect();
+        assert!(
+            matches!(
+                actions.as_slice(),
+                [
+                    ("app", RefreshAction::OutOfRoot),
+                    ("other", RefreshAction::Touched)
+                ]
+            ),
+            "unexpected actions: {actions:?}"
+        );
+        assert_ne!(env.fs.modified(&there).unwrap(), there_before);
+    }
+
+    /// A source that *lives* under the authorized root but *resolves*
+    /// outside it: the cache stored an in-root spelling, and touching it
+    /// would write through the link into another tree.
+    #[test]
+    fn a_source_symlinked_out_of_the_root_is_reported_not_touched() {
+        let env = TempEnvironment::builder().build();
+        let other_root = second_root_dir(&env);
+        let outside = other_root.join("real.toml.tmpl");
+        write_file(&env, &outside, b"src");
+
+        // The pack entry is a symlink pointing out of the root; the
+        // deployed file diverges, so it would be touched if the escape
+        // went unnoticed.
+        let link = env.dotfiles_root.join("app/cfg.toml.tmpl");
+        env.fs.mkdir_all(link.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        let deployed = env.paths.data_dir().join("packs/app/preprocessed/cfg.toml");
+        write_file(&env, &deployed, b"rendered EDITED");
+        Baseline::build(&link, b"rendered", b"src", Some(""), None)
+            .write(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                "app",
+                "preprocessed",
+                "cfg.toml",
+            )
+            .unwrap();
+        let before = env.fs.modified(&outside).unwrap();
+
+        let ctx = make_ctx(&env);
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
+
+        assert!(
+            matches!(r.entries[0].action, RefreshAction::OutOfRoot),
+            "unexpected action: {:?}",
+            r.entries[0].action
+        );
+        assert!(!r.touched_any);
+        assert_eq!(env.fs.modified(&outside).unwrap(), before);
+    }
+
+    /// A baseline written before the cache recorded source paths stores
+    /// an empty one. Nothing was looked for and nothing is missing — it
+    /// is a stale cache entry, reported apart from a source that was
+    /// deleted.
+    #[test]
+    fn a_baseline_without_a_source_path_is_reported_as_stale() {
+        let env = TempEnvironment::builder().build();
+        Baseline::build(
+            std::path::Path::new(""),
+            b"rendered",
+            b"src",
+            Some(""),
+            None,
+        )
+        .write(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "cfg.toml",
+        )
+        .unwrap();
+        let deployed = env.paths.data_dir().join("packs/app/preprocessed/cfg.toml");
+        write_file(&env, &deployed, b"rendered");
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::Report, &root(&env)).unwrap();
+
+        assert!(
+            matches!(r.entries[0].action, RefreshAction::StaleSource),
+            "unexpected action: {:?}",
+            r.entries[0].action
+        );
+        assert!(!r.touched_any);
+    }
+
+    /// `--list-paths` feeds watchers, so it must not hand out another
+    /// root's paths either: the scope is the mutation set, not a
+    /// rendering choice.
+    #[test]
+    fn list_paths_mode_reports_only_authorized_sources() {
+        let env = TempEnvironment::builder().build();
+        let other_root = second_root_dir(&env);
+        let (_here, here_deployed) = stage_one(&env, "app", "cfg.toml.tmpl", b"rendered", b"src");
+        let (_there, there_deployed) = stage_under(
+            &env,
+            &other_root,
+            "other",
+            "cfg.toml.tmpl",
+            b"rendered",
+            b"src",
+        );
+        env.fs
+            .write_file(&here_deployed, b"rendered EDITED")
+            .unwrap();
+        env.fs
+            .write_file(&there_deployed, b"rendered EDITED")
+            .unwrap();
+
+        let ctx = make_ctx(&env);
+        let r = refresh(&ctx, RefreshMode::ListPaths, &root(&env)).unwrap();
+
+        let touched: Vec<&str> = r
+            .entries
+            .iter()
+            .filter(|e| matches!(e.action, RefreshAction::Touched))
+            .map(|e| e.source_path.as_str())
+            .collect();
+        assert_eq!(touched.len(), 1, "unexpected touched set: {touched:?}");
+        assert!(touched[0].contains("/dotfiles/app/"), "{touched:?}");
     }
 }

--- a/crates/dodot-lib/src/commands/refresh.rs
+++ b/crates/dodot-lib/src/commands/refresh.rs
@@ -63,8 +63,10 @@ pub enum RefreshAction {
     OutOfRoot,
     /// Cached source path no longer exists on disk. Reported.
     MissingSource,
-    /// The baseline records no absolute source path at all — an entry
-    /// written before the cache tracked source paths. Reported; the next
+    /// The baseline records no absolute source path at all — the stored
+    /// path is empty (an entry written before the cache tracked source
+    /// paths) or relative (meaningless without the process working
+    /// directory, which Safety Lock does not read). Reported; the next
     /// `dodot up` rewrites it.
     StaleSource,
     /// The cached source exists but could not be resolved, so it cannot

--- a/crates/dodot-lib/src/commands/transform/mod.rs
+++ b/crates/dodot-lib/src/commands/transform/mod.rs
@@ -85,8 +85,10 @@ pub enum TransformAction {
     /// The cached source belongs to a different dotfiles root. Reported;
     /// this invocation is not authorized to patch it.
     OutOfRoot,
-    /// The baseline records no absolute source path at all — an entry
-    /// written before the cache tracked source paths. Reported; the next
+    /// The baseline records no absolute source path at all — the stored
+    /// path is empty (an entry written before the cache tracked source
+    /// paths) or relative (meaningless without the process working
+    /// directory, which Safety Lock does not read). Reported; the next
     /// `dodot up` rewrites it.
     StaleSource,
     /// The cached source exists but could not be resolved, so it cannot
@@ -152,8 +154,17 @@ pub struct TransformCheckResult {
     pub unresolved_markers: Vec<UnresolvedMarkerEntry>,
     /// True iff at least one entry has a non-clean state that should
     /// make the command exit non-zero (Conflict, NeedsRebaseline,
-    /// MissingSource, MissingDeployed) or `--strict` found unresolved
-    /// markers. CLI uses this to decide the process exit code.
+    /// MissingSource, MissingDeployed, StaleSource, UnresolvableSource)
+    /// or `--strict` found unresolved markers. CLI uses this to decide
+    /// the process exit code.
+    ///
+    /// `OutOfRoot` does *not* set this, and is the one out-of-mutation-set
+    /// action that does not: a baseline belonging to another root is a
+    /// supported arrangement of two roots sharing one cache, so it is
+    /// reported and nothing more. The other three — `MissingSource`,
+    /// `StaleSource`, `UnresolvableSource` — are this cache's health and
+    /// stay findings. [`TransformAction::out_of_root`] is where that split
+    /// is decided.
     ///
     /// `Patched` does *not* set this — an unambiguous reverse-merge is
     /// the auto-merge happy path: burgertocow + diffy produced a clean

--- a/crates/dodot-lib/src/commands/transform/mod.rs
+++ b/crates/dodot-lib/src/commands/transform/mod.rs
@@ -15,6 +15,9 @@
 //! | `MissingSource`  | report only (cache stale; next `up` will refresh)   |
 //! | `MissingDeployed`| report only (deployed file gone; manual recovery)   |
 //!
+//! A baseline whose source does not lie inside the authorized root never
+//! reaches that matrix — see "One cache, one root" below.
+//!
 //! For `OutputChanged` and `BothChanged`, the call into burgertocow
 //! returns either a clean unified diff (which is applied to the source
 //! file via `diffy`) or a conflict block (which is *not* written —
@@ -26,10 +29,24 @@
 //! # Strict mode
 //!
 //! `check(ctx, strict=true)` is the form used by the pre-commit hook.
-//! On top of the matrix work above, it scans every source file
-//! for unresolved [`crate::preprocessing::conflict`] markers — if any
-//! are found, the result reports them and the command exits non-zero
+//! On top of the matrix work above, it scans every authorized source
+//! file for unresolved [`crate::preprocessing::conflict`] markers — if
+//! any are found, the result reports them and the command exits non-zero
 //! so a commit is blocked until the user resolves them.
+//!
+//! # One cache, one root
+//!
+//! The baseline cache is shared across every dotfiles root on the
+//! machine, and reverse-merge writes each baseline's stored source path.
+//! Approval for one root must not authorize a patch into another root's
+//! user-authored source, so the mutation set is scoped to the root this
+//! invocation is authorized for: only sources that canonically lie
+//! inside it are classified, patched, or scanned, and every other
+//! baseline is reported
+//! (`docs/adr/0002-guard-root-derived-mutations.md`). Strict mode reuses
+//! that same authorized set rather than re-walking the cache, so the
+//! marker scan cannot reach a file the patching pass was not allowed to
+//! touch.
 
 use serde::Serialize;
 
@@ -40,6 +57,7 @@ use crate::preprocessing::divergence::{
 };
 use crate::preprocessing::no_reverse::is_no_reverse;
 use crate::preprocessing::reverse_merge::{reverse_merge, ReverseMergeOutcome};
+use crate::safety_lock::{scope_to_root, OsPathProbe, OutOfRootReason, RootIdentity, ScopeOutcome};
 use crate::Result;
 
 /// What `transform check` did to a single processed file.
@@ -64,6 +82,42 @@ pub enum TransformAction {
     MissingSource,
     /// The deployed file is gone from the datastore.
     MissingDeployed,
+    /// The cached source belongs to a different dotfiles root. Reported;
+    /// this invocation is not authorized to patch it.
+    OutOfRoot,
+    /// The baseline records no absolute source path at all — an entry
+    /// written before the cache tracked source paths. Reported; the next
+    /// `dodot up` rewrites it.
+    StaleSource,
+    /// The cached source exists but could not be resolved, so it cannot
+    /// be placed inside the root. Reported, never patched.
+    UnresolvableSource,
+}
+
+impl TransformAction {
+    /// Name the outcome for a baseline that stayed out of the mutation
+    /// set, and say whether it is a finding (i.e. a non-zero exit).
+    ///
+    /// One action per reason rather than a single "not mine" bucket: a
+    /// source under another root, a deleted source, a source path the
+    /// cache never recorded, and one Dodot cannot resolve are four
+    /// different states of the user's machine with four different fixes
+    /// — and only three of them are this repository's problem.
+    fn out_of_root(reason: OutOfRootReason) -> (Self, bool) {
+        match reason {
+            // A baseline belonging to *another* root is deliberately not
+            // a finding: two roots sharing one cache is a supported
+            // arrangement, and the pre-commit hook installed in one
+            // repository must not start refusing commits because a
+            // sibling repository also uses Dodot.
+            OutOfRootReason::OutsideRoot => (TransformAction::OutOfRoot, false),
+            // The rest are cache health, and stay findings exactly as a
+            // missing source always has.
+            OutOfRootReason::Missing => (TransformAction::MissingSource, true),
+            OutOfRootReason::Stale => (TransformAction::StaleSource, true),
+            OutOfRootReason::Uncanonicalizable => (TransformAction::UnresolvableSource, true),
+        }
+    }
 }
 
 /// One row in the transform-check report.
@@ -247,9 +301,30 @@ pub fn status(ctx: &ExecutionContext) -> Result<TransformStatusResult> {
     })
 }
 
-/// Run `dodot transform check`. See module docs for the matrix.
-pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResult> {
+/// Run `dodot transform check`, patching only sources under
+/// `authorized_root`. See module docs for the matrix and for the
+/// scoping.
+///
+/// `authorized_root` is the canonical root this invocation may write
+/// under — the root the user selected, and (once WS07 wires the gate)
+/// approved. It is not re-derived here: the root that was authorized and
+/// the root that is mutated must be the same one (ADR-0001).
+pub fn check(
+    ctx: &ExecutionContext,
+    strict: bool,
+    authorized_root: &RootIdentity,
+) -> Result<TransformCheckResult> {
     let baselines = collect_baselines(ctx.fs.as_ref(), ctx.paths.as_ref())?;
+    let sources: Vec<std::path::PathBuf> = baselines
+        .iter()
+        .map(|(_, _, _, baseline)| baseline.source_path.clone())
+        .collect();
+    // The command layer's filesystem is the real one (`OsFs`), so
+    // canonicalization asks the matching OS probe. Scoping happens once
+    // for the whole invocation; the strict pass below reuses this same
+    // authorized set.
+    let scope = scope_to_root(authorized_root, &sources, &OsPathProbe);
+
     let mut entries: Vec<TransformCheckEntry> = Vec::with_capacity(baselines.len());
     let mut has_findings = false;
     // Memoise no_reverse patterns by pack within this check
@@ -260,14 +335,37 @@ pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResul
     let mut no_reverse_cache: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
 
-    for (pack, handler, filename, baseline) in baselines {
+    for ((pack, handler, filename, baseline), outcome) in baselines.iter().zip(scope.outcomes()) {
+        // Only the authorized canonical path is ever written; everything
+        // else is a row in the report and nothing more.
+        let authorized = match outcome {
+            ScopeOutcome::InRoot(canonical) => canonical,
+            ScopeOutcome::OutOfRoot(target) => {
+                let (action, is_finding) = TransformAction::out_of_root(target.reason);
+                has_findings |= is_finding;
+                entries.push(TransformCheckEntry {
+                    pack: pack.clone(),
+                    handler: handler.clone(),
+                    filename: filename.clone(),
+                    source_path: render_path(&baseline.source_path, ctx.paths.home_dir()),
+                    deployed_path: render_path(
+                        &ctx.paths.handler_data_dir(pack, handler).join(filename),
+                        ctx.paths.home_dir(),
+                    ),
+                    action,
+                    conflict_block: String::new(),
+                });
+                continue;
+            }
+        };
+
         let report = classify_one(
             ctx.fs.as_ref(),
             ctx.paths.as_ref(),
-            &pack,
-            &handler,
-            &filename,
-            &baseline,
+            pack,
+            handler,
+            filename,
+            baseline,
         );
         // Per-pack [preprocessor.template] no_reverse opt-out: when a
         // file matches, we treat it as Synced regardless of which
@@ -278,7 +376,7 @@ pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResul
         // status still surfaces the underlying state for visibility.
         let no_reverse_patterns = no_reverse_cache
             .entry(pack.clone())
-            .or_insert_with(|| pack_no_reverse_patterns(ctx, &pack));
+            .or_insert_with(|| pack_no_reverse_patterns(ctx, pack));
         let no_reverse = is_no_reverse(&report.source_path, no_reverse_patterns);
         let action = match report.state {
             DivergenceState::Synced => TransformAction::Synced,
@@ -313,8 +411,12 @@ pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResul
                 } else {
                     // Run the reverse-merge engine. `Unchanged` means the
                     // deployed edit touched only variable values, so the
-                    // template source needs no change.
-                    let template_src = ctx.fs.read_to_string(&report.source_path)?;
+                    // template source needs no change. Both the read and
+                    // the write below go through the authorized canonical
+                    // path — the one containment was decided on — so a
+                    // source reached through an in-root symlink is merged
+                    // at its resolved location.
+                    let template_src = ctx.fs.read_to_string(authorized)?;
                     let deployed = ctx.fs.read_to_string(&report.deployed_path)?;
                     // Load the per-render secrets sidecar so the
                     // reverse-merge masks lines whose source-of-truth
@@ -324,9 +426,9 @@ pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResul
                     let secret_ranges = crate::preprocessing::baseline::SecretsSidecar::load(
                         ctx.fs.as_ref(),
                         ctx.paths.as_ref(),
-                        &pack,
-                        &handler,
-                        &filename,
+                        pack,
+                        handler,
+                        filename,
                     )?
                     .map(|s| s.secret_line_ranges)
                     .unwrap_or_default();
@@ -339,7 +441,7 @@ pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResul
                         ReverseMergeOutcome::Unchanged => TransformAction::Synced,
                         ReverseMergeOutcome::Patched(patched) => {
                             if !ctx.dry_run {
-                                ctx.fs.write_file(&report.source_path, patched.as_bytes())?;
+                                ctx.fs.write_file(authorized, patched.as_bytes())?;
                             }
                             // The auto-merge happy path: `has_findings`
                             // deliberately stays false (see
@@ -366,18 +468,23 @@ pub fn check(ctx: &ExecutionContext, strict: bool) -> Result<TransformCheckResul
 
     let mut unresolved_markers = Vec::new();
     if strict {
-        // Re-walk the cache, scanning each source for dodot-conflict
-        // markers. Any hit blocks a commit (when this is run from the
-        // pre-commit hook). We re-walk rather than reusing the loop
-        // above because the loop may have skipped entries via
-        // MissingSource / continue paths.
-        let baselines = collect_baselines(ctx.fs.as_ref(), ctx.paths.as_ref())?;
-        for (_pack, _handler, _filename, baseline) in baselines {
-            if baseline.source_path.as_os_str().is_empty() || !ctx.fs.exists(&baseline.source_path)
-            {
+        // Scan each source for dodot-conflict markers. Any hit blocks a
+        // commit (when this is run from the pre-commit hook).
+        //
+        // This walks the *same* authorized set as the loop above rather
+        // than re-collecting the cache: a second unscoped walk would
+        // read — and fail a commit over — sources under a root this
+        // invocation was never authorized for, and the caches are
+        // shared. Entries the loop above skipped via `continue` are
+        // still covered, because the set comes from the scoping pass and
+        // not from how far that loop got.
+        for ((_pack, _handler, _filename, baseline), outcome) in
+            baselines.iter().zip(scope.outcomes())
+        {
+            let ScopeOutcome::InRoot(authorized) = outcome else {
                 continue;
-            }
-            let bytes = ctx.fs.read_file(&baseline.source_path)?;
+            };
+            let bytes = ctx.fs.read_file(authorized)?;
             let content = String::from_utf8_lossy(&bytes);
             let lines = find_unresolved_marker_lines(&content);
             if !lines.is_empty() {
@@ -511,11 +618,77 @@ mod tests {
             .join(filename)
     }
 
+    /// The root this invocation is authorized to patch: the
+    /// environment's dotfiles root, canonicalized.
+    ///
+    /// Canonicalized because the command canonicalizes every source
+    /// before placing it, and a root that is not itself canonical
+    /// contains none of them — `TempDir` hands back `/var/…` on macOS
+    /// while every resolved source under it comes back as `/private/var/…`.
+    fn root(env: &TempEnvironment) -> RootIdentity {
+        canonical_root(&env.dotfiles_root)
+    }
+
+    fn canonical_root(path: &std::path::Path) -> RootIdentity {
+        RootIdentity::new(std::fs::canonicalize(path).unwrap()).unwrap()
+    }
+
+    /// A second dotfiles root beside the first, sharing this
+    /// environment's one data and cache directory — the arrangement the
+    /// scoping exists for.
+    fn second_root_dir(env: &TempEnvironment) -> std::path::PathBuf {
+        let dir = env.home.join("other-dotfiles");
+        env.fs.mkdir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Stage a baseline whose source lives at `source` and whose
+    /// deployed file was edited afterwards, i.e. an `OutputChanged`
+    /// entry the reverse-merge would patch if it were allowed to.
+    ///
+    /// Written by hand rather than through `dodot up` because a second
+    /// root's baselines cannot be produced by an `up` run against the
+    /// first one.
+    fn stage_edited(
+        env: &TempEnvironment,
+        pack: &str,
+        filename: &str,
+        source: &std::path::Path,
+        template_body: &str,
+        rendered: &str,
+        deployed_body: &str,
+    ) {
+        env.fs.mkdir_all(source.parent().unwrap()).unwrap();
+        env.fs.write_file(source, template_body.as_bytes()).unwrap();
+
+        let deployed = deployed_path(env, pack, filename);
+        env.fs.mkdir_all(deployed.parent().unwrap()).unwrap();
+        env.fs
+            .write_file(&deployed, deployed_body.as_bytes())
+            .unwrap();
+
+        crate::preprocessing::baseline::Baseline::build(
+            source,
+            rendered.as_bytes(),
+            template_body.as_bytes(),
+            Some(rendered),
+            None,
+        )
+        .write(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            pack,
+            "preprocessed",
+            filename,
+        )
+        .unwrap();
+    }
+
     #[test]
     fn empty_cache_yields_clean_no_findings() {
         let env = TempEnvironment::builder().build();
         let ctx = make_ctx(&env);
-        let result = check(&ctx, false).unwrap();
+        let result = check(&ctx, false, &root(&env)).unwrap();
         assert!(result.entries.is_empty());
         assert!(!result.has_findings);
         assert_eq!(result.exit_code(), 0);
@@ -532,7 +705,7 @@ mod tests {
             "[preprocessor.template.vars]\nname = \"Alice\"\n",
         );
         let ctx = make_ctx(&env);
-        let result = check(&ctx, false).unwrap();
+        let result = check(&ctx, false, &root(&env)).unwrap();
         assert_eq!(result.entries.len(), 1);
         assert!(matches!(result.entries[0].action, TransformAction::Synced));
         assert!(!result.has_findings);
@@ -554,7 +727,7 @@ mod tests {
             .unwrap();
 
         let ctx = make_ctx(&env);
-        let result = check(&ctx, false).unwrap();
+        let result = check(&ctx, false, &root(&env)).unwrap();
         assert_eq!(result.entries.len(), 1);
         assert!(
             matches!(result.entries[0].action, TransformAction::Patched),
@@ -588,7 +761,7 @@ mod tests {
         env.fs.write_file(&deployed, b"name = Bob\n").unwrap();
 
         let ctx = make_ctx(&env);
-        let result = check(&ctx, false).unwrap();
+        let result = check(&ctx, false, &root(&env)).unwrap();
         assert_eq!(result.entries.len(), 1);
         assert!(matches!(result.entries[0].action, TransformAction::Synced));
         assert_eq!(env.fs.read_to_string(&src_path).unwrap(), original_src);
@@ -621,7 +794,7 @@ mod tests {
             .unwrap();
 
         let ctx = make_ctx(&env);
-        let result = check(&ctx, false).unwrap();
+        let result = check(&ctx, false, &root(&env)).unwrap();
         assert_eq!(result.entries.len(), 1);
         assert!(
             matches!(result.entries[0].action, TransformAction::Synced),
@@ -655,7 +828,7 @@ mod tests {
             .unwrap();
 
         let ctx = make_ctx(&env);
-        let result = check(&ctx, false).unwrap();
+        let result = check(&ctx, false, &root(&env)).unwrap();
         assert_eq!(result.entries.len(), 1);
         assert!(matches!(result.entries[0].action, TransformAction::Synced));
         assert!(!result.has_findings);
@@ -684,7 +857,7 @@ mod tests {
 
         let mut ctx = make_ctx(&env);
         ctx.dry_run = true;
-        let result = check(&ctx, false).unwrap();
+        let result = check(&ctx, false, &root(&env)).unwrap();
         assert!(matches!(result.entries[0].action, TransformAction::Patched));
         assert_eq!(env.fs.read_to_string(&src_path).unwrap(), original_src);
     }
@@ -721,7 +894,7 @@ mod tests {
             .unwrap();
 
         let ctx = make_ctx(&env);
-        let result = check(&ctx, false).unwrap();
+        let result = check(&ctx, false, &root(&env)).unwrap();
         assert_eq!(result.entries.len(), 1);
         assert!(
             matches!(result.entries[0].action, TransformAction::NeedsRebaseline),
@@ -765,7 +938,7 @@ mod tests {
         env.fs.write_file(&deployed, b"rendered").unwrap();
 
         let ctx = make_ctx(&env);
-        let result = check(&ctx, false).unwrap();
+        let result = check(&ctx, false, &root(&env)).unwrap();
         assert!(matches!(
             result.entries[0].action,
             TransformAction::MissingSource
@@ -792,10 +965,10 @@ mod tests {
         env.fs.write_file(&src_path, dirty.as_bytes()).unwrap();
 
         let ctx = make_ctx(&env);
-        let lax = check(&ctx, false).unwrap();
+        let lax = check(&ctx, false, &root(&env)).unwrap();
         assert!(lax.unresolved_markers.is_empty());
 
-        let strict = check(&ctx, true).unwrap();
+        let strict = check(&ctx, true, &root(&env)).unwrap();
         assert_eq!(strict.unresolved_markers.len(), 1);
         assert_eq!(strict.unresolved_markers[0].line_numbers, vec![2, 4]);
         assert!(strict.has_findings);
@@ -813,7 +986,7 @@ mod tests {
             "[preprocessor.template.vars]\nname = \"Alice\"\n",
         );
         let ctx = make_ctx(&env);
-        let result = check(&ctx, true).unwrap();
+        let result = check(&ctx, true, &root(&env)).unwrap();
         assert!(result.unresolved_markers.is_empty());
         assert!(!result.has_findings);
         assert_eq!(result.exit_code(), 0);
@@ -834,7 +1007,7 @@ mod tests {
             "[preprocessor.template.vars]\nname = \"Alice\"\n",
         );
         let ctx = make_ctx(&env);
-        let result = check(&ctx, false).unwrap();
+        let result = check(&ctx, false, &root(&env)).unwrap();
         let entry = &result.entries[0];
         assert!(
             entry.source_path.starts_with("~/") || entry.deployed_path.starts_with("~/"),
@@ -842,6 +1015,222 @@ mod tests {
             entry.source_path,
             entry.deployed_path
         );
+    }
+
+    // ── mutation scoping (ACC01-WS06) ────────────────────────────
+
+    /// Two roots, one shared cache: whichever root the invocation is
+    /// authorized for, only that root's sources are patched. This is the
+    /// property the scoping exists for — approval for one root cannot
+    /// rewrite a second repository's user-authored template (ADR-0002).
+    #[test]
+    fn authorizing_one_root_never_patches_the_other_roots_sources() {
+        let env = TempEnvironment::builder().build();
+        let here = deploy_template(
+            &env,
+            "app",
+            "config.toml.tmpl",
+            "name = {{ name }}\nport = 5432\n",
+            "[preprocessor.template.vars]\nname = \"Alice\"\n",
+        );
+        env.fs
+            .write_file(
+                &deployed_path(&env, "app", "config.toml"),
+                b"name = Alice\nport = 9999\n",
+            )
+            .unwrap();
+
+        // A second root's baseline in the same cache, equally ready to
+        // be reverse-merged.
+        let other_root = second_root_dir(&env);
+        let there = other_root.join("other/config.toml.tmpl");
+        stage_edited(
+            &env,
+            "other",
+            "config.toml",
+            &there,
+            "port = 5432\n",
+            "port = 5432\n",
+            "port = 9999\n",
+        );
+
+        let ctx = make_ctx(&env);
+        let result = check(&ctx, false, &root(&env)).unwrap();
+
+        let actions: Vec<(&str, &TransformAction)> = result
+            .entries
+            .iter()
+            .map(|e| (e.pack.as_str(), &e.action))
+            .collect();
+        assert!(
+            matches!(
+                actions.as_slice(),
+                [
+                    ("app", TransformAction::Patched),
+                    ("other", TransformAction::OutOfRoot)
+                ]
+            ),
+            "unexpected actions: {actions:?}"
+        );
+        assert!(env.fs.read_to_string(&here).unwrap().contains("9999"));
+        assert_eq!(
+            env.fs.read_to_string(&there).unwrap(),
+            "port = 5432\n",
+            "another root's source was patched"
+        );
+        // A sibling root's baseline is not a finding: it must not make
+        // this repository's pre-commit hook refuse the commit.
+        assert!(!result.has_findings);
+        assert_eq!(result.exit_code(), 0);
+
+        // Authorize the other root instead: the mirror image, from the
+        // same cache.
+        let mirrored = check(&ctx, false, &canonical_root(&other_root)).unwrap();
+        let actions: Vec<(&str, &TransformAction)> = mirrored
+            .entries
+            .iter()
+            .map(|e| (e.pack.as_str(), &e.action))
+            .collect();
+        assert!(
+            matches!(
+                actions.as_slice(),
+                [
+                    ("app", TransformAction::OutOfRoot),
+                    ("other", TransformAction::Patched)
+                ]
+            ),
+            "unexpected actions: {actions:?}"
+        );
+        assert!(env.fs.read_to_string(&there).unwrap().contains("9999"));
+    }
+
+    /// Strict mode walks the authorized set, not the cache: an
+    /// unresolved conflict marker in *another* root's source must not
+    /// block a commit here, and must still block one there.
+    #[test]
+    fn strict_mode_scans_only_the_authorized_roots_sources() {
+        let env = TempEnvironment::builder().build();
+        deploy_template(
+            &env,
+            "app",
+            "config.toml.tmpl",
+            "name = {{ name }}\n",
+            "[preprocessor.template.vars]\nname = \"Alice\"\n",
+        );
+
+        let other_root = second_root_dir(&env);
+        let there = other_root.join("other/config.toml.tmpl");
+        let dirty = format!(
+            "first\n{}\nbody\n{}\n",
+            crate::preprocessing::conflict::MARKER_START,
+            crate::preprocessing::conflict::MARKER_END,
+        );
+        stage_edited(
+            &env,
+            "other",
+            "config.toml",
+            &there,
+            &dirty,
+            "rendered\n",
+            "rendered\n",
+        );
+
+        let ctx = make_ctx(&env);
+        let result = check(&ctx, true, &root(&env)).unwrap();
+        assert!(
+            result.unresolved_markers.is_empty(),
+            "scanned a source under another root: {:?}",
+            result.unresolved_markers
+        );
+        assert!(!result.has_findings);
+        assert_eq!(result.exit_code(), 0);
+
+        let mirrored = check(&ctx, true, &canonical_root(&other_root)).unwrap();
+        assert_eq!(mirrored.unresolved_markers.len(), 1);
+        assert_eq!(mirrored.unresolved_markers[0].line_numbers, vec![2, 4]);
+        assert_eq!(mirrored.exit_code(), 1);
+    }
+
+    /// A source that *lives* under the authorized root but *resolves*
+    /// outside it: patching the stored spelling would write through the
+    /// link into another tree.
+    #[test]
+    fn a_source_symlinked_out_of_the_root_is_reported_not_patched() {
+        let env = TempEnvironment::builder().build();
+        let other_root = second_root_dir(&env);
+        let outside = other_root.join("real.toml.tmpl");
+        env.fs.mkdir_all(outside.parent().unwrap()).unwrap();
+        env.fs.write_file(&outside, b"port = 5432\n").unwrap();
+
+        let link = env.dotfiles_root.join("app/config.toml.tmpl");
+        env.fs.mkdir_all(link.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        let deployed = deployed_path(&env, "app", "config.toml");
+        env.fs.mkdir_all(deployed.parent().unwrap()).unwrap();
+        env.fs.write_file(&deployed, b"port = 9999\n").unwrap();
+        crate::preprocessing::baseline::Baseline::build(
+            &link,
+            b"port = 5432\n",
+            b"port = 5432\n",
+            Some("port = 5432\n"),
+            None,
+        )
+        .write(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "config.toml",
+        )
+        .unwrap();
+
+        let ctx = make_ctx(&env);
+        let result = check(&ctx, false, &root(&env)).unwrap();
+
+        assert!(
+            matches!(result.entries[0].action, TransformAction::OutOfRoot),
+            "unexpected action: {:?}",
+            result.entries[0].action
+        );
+        assert_eq!(env.fs.read_to_string(&outside).unwrap(), "port = 5432\n");
+    }
+
+    /// A baseline written before the cache recorded source paths stores
+    /// an empty one. Nothing was looked for and nothing is missing — it
+    /// is a stale cache entry, reported apart from a deleted source, and
+    /// still a finding because the cache needs rebuilding.
+    #[test]
+    fn a_baseline_without_a_source_path_is_reported_as_stale() {
+        let env = TempEnvironment::builder().build();
+        crate::preprocessing::baseline::Baseline::build(
+            std::path::Path::new(""),
+            b"rendered",
+            b"src",
+            Some(""),
+            None,
+        )
+        .write(
+            env.fs.as_ref(),
+            env.paths.as_ref(),
+            "app",
+            "preprocessed",
+            "config.toml",
+        )
+        .unwrap();
+        let deployed = deployed_path(&env, "app", "config.toml");
+        env.fs.mkdir_all(deployed.parent().unwrap()).unwrap();
+        env.fs.write_file(&deployed, b"rendered").unwrap();
+
+        let ctx = make_ctx(&env);
+        let result = check(&ctx, true, &root(&env)).unwrap();
+
+        assert!(
+            matches!(result.entries[0].action, TransformAction::StaleSource),
+            "unexpected action: {:?}",
+            result.entries[0].action
+        );
+        assert!(result.has_findings);
+        assert!(result.unresolved_markers.is_empty());
     }
 
     // ── status ──────────────────────────────────────────────────

--- a/crates/dodot-lib/src/safety_lock.rs
+++ b/crates/dodot-lib/src/safety_lock.rs
@@ -83,17 +83,21 @@
 //! fills in [`files`] and composes both into [`selection`]; ACC01-WS04 fills in
 //! the trust lifecycle over the loaded collection — [`check`], [`list`], and
 //! [`forget`]; ACC01-WS05 adds the [`operation`] policy and the bounded
-//! [`inventory`]. Only [`scope_to_root`] still carries a documented signature
-//! with a `todo!()` body, for WS06.
+//! [`inventory`]; ACC01-WS06 fills in [`scope_to_root`] and scopes the two
+//! cache-derived mutations — `refresh` and `transform check` — to the root
+//! they were authorized for. Every signature here now has a body.
 //!
 //! Dodot's pre-Safety-Lock root resolution still runs in
 //! [`crate::paths`](crate::paths) and in the CLI: replacing those callers with
 //! [`resolve_root`] is the process-boundary work of WS07, which is where the
 //! environment, cwd, and Git capture this module refuses to perform lands.
 //!
-//! Nothing in this module is wired into a command yet: the process boundary
-//! that captures the environment, the current directory, and Git — and the
-//! gate that consults all of this — arrives with WS07.
+//! [`scope_to_root`] is the one part already wired into commands, because it
+//! is not a gate: `refresh` and `transform check` take a root they are
+//! authorized for and scope their write targets to it whether or not anything
+//! asked for approval first. The gate itself — the process boundary that
+//! captures the environment, the current directory, and Git, and the
+//! [`authorize`] call that consults all of it — arrives with WS07.
 
 pub mod check;
 pub mod environment;
@@ -126,6 +130,6 @@ pub use roots::{ResolvedRoot, RootIdentity, RootSource};
 pub use schema::{
     SafetyLockConfig, TrustedRootsSection, SAFETY_LOCK_FILE_NAME, SAFETY_LOCK_PERSIST_SCOPE,
 };
-pub use scope::{scope_to_root, MutationScope, OutOfRootReason, OutOfRootTarget};
+pub use scope::{scope_to_root, MutationScope, OutOfRootReason, OutOfRootTarget, ScopeOutcome};
 pub use selection::{resolve_root, RootSelectionInput};
 pub use util::{decode_native_path, encode_native_path, OsPathProbe, PathProbe, NATIVE_BYTES_TAG};

--- a/crates/dodot-lib/src/safety_lock/scope.rs
+++ b/crates/dodot-lib/src/safety_lock/scope.rs
@@ -11,11 +11,33 @@
 //! Trusting one root therefore cannot authorize a write into another root's
 //! user-authored source.
 //!
-//! Behaviour arrives in WS06; this Work Stream fixes the shape.
+//! # What "inside the root" means
+//!
+//! [`scope_to_root`] answers it in one pass per candidate: resolve the stored
+//! path through the injected [`PathProbe`] — which is where a symlink pointing
+//! out of the root stops being invisible — and ask the authorized
+//! [`RootIdentity`] whether it contains the *resolved* path. Nothing else is
+//! trusted: a candidate is authorized because Dodot placed it inside the root,
+//! never because it was in the cache.
+//!
+//! Every way that can fail is an outcome, not an error ([`OutOfRootReason`]).
+//! A source that is missing, stale, or unresolvable cannot be placed inside
+//! the root, and a mutation set is exactly the set Dodot could place — so
+//! these are reported and skipped rather than aborting a command that has real
+//! in-root work to do. That is also the fail-closed direction: every
+//! uncertainty ends outside the mutation set.
+//!
+//! # Order is the caller's index
+//!
+//! Callers hold per-candidate context the scope knows nothing about — a
+//! baseline's pack, handler, and cache filename. [`MutationScope`] therefore
+//! keeps one [`ScopeOutcome`] per candidate *in the order the candidates were
+//! given*, so a caller zips its own rows back onto the verdicts instead of
+//! matching them up by path (two baselines may legitimately share one source
+//! path, so a path is not a key).
 
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
-use super::error::Result;
 use super::roots::RootIdentity;
 use super::util::PathProbe;
 
@@ -29,6 +51,16 @@ pub enum OutOfRootReason {
     OutsideRoot,
     /// The source path no longer exists.
     Missing,
+    /// The cache entry does not name an absolute source path at all — it is
+    /// empty, or relative.
+    ///
+    /// Distinct from [`Missing`](Self::Missing) because nothing was looked
+    /// for: a baseline written before the cache recorded source paths has no
+    /// path to resolve, and a relative one has no meaning independent of the
+    /// process working directory — the ambient state Safety Lock resolves once
+    /// per invocation and never re-reads. The next `dodot up` rewrites such an
+    /// entry; until then it is reportable, not actionable.
+    Stale,
     /// The source path exists but could not be canonicalized, so it cannot be
     /// placed relative to the root.
     Uncanonicalizable,
@@ -38,64 +70,414 @@ pub enum OutOfRootReason {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutOfRootTarget {
     /// The candidate's source path as the cache stored it.
+    ///
+    /// The stored spelling, not a resolved one: it is what the user sees in
+    /// their own cache and the only coordinate they can act on. A resolved
+    /// path exists only for candidates that resolved at all.
     pub source_path: PathBuf,
     pub reason: OutOfRootReason,
 }
 
-/// The mutation set split against the authorized root.
+/// One candidate's verdict against the authorized root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScopeOutcome {
+    /// Authorized: the candidate's canonical path, which lies inside the
+    /// root.
+    ///
+    /// This is the path to write — not the candidate, which may have reached
+    /// it through a symlink or an alias. Writing what was checked is what
+    /// keeps the authorized path and the mutated path the same one.
+    InRoot(PathBuf),
+    /// Excluded: reportable, never written.
+    OutOfRoot(OutOfRootTarget),
+}
+
+/// The mutation set split against the authorized root: one outcome per
+/// candidate, in the order the candidates were given.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct MutationScope {
-    /// Canonical source paths inside the authorized root — the only ones that
-    /// may be written.
-    pub in_root: Vec<PathBuf>,
-    /// Everything else, with its reason.
-    pub out_of_root: Vec<OutOfRootTarget>,
+    outcomes: Vec<ScopeOutcome>,
 }
 
 impl MutationScope {
+    /// Build a scope from per-candidate outcomes already decided.
+    pub fn new(outcomes: Vec<ScopeOutcome>) -> Self {
+        Self { outcomes }
+    }
+
+    /// Every verdict, positionally aligned with the candidates that produced
+    /// them — what a caller zips its own rows onto.
+    pub fn outcomes(&self) -> &[ScopeOutcome] {
+        &self.outcomes
+    }
+
+    /// The canonical paths inside the authorized root — the only ones that
+    /// may be written.
+    pub fn in_root(&self) -> impl Iterator<Item = &Path> {
+        self.outcomes.iter().filter_map(|outcome| match outcome {
+            ScopeOutcome::InRoot(canonical) => Some(canonical.as_path()),
+            ScopeOutcome::OutOfRoot(_) => None,
+        })
+    }
+
+    /// Everything else, with its reason.
+    pub fn out_of_root(&self) -> impl Iterator<Item = &OutOfRootTarget> {
+        self.outcomes.iter().filter_map(|outcome| match outcome {
+            ScopeOutcome::OutOfRoot(target) => Some(target),
+            ScopeOutcome::InRoot(_) => None,
+        })
+    }
+
     /// Whether any candidate was excluded, i.e. whether the command has an
     /// out-of-root report to make.
     pub fn has_out_of_root(&self) -> bool {
-        !self.out_of_root.is_empty()
+        self.out_of_root().next().is_some()
     }
 }
 
 /// Split `candidates` into the paths `root` authorizes and the ones it does
 /// not.
+///
+/// Infallible by design. Every way a candidate can fail to be placed inside
+/// the root is a reportable [`OutOfRootReason`], because a command holding a
+/// cache full of other roots' baselines still has its own root's work to do —
+/// and because an error return would leave the caller deciding whether to
+/// proceed, which is the decision this function exists to make.
+///
+/// The probe is asked once per candidate, and only for candidates that name
+/// an absolute path: a relative one would be resolved against the process
+/// working directory, which Safety Lock does not read.
 pub fn scope_to_root(
     root: &RootIdentity,
     candidates: &[PathBuf],
     probe: &dyn PathProbe,
-) -> Result<MutationScope> {
-    let _ = (root, candidates, probe);
-    todo!("WS06: scope shared-cache mutations to one root")
+) -> MutationScope {
+    MutationScope::new(
+        candidates
+            .iter()
+            .map(|candidate| classify(root, candidate, probe))
+            .collect(),
+    )
+}
+
+/// Place one candidate relative to `root`, naming what stopped it when it
+/// cannot be placed.
+fn classify(root: &RootIdentity, candidate: &Path, probe: &dyn PathProbe) -> ScopeOutcome {
+    let excluded = |reason| {
+        ScopeOutcome::OutOfRoot(OutOfRootTarget {
+            source_path: candidate.to_path_buf(),
+            reason,
+        })
+    };
+
+    // Checked before the probe, so a path with no fixed meaning never reaches
+    // the filesystem.
+    if !candidate.is_absolute() {
+        return excluded(OutOfRootReason::Stale);
+    }
+
+    let canonical = match probe.canonicalize(candidate) {
+        Ok(canonical) => canonical,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return excluded(OutOfRootReason::Missing)
+        }
+        Err(_) => return excluded(OutOfRootReason::Uncanonicalizable),
+    };
+
+    // `RootIdentity::contains` answers `false` for a non-canonical candidate
+    // rather than trusting it, so containment alone would already fail
+    // closed. The shape is checked separately anyway so the report says which
+    // thing went wrong: "the probe gave back something unplaceable" and "this
+    // file belongs to another root" are different facts about the user's
+    // machine, and only the second one is about roots.
+    if !is_placeable(&canonical) {
+        return excluded(OutOfRootReason::Uncanonicalizable);
+    }
+
+    if root.contains(&canonical) {
+        ScopeOutcome::InRoot(canonical)
+    } else {
+        excluded(OutOfRootReason::OutsideRoot)
+    }
+}
+
+/// Whether a resolved path can be placed relative to a root at all: absolute,
+/// and free of the `..` components that would let a component-wise prefix
+/// test walk back out of the root it appears to be under.
+fn is_placeable(canonical: &Path) -> bool {
+    canonical.is_absolute()
+        && !canonical
+            .components()
+            .any(|component| component == Component::ParentDir)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_probe::{Entry, FakeProbe};
     use super::*;
+
+    fn root() -> RootIdentity {
+        RootIdentity::new("/srv/dots").unwrap()
+    }
+
+    fn scope(candidates: &[&str], probe: &dyn PathProbe) -> MutationScope {
+        let candidates: Vec<PathBuf> = candidates.iter().map(PathBuf::from).collect();
+        scope_to_root(&root(), &candidates, probe)
+    }
+
+    fn reasons(scope: &MutationScope) -> Vec<OutOfRootReason> {
+        scope.out_of_root().map(|target| target.reason).collect()
+    }
+
+    fn in_root(scope: &MutationScope) -> Vec<PathBuf> {
+        scope.in_root().map(Path::to_path_buf).collect()
+    }
 
     #[test]
     fn an_empty_scope_authorizes_and_reports_nothing() {
         let scope = MutationScope::default();
 
-        assert!(scope.in_root.is_empty());
+        assert!(scope.in_root().next().is_none());
         assert!(!scope.has_out_of_root());
     }
 
     #[test]
-    fn excluded_candidates_are_reported_not_written() {
-        let scope = MutationScope {
-            in_root: vec![PathBuf::from("/srv/dots/vim/vimrc")],
-            out_of_root: vec![OutOfRootTarget {
-                source_path: PathBuf::from("/other/dots/vim/vimrc"),
-                reason: OutOfRootReason::OutsideRoot,
-            }],
-        };
+    fn sources_inside_the_root_are_the_mutation_set() {
+        let probe = FakeProbe::default()
+            .add("/srv/dots/vim/vimrc", Entry::NotADirectory)
+            .add("/srv/dots", Entry::ReadableDir);
 
+        let scope = scope(&["/srv/dots/vim/vimrc", "/srv/dots"], &probe);
+
+        assert_eq!(
+            in_root(&scope),
+            vec![
+                PathBuf::from("/srv/dots/vim/vimrc"),
+                PathBuf::from("/srv/dots"),
+            ]
+        );
+        assert!(!scope.has_out_of_root());
+    }
+
+    /// The whole point of the exception (ADR-0002): a second root's baseline
+    /// sits in the same shared cache, and approving this root must not
+    /// authorize a write into that one.
+    #[test]
+    fn another_roots_source_is_reported_not_written() {
+        let probe = FakeProbe::default()
+            .add("/srv/dots/vim/vimrc", Entry::NotADirectory)
+            .add("/other/dots/vim/vimrc", Entry::NotADirectory);
+
+        let scope = scope(&["/srv/dots/vim/vimrc", "/other/dots/vim/vimrc"], &probe);
+
+        assert_eq!(in_root(&scope), vec![PathBuf::from("/srv/dots/vim/vimrc")]);
+        assert_eq!(reasons(&scope), vec![OutOfRootReason::OutsideRoot]);
+        assert_eq!(
+            scope.out_of_root().next().unwrap().source_path,
+            PathBuf::from("/other/dots/vim/vimrc"),
+            "the report names the path the cache stored"
+        );
+    }
+
+    /// A source that *lives* in the root but *resolves* elsewhere is the
+    /// escape a path-only check misses: the cache stored an in-root spelling,
+    /// and writing it would write through the link into another tree.
+    #[test]
+    fn a_symlink_out_of_the_root_escapes_the_mutation_set() {
+        let probe = FakeProbe::default().link("/srv/dots/vim/vimrc", "/other/dots/vim/vimrc");
+
+        let scope = scope(&["/srv/dots/vim/vimrc"], &probe);
+
+        assert!(in_root(&scope).is_empty());
+        assert_eq!(reasons(&scope), vec![OutOfRootReason::OutsideRoot]);
+    }
+
+    /// The mutation set is the resolved path, not the stored one — so the
+    /// write lands where containment was actually decided.
+    #[test]
+    fn an_in_root_symlink_is_authorized_at_its_resolved_path() {
+        let probe = FakeProbe::default().link("/srv/dots/vim/vimrc", "/srv/dots/shared/vimrc");
+
+        let scope = scope(&["/srv/dots/vim/vimrc"], &probe);
+
+        assert_eq!(
+            in_root(&scope),
+            vec![PathBuf::from("/srv/dots/shared/vimrc")]
+        );
+    }
+
+    /// A sibling whose name merely starts with the root's is not a
+    /// descendant. A string-prefix test says it is, and would authorize
+    /// writes into a neighbouring repository.
+    #[test]
+    fn prefix_confusable_siblings_are_not_descendants() {
+        let probe = FakeProbe::default()
+            .add("/srv/dots-backup/vim/vimrc", Entry::NotADirectory)
+            .add("/srv/dotsomething", Entry::NotADirectory);
+
+        let scope = scope(&["/srv/dots-backup/vim/vimrc", "/srv/dotsomething"], &probe);
+
+        assert!(in_root(&scope).is_empty());
+        assert_eq!(
+            reasons(&scope),
+            vec![OutOfRootReason::OutsideRoot, OutOfRootReason::OutsideRoot]
+        );
+    }
+
+    #[test]
+    fn a_missing_source_is_reported_as_missing() {
+        let probe = FakeProbe::default();
+
+        let scope = scope(&["/srv/dots/vim/vimrc"], &probe);
+
+        assert_eq!(reasons(&scope), vec![OutOfRootReason::Missing]);
+    }
+
+    /// A baseline written before the cache recorded source paths stores an
+    /// empty one. There is nothing to resolve, so it is stale rather than
+    /// missing — and the filesystem is never asked about it.
+    #[test]
+    fn a_baseline_with_no_source_path_is_stale_and_never_probed() {
+        let probe = FakeProbe::default();
+
+        let scope = scope(&[""], &probe);
+
+        assert_eq!(reasons(&scope), vec![OutOfRootReason::Stale]);
+        assert!(
+            probe.canonicalized().is_empty(),
+            "a path with no fixed meaning reached the filesystem probe"
+        );
+    }
+
+    /// A relative stored path would be resolved against the process working
+    /// directory — the ambient state Safety Lock refuses to read — so it is
+    /// refused before the probe, like an empty one.
+    #[test]
+    fn a_relative_source_path_is_stale_and_never_probed() {
+        let probe = FakeProbe::default();
+
+        let scope = scope(&["vim/vimrc"], &probe);
+
+        assert_eq!(reasons(&scope), vec![OutOfRootReason::Stale]);
+        assert!(probe.canonicalized().is_empty());
+    }
+
+    #[test]
+    fn a_source_that_cannot_be_resolved_is_reported_as_uncanonicalizable() {
+        let probe = FakeProbe::default().add(
+            "/srv/dots/vim/vimrc",
+            Entry::Unresolvable(std::io::ErrorKind::PermissionDenied),
+        );
+
+        let scope = scope(&["/srv/dots/vim/vimrc"], &probe);
+
+        assert_eq!(reasons(&scope), vec![OutOfRootReason::Uncanonicalizable]);
+    }
+
+    /// A resolved path that still carries `..` cannot be placed: it walks
+    /// back out of whatever it appears to be under. It is refused as
+    /// unresolvable rather than silently accepted by a prefix test.
+    #[test]
+    fn a_resolution_that_is_not_placeable_is_refused() {
+        let probe = FakeProbe::default().link("/srv/dots/vim/vimrc", "/srv/dots/../etc/passwd");
+
+        let scope = scope(&["/srv/dots/vim/vimrc"], &probe);
+
+        assert!(in_root(&scope).is_empty());
+        assert_eq!(reasons(&scope), vec![OutOfRootReason::Uncanonicalizable]);
+    }
+
+    /// The caller's index: verdicts stay positionally aligned with the
+    /// candidates, so a baseline's pack and handler can be zipped back on.
+    #[test]
+    fn outcomes_stay_aligned_with_the_candidates() {
+        let probe = FakeProbe::default()
+            .add("/srv/dots/a", Entry::NotADirectory)
+            .add("/other/dots/b", Entry::NotADirectory)
+            .add("/srv/dots/c", Entry::NotADirectory);
+
+        let scope = scope(
+            &["/srv/dots/a", "/other/dots/b", "/srv/dots/c", "/gone/d"],
+            &probe,
+        );
+
+        assert_eq!(
+            scope.outcomes(),
+            &[
+                ScopeOutcome::InRoot(PathBuf::from("/srv/dots/a")),
+                ScopeOutcome::OutOfRoot(OutOfRootTarget {
+                    source_path: PathBuf::from("/other/dots/b"),
+                    reason: OutOfRootReason::OutsideRoot,
+                }),
+                ScopeOutcome::InRoot(PathBuf::from("/srv/dots/c")),
+                ScopeOutcome::OutOfRoot(OutOfRootTarget {
+                    source_path: PathBuf::from("/gone/d"),
+                    reason: OutOfRootReason::Missing,
+                }),
+            ]
+        );
         assert!(scope.has_out_of_root());
-        assert!(!scope
-            .in_root
-            .contains(&PathBuf::from("/other/dots/vim/vimrc")));
+    }
+
+    /// Two roots, one shared cache: whichever root is authorized, only its
+    /// own sources enter the mutation set. Neither approval reaches the
+    /// other's tree.
+    #[test]
+    fn authorizing_either_root_never_reaches_the_other() {
+        let probe = FakeProbe::default()
+            .add("/srv/dots/vim/vimrc", Entry::NotADirectory)
+            .add("/other/dots/vim/vimrc", Entry::NotADirectory);
+        let cache = vec![
+            PathBuf::from("/srv/dots/vim/vimrc"),
+            PathBuf::from("/other/dots/vim/vimrc"),
+        ];
+
+        let here = scope_to_root(&RootIdentity::new("/srv/dots").unwrap(), &cache, &probe);
+        let there = scope_to_root(&RootIdentity::new("/other/dots").unwrap(), &cache, &probe);
+
+        assert_eq!(in_root(&here), vec![PathBuf::from("/srv/dots/vim/vimrc")]);
+        assert_eq!(
+            in_root(&there),
+            vec![PathBuf::from("/other/dots/vim/vimrc")]
+        );
+    }
+
+    /// The real filesystem, not only the stated one: containment and symlink
+    /// escape must hold against `std::fs::canonicalize` too.
+    #[test]
+    fn the_os_probe_scopes_a_real_directory() {
+        use super::super::util::OsPathProbe;
+
+        let temp = tempfile::tempdir().unwrap();
+        let base = std::fs::canonicalize(temp.path()).unwrap();
+        let root = base.join("dots");
+        let other = base.join("other");
+        std::fs::create_dir_all(root.join("vim")).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+        std::fs::write(root.join("vim/vimrc"), b"set nocompatible").unwrap();
+        std::fs::write(other.join("vimrc"), b"elsewhere").unwrap();
+        std::os::unix::fs::symlink(other.join("vimrc"), root.join("vim/escape")).unwrap();
+
+        let candidates = vec![
+            root.join("vim/vimrc"),
+            root.join("vim/escape"),
+            other.join("vimrc"),
+            root.join("vim/gone"),
+        ];
+        let scope = scope_to_root(
+            &RootIdentity::new(&root).unwrap(),
+            &candidates,
+            &OsPathProbe,
+        );
+
+        assert_eq!(in_root(&scope), vec![root.join("vim/vimrc")]);
+        assert_eq!(
+            reasons(&scope),
+            vec![
+                OutOfRootReason::OutsideRoot,
+                OutOfRootReason::OutsideRoot,
+                OutOfRootReason::Missing,
+            ]
+        );
     }
 }

--- a/crates/dodot-lib/src/templates/refresh.jinja
+++ b/crates/dodot-lib/src/templates/refresh.jinja
@@ -24,7 +24,7 @@
 {% elif e.action == "missing_deployed" -%}
   [warn]? missing deployed[/warn] {{ e.source_path }} [muted](rendered file gone; next [usage]dodot up[/usage] will recreate)[/muted]
 {% elif e.action == "stale_source" -%}
-  [warn]? stale entry[/warn] {{ e.pack }}/{{ e.filename }} [muted](baseline records no source path; next [usage]dodot up[/usage] will refresh)[/muted]
+  [warn]? stale entry[/warn] {{ e.pack }}/{{ e.handler }}/{{ e.filename }} [muted](baseline records no absolute source path; next [usage]dodot up[/usage] will refresh)[/muted]
 {% elif e.action == "unresolvable_source" -%}
   [warn]? unresolvable source[/warn] {{ e.source_path }} [muted](cannot be resolved, so it cannot be placed in this dotfiles root)[/muted]
 {% elif e.action == "out_of_root" -%}

--- a/crates/dodot-lib/src/templates/refresh.jinja
+++ b/crates/dodot-lib/src/templates/refresh.jinja
@@ -8,7 +8,7 @@
 {%- if entries|length == 0 -%}
 [muted]No template baselines. Run [usage]dodot up[/usage] to deploy templates first.[/muted]
 {%- else -%}
-{%- set missing = entries|rejectattr("action", "equalto", "touched")|rejectattr("action", "equalto", "clean")|list -%}
+{%- set missing = entries|rejectattr("action", "equalto", "touched")|rejectattr("action", "equalto", "clean")|rejectattr("action", "equalto", "out_of_root")|list -%}
 {%- if touched_any -%}
 [message]Touched {{ entries|selectattr("action", "equalto", "touched")|list|length }} source file(s) — `git status` will now see deployed-side edits.[/message]
 {%- elif missing|length > 0 -%}
@@ -23,6 +23,12 @@
   [warn]? missing source[/warn] {{ e.source_path }} [muted](baseline stale; next [usage]dodot up[/usage] will refresh)[/muted]
 {% elif e.action == "missing_deployed" -%}
   [warn]? missing deployed[/warn] {{ e.source_path }} [muted](rendered file gone; next [usage]dodot up[/usage] will recreate)[/muted]
+{% elif e.action == "stale_source" -%}
+  [warn]? stale entry[/warn] {{ e.pack }}/{{ e.filename }} [muted](baseline records no source path; next [usage]dodot up[/usage] will refresh)[/muted]
+{% elif e.action == "unresolvable_source" -%}
+  [warn]? unresolvable source[/warn] {{ e.source_path }} [muted](cannot be resolved, so it cannot be placed in this dotfiles root)[/muted]
+{% elif e.action == "out_of_root" -%}
+  [muted]· other root[/muted] {{ e.source_path }} [muted](belongs to a different dotfiles root; not touched)[/muted]
 {% endif -%}
 {%- endfor -%}
 {%- endif -%}

--- a/crates/dodot-lib/src/templates/transform-check.jinja
+++ b/crates/dodot-lib/src/templates/transform-check.jinja
@@ -25,7 +25,7 @@
     [muted]{{ e.pack }}/{{ e.handler }}/{{ e.filename }} — rendered file is gone; next [usage]dodot up[/usage] will recreate[/muted]
 {% elif e.action == "stale_source" -%}
   [warn]? stale entry[/warn] {{ e.pack }}/{{ e.handler }}/{{ e.filename }}
-    [muted]baseline records no source path; next [usage]dodot up[/usage] will refresh[/muted]
+    [muted]baseline records no absolute source path; next [usage]dodot up[/usage] will refresh[/muted]
 {% elif e.action == "unresolvable_source" -%}
   [warn]? unresolvable source[/warn] {{ e.source_path }}
     [muted]{{ e.pack }}/{{ e.handler }}/{{ e.filename }} — cannot be resolved, so it cannot be placed in this dotfiles root[/muted]

--- a/crates/dodot-lib/src/templates/transform-check.jinja
+++ b/crates/dodot-lib/src/templates/transform-check.jinja
@@ -23,6 +23,15 @@
 {% elif e.action == "missing_deployed" -%}
   [warn]? missing deployed[/warn] {{ e.deployed_path }}
     [muted]{{ e.pack }}/{{ e.handler }}/{{ e.filename }} — rendered file is gone; next [usage]dodot up[/usage] will recreate[/muted]
+{% elif e.action == "stale_source" -%}
+  [warn]? stale entry[/warn] {{ e.pack }}/{{ e.handler }}/{{ e.filename }}
+    [muted]baseline records no source path; next [usage]dodot up[/usage] will refresh[/muted]
+{% elif e.action == "unresolvable_source" -%}
+  [warn]? unresolvable source[/warn] {{ e.source_path }}
+    [muted]{{ e.pack }}/{{ e.handler }}/{{ e.filename }} — cannot be resolved, so it cannot be placed in this dotfiles root[/muted]
+{% elif e.action == "out_of_root" -%}
+  [muted]· other root[/muted] {{ e.source_path }}
+    [muted]{{ e.pack }}/{{ e.handler }}/{{ e.filename }} — belongs to a different dotfiles root; not patched[/muted]
 {% elif e.action == "needs_rebaseline" -%}
   [warn]? needs rebaseline[/warn] {{ e.source_path }}
     [muted]{{ e.pack }}/{{ e.handler }}/{{ e.filename }} — baseline cache predates tracked-render support; run [usage]dodot up[/usage] to refresh[/muted]


### PR DESCRIPTION
Scopes the mutation set of `refresh` and `transform check` to the one dotfiles root the invocation is authorized for, so trusting one root cannot authorize a write into another root's user-authored source (ADR-0002).

`for #311`

## Context

**The hole.** `refresh` and `transform check` are the two protected commands that take their write targets from the *shared* preprocessor baseline cache rather than from the root. That cache can name sources under any root that has ever run `dodot up` on this machine. Per-root cache namespaces are out of scope for this epic, so approving root A and running `refresh` would happily touch root B's sources — the gate's "the target is the selected root" invariant held for command *selection* and leaked at *execution*.

**The shape of the fix.** A new `safety_lock::scope` module answers one question per candidate — is this stored source path inside the authorized root? — and returns a verdict, never an error:

- Resolution goes through the injected `PathProbe`, so a source that *lives* in the root but *resolves* out of it (a symlink escape) is caught. Containment is asked of the *resolved* path.
- The authorized value is the canonical path, not the stored one, so the write lands where containment was actually decided.
- Every way a candidate can fail to be placed is an outcome, not an abort: `OutsideRoot`, `Missing`, `Stale` (empty or relative — no absolute path to resolve), `Uncanonicalizable`. Fail-closed in both directions: every uncertainty ends *outside* the mutation set, and a command holding another root's baselines still does its own root's work.
- Verdicts stay positionally aligned with the candidates, so callers zip their own pack/handler/filename rows back on (two baselines may legitimately share one source path, so path is not a key).

**Reporting.** Both commands gained four report actions apiece for the excluded rows. The one deliberate asymmetry: `OutOfRoot` is **report-only and not a finding** — two roots sharing one cache is a supported arrangement, and the pre-commit hook installed in one repository must not start refusing commits because a sibling repository also uses Dodot. The other three are cache health and stay findings, exactly as a missing source always has.

**Out of scope / do not "fix" here:** per-root cache or datastore namespaces (explicitly out of scope per ADR-0002); the interim `authorized_root()` helper in `handlers.rs`, which canonicalizes per command — ACC01-WS07 replaces it with the authorized `ResolvedRoot` the gate resolves once at the process boundary.

**Self-check:** the diff was checked against ADR-0001 (canonical-path root identity; root resolved once per invocation) and ADR-0002 (root-derived mutations, and its explicit paragraph on these two cache-driven commands).

## Tests

`pixi run test` → **1717 passed, 0 skipped**. Lint suite green via the commit and push hooks.

New coverage in `safety_lock/scope.rs` pins each contract against a `FakeProbe` and, for the last one, the real filesystem: another root's source is reported not written; an out-of-root symlink escapes the mutation set; an in-root symlink is authorized *at its resolved path*; prefix-confusable siblings (`/srv/dots-backup` vs `/srv/dots`) are not descendants; empty and relative paths are `Stale` **and never reach the probe**; a resolution still carrying `..` is refused as unplaceable; verdicts stay aligned with candidates; and authorizing either of two roots sharing one cache never reaches the other. `refresh.rs` and `transform/mod.rs` each cover their new actions end to end.
