### PR TITLE
ACC01-WS03: Epic: Safety Lock - Workstream: Implicit file-root resolution and path identity convergence correction

### DIFF
--- a/crates/dodot-cli/src/main.rs
+++ b/crates/dodot-cli/src/main.rs
@@ -89,9 +89,7 @@ fn main() {
     } else {
         logging::Verbosity::Quiet
     };
-    let log_dir = dodot_lib::paths::XdgPather::from_env()
-        .map(|p| dodot_lib::paths::Pather::log_dir(&p))
-        .unwrap_or_else(|_| std::env::temp_dir().join("dodot-logs"));
+    let log_dir = dodot_lib::paths::XdgPather::log_dir_from_env();
     let _log_guard = logging::init(&log_dir, verbosity);
 
     // Passthrough: config (clapfig handles its own output)

--- a/crates/dodot-cli/src/safety.rs
+++ b/crates/dodot-cli/src/safety.rs
@@ -261,9 +261,13 @@ impl ProcessFacts {
     /// or empty answer is `None` — "not inside a repository" — which is a
     /// selection input, not an error: the current directory is the next
     /// candidate.
+    ///
+    /// `HOME` is resolved exactly once; the data directory is derived from
+    /// that single reading, so the captured facts cannot disagree about which
+    /// home they came from.
     pub fn capture() -> Result<Self, anyhow::Error> {
         let home_dir = XdgPather::home_dir_from_env();
-        let data_dir = XdgPather::data_dir_from_env();
+        let data_dir = XdgPather::data_dir_for_home(&home_dir);
         let current_dir = std::env::current_dir()?;
 
         let mut selection = RootSelectionInput::new(current_dir, home_dir);

--- a/crates/dodot-cli/src/safety.rs
+++ b/crates/dodot-cli/src/safety.rs
@@ -58,7 +58,7 @@ use standout::OutputMode;
 use dodot_lib::commands::safety::SafetyPromptView;
 use dodot_lib::fs::OsFs;
 use dodot_lib::gates::HostFacts;
-use dodot_lib::paths::{Pather, XdgPather};
+use dodot_lib::paths::XdgPather;
 use dodot_lib::render;
 use dodot_lib::safety_lock::{
     approve, authorize, resolve_root, GateOutcome, OsPathProbe, ResolvedRoot, RootIdentity,
@@ -262,16 +262,17 @@ impl ProcessFacts {
     /// selection input, not an error: the current directory is the next
     /// candidate.
     pub fn capture() -> Result<Self, anyhow::Error> {
-        let pather = XdgPather::from_env()?;
+        let home_dir = XdgPather::home_dir_from_env();
+        let data_dir = XdgPather::data_dir_from_env();
         let current_dir = std::env::current_dir()?;
 
-        let mut selection = RootSelectionInput::new(current_dir, pather.home_dir());
+        let mut selection = RootSelectionInput::new(current_dir, home_dir);
         selection.dotfiles_root = std::env::var_os("DOTFILES_ROOT");
         selection.git_top_level = git_top_level();
 
         Ok(Self {
             selection,
-            data_dir: pather.data_dir().to_path_buf(),
+            data_dir,
         })
     }
 

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -408,10 +408,15 @@ impl XdgPather {
         resolve_home()
     }
 
-    /// Resolve dodot's root-independent data directory from the environment.
-    pub fn data_dir_from_env() -> PathBuf {
-        let home = resolve_home();
-        resolve_data_dir(&home)
+    /// Resolve dodot's root-independent data directory for an already
+    /// resolved home directory.
+    ///
+    /// Honors `XDG_DATA_HOME`, falling back to `<home>/.local/share`. Taking
+    /// the home as a parameter (rather than re-resolving it) lets a caller
+    /// that captures several environment-derived facts do so from one `HOME`
+    /// reading, keeping the captured set internally consistent.
+    pub fn data_dir_for_home(home: &Path) -> PathBuf {
+        resolve_data_dir(home)
     }
 
     /// Resolve dodot's root-independent log directory from the environment.

--- a/crates/dodot-lib/src/paths/mod.rs
+++ b/crates/dodot-lib/src/paths/mod.rs
@@ -12,12 +12,13 @@
 //!    actual `$HOME`. The `testing::TempEnvironment` builder does
 //!    exactly this.
 //!
-//! 2. **Centralisation of OS-shaped policy.** The XDG fallback chain,
-//!    the `DOTFILES_ROOT` env-var lookup, and the macOS
+//! 2. **Centralisation of OS-shaped policy.** The XDG fallback chain and the macOS
 //!    `app_support_dir` selection (`docs/proposals/macos-paths.lex`)
-//!    all live in one place. The resolver, the symlink
-//!    handler, and `adopt`'s source-path inference all consult the
-//!    same accessors — drift between them is impossible by construction.
+//!    live here. Dotfiles-root selection lives exclusively in
+//!    `crate::safety_lock`; callers inject its canonical result. The symlink
+//!    handler and `adopt`'s source-path inference then consult the same
+//!    accessor — drift between selection and use is impossible by
+//!    construction.
 //!
 //! ## Adopt source-root invariants
 //!
@@ -42,7 +43,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::Result;
+use crate::{DodotError, Result};
 
 /// Provides all path calculations for dodot.
 ///
@@ -267,9 +268,9 @@ pub trait Pather: Send + Sync {
 
 /// XDG-compliant path resolver.
 ///
-/// Reads standard environment variables (`HOME`, `XDG_DATA_HOME`, etc.)
-/// and the dodot-specific `DOTFILES_ROOT`. All paths can also be set
-/// explicitly via the builder for testing.
+/// Reads standard environment variables (`HOME`, `XDG_DATA_HOME`, etc.) for
+/// root-independent coordinates. The canonical dotfiles root is always
+/// injected explicitly; root selection belongs to `crate::safety_lock`.
 #[derive(Debug, Clone)]
 pub struct XdgPather {
     home: PathBuf,
@@ -284,8 +285,8 @@ pub struct XdgPather {
 
 /// Builder for [`XdgPather`].
 ///
-/// All fields are optional. Unset fields are resolved from environment
-/// variables or XDG defaults.
+/// The dotfiles root is required. Other unset fields are resolved from
+/// environment variables or XDG defaults.
 #[derive(Debug, Default)]
 pub struct XdgPatherBuilder {
     home: Option<PathBuf>,
@@ -343,9 +344,12 @@ impl XdgPatherBuilder {
     pub fn build(self) -> Result<XdgPather> {
         let home = self.home.unwrap_or_else(resolve_home);
 
-        let dotfiles_root = self
-            .dotfiles_root
-            .unwrap_or_else(|| resolve_dotfiles_root(&home));
+        let dotfiles_root = self.dotfiles_root.ok_or_else(|| {
+            DodotError::Other(
+                "XdgPather requires an explicitly resolved dotfiles root; resolve it once with safety_lock::resolve_root and inject that canonical path"
+                    .into(),
+            )
+        })?;
 
         let xdg_config_home = self.xdg_config_home.unwrap_or_else(|| {
             std::env::var("XDG_CONFIG_HOME")
@@ -353,23 +357,13 @@ impl XdgPatherBuilder {
                 .unwrap_or_else(|_| home.join(".config"))
         });
 
-        let data_dir = self.data_dir.unwrap_or_else(|| {
-            let xdg_data = std::env::var("XDG_DATA_HOME")
-                .map(PathBuf::from)
-                .unwrap_or_else(|_| home.join(".local").join("share"));
-            xdg_data.join("dodot")
-        });
+        let data_dir = self.data_dir.unwrap_or_else(|| resolve_data_dir(&home));
 
         let config_dir = self
             .config_dir
             .unwrap_or_else(|| xdg_config_home.join("dodot"));
 
-        let cache_dir = self.cache_dir.unwrap_or_else(|| {
-            let xdg_cache = std::env::var("XDG_CACHE_HOME")
-                .map(PathBuf::from)
-                .unwrap_or_else(|_| home.join(".cache"));
-            xdg_cache.join("dodot")
-        });
+        let cache_dir = self.cache_dir.unwrap_or_else(|| resolve_cache_dir(&home));
 
         let shell_dir = data_dir.join("shell");
 
@@ -403,9 +397,27 @@ impl XdgPather {
         XdgPatherBuilder::default()
     }
 
-    /// Creates an `XdgPather` using environment variables and XDG defaults.
-    pub fn from_env() -> Result<Self> {
-        Self::builder().build()
+    /// Creates an `XdgPather` from an already resolved dotfiles root, using
+    /// environment variables and XDG defaults for every other coordinate.
+    pub fn from_env(dotfiles_root: impl Into<PathBuf>) -> Result<Self> {
+        Self::builder().dotfiles_root(dotfiles_root).build()
+    }
+
+    /// Resolve the root-independent home directory from the environment.
+    pub fn home_dir_from_env() -> PathBuf {
+        resolve_home()
+    }
+
+    /// Resolve dodot's root-independent data directory from the environment.
+    pub fn data_dir_from_env() -> PathBuf {
+        let home = resolve_home();
+        resolve_data_dir(&home)
+    }
+
+    /// Resolve dodot's root-independent log directory from the environment.
+    pub fn log_dir_from_env() -> PathBuf {
+        let home = resolve_home();
+        resolve_cache_dir(&home).join("logs")
     }
 }
 
@@ -454,41 +466,18 @@ fn resolve_home() -> PathBuf {
         })
 }
 
-/// Resolve the dotfiles root directory.
-///
-/// Priority:
-/// 1. `DOTFILES_ROOT` environment variable
-/// 2. Git repository root (`git rev-parse --show-toplevel`)
-/// 3. `$HOME/dotfiles` fallback
-fn resolve_dotfiles_root(home: &Path) -> PathBuf {
-    if let Ok(root) = std::env::var("DOTFILES_ROOT") {
-        return expand_tilde(&root, home);
-    }
-
-    if let Ok(output) = std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-    {
-        if output.status.success() {
-            let toplevel = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !toplevel.is_empty() {
-                return PathBuf::from(toplevel);
-            }
-        }
-    }
-
-    home.join("dotfiles")
+fn resolve_data_dir(home: &Path) -> PathBuf {
+    std::env::var("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| home.join(".local").join("share"))
+        .join("dodot")
 }
 
-/// Expand a leading `~` to the home directory.
-fn expand_tilde(path: &str, home: &Path) -> PathBuf {
-    if let Some(rest) = path.strip_prefix("~/") {
-        home.join(rest)
-    } else if path == "~" {
-        home.to_path_buf()
-    } else {
-        PathBuf::from(path)
-    }
+fn resolve_cache_dir(home: &Path) -> PathBuf {
+    std::env::var("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| home.join(".cache"))
+        .join("dodot")
 }
 
 #[cfg(test)]
@@ -542,6 +531,7 @@ mod tests {
     fn pack_data_dir_structure() {
         let pather = XdgPather::builder()
             .home("/h")
+            .dotfiles_root("/h/dotfiles")
             .data_dir("/h/data/dodot")
             .build()
             .unwrap();
@@ -556,6 +546,7 @@ mod tests {
     fn handler_data_dir_structure() {
         let pather = XdgPather::builder()
             .home("/h")
+            .dotfiles_root("/h/dotfiles")
             .data_dir("/h/data/dodot")
             .build()
             .unwrap();
@@ -570,6 +561,7 @@ mod tests {
     fn init_script_path() {
         let pather = XdgPather::builder()
             .home("/h")
+            .dotfiles_root("/h/dotfiles")
             .data_dir("/h/data/dodot")
             .build()
             .unwrap();
@@ -588,6 +580,7 @@ mod tests {
     fn homebrew_cache_path_sits_next_to_the_init_script() {
         let pather = XdgPather::builder()
             .home("/h")
+            .dotfiles_root("/h/dotfiles")
             .data_dir("/h/data/dodot")
             .build()
             .unwrap();
@@ -620,18 +613,18 @@ mod tests {
     }
 
     #[test]
-    fn expand_tilde_cases() {
-        let home = Path::new("/home/alice");
-        assert_eq!(
-            expand_tilde("~/dotfiles", home),
-            PathBuf::from("/home/alice/dotfiles")
+    fn builder_refuses_to_rediscover_a_dotfiles_root() {
+        let error = XdgPather::builder()
+            .home("/home/alice")
+            .build()
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("requires an explicitly resolved dotfiles root"),
+            "unexpected error: {error}"
         );
-        assert_eq!(expand_tilde("~", home), PathBuf::from("/home/alice"));
-        assert_eq!(
-            expand_tilde("/absolute/path", home),
-            PathBuf::from("/absolute/path")
-        );
-        assert_eq!(expand_tilde("relative", home), PathBuf::from("relative"));
     }
 
     /// Default-XDG nesting: with no explicit `xdg_config_home`, the

--- a/docs/reference/terms-and-concepts.lex
+++ b/docs/reference/terms-and-concepts.lex
@@ -5,7 +5,7 @@ Terms and Concepts
 1. Foundational
 
     Dotfiles root:
-        The top-level directory containing your dotfile packs, under version control in git. Defaults to `~/dotfiles`; configurable via `$DOTFILES_ROOT`. The root IS the source of truth — dodot never stores user content outside it.
+        The top-level directory containing your dotfile packs. dodot selects it from `$DOTFILES_ROOT`, then the enclosing git repository's top level, then the current directory. A present but invalid `$DOTFILES_ROOT` is an error; there is no `~/dotfiles` fallback. The root IS the source of truth — dodot never stores user content outside it.
 
     Pack:
         A directory under the dotfiles root whose contents belong together — `vim/`, `git/`, `work/`. Packs are the unit dodot turns on and off. The organizing criterion is yours (by application, by role, by machine); dodot treats every top-level directory as a pack unless it contains a `.dodotignore` file.

--- a/docs/user/glossary/dotfiles-root.lex
+++ b/docs/user/glossary/dotfiles-root.lex
@@ -1,7 +1,7 @@
 :: verified ::
 Dotfiles root:
     The top-level directory holding your packs, kept under git. dodot picks it in this order:
-    - `$DOTFILES_ROOT` if set; an empty, missing, unreadable, or invalid path is an error, never a reason to choose another root
+    - `$DOTFILES_ROOT` if set; an empty value, or a path that doesn't exist, isn't a directory, or can't be read, is an error, never a reason to choose another root;
     - The git top-level of your current directory (so `cd ~/dotfiles/nvim && dodot up` finds the repo root);
     - Current directory itself.
 

--- a/docs/user/glossary/dotfiles-root.lex
+++ b/docs/user/glossary/dotfiles-root.lex
@@ -1,7 +1,7 @@
 :: verified ::
 Dotfiles root:
     The top-level directory holding your packs, kept under git. dodot picks it in this order:
-    - `$DOTFILES_ROOT` if set and the path exists
+    - `$DOTFILES_ROOT` if set; an empty, missing, unreadable, or invalid path is an error, never a reason to choose another root
     - The git top-level of your current directory (so `cd ~/dotfiles/nvim && dodot up` finds the repo root);
     - Current directory itself.
 


### PR DESCRIPTION
for #308

## Context

The post-workstream convergence audit found that `XdgPather` still carried the pre-Safety-Lock ambient resolver (`DOTFILES_ROOT` -> Git -> `$HOME/dotfiles`). That left a second public root-selection policy even though command execution already carries the canonical `ResolvedRoot`.

This correction removes that resolver and makes `dotfiles_root` a required builder input. Root-independent HOME/XDG lookup remains available for logging and trust-state capture before root selection; all actual `XdgPather` construction must receive the already selected root. The canonical glossary and terms definition now describe the authoritative environment behavior and Git/cwd fallback, including hard failure for an invalid explicit root.

Governing sources checked: issue #308 acceptance criteria, `docs/spec/safety-lock.md`, and the shipped Safety Lock selection module documentation.

Out of scope: broader CLI/help/tutorial/agent-guide documentation reconciliation belongs to ACC01-WS08/#313. This PR does not alter Safety Lock selection order, trust semantics, or canonical identity rules; reviewers should not reopen those settled decisions here.

Verification:
- `cargo test -p dodot-lib paths::tests --no-fail-fast` (14 passed)
- `lexd check docs/user/glossary/dotfiles-root.lex docs/reference/terms-and-concepts.lex`
- `pixi run lint --fix` (13 checks)
- `pixi run test` (1772 passed)