### PR TITLE
SIV01-WS02: Epic: Targeted Shell-Init Verification - Workstream: Verification after shell-hookup mutations

### DIFF
--- a/crates/dodot-lib/src/shell/probe.rs
+++ b/crates/dodot-lib/src/shell/probe.rs
@@ -386,10 +386,10 @@ pub fn spawn_captured(mut command: Command, timeout: Duration) -> SpawnOutcome {
 
 /// Spawn `shell` interactively and read the stamp back.
 ///
-/// Safe against hostile rc files by construction — the whole
-/// [`spawn_captured`] envelope. Never returns an error: every failure
-/// mode is an outcome, because a probe that could not run must
-/// degrade, not propagate (spec §3.3).
+/// Safe against hostile rc files by construction through the shared
+/// process-group and pipe-handling envelope. Never returns an error:
+/// every failure mode is an outcome, because a probe that could not
+/// run must degrade, not propagate (spec §3.3).
 pub fn run(shell: &Path, timeout: Duration) -> ProbeOutcome {
     run_targeted(shell, timeout).outcome
 }

--- a/crates/dodot-lib/src/shell/probe.rs
+++ b/crates/dodot-lib/src/shell/probe.rs
@@ -1,13 +1,14 @@
-//! The verification probe — measuring whether a *new* shell would
-//! activate dodot (`docs/proposals/shipped/shell-hookup.lex` §3).
+//! The shell verification probe — measuring whether a *new* shell
+//! reaches dodot's init hook.
 //!
 //! Signals 1 and 2 (the environment stamp and the heartbeat, both in
 //! [`crate::shell::activation`]) answer "is this shell live?" and "has
 //! any shell activated?". Neither answers the question a fresh install
-//! or a freshly broken hookup actually poses: *would the next terminal
-//! the user opens load dodot?* Only running one answers that, so when
-//! the cheap signals come back inconclusive, dodot spawns the user's
-//! shell and reads the stamp back out of it.
+//! or a freshly broken hookup actually poses: *would the next terminal the
+//! user opens reach the hook dodot just wrote?* Only running one answers
+//! that, so when the cheap signals come back inconclusive, dodot spawns the
+//! user's shell and accepts the nonce-bound response emitted at the start of
+//! current init scripts. Older hooks fall back to the post-rc stamp command.
 //!
 //! # Gating
 //!
@@ -24,18 +25,17 @@
 //! # Mechanics
 //!
 //! User rc files prompt, hang, `exec` into multiplexers, and fail in
-//! creative ways, so [`run`] is defensive by construction: interactive
-//! non-login shell (the mode that reads the file the hook lives in),
-//! stdin from `/dev/null`, output captured, a hard timeout that kills
-//! the whole process group, and `DODOT_INIT_*` scrubbed from the child
-//! environment — an inherited stamp would be a false positive every
-//! time the probe runs from an already-live shell.
+//! creative ways, so [`run_targeted`] is defensive by construction:
+//! interactive non-login shell (the mode that reads the file the hook lives
+//! in), stdin from `/dev/null`, output captured, a hard timeout that kills the
+//! whole process group, and `DODOT_INIT_*` scrubbed from the child environment
+//! — an inherited stamp would be a false positive whenever a legacy fallback
+//! probe runs from an already-live shell.
 //!
 //! That defensive envelope lives in [`spawn_captured`], which is the
-//! one place dodot spawns anything user-authored: [`run`] uses it for
-//! the activation probe, and [`crate::shell::trace`] reuses it
-//! unchanged for the hook-line trace (RCS01 WS02) — one audited
-//! process-group kill, not two.
+//! shared full-spawn helper: [`crate::shell::trace`] uses it for the hook-line
+//! trace, while targeted verification uses the same process-group and pipe
+//! handling in [`spawn_until_targeted_marker`].
 //!
 //! # Verdicts
 //!
@@ -125,7 +125,8 @@ pub enum ProbePolicy {
     #[default]
     Never,
     /// Spawn the shell when [`gate_says_probe`] says the cheap signals
-    /// are inconclusive, giving it `timeout` to finish starting up.
+    /// are inconclusive, giving it `timeout` to reach the hook or return
+    /// legacy fallback evidence.
     Gated { timeout: Duration },
 }
 

--- a/tests/e2e/bats/test_shell_hookup.bats
+++ b/tests/e2e/bats/test_shell_hookup.bats
@@ -34,7 +34,10 @@ assert_no_verification_side_effects() {
     if [ -d "$profiles_dir" ]; then
         local count
         count=$(find "$profiles_dir" -name 'profile-*.tsv' -type f | wc -l | tr -d ' ')
-        [ "$count" = "0" ]
+        if [ "$count" != "0" ]; then
+            echo "expected 0 shell-init profiles, got $count" >&2
+            return 1
+        fi
     fi
 }
 

--- a/tests/e2e/bats/test_shell_hookup.bats
+++ b/tests/e2e/bats/test_shell_hookup.bats
@@ -27,6 +27,34 @@ teardown() {
     sandbox_teardown
 }
 
+assert_no_verification_side_effects() {
+    assert_not_exists "$XDG_DATA_HOME/dodot/probes/hookup/heartbeat"
+
+    local profiles_dir="$XDG_DATA_HOME/dodot/probes/shell-init"
+    if [ -d "$profiles_dir" ]; then
+        local count
+        count=$(find "$profiles_dir" -name 'profile-*.tsv' -type f | wc -l | tr -d ' ')
+        [ "$count" = "0" ]
+    fi
+}
+
+append_slow_post_hook_work() {
+    local rc="$1"
+    cat >> "$rc" <<'SH'
+touch "$HOME/post-hook-ran"
+sleep 7
+SH
+}
+
+prepend_slow_pre_hook_work() {
+    local rc="$1"
+    {
+        printf '%s\n' 'sleep 7'
+        cat "$rc"
+    } > "$rc.new"
+    mv "$rc.new" "$rc"
+}
+
 # ── The acceptance story (spec §7) ──────────────────────────────
 
 @test "acceptance: up warns, install --write verifies, a new shell activates" {
@@ -167,6 +195,78 @@ echo tool output'
     run dodot up
     assert_output_contains "Shell hookup: a new shell did not load dodot."
     assert_output_contains "never reached"
+}
+
+# ── Targeted verification after mutations (SIV01 WS02) ──────────
+
+@test "up verifies bash at the hook without running pack contributions or post-hook rc work" {
+    dodot install --write
+    append_slow_post_hook_work "$HOME/.bashrc"
+    create_pack_file "shell" "aliases.sh" 'touch "$HOME/pack-contribution-ran"
+sleep 7'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+    assert_output_contains "Shell hookup: dodot is sourced in new shells."
+
+    assert_not_exists "$HOME/post-hook-ran"
+    assert_not_exists "$HOME/pack-contribution-ran"
+    assert_no_verification_side_effects
+}
+
+@test "up verifies zsh at the hook without running post-hook rc work" {
+    if ! command -v zsh >/dev/null 2>&1; then
+        skip "zsh not installed on this host"
+    fi
+    export SHELL
+    SHELL="$(command -v zsh)"
+
+    dodot install --write
+    append_slow_post_hook_work "$HOME/.zshrc"
+    create_pack_file "shell" "aliases.sh" 'touch "$HOME/pack-contribution-ran"
+sleep 7'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+    assert_output_contains "Shell hookup: dodot is sourced in new shells."
+
+    assert_not_exists "$HOME/post-hook-ran"
+    assert_not_exists "$HOME/pack-contribution-ran"
+    assert_no_verification_side_effects
+}
+
+@test "install --write verifies the replaced bash block at the hook" {
+    create_pack_file "shell" "aliases.sh" 'touch "$HOME/pack-contribution-ran"
+sleep 7'
+    dodot up
+    cat > "$HOME/.bashrc" <<'SH'
+# >>> dodot shell hookup >>>
+[ -f "$HOME/old-dodot-init.sh" ] && . "$HOME/old-dodot-init.sh"
+# <<< dodot shell hookup <<<
+touch "$HOME/post-hook-ran"
+sleep 7
+SH
+
+    run dodot install --write
+    [ "$status" -eq 0 ]
+    assert_output_contains "replaced"
+    assert_output_contains "Shell hookup: dodot is sourced in new shells."
+
+    assert_not_exists "$HOME/post-hook-ran"
+    assert_not_exists "$HOME/pack-contribution-ran"
+    assert_no_verification_side_effects
+}
+
+@test "up reports a bash timeout when work before the capable hook never yields evidence" {
+    dodot install --write
+    prepend_slow_pre_hook_work "$HOME/.bashrc"
+    create_pack_file "shell" "aliases.sh" 'alias dodot_hookup_alias="echo activated"'
+
+    run dodot up
+    [ "$status" -eq 0 ]
+    assert_output_contains "Shell hookup: a new shell did not load dodot."
+    assert_output_contains "never reached"
+    assert_no_verification_side_effects
 }
 
 # ── The version-stamped footer (RCS01 WS01) ─────────────────────


### PR DESCRIPTION
for #329

## Context

This work adopts the existing shared targeted shell-init verifier at the mutation acceptance surface by pinning command-level coverage for the `dodot up` and `dodot install --write` paths. The production code on the branch already routes both mutation paths through `shell::probe::measure` / `run_targeted`; the implementation change here is to make that contract explicit in the shell-hookup e2e suite and refresh the verifier module docs so they describe time-to-hook verification rather than the older full-startup stamp probe.

I self-checked the diff against `docs/proposals/targeted-shell-init-verification.lex`, `docs/proposals/shipped/shell-hookup.lex`, and `docs/proposals/shell-hookup-ergonomics.lex`. The tests cover the SIV01 WS02 boundaries: `up` remains evidence-first in the existing Rust gate tests, mutation verification uses the shared targeted verifier semantics, post-hook rc work and pack contributions do not run, heartbeat/profile evidence is not written by verification, and a known-capable hook blocked by pre-hook work reports a bounded not-reached verdict.

Out of scope: no protocol redesign, no bare `probe shell-init` UI changes, no `--trace-hook` behavior, no incomplete-profile semantics, and no changes to passive `dodot install` / `status` behavior. Review should not re-open the WS01 verifier protocol decisions or move full hook tracing back into the mutation path.

## Verification

- `pixi run test`
- commit and push hooks: `pixi run lint`

Note: I also tried the focused Bats e2e harness (`app-bin/e2e test_shell_hookup.bats`), but the image fails before any test body because `/tests/helpers/setup` is absent; the same setup failure affects all pre-existing tests in that file. The required `pixi run test` suite is green.

## Current coordinator handoff

The authoritative engine verdict is `addressing` with the `no-major-finding` breaker active: resolve the two remaining minor/nit threads with fix-or-reply, sweep for the same class, verify, push once, and park. No new review round will be requested.

- For the assertion-diagnostics nit, improve it if the repository's existing Bats helpers support a clearer failure without widening scope.
- For the missing-helper claim, reconcile it against the current hosted `ci / e2e` success on head `8e4e8e4` and the repository's actual Docker/harness setup. Fix only if the claim is valid; otherwise reply with concrete evidence and resolve.
- Governing documents and WS02 boundaries remain those in Context above.
- Required verification remains `pixi run test`; the commit/push hooks run `pixi run lint`.
