### PR TITLE
SIV01-WS03: Epic: Targeted Shell-Init Verification - Workstream: Explicit non-mutating hook tracing

### DIFF
--- a/crates/dodot-lib/src/commands/probe/shell_init.rs
+++ b/crates/dodot-lib/src/commands/probe/shell_init.rs
@@ -392,11 +392,15 @@ const VERSION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 /// wrong file.
 ///
 /// The spawn is announced before it runs and rides the INS01 envelope
-/// via [`crate::shell::trace::run_trace`].
+/// via [`crate::shell::trace::run_trace`]. Eval-form hooks first take
+/// a report-only PATH record so dodot can identify the target without
+/// running it; only targets whose emitted init script advertises
+/// diagnostic trace support get a second run that continues through
+/// generated contributions.
 fn trace_view(ctx: &ExecutionContext) -> ShellInitTraceView {
     use crate::shell::activation;
     use crate::shell::rc;
-    use crate::shell::trace::{self, HookForm, SourcedScript, TraceError};
+    use crate::shell::trace::{self, HookForm, SourcedScript};
 
     let fs = ctx.fs.as_ref();
     let home = ctx.paths.home_dir();
@@ -451,11 +455,12 @@ fn trace_view(ctx: &ExecutionContext) -> ShellInitTraceView {
             shell_name,
             rc_display,
             hook_line,
+            None,
         );
     };
 
     eprintln!("{}", trace::announcement(shell));
-    let request = trace::TraceRequest {
+    let mut request = trace::TraceRequest {
         shell_path: std::path::Path::new(&shell_path),
         shell,
         home,
@@ -469,46 +474,45 @@ fn trace_view(ctx: &ExecutionContext) -> ShellInitTraceView {
         timeout,
         execution,
     };
-    let run = match trace::run_trace(fs, &request) {
-        Ok(run) => run,
-        Err(TraceError::TimedOut) => {
-            return untraced(
-                "your shell did not finish starting up in time".to_string(),
-                shell_name,
-                rc_display,
+    let trace_started = std::time::Instant::now();
+    let run = match &hook.form {
+        HookForm::Eval => {
+            request.execution = trace::TraceExecution::ReportOnly;
+            let path_run =
+                match run_trace_for_view(fs, &request, trace_started, &shell_name, &rc_display) {
+                    Ok(run) => run,
+                    Err(view) => return *view,
+                };
+            let diagnostic_supported = trace::record_at(
+                &path_run.records,
+                &[target.nominal(), &target.path],
                 hook_line,
             )
+            .is_some_and(|record| eval_target_supports_diagnostic_trace(fs, record));
+            if diagnostic_supported {
+                request.execution = trace::TraceExecution::DiagnosticSupported;
+                let mut run =
+                    match run_trace_for_view(fs, &request, trace_started, &shell_name, &rc_display)
+                    {
+                        Ok(run) => run,
+                        Err(view) => return *view,
+                    };
+                run.elapsed_us = elapsed_since(trace_started);
+                run
+            } else {
+                path_run
+            }
         }
-        Err(TraceError::SpawnFailed(e)) => {
-            return untraced(
-                format!("could not run your shell ({e})"),
-                shell_name,
-                rc_display,
-                hook_line,
-            )
-        }
-        Err(TraceError::RcUnreadable(e)) => {
-            return untraced(
-                format!("could not read {rc_display} ({e})"),
-                shell_name,
-                rc_display,
-                hook_line,
-            )
-        }
-        Err(TraceError::FallbackUnfaithful(e)) => {
-            return untraced(
-                format!("could not reproduce your shell's startup files ({e})"),
-                shell_name,
-                rc_display,
-                hook_line,
-            )
-        }
+        _ => match run_trace_for_view(fs, &request, trace_started, &shell_name, &rc_display) {
+            Ok(run) => run,
+            Err(view) => return *view,
+        },
     };
 
     let record = trace::record_at(&run.records, &[target.nominal(), &target.path], hook_line);
     let verdict = match record {
         None => trace::TraceVerdict::HookNeverRan,
-        Some(record) => match hook.form {
+        Some(record) => match &hook.form {
             HookForm::Eval => {
                 // The verdict is an identity comparison against the
                 // running binary. Without it there is no comparison to
@@ -520,6 +524,7 @@ fn trace_view(ctx: &ExecutionContext) -> ShellInitTraceView {
                         shell_name,
                         rc_display,
                         hook_line,
+                        Some(run.elapsed_us),
                     );
                 };
                 trace::judge_eval_hook(fs, record, &running_exe, &version_by_running)
@@ -531,14 +536,14 @@ fn trace_view(ctx: &ExecutionContext) -> ShellInitTraceView {
             // the script rather than assumed from its existence.
             HookForm::FileSource(SourcedScript::Path(script)) => trace::judge_file_source_hook(
                 fs,
-                script,
+                script.clone(),
                 // The generation `dodot up` last wrote: what a sound
                 // hook's script should be carrying.
                 activation::read_script_generation(fs, ctx.paths.as_ref()),
                 activation::running_version(),
             ),
             HookForm::FileSource(SourcedScript::Unresolved { raw }) => {
-                trace::TraceVerdict::ScriptUnresolved { raw }
+                trace::TraceVerdict::ScriptUnresolved { raw: raw.clone() }
             }
         },
     };
@@ -551,6 +556,48 @@ fn trace_view(ctx: &ExecutionContext) -> ShellInitTraceView {
         run.used_fallback,
         run.elapsed_us,
     )
+}
+
+fn run_trace_for_view(
+    fs: &dyn crate::fs::Fs,
+    request: &crate::shell::trace::TraceRequest<'_>,
+    trace_started: std::time::Instant,
+    shell: &str,
+    rc: &str,
+) -> std::result::Result<crate::shell::trace::TraceRun, Box<ShellInitTraceView>> {
+    use crate::shell::trace::{self, TraceError};
+
+    match trace::run_trace(fs, request) {
+        Ok(run) => Ok(run),
+        Err(TraceError::TimedOut) => Err(Box::new(untraced(
+            "your shell did not finish starting up in time".to_string(),
+            shell.to_string(),
+            rc.to_string(),
+            request.hook_line,
+            Some(elapsed_since(trace_started)),
+        ))),
+        Err(TraceError::SpawnFailed(e)) => Err(Box::new(untraced(
+            format!("could not run your shell ({e})"),
+            shell.to_string(),
+            rc.to_string(),
+            request.hook_line,
+            Some(elapsed_since(trace_started)),
+        ))),
+        Err(TraceError::RcUnreadable(e)) => Err(Box::new(untraced(
+            format!("could not read {rc} ({e})"),
+            shell.to_string(),
+            rc.to_string(),
+            request.hook_line,
+            Some(elapsed_since(trace_started)),
+        ))),
+        Err(TraceError::FallbackUnfaithful(e)) => Err(Box::new(untraced(
+            format!("could not reproduce your shell's startup files ({e})"),
+            shell.to_string(),
+            rc.to_string(),
+            request.hook_line,
+            Some(elapsed_since(trace_started)),
+        ))),
+    }
 }
 
 /// A trace view for "nothing to trace": stated plainly, nothing
@@ -566,14 +613,21 @@ fn skipped_trace(reason: String, shell: String, rc: String) -> ShellInitTraceVie
         headline: reason,
         detail_lines: Vec::new(),
         elapsed_us: 0,
-        elapsed_label: humanize_us(0),
+        elapsed_label: String::new(),
         used_fallback: false,
     }
 }
 
 /// A trace view for "wanted to trace but could not": the recorded
 /// half stands alone, labeled honestly.
-fn untraced(reason: String, shell: String, rc: String, hook_line: usize) -> ShellInitTraceView {
+fn untraced(
+    reason: String,
+    shell: String,
+    rc: String,
+    hook_line: usize,
+    elapsed_us: Option<u64>,
+) -> ShellInitTraceView {
+    let elapsed_us = elapsed_us.unwrap_or(0);
     ShellInitTraceView {
         status: "untraced".into(),
         status_class: "warning",
@@ -583,8 +637,12 @@ fn untraced(reason: String, shell: String, rc: String, hook_line: usize) -> Shel
         verdict: String::new(),
         headline: format!("could not trace — {reason}"),
         detail_lines: Vec::new(),
-        elapsed_us: 0,
-        elapsed_label: humanize_us(0),
+        elapsed_us,
+        elapsed_label: if elapsed_us == 0 {
+            String::new()
+        } else {
+            humanize_us(elapsed_us)
+        },
         used_fallback: false,
     }
 }
@@ -816,6 +874,38 @@ fn trace_execution_for_hook(
         }
         _ => TraceExecution::ReportOnly,
     }
+}
+
+fn eval_target_supports_diagnostic_trace(
+    fs: &dyn crate::fs::Fs,
+    record: &crate::shell::trace::TraceRecord,
+) -> bool {
+    let resolution = crate::shell::trace::resolve_on_path(
+        fs,
+        &record.path,
+        std::path::Path::new(&record.cwd),
+        "dodot",
+    );
+    let Some(winner) = resolution.winner else {
+        return false;
+    };
+    init_script_by_running(&winner)
+        .as_deref()
+        .is_some_and(crate::shell::script_supports_diagnostic_trace)
+}
+
+fn init_script_by_running(binary: &std::path::Path) -> Option<String> {
+    use crate::shell::probe::{spawn_captured, SpawnOutcome};
+    let mut command = std::process::Command::new(binary);
+    command.arg("init-sh");
+    match spawn_captured(command, VERSION_TIMEOUT) {
+        SpawnOutcome::Finished(capture) if capture.status == Some(0) => Some(capture.stdout),
+        _ => None,
+    }
+}
+
+fn elapsed_since(started: std::time::Instant) -> u64 {
+    started.elapsed().as_micros().try_into().unwrap_or(u64::MAX)
 }
 
 fn shell_init_groups(grouped: &GroupedProfile) -> Vec<ShellInitGroup> {

--- a/crates/dodot-lib/src/commands/probe/shell_init.rs
+++ b/crates/dodot-lib/src/commands/probe/shell_init.rs
@@ -500,6 +500,8 @@ fn trace_view(ctx: &ExecutionContext) -> ShellInitTraceView {
                 run.elapsed_us = elapsed_since(trace_started);
                 run
             } else {
+                let mut path_run = path_run;
+                path_run.elapsed_us = elapsed_since(trace_started);
                 path_run
             }
         }

--- a/crates/dodot-lib/src/commands/probe/shell_init.rs
+++ b/crates/dodot-lib/src/commands/probe/shell_init.rs
@@ -441,6 +441,7 @@ fn trace_view(ctx: &ExecutionContext) -> ShellInitTraceView {
         );
     };
     let hook_line = hook.line;
+    let execution = trace_execution_for_hook(fs, &hook.form);
 
     // Only a context that may measure gets to spawn; every
     // non-production context leaves the policy at `Never`.
@@ -466,6 +467,7 @@ fn trace_view(ctx: &ExecutionContext) -> ShellInitTraceView {
         rc_resolved: &target.path,
         hook_line,
         timeout,
+        execution,
     };
     let run = match trace::run_trace(fs, &request) {
         Ok(run) => run,
@@ -547,6 +549,7 @@ fn trace_view(ctx: &ExecutionContext) -> ShellInitTraceView {
         rc_display,
         hook_line,
         run.used_fallback,
+        run.elapsed_us,
     )
 }
 
@@ -562,6 +565,8 @@ fn skipped_trace(reason: String, shell: String, rc: String) -> ShellInitTraceVie
         verdict: String::new(),
         headline: reason,
         detail_lines: Vec::new(),
+        elapsed_us: 0,
+        elapsed_label: humanize_us(0),
         used_fallback: false,
     }
 }
@@ -578,6 +583,8 @@ fn untraced(reason: String, shell: String, rc: String, hook_line: usize) -> Shel
         verdict: String::new(),
         headline: format!("could not trace — {reason}"),
         detail_lines: Vec::new(),
+        elapsed_us: 0,
+        elapsed_label: humanize_us(0),
         used_fallback: false,
     }
 }
@@ -607,6 +614,7 @@ fn verdict_trace_view(
     rc: String,
     hook_line: usize,
     used_fallback: bool,
+    elapsed_us: u64,
 ) -> ShellInitTraceView {
     use crate::shell::activation::running_version;
     use crate::shell::rc::display_home_relative;
@@ -786,7 +794,27 @@ fn verdict_trace_view(
         verdict: tag.into(),
         headline,
         detail_lines,
+        elapsed_us,
+        elapsed_label: humanize_us(elapsed_us),
         used_fallback,
+    }
+}
+
+fn trace_execution_for_hook(
+    fs: &dyn crate::fs::Fs,
+    hook: &crate::shell::trace::HookForm,
+) -> crate::shell::trace::TraceExecution {
+    use crate::shell::trace::{HookForm, SourcedScript, TraceExecution};
+
+    match hook {
+        HookForm::FileSource(SourcedScript::Path(script))
+            if fs
+                .read_to_string(script)
+                .is_ok_and(|text| crate::shell::script_supports_diagnostic_trace(&text)) =>
+        {
+            TraceExecution::DiagnosticSupported
+        }
+        _ => TraceExecution::ReportOnly,
     }
 }
 

--- a/crates/dodot-lib/src/commands/probe/types.rs
+++ b/crates/dodot-lib/src/commands/probe/types.rs
@@ -311,9 +311,13 @@ pub struct ShellInitTraceView {
     /// paths and versions compared, the next command to run.
     pub detail_lines: Vec<String>,
     /// Numeric elapsed wall-clock microseconds for the diagnostic
-    /// trace attempt, including a fallback attempt when one was needed.
+    /// trace attempt, including capability negotiation and a fallback
+    /// attempt when one was needed. `0` means no shell process was
+    /// attempted.
     pub elapsed_us: u64,
-    /// Human-readable elapsed duration for terminal output.
+    /// Human-readable elapsed duration for terminal output. Empty
+    /// when no shell process was attempted, so the terminal renderer
+    /// omits the elapsed line instead of reporting a fake duration.
     pub elapsed_label: String,
     /// True when the answer came from the fallback copy (temporary
     /// `ZDOTDIR` / `--rcfile`) rather than the primary xtrace run.

--- a/crates/dodot-lib/src/commands/probe/types.rs
+++ b/crates/dodot-lib/src/commands/probe/types.rs
@@ -310,6 +310,11 @@ pub struct ShellInitTraceView {
     /// Supporting lines: candidate binaries passed over and why, the
     /// paths and versions compared, the next command to run.
     pub detail_lines: Vec<String>,
+    /// Numeric elapsed wall-clock microseconds for the diagnostic
+    /// trace attempt, including a fallback attempt when one was needed.
+    pub elapsed_us: u64,
+    /// Human-readable elapsed duration for terminal output.
+    pub elapsed_label: String,
     /// True when the answer came from the fallback copy (temporary
     /// `ZDOTDIR` / `--rcfile`) rather than the primary xtrace run.
     pub used_fallback: bool,

--- a/crates/dodot-lib/src/commands/tests/probe.rs
+++ b/crates/dodot-lib/src/commands/tests/probe.rs
@@ -1537,6 +1537,64 @@ fi
 }
 
 #[test]
+fn probe_shell_init_trace_elapsed_includes_legacy_eval_capability_negotiation() {
+    if !std::path::Path::new("/bin/bash").exists() {
+        return;
+    }
+    let env = TempEnvironment::builder().build();
+    let _home = crate::testing::EnvVarGuard::set("HOME", &env.home.display().to_string());
+
+    let bin_dir = env.home.join("bin");
+    env.fs.mkdir_all(&bin_dir).unwrap();
+    env.fs
+        .write_file_with_mode(
+            &bin_dir.join("dodot"),
+            br#"#!/bin/sh
+if [ "$1" = "init-sh" ]; then
+  sleep 1
+  cat <<'SCRIPT'
+echo legacy-evidence > "$HOME/legacy-evidence"
+SCRIPT
+elif [ "$1" = "--version" ]; then
+  echo "dodot 5.0.0"
+fi
+"#,
+            0o755,
+        )
+        .unwrap();
+
+    env.fs
+        .write_file(
+            &env.home.join(".bashrc"),
+            format!(
+                "export PATH={}:$PATH\neval \"$(dodot init-sh)\"\n",
+                bin_dir.display()
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+
+    let ctx = make_tracing_ctx(&env, "/bin/bash");
+    let result = commands::probe::shell_init_trace(&ctx).unwrap();
+    let json = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(parsed["trace"]["status"], "verdict");
+    assert!(
+        parsed["trace"]["used_fallback"].as_bool().unwrap(),
+        "legacy eval hooks must stay report-only"
+    );
+    assert!(
+        !env.fs.exists(&env.home.join("legacy-evidence")),
+        "report-only legacy eval trace must not execute the hook"
+    );
+    assert!(
+        parsed["trace"]["elapsed_us"].as_u64().unwrap() >= 900_000,
+        "trace elapsed time must include legacy eval capability negotiation"
+    );
+}
+
+#[test]
 fn probe_shell_init_trace_reports_a_hook_the_shell_never_reaches() {
     // The fourth verdict: the hook is in the file but inside a branch
     // that does not run — a static scan calls this fine; only the

--- a/crates/dodot-lib/src/commands/tests/probe.rs
+++ b/crates/dodot-lib/src/commands/tests/probe.rs
@@ -1470,6 +1470,73 @@ fn probe_shell_init_trace_end_to_end_names_the_stale_binary_and_the_skips() {
 }
 
 #[test]
+fn probe_shell_init_trace_runs_diagnostic_capable_eval_contributions() {
+    if !std::path::Path::new("/bin/bash").exists() {
+        return;
+    }
+    let env = TempEnvironment::builder().build();
+    let _home = crate::testing::EnvVarGuard::set("HOME", &env.home.display().to_string());
+
+    let bin_dir = env.home.join("bin");
+    env.fs.mkdir_all(&bin_dir).unwrap();
+    env.fs
+        .write_file_with_mode(
+            &bin_dir.join("dodot"),
+            br#"#!/bin/sh
+if [ "$1" = "init-sh" ]; then
+cat <<'SCRIPT'
+# dodot shell-init-trace v1
+_dodot_trace=0
+if [ -n "${DODOT_INTERNAL_SHELL_INIT_TRACE-}" ]; then
+  unset DODOT_INTERNAL_SHELL_INIT_TRACE
+  _dodot_trace=1
+fi
+if [ "${_dodot_trace:-0}" != "1" ]; then
+  echo mutated > "$HOME/eval-evidence"
+fi
+echo contribution > "$HOME/eval-contribution"
+unset _dodot_trace
+SCRIPT
+elif [ "$1" = "--version" ]; then
+  echo "dodot 5.6.0"
+fi
+"#,
+            0o755,
+        )
+        .unwrap();
+
+    env.fs
+        .write_file(
+            &env.home.join(".bashrc"),
+            format!(
+                "export PATH={}:$PATH\neval \"$(dodot init-sh)\"\n",
+                bin_dir.display()
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+
+    let ctx = make_tracing_ctx(&env, "/bin/bash");
+    let result = commands::probe::shell_init_trace(&ctx).unwrap();
+    let json = render::render("probe", &result, OutputMode::Json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(parsed["trace"]["status"], "verdict");
+    assert!(
+        env.fs.exists(&env.home.join("eval-contribution")),
+        "diagnostic-capable eval hook should continue through generated contributions"
+    );
+    assert!(
+        !env.fs.exists(&env.home.join("eval-evidence")),
+        "diagnostic-capable eval hook must not write activation evidence"
+    );
+    assert!(
+        parsed["trace"]["elapsed_us"].as_u64().unwrap() > 0,
+        "trace elapsed time must include the capability negotiation"
+    );
+}
+
+#[test]
 fn probe_shell_init_trace_reports_a_hook_the_shell_never_reaches() {
     // The fourth verdict: the hook is in the file but inside a branch
     // that does not run — a static scan calls this fine; only the

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -206,7 +206,9 @@ fn append_empty_notice(script: &mut String) {
 ///
 /// When `profiling_enabled` is true and there is at least one entry to
 /// emit, the script also carries the per-line timing wrapper described
-/// in the module docs.
+/// in the module docs. Every generated completion path clears the
+/// temporary `_dodot_trace` shell variable before returning control to
+/// the user's interactive shell.
 pub fn generate_init_script(
     fs: &dyn Fs,
     paths: &dyn Pather,
@@ -232,6 +234,7 @@ pub fn generate_init_script(
     let packs_dir = paths.data_dir().join("packs");
     if !fs.exists(&packs_dir) {
         append_empty_notice(&mut script);
+        emit_trace_mode_cleanup(&mut script);
         return Ok(script);
     }
 
@@ -285,6 +288,7 @@ pub fn generate_init_script(
 
     if path_additions.is_empty() && shell_sources.is_empty() {
         append_empty_notice(&mut script);
+        emit_trace_mode_cleanup(&mut script);
         return Ok(script);
     }
 
@@ -338,6 +342,7 @@ pub fn generate_init_script(
     if profiling_active {
         emit_profiling_epilogue(&mut script);
     }
+    emit_trace_mode_cleanup(&mut script);
 
     Ok(script)
 }
@@ -457,6 +462,10 @@ fn emit_trace_mode_preamble(script: &mut String) {
     writeln!(script, "  _dodot_trace=1").unwrap();
     writeln!(script, "fi").unwrap();
     writeln!(script).unwrap();
+}
+
+fn emit_trace_mode_cleanup(script: &mut String) {
+    writeln!(script, "unset _dodot_trace 2>/dev/null").unwrap();
 }
 
 fn emit_activation_evidence(script: &mut String, generation: u64, heartbeat_path: &Path) {
@@ -1200,6 +1209,69 @@ mod tests {
             "diagnostic trace mode must be known before evidence/profile writes but keep contributions:\n{script}"
         );
         assert!(script_supports_diagnostic_trace(&script));
+    }
+
+    #[test]
+    fn generated_scripts_do_not_leave_trace_state_in_the_shell() {
+        let bash = std::path::Path::new("/bin/bash");
+        if !bash.exists() {
+            return;
+        }
+
+        let empty_env = TempEnvironment::builder().build();
+        let empty_script = generate_init_script(
+            empty_env.fs.as_ref(),
+            empty_env.paths.as_ref(),
+            false,
+            TEST_GEN,
+            None,
+        )
+        .unwrap();
+        assert_trace_state_is_cleaned(bash, &empty_env, &empty_script, "empty");
+
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("bin/tool", "#!/bin/sh\n")
+            .done()
+            .build();
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "path", &env.dotfiles_root.join("vim/bin"))
+            .unwrap();
+
+        for (label, profiling) in [("plain", false), ("profiled", true)] {
+            let script = generate_init_script(
+                env.fs.as_ref(),
+                env.paths.as_ref(),
+                profiling,
+                TEST_GEN,
+                None,
+            )
+            .unwrap();
+            assert_trace_state_is_cleaned(bash, &env, &script, label);
+        }
+    }
+
+    fn assert_trace_state_is_cleaned(
+        bash: &std::path::Path,
+        env: &TempEnvironment,
+        script: &str,
+        label: &str,
+    ) {
+        let script_path = env.home.join(format!("{label}-dodot-init.sh"));
+        env.fs.mkdir_all(&env.paths.probes_hookup_dir()).unwrap();
+        env.fs.write_file(&script_path, script.as_bytes()).unwrap();
+        let status = std::process::Command::new(bash)
+            .arg("-c")
+            .arg(format!(
+                ". {}; test -z \"${{_dodot_trace+x}}\"",
+                sh_quote(&script_path.display().to_string())
+            ))
+            .status()
+            .expect("bash runs");
+        assert!(
+            status.success(),
+            "{label}: generated script left _dodot_trace in scope:\n{script}"
+        );
     }
 
     #[test]

--- a/crates/dodot-lib/src/shell/mod.rs
+++ b/crates/dodot-lib/src/shell/mod.rs
@@ -29,6 +29,15 @@
 //! carry the challenge variables and continue into activation evidence
 //! unchanged.
 //!
+//! # Hook tracing
+//!
+//! Current init scripts also recognize the internal diagnostic mode
+//! used by `dodot probe shell-init --trace-hook`. In that mode they
+//! suppress activation evidence and profiling writes, then continue
+//! through Homebrew, PATH setup, and pack contributions so the trace
+//! can diagnose the same startup work without manufacturing heartbeat
+//! or profile evidence.
+//!
 //! # Activation evidence (shell-hookup-ergonomics.lex §2.1)
 //!
 //! Every generated script — profiled or not, empty datastore or not —
@@ -75,8 +84,9 @@
 //! check (`bash 5+` / `zsh` with `EPOCHREALTIME` available); shells
 //! without the variable fall through to the unchanged source/PATH
 //! path with a single `[ "$_dodot_prof" = "1" ]` test of overhead.
-//! When `profiling_enabled = false`, the generated script is
-//! byte-identical to the unwrapped form.
+//! When `profiling_enabled = false`, the profile writer is omitted;
+//! the verification and diagnostic branches still remain at the top
+//! because they serve separate command paths.
 //!
 //! Sources are *not* wrapped in a shell function: in zsh, `source`
 //! inside a function changes scoping for plain variable assignments
@@ -135,6 +145,15 @@ pub fn script_supports_targeted_probe(script: &str) -> bool {
     script
         .lines()
         .any(|line| line.trim() == "# dodot shell-init-probe v1")
+}
+
+/// Whether a generated script can suppress activation evidence and
+/// shell-init profile writes while a hook trace runs through the rest
+/// of the init body.
+pub fn script_supports_diagnostic_trace(script: &str) -> bool {
+    script
+        .lines()
+        .any(|line| line.trim() == "# dodot shell-init-trace v1")
 }
 
 /// Generate the guarded challenge response fragment used by current
@@ -203,6 +222,7 @@ pub fn generate_init_script(
     writeln!(script).unwrap();
 
     emit_init_probe_response(&mut script, generation);
+    emit_trace_mode_preamble(&mut script);
     emit_activation_evidence(&mut script, generation, &paths.hookup_heartbeat_path());
 
     if let Some(blocks) = homebrew {
@@ -424,17 +444,39 @@ fn emit_init_probe_response(script: &mut String, generation: u64) {
 ///
 /// Still two exports and one redirect: no command execution, no `dodot`
 /// invocation on the shell startup path.
+fn emit_trace_mode_preamble(script: &mut String) {
+    writeln!(script, "# dodot shell-init-trace v1").unwrap();
+    writeln!(script, "_dodot_trace=0").unwrap();
+    writeln!(
+        script,
+        "if [ -n \"${{{}-}}\" ]; then",
+        trace::DIAGNOSTIC_TRACE_ENV
+    )
+    .unwrap();
+    writeln!(script, "  unset {}", trace::DIAGNOSTIC_TRACE_ENV).unwrap();
+    writeln!(script, "  _dodot_trace=1").unwrap();
+    writeln!(script, "fi").unwrap();
+    writeln!(script).unwrap();
+}
+
 fn emit_activation_evidence(script: &mut String, generation: u64, heartbeat_path: &Path) {
     let heartbeat = sh_quote(&heartbeat_path.display().to_string());
     let version = activation::running_version();
+    writeln!(script, "if [ \"${{_dodot_trace:-0}}\" != \"1\" ]; then").unwrap();
     writeln!(script, "# ── dodot activation evidence ──").unwrap();
-    writeln!(script, "export {}={generation}", activation::INIT_GEN_ENV).unwrap();
-    writeln!(script, "export {}={version}", activation::INIT_VERSION_ENV).unwrap();
+    writeln!(script, "  export {}={generation}", activation::INIT_GEN_ENV).unwrap();
     writeln!(
         script,
-        "echo {generation} {version} >| {heartbeat} 2>/dev/null || :"
+        "  export {}={version}",
+        activation::INIT_VERSION_ENV
     )
     .unwrap();
+    writeln!(
+        script,
+        "  echo {generation} {version} >| {heartbeat} 2>/dev/null || :"
+    )
+    .unwrap();
+    writeln!(script, "fi").unwrap();
     writeln!(script).unwrap();
 }
 
@@ -450,9 +492,10 @@ fn emit_profiling_preamble(script: &mut String, profiles_dir: &Path, init_script
     let init_script = sh_quote(&init_script_path.display().to_string());
     writeln!(script, "# ── dodot shell-init profiling (Phase 2) ──").unwrap();
     writeln!(script, "_dodot_prof=0").unwrap();
+    writeln!(script, "if [ \"${{_dodot_trace:-0}}\" != \"1\" ]; then").unwrap();
     writeln!(
         script,
-        "if [ -n \"${{BASH_VERSION:-}}\" ] || [ -n \"${{ZSH_VERSION:-}}\" ]; then"
+        "  if [ -n \"${{BASH_VERSION:-}}\" ] || [ -n \"${{ZSH_VERSION:-}}\" ]; then"
     )
     .unwrap();
     // zsh exposes EPOCHREALTIME only after `zmodload zsh/datetime`. Load
@@ -462,14 +505,14 @@ fn emit_profiling_preamble(script: &mut String, profiles_dir: &Path, init_script
     // hot paths in plain sh.
     writeln!(
         script,
-        "  [ -n \"${{ZSH_VERSION:-}}\" ] && zmodload zsh/datetime 2>/dev/null"
+        "    [ -n \"${{ZSH_VERSION:-}}\" ] && zmodload zsh/datetime 2>/dev/null"
     )
     .unwrap();
-    writeln!(script, "  if [ -n \"${{EPOCHREALTIME:-}}\" ]; then").unwrap();
-    writeln!(script, "    _dodot_prof_dir={dir}").unwrap();
+    writeln!(script, "    if [ -n \"${{EPOCHREALTIME:-}}\" ]; then").unwrap();
+    writeln!(script, "      _dodot_prof_dir={dir}").unwrap();
     writeln!(
         script,
-        "    _dodot_prof_file=\"$_dodot_prof_dir/profile-${{EPOCHSECONDS:-0}}-$$-${{RANDOM}}.tsv\""
+        "      _dodot_prof_file=\"$_dodot_prof_dir/profile-${{EPOCHSECONDS:-0}}-$$-${{RANDOM}}.tsv\""
     )
     .unwrap();
     // Sibling errors log: one record per source whose stderr was non-empty.
@@ -479,43 +522,51 @@ fn emit_profiling_preamble(script: &mut String, profiles_dir: &Path, init_script
     // and parsed by `probe::shell_init::parse_errors_log`.
     writeln!(
         script,
-        "    _dodot_err_file=\"${{_dodot_prof_file%.tsv}}.errors.log\""
+        "      _dodot_err_file=\"${{_dodot_prof_file%.tsv}}.errors.log\""
     )
     .unwrap();
     // Per-shell scratch file for capturing each source's stderr. Reused
     // across every source in this shell startup; truncated each time.
-    writeln!(script, "    _dodot_err_tmp=\"$_dodot_prof_dir/.errtmp-$$\"").unwrap();
     writeln!(
         script,
-        "    if mkdir -p \"$_dodot_prof_dir\" 2>/dev/null; then"
-    )
-    .unwrap();
-    writeln!(script, "      _dodot_prof_t0=$EPOCHREALTIME").unwrap();
-    writeln!(script, "      {{").unwrap();
-    writeln!(script, "        printf '# dodot shell-init profile v1\\n'").unwrap();
-    writeln!(
-        script,
-        "        printf '# shell\\t%s\\n' \"${{BASH_VERSION:+bash $BASH_VERSION}}${{ZSH_VERSION:+zsh $ZSH_VERSION}}\""
+        "      _dodot_err_tmp=\"$_dodot_prof_dir/.errtmp-$$\""
     )
     .unwrap();
     writeln!(
         script,
-        "        printf '# start_t\\t%s\\n' \"$_dodot_prof_t0\""
+        "      if mkdir -p \"$_dodot_prof_dir\" 2>/dev/null; then"
+    )
+    .unwrap();
+    writeln!(script, "        _dodot_prof_t0=$EPOCHREALTIME").unwrap();
+    writeln!(script, "        {{").unwrap();
+    writeln!(
+        script,
+        "          printf '# dodot shell-init profile v1\\n'"
     )
     .unwrap();
     writeln!(
         script,
-        "        printf '# init_script\\t%s\\n' {init_script}"
+        "          printf '# shell\\t%s\\n' \"${{BASH_VERSION:+bash $BASH_VERSION}}${{ZSH_VERSION:+zsh $ZSH_VERSION}}\""
     )
     .unwrap();
     writeln!(
         script,
-        "        printf '# columns\\tphase\\tpack\\thandler\\ttarget\\tstart_t\\tend_t\\texit_status\\n'"
+        "          printf '# start_t\\t%s\\n' \"$_dodot_prof_t0\""
     )
     .unwrap();
     writeln!(
         script,
-        "      }} > \"$_dodot_prof_file\" 2>/dev/null && _dodot_prof=1"
+        "          printf '# init_script\\t%s\\n' {init_script}"
+    )
+    .unwrap();
+    writeln!(
+        script,
+        "          printf '# columns\\tphase\\tpack\\thandler\\ttarget\\tstart_t\\tend_t\\texit_status\\n'"
+    )
+    .unwrap();
+    writeln!(
+        script,
+        "        }} > \"$_dodot_prof_file\" 2>/dev/null && _dodot_prof=1"
     )
     .unwrap();
     // Errors log is created lazily — see `emit_timed_source`. Most shell
@@ -523,6 +574,7 @@ fn emit_profiling_preamble(script: &mut String, profiles_dir: &Path, init_script
     // header file for each one would defeat the "fast path is free"
     // claim. The first source that actually emits stderr seeds the
     // header before appending its record.
+    writeln!(script, "      fi").unwrap();
     writeln!(script, "    fi").unwrap();
     writeln!(script, "  fi").unwrap();
     writeln!(script, "fi").unwrap();
@@ -1124,6 +1176,33 @@ mod tests {
     }
 
     #[test]
+    fn diagnostic_trace_mode_precedes_and_guards_mutating_evidence() {
+        let env = TempEnvironment::builder()
+            .pack("vim")
+            .file("aliases.sh", "alias vi=vim")
+            .done()
+            .build();
+        let ds = make_datastore(&env);
+        ds.create_data_link("vim", "shell", &env.dotfiles_root.join("vim/aliases.sh"))
+            .unwrap();
+
+        let script =
+            generate_init_script(env.fs.as_ref(), env.paths.as_ref(), true, TEST_GEN, None)
+                .unwrap();
+
+        let trace = script.find("# dodot shell-init-trace v1").unwrap();
+        let evidence_guard = script
+            .find("if [ \"${_dodot_trace:-0}\" != \"1\" ]; then")
+            .unwrap();
+        let path_or_shell = script.find("# Shell scripts").unwrap();
+        assert!(
+            trace < evidence_guard && evidence_guard < path_or_shell,
+            "diagnostic trace mode must be known before evidence/profile writes but keep contributions:\n{script}"
+        );
+        assert!(script_supports_diagnostic_trace(&script));
+    }
+
+    #[test]
     fn eval_probe_response_contains_no_ordinary_init_body() {
         let script = generate_init_probe_response(TEST_GEN);
 
@@ -1138,10 +1217,10 @@ mod tests {
     // ── Phase 2: profiling wrapper ──────────────────────────────────
 
     #[test]
-    fn profiling_disabled_matches_phase1_byte_for_byte() {
-        // The contract: when profiling is off, the script must be the
-        // exact same bytes a Phase-1 generator would have produced. This
-        // protects users who don't want any change to their init script.
+    fn profiling_disabled_omits_the_profile_wrapper() {
+        // The contract: when profiling is off, the profile writer is
+        // absent. Other top-of-file protocol branches may still be
+        // present because they serve verification and tracing.
         let env = TempEnvironment::builder()
             .pack("vim")
             .file("aliases.sh", "alias vi=vim")
@@ -1496,9 +1575,13 @@ mod tests {
             .filter(|l| l.contains("DODOT_INIT") || l.contains("heartbeat"))
             .collect();
         assert_eq!(evidence.len(), 3, "evidence block: {evidence:?}");
-        assert!(evidence[0].starts_with("export DODOT_INIT_GEN="));
-        assert!(evidence[1].starts_with("export DODOT_INIT_VERSION="));
-        assert!(evidence[2].starts_with("echo "));
+        assert!(evidence[0]
+            .trim_start()
+            .starts_with("export DODOT_INIT_GEN="));
+        assert!(evidence[1]
+            .trim_start()
+            .starts_with("export DODOT_INIT_VERSION="));
+        assert!(evidence[2].trim_start().starts_with("echo "));
         for forbidden in ["mkdir", "dodot ", "date", "$(", "`"] {
             assert!(
                 !evidence.iter().any(|l| l.contains(forbidden)),

--- a/crates/dodot-lib/src/shell/probe.rs
+++ b/crates/dodot-lib/src/shell/probe.rs
@@ -107,7 +107,28 @@ const POLL_INTERVAL: Duration = Duration::from_millis(20);
 const POST_EXIT_DRAIN: Duration = Duration::from_millis(200);
 
 /// Descriptor inherited by a report-only hold from the Rust parent.
-pub(crate) const PARENT_LIVENESS_FD: RawFd = 3;
+/// Kept above the range rc files conventionally use for saved streams.
+pub(crate) const PARENT_LIVENESS_FD: RawFd = 63;
+
+/// Put a probed shell in its own session and process group.
+///
+/// Besides making whole-group timeout termination possible, dropping the
+/// controlling terminal prevents an explicitly interactive shell from
+/// stopping itself with `SIGTTIN` or `SIGTTOU` when dodot runs under a PTY.
+pub(crate) fn configure_probe_session(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    // SAFETY: `setsid` is an async-signal-safe syscall and touches no Rust
+    // state between fork and exec. A failure is returned by `spawn`.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
 
 /// A close-on-exec socket pair whose child end is installed at the
 /// stable descriptor consumed by the report-only hold.
@@ -128,13 +149,6 @@ impl ParentLiveness {
         // alive in `Self` until `Command::spawn` returns.
         unsafe {
             command.pre_exec(move || {
-                // A session leader is also its own process-group leader,
-                // while having no controlling terminal. That prevents an
-                // explicitly interactive zsh from stopping itself when the
-                // caller happens to run under a PTY.
-                if libc::setsid() == -1 {
-                    return Err(std::io::Error::last_os_error());
-                }
                 libc::close(parent_fd);
                 if libc::dup2(child_fd, PARENT_LIVENESS_FD) == -1 {
                     return Err(std::io::Error::last_os_error());
@@ -391,13 +405,7 @@ pub fn spawn_captured(mut command: Command, timeout: Duration) -> SpawnOutcome {
     for key in scrubbed_keys(std::env::vars().map(|(k, _)| k)) {
         command.env_remove(key);
     }
-    // Its own process group, so a timeout can take out everything the
-    // rc file spawned, not just the shell we can see.
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
-    }
+    configure_probe_session(&mut command);
 
     let mut child = match command.spawn() {
         Ok(c) => c,
@@ -465,6 +473,7 @@ pub fn spawn_captured_until_stderr(
     for key in scrubbed_keys(std::env::vars().map(|(k, _)| k)) {
         command.env_remove(key);
     }
+    configure_probe_session(&mut command);
     let liveness = match ParentLiveness::attach(&mut command) {
         Ok(liveness) => liveness,
         Err(e) => return SpawnOutcome::SpawnFailed(format!("{e}")),
@@ -639,11 +648,7 @@ fn spawn_until_targeted_marker(
     for key in scrubbed_keys(std::env::vars().map(|(k, _)| k)) {
         command.env_remove(key);
     }
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
-    }
+    configure_probe_session(&mut command);
 
     let mut child = match command.spawn() {
         Ok(c) => c,
@@ -1446,6 +1451,174 @@ mod tests {
         assert!(
             profile_entries.is_empty(),
             "targeted verification must not create startup profiles: {profile_entries:?}"
+        );
+    }
+
+    const PTY_DRIVER_ENV: &str = "DODOT_TEST_PROBE_PTY_DRIVER";
+
+    #[test]
+    fn primary_trace_spawn_finishes_under_a_pty() {
+        if std::env::var(PTY_DRIVER_ENV).as_deref() == Ok("primary") {
+            let shell = Path::new("/bin/zsh");
+            if !shell.exists() {
+                return;
+            }
+            let mut command = Command::new(shell);
+            command.args(["-ic", "printf 'primary-pty-ok\\n'"]);
+            let outcome = spawn_captured(command, Duration::from_secs(2));
+            assert!(
+                matches!(
+                    outcome,
+                    SpawnOutcome::Finished(SpawnCapture { ref stdout, .. })
+                        if stdout.contains("primary-pty-ok")
+                ),
+                "primary trace spawn did not finish under a PTY: {outcome:?}"
+            );
+            eprintln!("pty-driver-primary-complete");
+            return;
+        }
+
+        run_current_test_under_pty(
+            "shell::probe::tests::primary_trace_spawn_finishes_under_a_pty",
+            "primary",
+        );
+    }
+
+    #[test]
+    fn targeted_marker_spawn_finishes_under_a_pty() {
+        if std::env::var(PTY_DRIVER_ENV).as_deref() == Ok("targeted") {
+            let shell = Path::new("/bin/zsh");
+            if !shell.exists() {
+                return;
+            }
+            let nonce = "pty-nonce";
+            let verifier_pid = std::process::id();
+            let mut command = Command::new(shell);
+            command.args([
+                "-ic",
+                &format!(
+                    "printf '{TARGET_PROBE_MARKER}{nonce}|{verifier_pid}|%s|42|5.7.0\\n' \
+                     \"$$\"; sleep 5"
+                ),
+            ]);
+
+            let outcome =
+                spawn_until_targeted_marker(command, Duration::from_secs(2), nonce, verifier_pid);
+            assert!(
+                matches!(
+                    outcome,
+                    TargetedSpawnOutcome::TargetedStamp(ProbeStamp {
+                        generation: 42,
+                        version: EvidenceVersion::Known(ref version),
+                    }) if version == "5.7.0"
+                ),
+                "targeted marker spawn did not finish under a PTY"
+            );
+            eprintln!("pty-driver-targeted-complete");
+            return;
+        }
+
+        run_current_test_under_pty(
+            "shell::probe::tests::targeted_marker_spawn_finishes_under_a_pty",
+            "targeted",
+        );
+    }
+
+    fn run_current_test_under_pty(test_name: &str, driver: &str) {
+        use std::io::Read as _;
+        use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+        use std::os::unix::process::CommandExt as _;
+
+        let mut master_fd = -1;
+        let mut slave_fd = -1;
+        // SAFETY: `openpty` initializes both descriptors on success; the
+        // null termios and window-size pointers request system defaults.
+        let opened = unsafe {
+            libc::openpty(
+                &mut master_fd,
+                &mut slave_fd,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(opened, 0, "openpty: {}", std::io::Error::last_os_error());
+        // SAFETY: successful `openpty` returned two newly owned descriptors.
+        let mut master = unsafe { std::fs::File::from_raw_fd(master_fd) };
+        let slave = unsafe { OwnedFd::from_raw_fd(slave_fd) };
+        set_close_on_exec(master.as_raw_fd());
+        set_close_on_exec(slave.as_raw_fd());
+
+        let slave_fd = slave.as_raw_fd();
+        let mut command = Command::new(std::env::current_exe().expect("current test binary"));
+        command
+            .args(["--exact", test_name, "--nocapture"])
+            .env(PTY_DRIVER_ENV, driver)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        // SAFETY: the closure uses only async-signal-safe descriptor and
+        // session syscalls before exec. `slave` remains alive through spawn.
+        unsafe {
+            command.pre_exec(move || {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::ioctl(slave_fd, libc::TIOCSCTTY as _, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                for target in [libc::STDIN_FILENO, libc::STDOUT_FILENO, libc::STDERR_FILENO] {
+                    if libc::dup2(slave_fd, target) == -1 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                }
+                if slave_fd > libc::STDERR_FILENO {
+                    libc::close(slave_fd);
+                }
+                Ok(())
+            });
+        }
+
+        let mut child = command.spawn().expect("PTY test driver starts");
+        drop(slave);
+        let output = std::thread::spawn(move || {
+            let mut output = Vec::new();
+            let _ = master.read_to_end(&mut output);
+            output
+        });
+        let deadline = Instant::now() + Duration::from_secs(8);
+        let status = loop {
+            if let Some(status) = child.try_wait().expect("PTY driver remains waitable") {
+                break status;
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("PTY test driver timed out: {test_name}");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        };
+        let output = output.join().expect("PTY output reader joins");
+        let output = String::from_utf8_lossy(&output);
+        assert!(
+            status.success(),
+            "PTY test driver failed: {test_name}\n{output}"
+        );
+        assert!(
+            output.contains(&format!("pty-driver-{driver}-complete")),
+            "PTY test driver did not exercise its inner branch: {test_name}\n{output}"
+        );
+    }
+
+    fn set_close_on_exec(fd: RawFd) {
+        // SAFETY: `fd` is live for both fcntl calls and no pointer is involved.
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        assert_ne!(flags, -1, "F_GETFD: {}", std::io::Error::last_os_error());
+        assert_ne!(
+            unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) },
+            -1,
+            "F_SETFD: {}",
+            std::io::Error::last_os_error()
         );
     }
 

--- a/crates/dodot-lib/src/shell/probe.rs
+++ b/crates/dodot-lib/src/shell/probe.rs
@@ -55,6 +55,8 @@
 //! run this probe exists for.
 
 use std::io::{BufRead, BufReader, Read};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
@@ -103,6 +105,60 @@ const POLL_INTERVAL: Duration = Duration::from_millis(20);
 /// thread to deliver already-written output. This stays bounded because
 /// rc-started background jobs can inherit stdout.
 const POST_EXIT_DRAIN: Duration = Duration::from_millis(200);
+
+/// Descriptor inherited by a report-only hold from the Rust parent.
+pub(crate) const PARENT_LIVENESS_FD: RawFd = 3;
+
+/// A close-on-exec socket pair whose child end is installed at the
+/// stable descriptor consumed by the report-only hold.
+pub(crate) struct ParentLiveness {
+    child_end: UnixStream,
+    parent_end: UnixStream,
+}
+
+impl ParentLiveness {
+    pub(crate) fn attach(command: &mut Command) -> std::io::Result<Self> {
+        use std::os::unix::process::CommandExt;
+
+        let (child_end, parent_end) = UnixStream::pair()?;
+        let child_fd = child_end.as_raw_fd();
+        let parent_fd = parent_end.as_raw_fd();
+        // SAFETY: the closure uses only async-signal-safe descriptor
+        // syscalls between fork and exec. Both source descriptors stay
+        // alive in `Self` until `Command::spawn` returns.
+        unsafe {
+            command.pre_exec(move || {
+                // A session leader is also its own process-group leader,
+                // while having no controlling terminal. That prevents an
+                // explicitly interactive zsh from stopping itself when the
+                // caller happens to run under a PTY.
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                libc::close(parent_fd);
+                if libc::dup2(child_fd, PARENT_LIVENESS_FD) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::fcntl(PARENT_LIVENESS_FD, libc::F_SETFD, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if child_fd != PARENT_LIVENESS_FD {
+                    libc::close(child_fd);
+                }
+                Ok(())
+            });
+        }
+        Ok(Self {
+            child_end,
+            parent_end,
+        })
+    }
+
+    pub(crate) fn child_spawned(self) -> UnixStream {
+        drop(self.child_end);
+        self.parent_end
+    }
+}
 
 // ── Policy ──────────────────────────────────────────────────────
 
@@ -385,13 +441,18 @@ pub fn spawn_captured(mut command: Command, timeout: Duration) -> SpawnOutcome {
 }
 
 /// Run `command` under the probe envelope and stop its process group as
-/// soon as `stop_when` matches the captured stderr.
+/// soon as `stop_when` matches one newly captured stderr line.
 ///
 /// This is the streaming counterpart to [`spawn_captured`]. It keeps the
-/// same stdin, environment scrub, output capture, process-group, and
+/// same environment scrub, stderr capture, process-group, and
 /// timeout guarantees, but lets a protocol response end a shell whose rc
-/// deliberately waits after writing that response. A response-stopped
-/// process returns [`SpawnOutcome::Finished`] with `status: None`.
+/// deliberately waits after writing that response. Stdout is discarded:
+/// the caller's protocol is on stderr, and a descendant retaining stdout
+/// must not outlive the hard timeout. A private inherited descriptor is
+/// an unwritten liveness pipe: a report-only hold can detect the Rust
+/// process disappearing by reading EOF without interfering with an
+/// interactive shell's stdin. A response-stopped process returns
+/// [`SpawnOutcome::Finished`] with `status: None`.
 pub fn spawn_captured_until_stderr(
     mut command: Command,
     timeout: Duration,
@@ -399,23 +460,23 @@ pub fn spawn_captured_until_stderr(
 ) -> SpawnOutcome {
     command
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
+        .stdout(Stdio::null())
         .stderr(Stdio::piped());
     for key in scrubbed_keys(std::env::vars().map(|(k, _)| k)) {
         command.env_remove(key);
     }
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
-    }
+    let liveness = match ParentLiveness::attach(&mut command) {
+        Ok(liveness) => liveness,
+        Err(e) => return SpawnOutcome::SpawnFailed(format!("{e}")),
+    };
 
     let mut child = match command.spawn() {
         Ok(child) => child,
         Err(e) => return SpawnOutcome::SpawnFailed(format!("{e}")),
     };
     let child_pid = child.id();
-    let stdout = child.stdout.take().map(drain);
+    // Keep the parent end alive for exactly as long as this Rust scope.
+    let _parent_liveness = liveness.child_spawned();
     let (tx, rx) = mpsc::channel();
     if let Some(stderr) = child.stderr.take() {
         read_lines(stderr, tx);
@@ -423,19 +484,35 @@ pub fn spawn_captured_until_stderr(
 
     let deadline = Instant::now() + timeout;
     let mut stderr = String::new();
+    let mut stderr_connected = true;
     let mut stopped_on_output = false;
     let status = 'running: loop {
-        while let Ok(line) = rx.try_recv() {
-            stderr.push_str(&line);
-            if stop_when(&stderr) {
-                kill_process_group(child_pid);
-                let _ = child.wait();
-                stopped_on_output = true;
-                break 'running None;
+        loop {
+            match rx.try_recv() {
+                Ok(line) => {
+                    let should_stop = stop_when(&line);
+                    stderr.push_str(&line);
+                    if should_stop {
+                        kill_process_group(child_pid);
+                        let _ = child.wait();
+                        stopped_on_output = true;
+                        break 'running None;
+                    }
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    stderr_connected = false;
+                    break;
+                }
             }
         }
         match child.try_wait() {
-            Ok(Some(status)) => break Some(status),
+            Ok(Some(status)) => {
+                // The direct shell is done, but descendants may still
+                // hold its pipes or continue diagnostic side effects.
+                kill_process_group(child_pid);
+                break Some(status);
+            }
             Ok(None) => {}
             Err(e) => return SpawnOutcome::SpawnFailed(format!("{e}")),
         }
@@ -448,27 +525,22 @@ pub fn spawn_captured_until_stderr(
         if wait.is_zero() {
             continue;
         }
-        match rx.recv_timeout(wait) {
-            Ok(line) => {
-                stderr.push_str(&line);
-                if stop_when(&stderr) {
-                    kill_process_group(child_pid);
-                    let _ = child.wait();
-                    stopped_on_output = true;
-                    break 'running None;
-                }
+        if let Some(line) = receive_line_or_wait(&rx, wait, &mut stderr_connected) {
+            let should_stop = stop_when(&line);
+            stderr.push_str(&line);
+            if should_stop {
+                kill_process_group(child_pid);
+                let _ = child.wait();
+                stopped_on_output = true;
+                break 'running None;
             }
-            Err(mpsc::RecvTimeoutError::Disconnected | mpsc::RecvTimeoutError::Timeout) => {}
         }
     };
 
-    let stdout = stdout
-        .and_then(|handle| handle.join().ok())
-        .unwrap_or_default();
     drain_pending_lines(&rx, &mut stderr, POST_EXIT_DRAIN);
     if stopped_on_output {
         return SpawnOutcome::Finished(SpawnCapture {
-            stdout,
+            stdout: String::new(),
             stderr,
             status: None,
         });
@@ -477,10 +549,31 @@ pub fn spawn_captured_until_stderr(
         return SpawnOutcome::TimedOut;
     };
     SpawnOutcome::Finished(SpawnCapture {
-        stdout,
+        stdout: String::new(),
         stderr,
         status: status.code(),
     })
+}
+
+/// Receive one stderr line without spinning after the reader exits.
+fn receive_line_or_wait(
+    rx: &mpsc::Receiver<String>,
+    wait: Duration,
+    connected: &mut bool,
+) -> Option<String> {
+    if !*connected {
+        std::thread::sleep(wait);
+        return None;
+    }
+    match rx.recv_timeout(wait) {
+        Ok(line) => Some(line),
+        Err(mpsc::RecvTimeoutError::Timeout) => None,
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            *connected = false;
+            std::thread::sleep(wait);
+            None
+        }
+    }
 }
 
 /// Spawn `shell` interactively and read the stamp back.
@@ -704,17 +797,18 @@ pub fn scrubbed_keys(keys: impl Iterator<Item = String>) -> Vec<String> {
 
 /// Kill the probed shell's whole process group.
 ///
-/// The shell was spawned as its own group leader, so its pid is the
-/// group id and a negative-pid signal reaches every process the rc
-/// file started — the `exec`-into-a-multiplexer case, where killing
-/// only the shell we can see would leave the real hang behind.
+/// The shell was spawned as its own group leader, either directly or
+/// as a new session leader, so its pid is the group id and a negative-
+/// pid signal reaches every process the rc file started — the
+/// `exec`-into-a-multiplexer case, where killing only the shell we can
+/// see would leave the real hang behind.
 #[cfg(unix)]
 fn kill_process_group(pid: u32) {
     // SAFETY: `kill` is a plain syscall wrapper with no memory
     // effects. A negative pid addresses the process group; the group
-    // is one we created via `process_group(0)`, so we are not
-    // signalling anything we did not spawn. A failure (the group
-    // already exited) is nothing to handle.
+    // is one we created for this child, so we are not signalling
+    // anything we did not spawn. A failure (the group already exited)
+    // is nothing to handle.
     unsafe {
         libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
     }
@@ -1223,6 +1317,86 @@ mod tests {
             matching_targeted_stamp_in_output(&stdout, "abc", 10, 21),
             None
         );
+    }
+
+    #[test]
+    fn stderr_stop_does_not_wait_for_a_descendant_retaining_stdout() {
+        let shell = Path::new("/bin/sh");
+        if !shell.exists() {
+            return;
+        }
+        let mut command = Command::new(shell);
+        command.args(["-c", "(sleep 5) &"]);
+
+        let started = Instant::now();
+        let outcome = spawn_captured_until_stderr(command, Duration::from_secs(2), |_| false);
+
+        assert!(
+            matches!(
+                outcome,
+                SpawnOutcome::Finished(SpawnCapture {
+                    status: Some(0),
+                    ..
+                })
+            ),
+            "direct child should finish normally: {outcome:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "a descendant retaining stdout must not block completion"
+        );
+    }
+
+    #[test]
+    fn disconnected_stderr_waits_instead_of_spinning() {
+        let (tx, rx) = mpsc::channel::<String>();
+        drop(tx);
+        let mut connected = true;
+        let wait = Duration::from_millis(30);
+
+        let started = Instant::now();
+        assert_eq!(receive_line_or_wait(&rx, wait, &mut connected), None);
+
+        assert!(!connected);
+        assert!(
+            started.elapsed() >= Duration::from_millis(25),
+            "a disconnected channel must still yield the polling interval"
+        );
+    }
+
+    #[test]
+    fn stderr_stop_matches_each_line_and_retains_complete_diagnostics() {
+        let shell = Path::new("/bin/sh");
+        if !shell.exists() {
+            return;
+        }
+        let mut command = Command::new(shell);
+        command.args([
+            "-c",
+            "i=0; while [ \"$i\" -lt 2000 ]; do printf 'noise-%s\\n' \"$i\" >&2; \
+             i=$((i + 1)); done; printf 'stop\\n' >&2; sleep 5",
+        ]);
+        let mut inspected = 0;
+
+        let outcome = spawn_captured_until_stderr(command, Duration::from_secs(5), |line| {
+            inspected += 1;
+            assert_eq!(
+                line.lines().count(),
+                1,
+                "predicate received more than one line"
+            );
+            line == "stop\n"
+        });
+        let SpawnOutcome::Finished(capture) = outcome else {
+            panic!("expected marker-stopped capture, got {outcome:?}");
+        };
+
+        assert_eq!(inspected, 2001);
+        assert_eq!(capture.stderr.lines().count(), 2001);
+        assert!(capture.stderr.starts_with("noise-0\n"));
+        assert!(capture.stderr.ends_with("stop\n"));
+        assert_eq!(capture.status, None);
+        assert!(capture.stdout.is_empty());
     }
 
     #[test]

--- a/crates/dodot-lib/src/shell/probe.rs
+++ b/crates/dodot-lib/src/shell/probe.rs
@@ -55,7 +55,7 @@
 //! run this probe exists for.
 
 use std::io::{BufRead, BufReader, Read};
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -106,9 +106,9 @@ const POLL_INTERVAL: Duration = Duration::from_millis(20);
 /// rc-started background jobs can inherit stdout.
 const POST_EXIT_DRAIN: Duration = Duration::from_millis(200);
 
-/// Descriptor inherited by a report-only hold from the Rust parent.
-/// Kept above the range rc files conventionally use for saved streams.
-pub(crate) const PARENT_LIVENESS_FD: RawFd = 63;
+/// Preferred lower bound for the descriptor inherited by a report-only hold.
+/// The actual descriptor is selected below the process's soft open-file limit.
+const PREFERRED_PARENT_LIVENESS_FD: RawFd = 63;
 
 /// Put a probed shell in its own session and process group.
 ///
@@ -130,8 +130,8 @@ pub(crate) fn configure_probe_session(command: &mut Command) {
     }
 }
 
-/// A close-on-exec socket pair whose child end is installed at the
-/// stable descriptor consumed by the report-only hold.
+/// A close-on-exec socket pair whose child end is inherited by the
+/// report-only hold at a dynamically selected descriptor.
 pub(crate) struct ParentLiveness {
     child_end: UnixStream,
     parent_end: UnixStream,
@@ -142,6 +142,7 @@ impl ParentLiveness {
         use std::os::unix::process::CommandExt;
 
         let (child_end, parent_end) = UnixStream::pair()?;
+        let child_end = duplicate_liveness_descriptor(&child_end)?;
         let child_fd = child_end.as_raw_fd();
         let parent_fd = parent_end.as_raw_fd();
         // SAFETY: the closure uses only async-signal-safe descriptor
@@ -150,14 +151,8 @@ impl ParentLiveness {
         unsafe {
             command.pre_exec(move || {
                 libc::close(parent_fd);
-                if libc::dup2(child_fd, PARENT_LIVENESS_FD) == -1 {
+                if libc::fcntl(child_fd, libc::F_SETFD, 0) == -1 {
                     return Err(std::io::Error::last_os_error());
-                }
-                if libc::fcntl(PARENT_LIVENESS_FD, libc::F_SETFD, 0) == -1 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                if child_fd != PARENT_LIVENESS_FD {
-                    libc::close(child_fd);
                 }
                 Ok(())
             });
@@ -168,10 +163,56 @@ impl ParentLiveness {
         })
     }
 
+    pub(crate) fn descriptor(&self) -> RawFd {
+        self.child_end.as_raw_fd()
+    }
+
     pub(crate) fn child_spawned(self) -> UnixStream {
         drop(self.child_end);
         self.parent_end
     }
+}
+
+fn duplicate_liveness_descriptor(child_end: &UnixStream) -> std::io::Result<UnixStream> {
+    let soft_limit = descriptor_soft_limit()?;
+    let preferred = PREFERRED_PARENT_LIVENESS_FD.min(soft_limit - 1);
+    let duplicated =
+        duplicate_from(child_end.as_raw_fd(), preferred).or_else(|preferred_error| {
+            if preferred <= libc::STDERR_FILENO + 1 {
+                return Err(preferred_error);
+            }
+            duplicate_from(child_end.as_raw_fd(), libc::STDERR_FILENO + 1)
+        })?;
+
+    // SAFETY: F_DUPFD_CLOEXEC returned a new descriptor owned by this process.
+    Ok(unsafe { UnixStream::from_raw_fd(duplicated) })
+}
+
+fn duplicate_from(source: RawFd, minimum: RawFd) -> std::io::Result<RawFd> {
+    // SAFETY: `source` is a live descriptor and F_DUPFD_CLOEXEC takes an integer.
+    let duplicated = unsafe { libc::fcntl(source, libc::F_DUPFD_CLOEXEC, minimum) };
+    if duplicated == -1 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(duplicated)
+    }
+}
+
+fn descriptor_soft_limit() -> std::io::Result<RawFd> {
+    let mut limit = std::mem::MaybeUninit::<libc::rlimit>::uninit();
+    // SAFETY: getrlimit initializes `limit` on success.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, limit.as_mut_ptr()) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: the successful getrlimit call initialized the value.
+    let current = unsafe { limit.assume_init() }.rlim_cur;
+    let capped = current.min(RawFd::MAX as libc::rlim_t);
+    if capped <= (libc::STDERR_FILENO + 1) as libc::rlim_t {
+        return Err(std::io::Error::other(
+            "open-file limit leaves no descriptor for parent liveness",
+        ));
+    }
+    Ok(capped as RawFd)
 }
 
 // ── Policy ──────────────────────────────────────────────────────
@@ -464,6 +505,19 @@ pub fn spawn_captured(mut command: Command, timeout: Duration) -> SpawnOutcome {
 pub fn spawn_captured_until_stderr(
     mut command: Command,
     timeout: Duration,
+    stop_when: impl FnMut(&str) -> bool,
+) -> SpawnOutcome {
+    let liveness = match ParentLiveness::attach(&mut command) {
+        Ok(liveness) => liveness,
+        Err(e) => return SpawnOutcome::SpawnFailed(format!("{e}")),
+    };
+    spawn_captured_until_stderr_with_liveness(command, timeout, liveness, stop_when)
+}
+
+pub(crate) fn spawn_captured_until_stderr_with_liveness(
+    mut command: Command,
+    timeout: Duration,
+    liveness: ParentLiveness,
     mut stop_when: impl FnMut(&str) -> bool,
 ) -> SpawnOutcome {
     command
@@ -474,10 +528,6 @@ pub fn spawn_captured_until_stderr(
         command.env_remove(key);
     }
     configure_probe_session(&mut command);
-    let liveness = match ParentLiveness::attach(&mut command) {
-        Ok(liveness) => liveness,
-        Err(e) => return SpawnOutcome::SpawnFailed(format!("{e}")),
-    };
 
     let mut child = match command.spawn() {
         Ok(child) => child,
@@ -1455,14 +1505,13 @@ mod tests {
     }
 
     const PTY_DRIVER_ENV: &str = "DODOT_TEST_PROBE_PTY_DRIVER";
+    const PTY_SHELL_ENV: &str = "DODOT_TEST_PROBE_PTY_SHELL";
 
     #[test]
     fn primary_trace_spawn_finishes_under_a_pty() {
         if std::env::var(PTY_DRIVER_ENV).as_deref() == Ok("primary") {
-            let shell = Path::new("/bin/zsh");
-            if !shell.exists() {
-                return;
-            }
+            let shell_path = std::env::var_os(PTY_SHELL_ENV).expect("PTY shell is selected");
+            let shell = Path::new(&shell_path);
             let mut command = Command::new(shell);
             command.args(["-ic", "printf 'primary-pty-ok\\n'"]);
             let outcome = spawn_captured(command, Duration::from_secs(2));
@@ -1478,19 +1527,21 @@ mod tests {
             return;
         }
 
+        let Some(shell) = pty_test_shell() else {
+            return;
+        };
         run_current_test_under_pty(
             "shell::probe::tests::primary_trace_spawn_finishes_under_a_pty",
             "primary",
+            shell,
         );
     }
 
     #[test]
     fn targeted_marker_spawn_finishes_under_a_pty() {
         if std::env::var(PTY_DRIVER_ENV).as_deref() == Ok("targeted") {
-            let shell = Path::new("/bin/zsh");
-            if !shell.exists() {
-                return;
-            }
+            let shell_path = std::env::var_os(PTY_SHELL_ENV).expect("PTY shell is selected");
+            let shell = Path::new(&shell_path);
             let nonce = "pty-nonce";
             let verifier_pid = std::process::id();
             let mut command = Command::new(shell);
@@ -1518,13 +1569,24 @@ mod tests {
             return;
         }
 
+        let Some(shell) = pty_test_shell() else {
+            return;
+        };
         run_current_test_under_pty(
             "shell::probe::tests::targeted_marker_spawn_finishes_under_a_pty",
             "targeted",
+            shell,
         );
     }
 
-    fn run_current_test_under_pty(test_name: &str, driver: &str) {
+    fn pty_test_shell() -> Option<&'static Path> {
+        ["/bin/zsh", "/usr/bin/zsh", "/bin/bash", "/usr/bin/bash"]
+            .into_iter()
+            .map(Path::new)
+            .find(|path| path.exists())
+    }
+
+    fn run_current_test_under_pty(test_name: &str, driver: &str, shell: &Path) {
         use std::io::Read as _;
         use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
         use std::os::unix::process::CommandExt as _;
@@ -1554,6 +1616,7 @@ mod tests {
         command
             .args(["--exact", test_name, "--nocapture"])
             .env(PTY_DRIVER_ENV, driver)
+            .env(PTY_SHELL_ENV, shell)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());

--- a/crates/dodot-lib/src/shell/probe.rs
+++ b/crates/dodot-lib/src/shell/probe.rs
@@ -31,11 +31,10 @@
 //! environment — an inherited stamp would be a false positive every
 //! time the probe runs from an already-live shell.
 //!
-//! That defensive envelope lives in [`spawn_captured`], which is the
-//! one place dodot spawns anything user-authored: [`run`] uses it for
-//! the activation probe, and [`crate::shell::trace`] reuses it
-//! unchanged for the hook-line trace (RCS01 WS02) — one audited
-//! process-group kill, not two.
+//! That defensive envelope lives in [`spawn_captured`] and its streaming
+//! sibling [`spawn_captured_until_stderr`]. [`run`] uses the targeted
+//! response variant below, and [`crate::shell::trace`] uses the capture
+//! helpers for hook-line tracing — all with the same process-group kill.
 //!
 //! # Verdicts
 //!
@@ -373,6 +372,105 @@ pub fn spawn_captured(mut command: Command, timeout: Duration) -> SpawnOutcome {
     let stdout = stdout.and_then(|h| h.join().ok()).unwrap_or_default();
     let stderr = stderr.and_then(|h| h.join().ok()).unwrap_or_default();
 
+    let Some(status) = status else {
+        return SpawnOutcome::TimedOut;
+    };
+    SpawnOutcome::Finished(SpawnCapture {
+        stdout,
+        stderr,
+        status: status.code(),
+    })
+}
+
+/// Run `command` under the probe envelope and stop its process group as
+/// soon as `stop_when` matches the captured stderr.
+///
+/// This is the streaming counterpart to [`spawn_captured`]. It keeps the
+/// same stdin, environment scrub, output capture, process-group, and
+/// timeout guarantees, but lets a protocol response end a shell whose rc
+/// deliberately waits after writing that response. A response-stopped
+/// process returns [`SpawnOutcome::Finished`] with `status: None`.
+pub fn spawn_captured_until_stderr(
+    mut command: Command,
+    timeout: Duration,
+    mut stop_when: impl FnMut(&str) -> bool,
+) -> SpawnOutcome {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for key in scrubbed_keys(std::env::vars().map(|(k, _)| k)) {
+        command.env_remove(key);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) => return SpawnOutcome::SpawnFailed(format!("{e}")),
+    };
+    let child_pid = child.id();
+    let stdout = child.stdout.take().map(drain);
+    let (tx, rx) = mpsc::channel();
+    if let Some(stderr) = child.stderr.take() {
+        read_lines(stderr, tx);
+    }
+
+    let deadline = Instant::now() + timeout;
+    let mut stderr = String::new();
+    let mut stopped_on_output = false;
+    let status = 'running: loop {
+        while let Ok(line) = rx.try_recv() {
+            stderr.push_str(&line);
+            if stop_when(&stderr) {
+                kill_process_group(child_pid);
+                let _ = child.wait();
+                stopped_on_output = true;
+                break 'running None;
+            }
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {}
+            Err(e) => return SpawnOutcome::SpawnFailed(format!("{e}")),
+        }
+        if Instant::now() >= deadline {
+            kill_process_group(child_pid);
+            let _ = child.wait();
+            break None;
+        }
+        let wait = POLL_INTERVAL.min(deadline.saturating_duration_since(Instant::now()));
+        if wait.is_zero() {
+            continue;
+        }
+        match rx.recv_timeout(wait) {
+            Ok(line) => {
+                stderr.push_str(&line);
+                if stop_when(&stderr) {
+                    kill_process_group(child_pid);
+                    let _ = child.wait();
+                    stopped_on_output = true;
+                    break 'running None;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected | mpsc::RecvTimeoutError::Timeout) => {}
+        }
+    };
+
+    let stdout = stdout
+        .and_then(|handle| handle.join().ok())
+        .unwrap_or_default();
+    drain_pending_lines(&rx, &mut stderr, POST_EXIT_DRAIN);
+    if stopped_on_output {
+        return SpawnOutcome::Finished(SpawnCapture {
+            stdout,
+            stderr,
+            status: None,
+        });
+    }
     let Some(status) = status else {
         return SpawnOutcome::TimedOut;
     };

--- a/crates/dodot-lib/src/shell/trace.rs
+++ b/crates/dodot-lib/src/shell/trace.rs
@@ -44,9 +44,10 @@
 //! ends.
 //!
 //! For capability-unknown hooks, the copy prints the hook-line record
-//! and exits before the hook itself. That is the only trace shape that
-//! cannot create heartbeat/profile evidence through a legacy init
-//! script that does not understand diagnostic suppression.
+//! and kills the diagnostic shell before the hook itself. That is the
+//! only trace shape that cannot create heartbeat/profile evidence
+//! through a legacy init script that does not understand diagnostic
+//! suppression.
 //!
 //! The copy must reproduce the shell's startup, not approximate it. A
 //! shell that read a different set of files than the real one does
@@ -1011,7 +1012,11 @@ fn insert_report_line(
     hook_line: usize,
     exit_before_hook: bool,
 ) -> String {
-    let maybe_exit = if exit_before_hook { "exit 0\n" } else { "" };
+    let maybe_exit = if exit_before_hook {
+        "/bin/kill -KILL \"$$\"\n"
+    } else {
+        ""
+    };
     let report = format!(
         "printf '+{TRACE_MARKER}%s|%s|%s|%s{RECORD_SUFFIX}\\n' {} {} \"$PWD\" \"$PATH\" >&2\n{maybe_exit}",
         shell_quote(&rc_nominal.display().to_string()),
@@ -1663,12 +1668,12 @@ mod tests {
     }
 
     #[test]
-    fn report_only_copy_exits_before_the_hook() {
+    fn report_only_copy_stops_before_the_hook() {
         let rc = "eval \"$(dodot init-sh)\"\necho after\n";
         let copy = insert_report_line(rc, Path::new("/home/u/.bashrc"), 1, true);
         let lines: Vec<&str> = copy.lines().collect();
         assert!(lines[0].starts_with("printf '+dodot-trace|"), "{copy}");
-        assert_eq!(lines[1], "exit 0");
+        assert_eq!(lines[1], "/bin/kill -KILL \"$$\"");
         assert_eq!(lines[2], "eval \"$(dodot init-sh)\"");
         assert_eq!(lines[3], "echo after");
     }
@@ -1817,6 +1822,59 @@ mod tests {
         assert!(
             !env.fs.exists(&touched),
             "report-only fallback must exit before executing the unknown hook"
+        );
+    }
+
+    #[test]
+    fn report_only_trace_ignores_shadowed_exit_in_bash() {
+        let Some(bash) = bash() else { return };
+        report_only_trace_ignores_shadowed_exit(bash, HookupShell::Bash, ".bashrc");
+    }
+
+    #[test]
+    fn report_only_trace_ignores_shadowed_exit_in_zsh() {
+        let Some(zsh) = zsh() else { return };
+        report_only_trace_ignores_shadowed_exit(zsh, HookupShell::Zsh, ".zshrc");
+    }
+
+    fn report_only_trace_ignores_shadowed_exit(
+        shell_path: &Path,
+        shell: HookupShell,
+        rc_name: &str,
+    ) {
+        if !Path::new("/bin/kill").exists() {
+            return;
+        }
+        let env = TempEnvironment::builder().build();
+        let _home = EnvVarGuard::set("HOME", &env.home.display().to_string());
+        let rc = env.home.join(rc_name);
+        let touched = env.home.join("hook-ran");
+        env.fs
+            .write_file(
+                &rc,
+                format!(
+                    "exit() {{ echo shadowed-exit; return 0; }}\n\
+                     alias exit='echo alias-exit'\n\
+                     export PATH=/before-hook\n\
+                     echo should-not-run > {}\n",
+                    touched.display()
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+
+        let mut req = request(&env, shell_path, shell, &rc, 4);
+        req.execution = TraceExecution::ReportOnly;
+        let run = run_trace(env.fs.as_ref(), &req).expect("report-only trace runs");
+
+        assert!(run.used_fallback);
+        assert!(
+            record_at(&run.records, &[&rc], 4).is_some(),
+            "report-only trace must still print the hook-line record"
+        );
+        assert!(
+            !env.fs.exists(&touched),
+            "a shadowed exit must not let report-only tracing continue into the hook"
         );
     }
 

--- a/crates/dodot-lib/src/shell/trace.rs
+++ b/crates/dodot-lib/src/shell/trace.rs
@@ -111,6 +111,9 @@ pub const RECORD_SUFFIX: &str = "|> ";
 /// shell continues through PATH and source work.
 pub const DIAGNOSTIC_TRACE_ENV: &str = "DODOT_INTERNAL_SHELL_INIT_TRACE";
 
+const REPORT_ONLY_TERMINATION: &str =
+    "\\command kill -KILL \"$$\" 2>/dev/null || \\builtin kill -KILL \"$$\" 2>/dev/null || kill -KILL \"$$\"";
+
 // ── The PS4 contract ────────────────────────────────────────────
 
 /// The `PS4` value handed to the spawned shell.
@@ -1013,9 +1016,9 @@ fn insert_report_line(
     exit_before_hook: bool,
 ) -> String {
     let maybe_exit = if exit_before_hook {
-        "/bin/kill -KILL \"$$\"\n"
+        format!("{REPORT_ONLY_TERMINATION}\n")
     } else {
-        ""
+        String::new()
     };
     let report = format!(
         "printf '+{TRACE_MARKER}%s|%s|%s|%s{RECORD_SUFFIX}\\n' {} {} \"$PWD\" \"$PATH\" >&2\n{maybe_exit}",
@@ -1673,7 +1676,7 @@ mod tests {
         let copy = insert_report_line(rc, Path::new("/home/u/.bashrc"), 1, true);
         let lines: Vec<&str> = copy.lines().collect();
         assert!(lines[0].starts_with("printf '+dodot-trace|"), "{copy}");
-        assert_eq!(lines[1], "/bin/kill -KILL \"$$\"");
+        assert_eq!(lines[1], REPORT_ONLY_TERMINATION);
         assert_eq!(lines[2], "eval \"$(dodot init-sh)\"");
         assert_eq!(lines[3], "echo after");
     }
@@ -1842,9 +1845,6 @@ mod tests {
         shell: HookupShell,
         rc_name: &str,
     ) {
-        if !Path::new("/bin/kill").exists() {
-            return;
-        }
         let env = TempEnvironment::builder().build();
         let _home = EnvVarGuard::set("HOME", &env.home.display().to_string());
         let rc = env.home.join(rc_name);

--- a/crates/dodot-lib/src/shell/trace.rs
+++ b/crates/dodot-lib/src/shell/trace.rs
@@ -74,19 +74,19 @@
 //! - **The rc runs up to twice for diagnostic-capable hooks.** The
 //!   fallback re-runs it on a copy, so side effects before the hook
 //!   can happen again. Capability-unknown hooks use only the copy and
-//!   exit before the hook. [`announcement`] says the upper bound
+//!   stop before the hook. [`announcement`] says the upper bound
 //!   before anything is spawned.
 //!
 //! # Boundaries
 //!
 //! Only `dodot probe shell-init` reaches this module; `status` and
-//! `up` never do (INS01 §9 still binds). Every spawn goes through
-//! [`crate::shell::probe::spawn_captured`] — the INS01 envelope
-//! (announced, stdin from `/dev/null`, output captured, hard timeout
-//! with a process-group kill, `DODOT_INIT_*` scrubbed) reused
-//! unchanged. The spawned shell is interactive non-login (the mode
-//! that reads the file the hook lives in) and inherits this process's
-//! environment minus the scrub, same as the INS01 probe.
+//! `up` never do (INS01 §9 still binds). Every spawn uses the capture
+//! helpers in [`crate::shell::probe`] — the INS01 envelope (announced,
+//! stdin from `/dev/null`, output captured, hard timeout with a
+//! process-group kill, `DODOT_INIT_*` scrubbed). The spawned shell is
+//! interactive non-login (the mode that reads the file the hook lives
+//! in) and inherits this process's environment minus the scrub, same as
+//! the INS01 probe.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -94,7 +94,7 @@ use std::time::{Duration, Instant};
 
 use crate::fs::Fs;
 use crate::shell::activation::{self, EvidenceVersion};
-use crate::shell::probe::{spawn_captured, SpawnOutcome};
+use crate::shell::probe::{spawn_captured, spawn_captured_until_stderr, SpawnOutcome};
 use crate::shell::rc::{self, HookupShell};
 
 /// The field prefix every trace record carries, behind the leading
@@ -111,8 +111,11 @@ pub const RECORD_SUFFIX: &str = "|> ";
 /// shell continues through PATH and source work.
 pub const DIAGNOSTIC_TRACE_ENV: &str = "DODOT_INTERNAL_SHELL_INIT_TRACE";
 
-const REPORT_ONLY_TERMINATION: &str =
-    "\\command kill -KILL \"$$\" 2>/dev/null || \\builtin kill -KILL \"$$\" 2>/dev/null || kill -KILL \"$$\"";
+/// Holds a report-only rc at the insertion point until the parent sees
+/// the record and stops the process group. Arithmetic commands are shell
+/// grammar in bash and zsh, so rc-defined aliases and functions cannot
+/// redirect this loop into returning normally.
+const REPORT_ONLY_HOLD: &str = "while (( 1 )); do (( 1 )); done";
 
 // ── The PS4 contract ────────────────────────────────────────────
 
@@ -752,7 +755,7 @@ impl TraceRequest<'_> {
 /// Current generated scripts understand [`DIAGNOSTIC_TRACE_ENV`], so
 /// primary tracing can run the hook without creating heartbeat/profile
 /// evidence. Capability-unknown hooks are traced through the temporary
-/// copy only, with a report line that exits before the hook.
+/// copy only, with a report line that stops before the hook.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TraceExecution {
     DiagnosticSupported,
@@ -821,7 +824,7 @@ pub fn run_trace(fs: &dyn Fs, req: &TraceRequest) -> Result<TraceRun, TraceError
 fn run_fallback(
     fs: &dyn Fs,
     req: &TraceRequest,
-    exit_before_hook: bool,
+    stop_before_hook: bool,
 ) -> Result<Vec<TraceRecord>, TraceError> {
     let rc_text = fs
         .read_to_string(req.rc_resolved)
@@ -832,10 +835,10 @@ fn run_fallback(
     let temp = scratch.path();
     let unfaithful = |e: crate::DodotError| TraceError::FallbackUnfaithful(format!("{e}"));
     let mut command = Command::new(req.shell_path);
-    if !exit_before_hook {
+    if !stop_before_hook {
         command.env(DIAGNOSTIC_TRACE_ENV, "1");
     }
-    let copy = insert_report_line(&rc_text, req.rc_nominal, req.hook_line, exit_before_hook);
+    let copy = insert_report_line(&rc_text, req.rc_nominal, req.hook_line, stop_before_hook);
     // The file that stands in for the user's rc — the one whose parse
     // has to survive the insertion.
     let copy_path;
@@ -865,7 +868,15 @@ fn run_fallback(
     if let Some(broken) = insertion_broke_the_parse(req, copy_path) {
         return Err(TraceError::FallbackUnfaithful(broken));
     }
-    match spawn_captured(command, req.timeout) {
+    let outcome = if stop_before_hook {
+        spawn_captured_until_stderr(command, req.timeout, |stderr| {
+            let records = parse_trace(stderr);
+            record_at(&records, &req.rc_paths(), req.hook_line).is_some()
+        })
+    } else {
+        spawn_captured(command, req.timeout)
+    };
+    match outcome {
         SpawnOutcome::TimedOut => Err(TraceError::TimedOut),
         SpawnOutcome::SpawnFailed(e) => Err(TraceError::SpawnFailed(e)),
         SpawnOutcome::Finished(capture) => Ok(parse_trace(&capture.stderr)),
@@ -1013,15 +1024,15 @@ fn insert_report_line(
     rc_text: &str,
     rc_nominal: &Path,
     hook_line: usize,
-    exit_before_hook: bool,
+    stop_before_hook: bool,
 ) -> String {
-    let maybe_exit = if exit_before_hook {
-        format!("{REPORT_ONLY_TERMINATION}\n")
+    let maybe_hold = if stop_before_hook {
+        format!("{REPORT_ONLY_HOLD}\n")
     } else {
         String::new()
     };
     let report = format!(
-        "printf '+{TRACE_MARKER}%s|%s|%s|%s{RECORD_SUFFIX}\\n' {} {} \"$PWD\" \"$PATH\" >&2\n{maybe_exit}",
+        "printf '+{TRACE_MARKER}%s|%s|%s|%s{RECORD_SUFFIX}\\n' {} {} \"$PWD\" \"$PATH\" >&2\n{maybe_hold}",
         shell_quote(&rc_nominal.display().to_string()),
         hook_line,
     );
@@ -1676,7 +1687,7 @@ mod tests {
         let copy = insert_report_line(rc, Path::new("/home/u/.bashrc"), 1, true);
         let lines: Vec<&str> = copy.lines().collect();
         assert!(lines[0].starts_with("printf '+dodot-trace|"), "{copy}");
-        assert_eq!(lines[1], REPORT_ONLY_TERMINATION);
+        assert_eq!(lines[1], REPORT_ONLY_HOLD);
         assert_eq!(lines[2], "eval \"$(dodot init-sh)\"");
         assert_eq!(lines[3], "echo after");
     }
@@ -1829,18 +1840,18 @@ mod tests {
     }
 
     #[test]
-    fn report_only_trace_ignores_shadowed_exit_in_bash() {
+    fn report_only_trace_ignores_shadowed_termination_commands_in_bash() {
         let Some(bash) = bash() else { return };
-        report_only_trace_ignores_shadowed_exit(bash, HookupShell::Bash, ".bashrc");
+        report_only_trace_ignores_shadowed_termination_commands(bash, HookupShell::Bash, ".bashrc");
     }
 
     #[test]
-    fn report_only_trace_ignores_shadowed_exit_in_zsh() {
+    fn report_only_trace_ignores_shadowed_termination_commands_in_zsh() {
         let Some(zsh) = zsh() else { return };
-        report_only_trace_ignores_shadowed_exit(zsh, HookupShell::Zsh, ".zshrc");
+        report_only_trace_ignores_shadowed_termination_commands(zsh, HookupShell::Zsh, ".zshrc");
     }
 
-    fn report_only_trace_ignores_shadowed_exit(
+    fn report_only_trace_ignores_shadowed_termination_commands(
         shell_path: &Path,
         shell: HookupShell,
         rc_name: &str,
@@ -1848,33 +1859,67 @@ mod tests {
         let env = TempEnvironment::builder().build();
         let _home = EnvVarGuard::set("HOME", &env.home.display().to_string());
         let rc = env.home.join(rc_name);
-        let touched = env.home.join("hook-ran");
+        let heartbeat = env.paths.hookup_heartbeat_path();
+        let profiles_dir = env.paths.probes_shell_init_dir();
+        let profile = profiles_dir.join("profile-existing.jsonl");
+        let touched = env.home.join("after-hook-ran");
+        env.fs.mkdir_all(heartbeat.parent().unwrap()).unwrap();
+        env.fs.mkdir_all(&profiles_dir).unwrap();
+        let heartbeat_contents = "existing-heartbeat-bytes\n";
+        env.fs
+            .write_file(&heartbeat, heartbeat_contents.as_bytes())
+            .unwrap();
+        env.fs
+            .write_file(&profile, b"existing-profile-bytes\n")
+            .unwrap();
+        let profiles_before = profile_snapshot(&env);
         env.fs
             .write_file(
                 &rc,
                 format!(
-                    "exit() {{ echo shadowed-exit; return 0; }}\n\
-                     alias exit='echo alias-exit'\n\
+                    "command() {{ return 0; }}\n\
+                     builtin() {{ return 0; }}\n\
+                     kill() {{ return 0; }}\n\
+                     exit() {{ return 0; }}\n\
+                     alias command='true'\n\
+                     alias builtin='true'\n\
+                     alias kill='true'\n\
+                     alias exit='true'\n\
                      export PATH=/before-hook\n\
-                     echo should-not-run > {}\n",
-                    touched.display()
+                     printf changed > {}; printf changed > {}\n\
+                     printf should-not-run > {}\n",
+                    shell_quote(&heartbeat.display().to_string()),
+                    shell_quote(&profile.display().to_string()),
+                    shell_quote(&touched.display().to_string()),
                 )
                 .as_bytes(),
             )
             .unwrap();
+        let rc_before = env.fs.read_to_string(&rc).unwrap();
 
-        let mut req = request(&env, shell_path, shell, &rc, 4);
+        let mut req = request(&env, shell_path, shell, &rc, 10);
         req.execution = TraceExecution::ReportOnly;
         let run = run_trace(env.fs.as_ref(), &req).expect("report-only trace runs");
 
         assert!(run.used_fallback);
         assert!(
-            record_at(&run.records, &[&rc], 4).is_some(),
+            record_at(&run.records, &[&rc], 10).is_some(),
             "report-only trace must still print the hook-line record"
         );
         assert!(
             !env.fs.exists(&touched),
-            "a shadowed exit must not let report-only tracing continue into the hook"
+            "report-only tracing must not continue past the inserted record"
+        );
+        assert_eq!(env.fs.read_to_string(&rc).unwrap(), rc_before);
+        assert_eq!(
+            env.fs.read_to_string(&heartbeat).unwrap(),
+            heartbeat_contents,
+            "the legacy hook must not rewrite heartbeat evidence"
+        );
+        assert_eq!(
+            profile_snapshot(&env),
+            profiles_before,
+            "the legacy hook must not rewrite profile evidence"
         );
     }
 

--- a/crates/dodot-lib/src/shell/trace.rs
+++ b/crates/dodot-lib/src/shell/trace.rs
@@ -88,6 +88,7 @@
 //! in) and inherits this process's environment minus the scrub, same as
 //! the INS01 probe.
 
+use std::os::fd::RawFd;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -95,7 +96,7 @@ use std::time::{Duration, Instant};
 use crate::fs::Fs;
 use crate::shell::activation::{self, EvidenceVersion};
 use crate::shell::probe::{
-    spawn_captured, spawn_captured_until_stderr, SpawnOutcome, PARENT_LIVENESS_FD,
+    spawn_captured, spawn_captured_until_stderr_with_liveness, ParentLiveness, SpawnOutcome,
 };
 use crate::shell::rc::{self, HookupShell};
 
@@ -117,9 +118,9 @@ pub const DIAGNOSTIC_TRACE_ENV: &str = "DODOT_INTERNAL_SHELL_INIT_TRACE";
 /// process group. The clean `/bin/sh` waits for EOF on the liveness pipe;
 /// if Rust disappears first, its unshadowed builtin sends uncatchable
 /// SIGKILL to the traced shell. No path lookup or external `kill` is used.
-fn report_only_hold() -> String {
+fn report_only_hold(parent_liveness_fd: RawFd) -> String {
     format!(
-        "/bin/sh -c 'IFS= read -r _ <&{PARENT_LIVENESS_FD}; kill -s KILL 0' \
+        "/bin/sh -c 'IFS= read -r _ <&{parent_liveness_fd}; kill -s KILL 0' \
          dodot-report-only"
     )
 }
@@ -842,10 +843,21 @@ fn run_fallback(
     let temp = scratch.path();
     let unfaithful = |e: crate::DodotError| TraceError::FallbackUnfaithful(format!("{e}"));
     let mut command = Command::new(req.shell_path);
-    if !stop_before_hook {
+    let liveness = if stop_before_hook {
+        Some(
+            ParentLiveness::attach(&mut command)
+                .map_err(|e| TraceError::SpawnFailed(format!("{e}")))?,
+        )
+    } else {
         command.env(DIAGNOSTIC_TRACE_ENV, "1");
-    }
-    let copy = insert_report_line(&rc_text, req.rc_nominal, req.hook_line, stop_before_hook);
+        None
+    };
+    let copy = insert_report_line(
+        &rc_text,
+        req.rc_nominal,
+        req.hook_line,
+        liveness.as_ref().map(ParentLiveness::descriptor),
+    );
     // The file that stands in for the user's rc — the one whose parse
     // has to survive the insertion.
     let copy_path;
@@ -875,8 +887,8 @@ fn run_fallback(
     if let Some(broken) = insertion_broke_the_parse(req, copy_path) {
         return Err(TraceError::FallbackUnfaithful(broken));
     }
-    let outcome = if stop_before_hook {
-        spawn_captured_until_stderr(command, req.timeout, |line| {
+    let outcome = if let Some(liveness) = liveness {
+        spawn_captured_until_stderr_with_liveness(command, req.timeout, liveness, |line| {
             let records = parse_trace(line);
             record_at(&records, &req.rc_paths(), req.hook_line).is_some()
         })
@@ -1031,10 +1043,10 @@ fn insert_report_line(
     rc_text: &str,
     rc_nominal: &Path,
     hook_line: usize,
-    stop_before_hook: bool,
+    parent_liveness_fd: Option<RawFd>,
 ) -> String {
-    let maybe_hold = if stop_before_hook {
-        format!("{}\n", report_only_hold())
+    let maybe_hold = if let Some(parent_liveness_fd) = parent_liveness_fd {
+        format!("{}\n", report_only_hold(parent_liveness_fd))
     } else {
         String::new()
     };
@@ -1674,7 +1686,7 @@ mod tests {
     #[test]
     fn the_report_line_is_inserted_not_truncated() {
         let rc = "if true; then\n  eval \"$(dodot init-sh)\"\nfi\n";
-        let copy = insert_report_line(rc, Path::new("/home/u/.zshrc"), 2, false);
+        let copy = insert_report_line(rc, Path::new("/home/u/.zshrc"), 2, None);
         let lines: Vec<&str> = copy.lines().collect();
         assert_eq!(lines.len(), 4, "insertion, not replacement: {copy}");
         assert!(lines[1].starts_with("printf '+dodot-trace|"), "{copy}");
@@ -1691,10 +1703,10 @@ mod tests {
     #[test]
     fn report_only_copy_stops_before_the_hook() {
         let rc = "eval \"$(dodot init-sh)\"\necho after\n";
-        let copy = insert_report_line(rc, Path::new("/home/u/.bashrc"), 1, true);
+        let copy = insert_report_line(rc, Path::new("/home/u/.bashrc"), 1, Some(42));
         let lines: Vec<&str> = copy.lines().collect();
         assert!(lines[0].starts_with("printf '+dodot-trace|"), "{copy}");
-        assert_eq!(lines[1], report_only_hold());
+        assert_eq!(lines[1], report_only_hold(42));
         assert_eq!(lines[2], "eval \"$(dodot init-sh)\"");
         assert_eq!(lines[3], "echo after");
     }
@@ -1738,6 +1750,7 @@ mod tests {
     }
 
     const TIMEOUT: Duration = Duration::from_secs(10);
+    const REDUCED_NOFILE_DRIVER_ENV: &str = "DODOT_TEST_REDUCED_NOFILE_DRIVER";
 
     #[test]
     fn report_only_hold_terminates_with_parent_liveness_in_bash() {
@@ -1751,28 +1764,93 @@ mod tests {
         report_only_hold_terminates_with_parent_liveness(zsh);
     }
 
-    fn report_only_hold_terminates_with_parent_liveness(shell_path: &Path) {
+    #[test]
+    fn report_only_hold_uses_a_descriptor_below_a_reduced_soft_limit() {
+        const SOFT_LIMIT: libc::rlim_t = 32;
+
+        if std::env::var(REDUCED_NOFILE_DRIVER_ENV).as_deref() == Ok("1") {
+            let bash = bash().expect("outer driver requires bash");
+            report_only_trace_survives_fd_three_and_shadowed_commands(
+                bash,
+                HookupShell::Bash,
+                ".bashrc",
+            );
+            let descriptor = report_only_hold_terminates_with_parent_liveness(bash);
+            assert!(descriptor > libc::STDERR_FILENO, "descriptor: {descriptor}");
+            assert!(descriptor < SOFT_LIMIT as RawFd, "descriptor: {descriptor}");
+            return;
+        }
+        if bash().is_none() {
+            return;
+        }
+
+        use std::os::unix::process::CommandExt as _;
+
+        let mut inherited = std::mem::MaybeUninit::<libc::rlimit>::uninit();
+        // SAFETY: getrlimit initializes `inherited` on success.
+        assert_ne!(
+            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, inherited.as_mut_ptr()) },
+            -1,
+            "getrlimit: {}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: the successful getrlimit call initialized the value.
+        let inherited = unsafe { inherited.assume_init() };
+        assert!(inherited.rlim_max >= SOFT_LIMIT);
+        let reduced = libc::rlimit {
+            rlim_cur: SOFT_LIMIT,
+            rlim_max: inherited.rlim_max,
+        };
+        let mut command = Command::new(std::env::current_exe().expect("current test binary"));
+        command
+            .args([
+                "--exact",
+                "shell::trace::tests::report_only_hold_uses_a_descriptor_below_a_reduced_soft_limit",
+                "--nocapture",
+            ])
+            .env(REDUCED_NOFILE_DRIVER_ENV, "1");
+        // SAFETY: setrlimit is an async-signal-safe syscall and `reduced`
+        // remains captured by value until the child execs.
+        unsafe {
+            command.pre_exec(move || {
+                if libc::setrlimit(libc::RLIMIT_NOFILE, &reduced) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let output = command.output().expect("reduced-limit test driver starts");
+        assert!(
+            output.status.success(),
+            "reduced-limit test driver failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn report_only_hold_terminates_with_parent_liveness(shell_path: &Path) -> RawFd {
         use std::os::unix::process::ExitStatusExt;
 
         let env = TempEnvironment::builder().build();
         let touched = env.home.join("continued-after-hold");
         let script = env.home.join("report-only-hold.sh");
+        let mut command = Command::new(shell_path);
+        command.stdin(std::process::Stdio::null());
+        crate::shell::probe::configure_probe_session(&mut command);
+        let liveness = crate::shell::probe::ParentLiveness::attach(&mut command)
+            .expect("liveness pipe attaches");
+        let descriptor = liveness.descriptor();
         env.fs
             .write_file(
                 &script,
                 format!(
                     "{}\nprintf should-not-run > {}\n",
-                    report_only_hold(),
+                    report_only_hold(descriptor),
                     shell_quote(&touched.display().to_string()),
                 )
                 .as_bytes(),
             )
             .unwrap();
-        let mut command = Command::new(shell_path);
-        command.arg(&script).stdin(std::process::Stdio::null());
-        crate::shell::probe::configure_probe_session(&mut command);
-        let liveness = crate::shell::probe::ParentLiveness::attach(&mut command)
-            .expect("liveness pipe attaches");
+        command.arg(&script);
         let mut child = command.spawn().expect("shell starts");
 
         // Dropping the Rust end is the same kernel event as process death:
@@ -1795,6 +1873,7 @@ mod tests {
             !env.fs.exists(&touched),
             "the liveness hold must terminate before later rc code"
         );
+        descriptor
     }
 
     /// A request tracing `rc` at `hook_line` with the given shell,

--- a/crates/dodot-lib/src/shell/trace.rs
+++ b/crates/dodot-lib/src/shell/trace.rs
@@ -115,13 +115,20 @@ pub const RECORD_SUFFIX: &str = "|> ";
 pub const DIAGNOSTIC_TRACE_ENV: &str = "DODOT_INTERNAL_SHELL_INIT_TRACE";
 
 /// Hold a report-only rc until the parent sees the record and stops the
-/// process group. The clean `/bin/sh` waits for EOF on the liveness pipe;
-/// if Rust disappears first, its unshadowed builtin sends uncatchable
+/// process group. A clean instance of the supported shell receives the
+/// liveness descriptor as data, avoiding multi-digit redirection syntax.
+/// If Rust disappears first, its unshadowed builtin sends uncatchable
 /// SIGKILL to the traced shell. No path lookup or external `kill` is used.
-fn report_only_hold(parent_liveness_fd: RawFd) -> String {
+fn report_only_hold(shell_path: &Path, shell: HookupShell, parent_liveness_fd: RawFd) -> String {
+    let clean_flags = match shell {
+        // Privileged mode suppresses BASH_ENV and imported functions.
+        HookupShell::Bash => "--noprofile --norc -p",
+        HookupShell::Zsh => "-f",
+    };
     format!(
-        "/bin/sh -c 'IFS= read -r _ <&{parent_liveness_fd}; kill -s KILL 0' \
-         dodot-report-only"
+        "{} {clean_flags} -c 'IFS= read -r -u \"$1\" _; kill -s KILL 0' \
+         dodot-report-only {parent_liveness_fd}",
+        shell_quote(&shell_path.display().to_string()),
     )
 }
 
@@ -856,6 +863,8 @@ fn run_fallback(
         &rc_text,
         req.rc_nominal,
         req.hook_line,
+        req.shell_path,
+        req.shell,
         liveness.as_ref().map(ParentLiveness::descriptor),
     );
     // The file that stands in for the user's rc — the one whose parse
@@ -1043,10 +1052,15 @@ fn insert_report_line(
     rc_text: &str,
     rc_nominal: &Path,
     hook_line: usize,
+    shell_path: &Path,
+    shell: HookupShell,
     parent_liveness_fd: Option<RawFd>,
 ) -> String {
     let maybe_hold = if let Some(parent_liveness_fd) = parent_liveness_fd {
-        format!("{}\n", report_only_hold(parent_liveness_fd))
+        format!(
+            "{}\n",
+            report_only_hold(shell_path, shell, parent_liveness_fd)
+        )
     } else {
         String::new()
     };
@@ -1686,7 +1700,14 @@ mod tests {
     #[test]
     fn the_report_line_is_inserted_not_truncated() {
         let rc = "if true; then\n  eval \"$(dodot init-sh)\"\nfi\n";
-        let copy = insert_report_line(rc, Path::new("/home/u/.zshrc"), 2, None);
+        let copy = insert_report_line(
+            rc,
+            Path::new("/home/u/.zshrc"),
+            2,
+            Path::new("/bin/zsh"),
+            HookupShell::Zsh,
+            None,
+        );
         let lines: Vec<&str> = copy.lines().collect();
         assert_eq!(lines.len(), 4, "insertion, not replacement: {copy}");
         assert!(lines[1].starts_with("printf '+dodot-trace|"), "{copy}");
@@ -1703,10 +1724,20 @@ mod tests {
     #[test]
     fn report_only_copy_stops_before_the_hook() {
         let rc = "eval \"$(dodot init-sh)\"\necho after\n";
-        let copy = insert_report_line(rc, Path::new("/home/u/.bashrc"), 1, Some(42));
+        let copy = insert_report_line(
+            rc,
+            Path::new("/home/u/.bashrc"),
+            1,
+            Path::new("/bin/bash"),
+            HookupShell::Bash,
+            Some(42),
+        );
         let lines: Vec<&str> = copy.lines().collect();
         assert!(lines[0].starts_with("printf '+dodot-trace|"), "{copy}");
-        assert_eq!(lines[1], report_only_hold(42));
+        assert_eq!(
+            lines[1],
+            report_only_hold(Path::new("/bin/bash"), HookupShell::Bash, 42)
+        );
         assert_eq!(lines[2], "eval \"$(dodot init-sh)\"");
         assert_eq!(lines[3], "echo after");
     }
@@ -1749,19 +1780,34 @@ mod tests {
         p.exists().then_some(p)
     }
 
+    fn dash() -> Option<&'static Path> {
+        ["/bin/dash", "/usr/bin/dash"]
+            .into_iter()
+            .map(Path::new)
+            .find(|path| path.exists())
+    }
+
     const TIMEOUT: Duration = Duration::from_secs(10);
     const REDUCED_NOFILE_DRIVER_ENV: &str = "DODOT_TEST_REDUCED_NOFILE_DRIVER";
 
     #[test]
     fn report_only_hold_terminates_with_parent_liveness_in_bash() {
         let Some(bash) = bash() else { return };
-        report_only_hold_terminates_with_parent_liveness(bash);
+        report_only_hold_terminates_with_parent_liveness(bash, HookupShell::Bash);
     }
 
     #[test]
     fn report_only_hold_terminates_with_parent_liveness_in_zsh() {
         let Some(zsh) = zsh() else { return };
-        report_only_hold_terminates_with_parent_liveness(zsh);
+        report_only_hold_terminates_with_parent_liveness(zsh, HookupShell::Zsh);
+    }
+
+    #[test]
+    fn report_only_hold_avoids_multi_digit_redirection_in_dash() {
+        let (Some(dash), Some(bash)) = (dash(), bash()) else {
+            return;
+        };
+        report_only_hold_terminates_with_parent_liveness_using(dash, bash, HookupShell::Bash);
     }
 
     #[test]
@@ -1775,7 +1821,8 @@ mod tests {
                 HookupShell::Bash,
                 ".bashrc",
             );
-            let descriptor = report_only_hold_terminates_with_parent_liveness(bash);
+            let descriptor =
+                report_only_hold_terminates_with_parent_liveness(bash, HookupShell::Bash);
             assert!(descriptor > libc::STDERR_FILENO, "descriptor: {descriptor}");
             assert!(descriptor < SOFT_LIMIT as RawFd, "descriptor: {descriptor}");
             return;
@@ -1827,13 +1874,24 @@ mod tests {
         );
     }
 
-    fn report_only_hold_terminates_with_parent_liveness(shell_path: &Path) -> RawFd {
+    fn report_only_hold_terminates_with_parent_liveness(
+        shell_path: &Path,
+        shell: HookupShell,
+    ) -> RawFd {
+        report_only_hold_terminates_with_parent_liveness_using(shell_path, shell_path, shell)
+    }
+
+    fn report_only_hold_terminates_with_parent_liveness_using(
+        outer_shell_path: &Path,
+        clean_shell_path: &Path,
+        shell: HookupShell,
+    ) -> RawFd {
         use std::os::unix::process::ExitStatusExt;
 
         let env = TempEnvironment::builder().build();
         let touched = env.home.join("continued-after-hold");
         let script = env.home.join("report-only-hold.sh");
-        let mut command = Command::new(shell_path);
+        let mut command = Command::new(outer_shell_path);
         command.stdin(std::process::Stdio::null());
         crate::shell::probe::configure_probe_session(&mut command);
         let liveness = crate::shell::probe::ParentLiveness::attach(&mut command)
@@ -1844,7 +1902,7 @@ mod tests {
                 &script,
                 format!(
                     "{}\nprintf should-not-run > {}\n",
-                    report_only_hold(descriptor),
+                    report_only_hold(clean_shell_path, shell, descriptor),
                     shell_quote(&touched.display().to_string()),
                 )
                 .as_bytes(),

--- a/crates/dodot-lib/src/shell/trace.rs
+++ b/crates/dodot-lib/src/shell/trace.rs
@@ -94,7 +94,9 @@ use std::time::{Duration, Instant};
 
 use crate::fs::Fs;
 use crate::shell::activation::{self, EvidenceVersion};
-use crate::shell::probe::{spawn_captured, spawn_captured_until_stderr, SpawnOutcome};
+use crate::shell::probe::{
+    spawn_captured, spawn_captured_until_stderr, SpawnOutcome, PARENT_LIVENESS_FD,
+};
 use crate::shell::rc::{self, HookupShell};
 
 /// The field prefix every trace record carries, behind the leading
@@ -111,11 +113,16 @@ pub const RECORD_SUFFIX: &str = "|> ";
 /// shell continues through PATH and source work.
 pub const DIAGNOSTIC_TRACE_ENV: &str = "DODOT_INTERNAL_SHELL_INIT_TRACE";
 
-/// Holds a report-only rc at the insertion point until the parent sees
-/// the record and stops the process group. Arithmetic commands are shell
-/// grammar in bash and zsh, so rc-defined aliases and functions cannot
-/// redirect this loop into returning normally.
-const REPORT_ONLY_HOLD: &str = "while (( 1 )); do (( 1 )); done";
+/// Hold a report-only rc until the parent sees the record and stops the
+/// process group. The clean `/bin/sh` waits for EOF on the liveness pipe;
+/// if Rust disappears first, its unshadowed builtin sends uncatchable
+/// SIGKILL to the traced shell. No path lookup or external `kill` is used.
+fn report_only_hold() -> String {
+    format!(
+        "/bin/sh -c 'IFS= read -r _ <&{PARENT_LIVENESS_FD}; kill -s KILL 0' \
+         dodot-report-only"
+    )
+}
 
 // ── The PS4 contract ────────────────────────────────────────────
 
@@ -702,10 +709,10 @@ pub enum TraceError {
     RcUnreadable(String),
     /// The fallback's scratch copy could not be built so that it
     /// reproduces the shell's startup faithfully — the scratch
-    /// directory would not open, or one of the files that stands in
-    /// for a startup file could not be written. A verdict computed
-    /// from a shell that read a different set of files than the real
-    /// one does is worse than no verdict, because the user acts on it.
+    /// directory would not open, or one of the files that stands in for
+    /// a startup file could not be written. A verdict computed from a
+    /// shell that read a different set of files than the real one does
+    /// is worse than no verdict, because the user acts on it.
     FallbackUnfaithful(String),
 }
 
@@ -869,8 +876,8 @@ fn run_fallback(
         return Err(TraceError::FallbackUnfaithful(broken));
     }
     let outcome = if stop_before_hook {
-        spawn_captured_until_stderr(command, req.timeout, |stderr| {
-            let records = parse_trace(stderr);
+        spawn_captured_until_stderr(command, req.timeout, |line| {
+            let records = parse_trace(line);
             record_at(&records, &req.rc_paths(), req.hook_line).is_some()
         })
     } else {
@@ -1027,7 +1034,7 @@ fn insert_report_line(
     stop_before_hook: bool,
 ) -> String {
     let maybe_hold = if stop_before_hook {
-        format!("{REPORT_ONLY_HOLD}\n")
+        format!("{}\n", report_only_hold())
     } else {
         String::new()
     };
@@ -1687,7 +1694,7 @@ mod tests {
         let copy = insert_report_line(rc, Path::new("/home/u/.bashrc"), 1, true);
         let lines: Vec<&str> = copy.lines().collect();
         assert!(lines[0].starts_with("printf '+dodot-trace|"), "{copy}");
-        assert_eq!(lines[1], REPORT_ONLY_HOLD);
+        assert_eq!(lines[1], report_only_hold());
         assert_eq!(lines[2], "eval \"$(dodot init-sh)\"");
         assert_eq!(lines[3], "echo after");
     }
@@ -1731,6 +1738,63 @@ mod tests {
     }
 
     const TIMEOUT: Duration = Duration::from_secs(10);
+
+    #[test]
+    fn report_only_hold_terminates_with_parent_liveness_in_bash() {
+        let Some(bash) = bash() else { return };
+        report_only_hold_terminates_with_parent_liveness(bash);
+    }
+
+    #[test]
+    fn report_only_hold_terminates_with_parent_liveness_in_zsh() {
+        let Some(zsh) = zsh() else { return };
+        report_only_hold_terminates_with_parent_liveness(zsh);
+    }
+
+    fn report_only_hold_terminates_with_parent_liveness(shell_path: &Path) {
+        use std::os::unix::process::ExitStatusExt;
+
+        let env = TempEnvironment::builder().build();
+        let touched = env.home.join("continued-after-hold");
+        let script = env.home.join("report-only-hold.sh");
+        env.fs
+            .write_file(
+                &script,
+                format!(
+                    "{}\nprintf should-not-run > {}\n",
+                    report_only_hold(),
+                    shell_quote(&touched.display().to_string()),
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+        let mut command = Command::new(shell_path);
+        command.arg(&script).stdin(std::process::Stdio::null());
+        let liveness = crate::shell::probe::ParentLiveness::attach(&mut command)
+            .expect("liveness pipe attaches");
+        let mut child = command.spawn().expect("shell starts");
+
+        // Dropping the Rust end is the same kernel event as process death:
+        // the clean helper reads EOF and kills its parent shell.
+        drop(liveness.child_spawned());
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let status = loop {
+            if let Some(status) = child.try_wait().expect("shell remains waitable") {
+                break status;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "liveness EOF must terminate the shell"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        };
+
+        assert_eq!(status.signal(), Some(libc::SIGKILL));
+        assert!(
+            !env.fs.exists(&touched),
+            "the liveness hold must terminate before later rc code"
+        );
+    }
 
     /// A request tracing `rc` at `hook_line` with the given shell,
     /// rooted at the test environment's home.
@@ -1837,6 +1901,37 @@ mod tests {
             !env.fs.exists(&touched),
             "report-only fallback must exit before executing the unknown hook"
         );
+    }
+
+    #[test]
+    fn report_only_trace_reaches_the_record_after_noisy_rc_output() {
+        let Some(bash) = bash() else { return };
+        let env = TempEnvironment::builder().build();
+        let _home = EnvVarGuard::set("HOME", &env.home.display().to_string());
+        let rc = env.home.join(".bashrc");
+        let touched = env.home.join("noisy-hook-ran");
+        env.fs
+            .write_file(
+                &rc,
+                format!(
+                    "i=0\n\
+                     while (( i < 5000 )); do printf 'noise-%s\\n' \"$i\" >&2; \
+                     (( i += 1 )); done\n\
+                     export PATH=/after-noise\n\
+                     printf should-not-run > {}\n",
+                    shell_quote(&touched.display().to_string()),
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+
+        let mut req = request(&env, bash, HookupShell::Bash, &rc, 4);
+        req.execution = TraceExecution::ReportOnly;
+        let run = run_trace(env.fs.as_ref(), &req).expect("noisy report-only trace runs");
+
+        let record = record_at(&run.records, &[&rc], 4).expect("hook-line record");
+        assert_eq!(record.path, "/after-noise");
+        assert!(!env.fs.exists(&touched));
     }
 
     #[test]

--- a/crates/dodot-lib/src/shell/trace.rs
+++ b/crates/dodot-lib/src/shell/trace.rs
@@ -43,6 +43,11 @@
 //! name at mode `0700` (see [`scratch_dir`]) and removed when the run
 //! ends.
 //!
+//! For capability-unknown hooks, the copy prints the hook-line record
+//! and exits before the hook itself. That is the only trace shape that
+//! cannot create heartbeat/profile evidence through a legacy init
+//! script that does not understand diagnostic suppression.
+//!
 //! The copy must reproduce the shell's startup, not approximate it. A
 //! shell that read a different set of files than the real one does
 //! yields a verdict the user would act on and should not — so a copy
@@ -65,8 +70,10 @@
 //!   different path under the trace than it does in earnest. Reading
 //!   `PATH` at the hook line is what this buys, and there is no way to
 //!   buy it without the option set.
-//! - **The rc runs up to twice.** The fallback re-runs it on a copy,
-//!   so side effects in the rc happen again. [`announcement`] says so
+//! - **The rc runs up to twice for diagnostic-capable hooks.** The
+//!   fallback re-runs it on a copy, so side effects before the hook
+//!   can happen again. Capability-unknown hooks use only the copy and
+//!   exit before the hook. [`announcement`] says the upper bound
 //!   before anything is spawned.
 //!
 //! # Boundaries
@@ -82,7 +89,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::fs::Fs;
 use crate::shell::activation::{self, EvidenceVersion};
@@ -96,6 +103,12 @@ pub const TRACE_MARKER: &str = "dodot-trace|";
 /// Terminates the PATH field of a record, separating it from the
 /// traced command text that follows on the same line.
 pub const RECORD_SUFFIX: &str = "|> ";
+
+/// Internal environment flag carried by `probe shell-init --trace-hook`.
+/// Current init scripts consume it before pack contributions and use it
+/// only to suppress heartbeat and profile writes while the diagnostic
+/// shell continues through PATH and source work.
+pub const DIAGNOSTIC_TRACE_ENV: &str = "DODOT_INTERNAL_SHELL_INIT_TRACE";
 
 // ── The PS4 contract ────────────────────────────────────────────
 
@@ -695,6 +708,7 @@ pub enum TraceError {
 pub struct TraceRun {
     pub records: Vec<TraceRecord>,
     pub used_fallback: bool,
+    pub elapsed_us: u64,
 }
 
 /// Everything one trace needs to know about the shell it is
@@ -719,6 +733,7 @@ pub struct TraceRequest<'a> {
     /// 1-indexed line the hook sits on.
     pub hook_line: usize,
     pub timeout: Duration,
+    pub execution: TraceExecution,
 }
 
 impl TraceRequest<'_> {
@@ -726,6 +741,18 @@ impl TraceRequest<'_> {
     fn rc_paths(&self) -> [&Path; 2] {
         [self.rc_nominal, self.rc_resolved]
     }
+}
+
+/// Whether it is safe to run the real hook during a trace.
+///
+/// Current generated scripts understand [`DIAGNOSTIC_TRACE_ENV`], so
+/// primary tracing can run the hook without creating heartbeat/profile
+/// evidence. Capability-unknown hooks are traced through the temporary
+/// copy only, with a report line that exits before the hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceExecution {
+    DiagnosticSupported,
+    ReportOnly,
 }
 
 /// Spawn the shell under xtrace and read the hook-line records back,
@@ -737,12 +764,23 @@ impl TraceRequest<'_> {
 /// `PS4` override can strip the marker from any suffix of the file,
 /// so absence alone cannot distinguish "hook never ran" from "marker
 /// lost"; the fallback's inserted report can, because it fires exactly
-/// when the hook line would be reached. A missing record *after* the
-/// fallback is therefore the hook-never-ran answer, confirmed on a
-/// copy that cannot lose the marker.
+/// when the hook line would be reached. Capability-unknown hooks skip
+/// the primary run and use that copy in report-only mode so a legacy
+/// init script cannot write activation evidence before dodot has the
+/// PATH answer.
 pub fn run_trace(fs: &dyn Fs, req: &TraceRequest) -> Result<TraceRun, TraceError> {
+    let started = Instant::now();
+    if req.execution == TraceExecution::ReportOnly {
+        return run_fallback(fs, req, true).map(|records| TraceRun {
+            records,
+            used_fallback: true,
+            elapsed_us: elapsed_us(started),
+        });
+    }
+
     let mut command = Command::new(req.shell_path);
     command
+        .env(DIAGNOSTIC_TRACE_ENV, "1")
         .env("PS4", ps4(req.shell))
         .args(trace_args(req.shell));
     let records = match spawn_captured(command, req.timeout) {
@@ -754,11 +792,13 @@ pub fn run_trace(fs: &dyn Fs, req: &TraceRequest) -> Result<TraceRun, TraceError
         return Ok(TraceRun {
             records,
             used_fallback: false,
+            elapsed_us: elapsed_us(started),
         });
     }
-    run_fallback(fs, req).map(|records| TraceRun {
+    run_fallback(fs, req, false).map(|records| TraceRun {
         records,
         used_fallback: true,
+        elapsed_us: elapsed_us(started),
     })
 }
 
@@ -774,7 +814,11 @@ pub fn run_trace(fs: &dyn Fs, req: &TraceRequest) -> Result<TraceRun, TraceError
 /// of files than the real one does ends the trace with
 /// [`TraceError::FallbackUnfaithful`] rather than yielding a verdict
 /// the user would act on.
-fn run_fallback(fs: &dyn Fs, req: &TraceRequest) -> Result<Vec<TraceRecord>, TraceError> {
+fn run_fallback(
+    fs: &dyn Fs,
+    req: &TraceRequest,
+    exit_before_hook: bool,
+) -> Result<Vec<TraceRecord>, TraceError> {
     let rc_text = fs
         .read_to_string(req.rc_resolved)
         .map_err(|e| TraceError::RcUnreadable(format!("{e}")))?;
@@ -784,7 +828,10 @@ fn run_fallback(fs: &dyn Fs, req: &TraceRequest) -> Result<Vec<TraceRecord>, Tra
     let temp = scratch.path();
     let unfaithful = |e: crate::DodotError| TraceError::FallbackUnfaithful(format!("{e}"));
     let mut command = Command::new(req.shell_path);
-    let copy = insert_report_line(&rc_text, req.rc_nominal, req.hook_line);
+    if !exit_before_hook {
+        command.env(DIAGNOSTIC_TRACE_ENV, "1");
+    }
+    let copy = insert_report_line(&rc_text, req.rc_nominal, req.hook_line, exit_before_hook);
     // The file that stands in for the user's rc — the one whose parse
     // has to survive the insertion.
     let copy_path;
@@ -958,9 +1005,15 @@ fn zshrc_copy(rc_copy: &str) -> String {
 /// stop the parse. [`insertion_broke_the_parse`] is what turns that
 /// from a silent wrong verdict into a refusal to answer, because
 /// nothing in this function can tell.
-fn insert_report_line(rc_text: &str, rc_nominal: &Path, hook_line: usize) -> String {
+fn insert_report_line(
+    rc_text: &str,
+    rc_nominal: &Path,
+    hook_line: usize,
+    exit_before_hook: bool,
+) -> String {
+    let maybe_exit = if exit_before_hook { "exit 0\n" } else { "" };
     let report = format!(
-        "printf '+{TRACE_MARKER}%s|%s|%s|%s{RECORD_SUFFIX}\\n' {} {} \"$PWD\" \"$PATH\" >&2\n",
+        "printf '+{TRACE_MARKER}%s|%s|%s|%s{RECORD_SUFFIX}\\n' {} {} \"$PWD\" \"$PATH\" >&2\n{maybe_exit}",
         shell_quote(&rc_nominal.display().to_string()),
         hook_line,
     );
@@ -976,6 +1029,10 @@ fn insert_report_line(rc_text: &str, rc_nominal: &Path, hook_line: usize) -> Str
     // yields a well-formed copy; the missing record then reads as
     // "hook never ran", which is true of the copy that was run.
     out
+}
+
+fn elapsed_us(started: Instant) -> u64 {
+    started.elapsed().as_micros().try_into().unwrap_or(u64::MAX)
 }
 
 /// Single-quote `value` for the shell, the only quoting that needs no
@@ -1007,6 +1064,7 @@ fn scratch_dir() -> Result<tempfile::TempDir, TraceError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::Pather;
     use crate::testing::TempEnvironment;
 
     // ── Trace parsing, against captured real traces ─────────────
@@ -1590,7 +1648,7 @@ mod tests {
     #[test]
     fn the_report_line_is_inserted_not_truncated() {
         let rc = "if true; then\n  eval \"$(dodot init-sh)\"\nfi\n";
-        let copy = insert_report_line(rc, Path::new("/home/u/.zshrc"), 2);
+        let copy = insert_report_line(rc, Path::new("/home/u/.zshrc"), 2, false);
         let lines: Vec<&str> = copy.lines().collect();
         assert_eq!(lines.len(), 4, "insertion, not replacement: {copy}");
         assert!(lines[1].starts_with("printf '+dodot-trace|"), "{copy}");
@@ -1602,6 +1660,17 @@ mod tests {
         assert_eq!(lines[0], "if true; then");
         assert_eq!(lines[2], "  eval \"$(dodot init-sh)\"");
         assert_eq!(lines[3], "fi");
+    }
+
+    #[test]
+    fn report_only_copy_exits_before_the_hook() {
+        let rc = "eval \"$(dodot init-sh)\"\necho after\n";
+        let copy = insert_report_line(rc, Path::new("/home/u/.bashrc"), 1, true);
+        let lines: Vec<&str> = copy.lines().collect();
+        assert!(lines[0].starts_with("printf '+dodot-trace|"), "{copy}");
+        assert_eq!(lines[1], "exit 0");
+        assert_eq!(lines[2], "eval \"$(dodot init-sh)\"");
+        assert_eq!(lines[3], "echo after");
     }
 
     #[test]
@@ -1662,6 +1731,7 @@ mod tests {
             rc_resolved: rc,
             hook_line,
             timeout: TIMEOUT,
+            execution: TraceExecution::DiagnosticSupported,
         }
     }
 
@@ -1716,6 +1786,119 @@ mod tests {
         assert_eq!(record.path, "/from/fallback");
         // The user's real rc was never written.
         assert_eq!(env.fs.read_to_string(&rc).unwrap(), before);
+    }
+
+    #[test]
+    fn report_only_trace_does_not_execute_a_capability_unknown_hook() {
+        let Some(bash) = bash() else { return };
+        let env = TempEnvironment::builder().build();
+        let _home = EnvVarGuard::set("HOME", &env.home.display().to_string());
+        let rc = env.home.join(".bashrc");
+        let touched = env.home.join("touched");
+        env.fs
+            .write_file(
+                &rc,
+                format!(
+                    "export PATH=/before-hook\necho should-not-run > {}\n",
+                    touched.display()
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+
+        let mut req = request(&env, bash, HookupShell::Bash, &rc, 2);
+        req.execution = TraceExecution::ReportOnly;
+        let run = run_trace(env.fs.as_ref(), &req).expect("report-only trace runs");
+
+        assert!(run.used_fallback);
+        assert!(run.elapsed_us > 0);
+        let record = record_at(&run.records, &[&rc], 2).expect("inserted report record");
+        assert_eq!(record.path, "/before-hook");
+        assert!(
+            !env.fs.exists(&touched),
+            "report-only fallback must exit before executing the unknown hook"
+        );
+    }
+
+    #[test]
+    fn diagnostic_supported_trace_leaves_evidence_untouched_and_runs_contributions() {
+        let Some(bash) = bash() else { return };
+        let env = TempEnvironment::builder()
+            .pack("shell")
+            .file(
+                "trace.sh",
+                "echo trace contribution > \"$HOME/trace-contribution\"",
+            )
+            .done()
+            .build();
+        let _home = EnvVarGuard::set("HOME", &env.home.display().to_string());
+
+        let handler_dir = env.paths.handler_data_dir("shell", "shell");
+        env.fs.mkdir_all(&handler_dir).unwrap();
+        env.fs
+            .symlink(
+                &env.dotfiles_root.join("shell/trace.sh"),
+                &handler_dir.join("trace.sh"),
+            )
+            .unwrap();
+        crate::shell::write_init_script(env.fs.as_ref(), env.paths.as_ref(), true, None).unwrap();
+
+        let rc = env.home.join(".bashrc");
+        let init = env.paths.init_script_path();
+        env.fs
+            .write_file(
+                &rc,
+                format!(
+                    "[ -f \"{}\" ] && . \"{}\"\n",
+                    init.display(),
+                    init.display()
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+
+        std::process::Command::new(bash)
+            .arg("-ic")
+            .arg("true")
+            .status()
+            .expect("seed shell runs");
+
+        let heartbeat = env.paths.hookup_heartbeat_path();
+        let heartbeat_contents = env.fs.read_to_string(&heartbeat).unwrap();
+        let heartbeat_mtime = std::fs::metadata(&heartbeat).unwrap().modified().unwrap();
+        let profiles_before = profile_snapshot(&env);
+        let contribution = env.home.join("trace-contribution");
+        std::fs::remove_file(&contribution).unwrap();
+
+        let run = run_trace(
+            env.fs.as_ref(),
+            &request(&env, bash, HookupShell::Bash, &rc, 1),
+        )
+        .expect("diagnostic trace runs");
+
+        assert!(run.elapsed_us > 0);
+        assert!(
+            record_at(&run.records, &[&rc], 1).is_some(),
+            "hook-line record must be present"
+        );
+        assert!(
+            env.fs.exists(&contribution),
+            "diagnostic-capable trace should continue through pack contributions"
+        );
+        assert_eq!(
+            env.fs.read_to_string(&heartbeat).unwrap(),
+            heartbeat_contents
+        );
+        assert_eq!(
+            std::fs::metadata(&heartbeat).unwrap().modified().unwrap(),
+            heartbeat_mtime,
+            "trace must not refresh activation heartbeat evidence"
+        );
+        assert_eq!(
+            profile_snapshot(&env),
+            profiles_before,
+            "trace must not create or rewrite shell-init profiles"
+        );
     }
 
     /// The insertion is not free. A `case` pattern line is a shape
@@ -1954,5 +2137,23 @@ mod tests {
             ),
             Err(TraceError::SpawnFailed(_))
         ));
+    }
+
+    fn profile_snapshot(env: &TempEnvironment) -> Vec<(String, String)> {
+        let dir = env.paths.probes_shell_init_dir();
+        let Ok(mut entries) = env.fs.read_dir(&dir) else {
+            return Vec::new();
+        };
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        entries
+            .into_iter()
+            .filter(|entry| entry.is_file && entry.name.starts_with("profile-"))
+            .map(|entry| {
+                (
+                    entry.name,
+                    env.fs.read_to_string(&entry.path).unwrap_or_default(),
+                )
+            })
+            .collect()
     }
 }

--- a/crates/dodot-lib/src/shell/trace.rs
+++ b/crates/dodot-lib/src/shell/trace.rs
@@ -1770,6 +1770,7 @@ mod tests {
             .unwrap();
         let mut command = Command::new(shell_path);
         command.arg(&script).stdin(std::process::Stdio::null());
+        crate::shell::probe::configure_probe_session(&mut command);
         let liveness = crate::shell::probe::ParentLiveness::attach(&mut command)
             .expect("liveness pipe attaches");
         let mut child = command.spawn().expect("shell starts");
@@ -1935,18 +1936,22 @@ mod tests {
     }
 
     #[test]
-    fn report_only_trace_ignores_shadowed_termination_commands_in_bash() {
+    fn report_only_trace_survives_fd_three_and_shadowed_commands_in_bash() {
         let Some(bash) = bash() else { return };
-        report_only_trace_ignores_shadowed_termination_commands(bash, HookupShell::Bash, ".bashrc");
+        report_only_trace_survives_fd_three_and_shadowed_commands(
+            bash,
+            HookupShell::Bash,
+            ".bashrc",
+        );
     }
 
     #[test]
-    fn report_only_trace_ignores_shadowed_termination_commands_in_zsh() {
+    fn report_only_trace_survives_fd_three_and_shadowed_commands_in_zsh() {
         let Some(zsh) = zsh() else { return };
-        report_only_trace_ignores_shadowed_termination_commands(zsh, HookupShell::Zsh, ".zshrc");
+        report_only_trace_survives_fd_three_and_shadowed_commands(zsh, HookupShell::Zsh, ".zshrc");
     }
 
-    fn report_only_trace_ignores_shadowed_termination_commands(
+    fn report_only_trace_survives_fd_three_and_shadowed_commands(
         shell_path: &Path,
         shell: HookupShell,
         rc_name: &str,
@@ -1972,7 +1977,8 @@ mod tests {
             .write_file(
                 &rc,
                 format!(
-                    "command() {{ return 0; }}\n\
+                    "exec 3>&1\n\
+                     command() {{ return 0; }}\n\
                      builtin() {{ return 0; }}\n\
                      kill() {{ return 0; }}\n\
                      exit() {{ return 0; }}\n\
@@ -1992,13 +1998,13 @@ mod tests {
             .unwrap();
         let rc_before = env.fs.read_to_string(&rc).unwrap();
 
-        let mut req = request(&env, shell_path, shell, &rc, 10);
+        let mut req = request(&env, shell_path, shell, &rc, 11);
         req.execution = TraceExecution::ReportOnly;
         let run = run_trace(env.fs.as_ref(), &req).expect("report-only trace runs");
 
         assert!(run.used_fallback);
         assert!(
-            record_at(&run.records, &[&rc], 10).is_some(),
+            record_at(&run.records, &[&rc], 11).is_some(),
             "report-only trace must still print the hook-line record"
         );
         assert!(

--- a/crates/dodot-lib/src/templates/probe.jinja
+++ b/crates/dodot-lib/src/templates/probe.jinja
@@ -48,13 +48,15 @@
 [header]Hook verification[/header]{% if verification.rc %} [dim]{{ verification.rc }}{% if verification.hook_line > 0 %}:{{ verification.hook_line }}{% endif %} ({{ verification.shell }})[/dim]{% endif %}
   [{{ verification.status_class }}]{{ verification.headline }}[/{{ verification.status_class }}]
 {% for line in verification.detail_lines %}  [dim]{{ line }}[/dim]
-{% endfor %}  [dim]elapsed:[/dim] {{ verification.elapsed_us }} µs
+{% endfor %}{% if verification.elapsed_label %}  [dim]elapsed:[/dim] {{ verification.elapsed_label }}
+{% endif %}
 {% endif %}{% if trace %}
 [header]Hook resolution[/header]{% if trace.rc %} [dim]{{ trace.rc }}{% if trace.hook_line > 0 %}:{{ trace.hook_line }}{% endif %} ({{ trace.shell }})[/dim]{% endif %}
   [{{ trace.status_class }}]{{ trace.headline }}[/{{ trace.status_class }}]
 {% for line in trace.detail_lines %}  [dim]{{ line }}[/dim]
 {% endfor %}{% if trace.used_fallback %}  [dim](traced via a temporary copy of your rc — your real files were not touched)[/dim]
-{% endif %}  [dim]elapsed:[/dim] {{ trace.elapsed_us }} µs
+{% endif %}{% if trace.elapsed_label %}  [dim]elapsed:[/dim] {{ trace.elapsed_label }}
+{% endif %}
 {% endif %}
   [dim]profiles dir:[/dim] {{ profiles_dir }}
   [dim]for intra-file profiling, see `zprof` (zsh) or PS4 tracing (bash).[/dim]

--- a/crates/dodot-lib/src/templates/probe.jinja
+++ b/crates/dodot-lib/src/templates/probe.jinja
@@ -54,7 +54,8 @@
   [{{ trace.status_class }}]{{ trace.headline }}[/{{ trace.status_class }}]
 {% for line in trace.detail_lines %}  [dim]{{ line }}[/dim]
 {% endfor %}{% if trace.used_fallback %}  [dim](traced via a temporary copy of your rc — your real files were not touched)[/dim]
-{% endif %}{% endif %}
+{% endif %}  [dim]elapsed:[/dim] {{ trace.elapsed_us }} µs
+{% endif %}
   [dim]profiles dir:[/dim] {{ profiles_dir }}
   [dim]for intra-file profiling, see `zprof` (zsh) or PS4 tracing (bash).[/dim]
 {%- elif kind == "shell-init-aggregate" -%}

--- a/tests/e2e/bats/test_shell_hookup.bats
+++ b/tests/e2e/bats/test_shell_hookup.bats
@@ -250,6 +250,61 @@ echo tool output'
     assert_output_contains "5.0.0"
 }
 
+_mtime_of() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
+
+_profiles_snapshot() {
+    local dir="$XDG_DATA_HOME/dodot/probes/shell-init"
+    if [[ ! -d "$dir" ]]; then
+        return 0
+    fi
+    while IFS= read -r file; do
+        printf '%s ' "${file#$dir/}"
+        cksum "$file"
+    done < <(find "$dir" -type f -name 'profile-*' | sort)
+}
+
+@test "trace-hook current file-source target leaves evidence untouched and runs contributions" {
+    create_pack_file "shell" "trace.sh" 'echo trace contribution > "$HOME/trace-contribution"'
+    dodot up
+    dodot install --write
+
+    bash -ic true
+    local hb="$XDG_DATA_HOME/dodot/probes/hookup/heartbeat"
+    local hb_contents hb_mtime profiles_before
+    hb_contents="$(cat "$hb")"
+    hb_mtime="$(_mtime_of "$hb")"
+    profiles_before="$(_profiles_snapshot)"
+    rm -f "$HOME/trace-contribution"
+
+    run dodot probe shell-init --trace-hook
+    [ "$status" -eq 0 ]
+    assert_output_contains "Hook resolution"
+    assert_output_contains "the hookup is sound"
+    assert_output_contains "elapsed:"
+
+    assert_exists "$HOME/trace-contribution"
+    [ "$(cat "$hb")" = "$hb_contents" ]
+    [ "$(_mtime_of "$hb")" = "$hb_mtime" ]
+    [ "$(_profiles_snapshot)" = "$profiles_before" ]
+}
+
+@test "trace-hook capability-unknown eval target uses copy and exits before the hook" {
+    dodot up
+    printf 'echo should-not-run > "$HOME/eval-hook-ran"; eval "$(dodot init-sh)"\n' \
+        > "$HOME/.bashrc"
+
+    run dodot probe shell-init --trace-hook
+    [ "$status" -eq 0 ]
+    assert_output_contains "Hook resolution"
+    assert_output_contains "temporary copy"
+    assert_output_contains "elapsed:"
+    assert_not_exists "$HOME/eval-hook-ran"
+    assert_not_exists "$XDG_DATA_HOME/dodot/probes/hookup/heartbeat"
+    [ -z "$(_profiles_snapshot)" ]
+}
+
 @test "probe shell-init --no-trace keeps the report passive" {
     dodot up
     printf 'eval "$(dodot init-sh)"\n' > "$HOME/.bashrc"

--- a/tests/e2e/bats/test_shell_hookup.bats
+++ b/tests/e2e/bats/test_shell_hookup.bats
@@ -290,6 +290,32 @@ _profiles_snapshot() {
     [ "$(_profiles_snapshot)" = "$profiles_before" ]
 }
 
+@test "trace-hook current eval target leaves evidence untouched and runs contributions" {
+    create_pack_file "shell" "trace.sh" 'echo trace contribution > "$HOME/trace-contribution"'
+    dodot up
+    printf 'export PATH=%s:$PATH\neval "$(dodot init-sh)"\n' "$(dirname "$DODOT_BIN")" \
+        > "$HOME/.bashrc"
+
+    bash -ic true
+    local hb="$XDG_DATA_HOME/dodot/probes/hookup/heartbeat"
+    local hb_contents hb_mtime profiles_before
+    hb_contents="$(cat "$hb")"
+    hb_mtime="$(_mtime_of "$hb")"
+    profiles_before="$(_profiles_snapshot)"
+    rm -f "$HOME/trace-contribution"
+
+    run dodot probe shell-init --trace-hook
+    [ "$status" -eq 0 ]
+    assert_output_contains "Hook resolution"
+    assert_output_contains "the hookup is sound"
+    assert_output_contains "elapsed:"
+
+    assert_exists "$HOME/trace-contribution"
+    [ "$(cat "$hb")" = "$hb_contents" ]
+    [ "$(_mtime_of "$hb")" = "$hb_mtime" ]
+    [ "$(_profiles_snapshot)" = "$profiles_before" ]
+}
+
 @test "trace-hook capability-unknown eval target uses copy and exits before the hook" {
     dodot up
     printf 'echo should-not-run > "$HOME/eval-hook-ran"; eval "$(dodot init-sh)"\n' \


### PR DESCRIPTION
for #330

## Summary
- add an explicit diagnostic trace mode for generated shell-init scripts that skips activation heartbeat/profile writes while continuing through shell startup contributions
- make capability-unknown hook tracing use a faithful temporary rc copy that reports PATH and exits before the hook
- report trace elapsed time in probe output and cover the primary, fallback, and report-only paths with tests

## Context
This keeps bare `probe shell-init` on targeted verification and routes explicit `--trace-hook` through a separate diagnostic mode. Current generated init scripts advertise `shell-init-trace v1`; when the internal trace environment is present they skip heartbeat/profile writes but still continue through Homebrew, PATH, and pack contributions. Capability-unknown hooks use the faithful temporary rc copy in report-only mode and exit before the hook, so legacy init scripts cannot mutate activation evidence before the PATH answer is captured.

I self-checked the diff against `docs/proposals/targeted-shell-init-verification.lex`, `docs/proposals/shipped/shell-hookup.lex`, `docs/proposals/shell-hookup-ergonomics.lex`, and `docs/user/commands/probe.lex` before opening this PR.

Out of scope: changing default targeted verification, WS02 mutation-path adoption, WS04 incomplete-profile semantics, or repairing/restoring evidence after mutation. Do not reopen the older default-trace behavior; `--trace-hook` is now the explicit diagnostic surface.

Verification: `pixi run test` passed with 1800 tests. Commit and push hooks also ran `pixi run lint` successfully. Additional Rust real-shell tests cover diagnostic-supported primary/fallback behavior and report-only legacy/eval behavior. `app-bin/e2e --rebuild test_shell_hookup.bats` could not run any Bats test because the E2E image/worktree is missing `/tests/helpers/setup.bash`; every case failed in `setup()` before executing.

## Current coordinator handoff

The authoritative engine is `blocked` only on hosted CI for capped head `f26588f`: the PR is mergeable, all review threads are resolved, and lint is green. Fix the concrete Linux shell-compatibility failure below, sweep the report-only hold for the same shell-parser assumption, run `pixi run test`, let commit/push hooks run lint, push atomically, report head and verification, then park. The round cap remains active: do not request reviews.

Hosted Ubuntu uses dash as `/bin/sh`. Both `report_only_hold_terminates_with_parent_liveness_in_bash` and the low-`RLIMIT_NOFILE` regression fail because dash rejects multi-digit descriptor syntax in `read ... <&63` with `Syntax error: Bad fd number`; the shell exits normally instead of the clean helper sending SIGKILL. Preserve the dynamically selected private descriptor and low-limit behavior, but bridge it into syntax accepted by the clean `/bin/sh` on both macOS and Linux. One likely direction is for the outer supported bash/zsh rc to duplicate the dynamic high descriptor onto a known single-digit descriptor only for the clean helper process, then have `/bin/sh` read that single-digit fd; validate the exact construct in real bash, zsh, macOS sh, and Linux-compatible dash where available. Retain the fd-3 hijack, shadowed commands, parent-death, and evidence-preservation guarantees.

Do not wait, flip ready, or merge; the coordinator owns those actions.